### PR TITLE
feat(make): seven-phase check ledger in the agent report

### DIFF
--- a/compiler/tests/e2e/test_check_phase_ledger.sh
+++ b/compiler/tests/e2e/test_check_phase_ledger.sh
@@ -53,19 +53,23 @@ run_test() {
 SCRATCH="$(mktemp -d -t sfn-check-ledger-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-# Read a flat-JSON string field without a hard jq dependency (mirrors
-# test_make_result_contract.sh's json_field).
+# Read a top-level JSON string/null field without a hard jq dependency.
+# Unlike test_make_result_contract.sh's flat-JSON helper, the check report
+# nests seven `"status"` keys inside phases[], so the jq-less fallback must
+# take the *first* occurrence of the key — a greedy/last match would shadow
+# the top-level value with a phase value. The report writes every top-level
+# field before phases[], so first-occurrence is the top-level value.
 json_field() {
-    local json="$1" field="$2"
+    local json="$1" field="$2" match
     if command -v jq >/dev/null 2>&1; then
         printf '%s' "$json" | jq -r ".${field} // \"null\"" 2>/dev/null
         return
     fi
-    if printf '%s' "$json" | grep -q "\"${field}\":null"; then
-        printf 'null'
-        return
-    fi
-    printf '%s' "$json" | sed -nE "s/.*\"${field}\":\"([^\"]*)\".*/\1/p"
+    match="$(printf '%s' "$json" | grep -oE "\"${field}\":(\"[^\"]*\"|null)" | head -n1)"
+    case "$match" in
+        *:null) printf 'null' ;;
+        *) printf '%s' "$match" | sed -E "s/.*:\"([^\"]*)\"/\1/" ;;
+    esac
 }
 
 # Run agent_report.sh for `--target check` over a stub that prints $1 (a banner

--- a/compiler/tests/e2e/test_check_phase_ledger.sh
+++ b/compiler/tests/e2e/test_check_phase_ledger.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# End-to-end test for the seven-phase `make check` ledger (#1124, epic #1056
+# Phase 2). Locks the `phases[]` array that scripts/agent_report.sh composes
+# into build/agent-report.check.json when `make check` runs under the report
+# gate (JSON=1 / SAILFIN_AGENT_REPORT=1).
+#
+# Rather than run the real ~20-min `make check`, this drives agent_report.sh
+# directly with a stub command that echoes the human phase banners check-impl
+# prints, then asserts the derived ledger. The composer keys off exactly those
+# banners (the same marker set detect_check_phase uses), so a stub that prints
+# them exercises the real derivation logic deterministically in milliseconds.
+#
+# Cases:
+#   - green:  all seven banners + fixed-point match, exit 0
+#             -> seven phases in order, every status "pass".
+#   - fail:   banners through seedcheck-tests then a test-failure, exit 1
+#             -> seedcheck-tests "fail", stage3-build + fixed-point "skipped",
+#                top-level status "fail" / phase "seedcheck-tests".
+#   - warn:   all banners but `stage2 != stage3`, exit 0
+#             -> fixed-point "warn", top-level status "warn" /
+#                failure "nondeterminism", exit 0.
+#
+# Schema: docs/reference/make-result-schema.md (`sailfin-make/1`, phases[]).
+#
+# Usage:
+#   compiler/tests/e2e/test_check_phase_ledger.sh [compiler-binary]
+# (The compiler binary arg is accepted for harness uniformity but unused —
+#  this test exercises the shell composer, not the compiler.)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/agent_report.sh"
+if [ ! -f "$WRAPPER" ]; then
+    echo "test_check_phase_ledger.sh: missing $WRAPPER" >&2
+    exit 2
+fi
+
+PASS=0
+FAIL=0
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+SCRATCH="$(mktemp -d -t sfn-check-ledger-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Read a flat-JSON string field without a hard jq dependency (mirrors
+# test_make_result_contract.sh's json_field).
+json_field() {
+    local json="$1" field="$2"
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$json" | jq -r ".${field} // \"null\"" 2>/dev/null
+        return
+    fi
+    if printf '%s' "$json" | grep -q "\"${field}\":null"; then
+        printf 'null'
+        return
+    fi
+    printf '%s' "$json" | sed -nE "s/.*\"${field}\":\"([^\"]*)\".*/\1/p"
+}
+
+# Run agent_report.sh for `--target check` over a stub that prints $1 (a banner
+# script) and exits with $2. Writes the report under $SCRATCH/build and echoes
+# the report path. SAILFIN_INNER is cleared so the wrapper claims the verdict
+# (this test itself runs under the wrapped test-e2e-sh, which exports it).
+run_check_stub() {
+    local banners="$1" rc="$2" sub
+    sub="$SCRATCH/run.$$"
+    rm -rf "$sub"
+    mkdir -p "$sub"
+    ( cd "$sub"
+      env -u SAILFIN_INNER SAILFIN_AGENT_REPORT=1 \
+          bash "$WRAPPER" --target check -- \
+          bash -c "$banners"$'\n'"exit $rc" >/dev/null 2>&1 || true )
+    printf '%s' "$sub/build/agent-report.check.json"
+}
+
+# Banner fragments matching check-impl's human output (Makefile check-impl).
+B_FPTESTS='echo "[check] running test suite on first-pass binary (early gate)..."'
+B_SCBUILD='echo "[check] first-pass tests passed — proceeding to seedcheck build..."'
+B_SCSMOKE='echo "[check] validating seedcheck binary can run programs..."'
+B_SCTESTS='echo "[check] running test suite with seedcheck binary (no fallbacks)..."'
+B_S3BUILD='echo "[check] stage2 tests passed — building stage3 for fixed-point comparison..."'
+B_FIXED='echo "[check] comparing stage2 vs stage3 LLVM IR (fixed-point check)..."'
+
+# Assert the report's phases[] names are the canonical seven in order.
+assert_seven_names() {
+    local report="$1" json names
+    [ -f "$report" ] || { echo "  missing report $report" >&2; return 1; }
+    json="$(cat "$report")"
+    if command -v jq >/dev/null 2>&1; then
+        if ! printf '%s' "$json" | jq -e \
+            '[.phases[].name] == ["compile","first-pass-tests","seedcheck-build","seedcheck-smoke","seedcheck-tests","stage3-build","fixed-point"]' \
+            >/dev/null 2>&1; then
+            echo "  phases[] names not the canonical seven in order:" >&2
+            printf '%s' "$json" | jq -c '.phases' >&2 2>/dev/null || echo "$json" >&2
+            return 1
+        fi
+        return 0
+    fi
+    # jq-less fallback: check the names substring in order.
+    names='"name":"compile".*"name":"first-pass-tests".*"name":"seedcheck-build".*"name":"seedcheck-smoke".*"name":"seedcheck-tests".*"name":"stage3-build".*"name":"fixed-point"'
+    printf '%s' "$json" | grep -Eq "$names" || {
+        echo "  phases[] names not the canonical seven in order: $json" >&2
+        return 1
+    }
+}
+
+# Assert phase <name> has status <want> in the report (jq required; skip when
+# jq is unavailable — the names check above already runs jq-less).
+assert_phase_status() {
+    local report="$1" name="$2" want="$3" got
+    command -v jq >/dev/null 2>&1 || return 0
+    got="$(jq -r --arg n "$name" '.phases[] | select(.name==$n) | .status' "$report" 2>/dev/null)"
+    if [ "$got" != "$want" ]; then
+        echo "  phase $name: expected status $want, got '$got'" >&2
+        jq -c '.phases' "$report" >&2 2>/dev/null
+        return 1
+    fi
+}
+
+# ---- Case 1: green tree -> seven phases, all pass ----
+check_green() {
+    local report
+    report="$(run_check_stub "$B_FPTESTS"$'\n'"$B_SCBUILD"$'\n'"$B_SCSMOKE"$'\n'"$B_SCTESTS"$'\n'"$B_S3BUILD"$'\n'"$B_FIXED"$'\n''echo "[check] stage2 == stage3: compiler is a fixed point"' 0)"
+    assert_seven_names "$report" || return 1
+    local p
+    for p in compile first-pass-tests seedcheck-build seedcheck-smoke seedcheck-tests stage3-build fixed-point; do
+        assert_phase_status "$report" "$p" pass || return 1
+    done
+    # Top-level verdict is a clean pass.
+    local json status
+    json="$(cat "$report")"
+    status="$(json_field "$json" status)"
+    [ "$status" = "pass" ] || { echo "  top-level status: expected pass, got $status" >&2; return 1; }
+}
+run_test "green check: seven phases in order, all pass" check_green
+
+# ---- Case 2: seedcheck-tests failure -> fail + trailing skipped ----
+check_fail() {
+    local report
+    # Banners through the seedcheck-tests start, then a test-failure marker.
+    report="$(run_check_stub "$B_FPTESTS"$'\n'"$B_SCBUILD"$'\n'"$B_SCSMOKE"$'\n''echo "[check] seedcheck binary runs hello-world.sfn OK"'$'\n'"$B_SCTESTS"$'\n''echo "═══ unit: 3/4 passed, 1 failed ═══"' 1)"
+    assert_seven_names "$report" || return 1
+    assert_phase_status "$report" compile pass || return 1
+    assert_phase_status "$report" first-pass-tests pass || return 1
+    assert_phase_status "$report" seedcheck-build pass || return 1
+    assert_phase_status "$report" seedcheck-smoke pass || return 1
+    assert_phase_status "$report" seedcheck-tests fail || return 1
+    assert_phase_status "$report" stage3-build skipped || return 1
+    assert_phase_status "$report" fixed-point skipped || return 1
+    local json status phase failure
+    json="$(cat "$report")"
+    status="$(json_field "$json" status)"
+    phase="$(json_field "$json" phase)"
+    failure="$(json_field "$json" failure)"
+    [ "$status" = "fail" ] || { echo "  top-level status: expected fail, got $status" >&2; return 1; }
+    [ "$phase" = "seedcheck-tests" ] || { echo "  top-level phase: expected seedcheck-tests, got $phase" >&2; return 1; }
+    [ "$failure" = "test-failure" ] || { echo "  top-level failure: expected test-failure, got $failure" >&2; return 1; }
+}
+run_test "seedcheck-tests fail: that phase fail, trailing skipped" check_fail
+
+# ---- Case 3: nondeterminism -> fixed-point warn, exit 0 ----
+check_warn() {
+    local report
+    report="$(run_check_stub "$B_FPTESTS"$'\n'"$B_SCBUILD"$'\n'"$B_SCSMOKE"$'\n'"$B_SCTESTS"$'\n'"$B_S3BUILD"$'\n'"$B_FIXED"$'\n''echo "[check][WARN] stage2 != stage3: compiler output is not yet a fixed point"' 0)"
+    assert_seven_names "$report" || return 1
+    local p
+    for p in compile first-pass-tests seedcheck-build seedcheck-smoke seedcheck-tests stage3-build; do
+        assert_phase_status "$report" "$p" pass || return 1
+    done
+    assert_phase_status "$report" fixed-point warn || return 1
+    local json status failure
+    json="$(cat "$report")"
+    status="$(json_field "$json" status)"
+    failure="$(json_field "$json" failure)"
+    [ "$status" = "warn" ] || { echo "  top-level status: expected warn, got $status" >&2; return 1; }
+    [ "$failure" = "nondeterminism" ] || { echo "  top-level failure: expected nondeterminism, got $failure" >&2; return 1; }
+}
+run_test "nondeterminism: fixed-point warn, top-level warn, exit 0" check_warn
+
+echo "[test] check phase ledger: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docs/reference/make-result-schema.md
+++ b/docs/reference/make-result-schema.md
@@ -3,9 +3,9 @@
 Status: epic #1056 of `docs/proposals/agent-output-orchestration.md`. The
 always-last verdict block ships now (Phase 1, #1059). The opt-in per-target
 full report file (`build/agent-report.<target>.json`, #1119) carries a composed
-single-entry `phases[]` built from the matching tool JSON (#1123); the
-seven-phase `check` ledger and precise `first_error` extraction are later
-phases.
+`phases[]`: a single entry built from the matching tool JSON for the
+single-tool targets (#1123), and the ordered **seven-phase ledger** for
+`make check` (#1124). Precise `first_error` extraction is a later phase.
 
 Every agent-facing `make` target ends — on success **and** on failure — by
 printing a single greppable verdict block as the **last lines of its output**,
@@ -181,17 +181,16 @@ fields, plus a self-referential `report` and a composed `phases` array.
 ### `phases[]`
 
 For the single-tool targets, `phases` carries **one** entry composed from the
-tool JSON the Makefile teed under the same `JSON=1` gate. The seven-phase
-ledger for `make check` is a later issue; `check` gets a single synthetic entry
-here.
+tool JSON the Makefile teed under the same `JSON=1` gate. `make check` is the
+exception: it carries the ordered **seven-phase ledger** (see below).
 
 | Field | Type | Notes |
 |---|---|---|
-| `name` | string | The phase name. Single-tool targets echo the target (`compile`, `test-unit`, `check-fast`, …); `check` is the lone synthetic `check` entry until the seven-phase ledger lands. |
-| `status` | string | `pass` \| `fail` \| `skipped`. Mirrors the verdict: `fail` when the target failed, else `pass` (a `warn` target ran every phase, so the phase is `pass`). |
-| `passed` | number | **Test targets only.** Count of passing tests, tallied from the `summary` event(s) of the `sfn test --json` jsonl (`build/agent-test.<target>.jsonl`). |
-| `failed` | number | **Test targets only.** Count of failing tests, from the same `summary` tally. |
-| `report` | string | Path to the captured tool JSON for this phase: `build/native/.build-report.json` (`compile`/`rebuild`, the `sfn build --json` BuildReport), `build/agent-test.<target>.jsonl` (test targets), or `build/agent-check-fast.json` (`check-fast`, the `sailfin-check/1` envelope). Omitted on the synthetic `check` entry, which has no single tool artifact. |
+| `name` | string | The phase name. Single-tool targets echo the target (`compile`, `test-unit`, `check-fast`, …); `check` carries the seven check phases. |
+| `status` | string | `pass` \| `warn` \| `fail` \| `skipped`. Mirrors the verdict per phase (see the ledger rules below). For single-tool targets: `fail` when the target failed, else `pass` (a `warn` target ran every phase, so the phase is `pass`). |
+| `passed` | number | **Single-tool test targets only.** Count of passing tests, tallied from the `summary` event(s) of the `sfn test --json` jsonl (`build/agent-test.<target>.jsonl`). |
+| `failed` | number | **Single-tool test targets only.** Count of failing tests, from the same `summary` tally. |
+| `report` | string | Path to the captured tool JSON for this phase: `build/native/.build-report.json` (`compile`/`rebuild`, the `sfn build --json` BuildReport), `build/agent-test.<target>.jsonl` (test targets), or `build/agent-check-fast.json` (`check-fast`, the `sailfin-check/1` envelope). Omitted on the `check` ledger entries, whose per-phase tool artifacts are a later phase. |
 
 **Per-target artifact map.** The composer reads the artifact captured under the
 gate by the matching Makefile wiring:
@@ -201,12 +200,42 @@ gate by the matching Makefile wiring:
 | `compile`, `rebuild` | `build/native/.build-report.json` | BuildReport `schema_version "1"` |
 | `test`, `test-unit`, `test-integration`, `test-e2e`, `test-capsules` | `build/agent-test.<target>.jsonl` | `sfn test --json` jsonl `schema_version 1` |
 | `check-fast` | `build/agent-check-fast.json` | `sailfin-check/1` |
-| `check` | — (synthetic single entry) | — |
+| `check` | — (seven-phase ledger; see below) | — |
 
 **Graceful degradation.** When the expected tool artifact is missing or does
 not parse, `phases` degrades to `[]` and the report keeps the verdict-derived
 top-level fields — the verdict block and the stream-after-verdict invariant are
 never broken by a missing or malformed artifact.
+
+### Seven-phase `check` ledger
+
+`make check` runs seven phases in a fixed pipeline order. Under the report gate,
+`build/agent-report.check.json` carries all seven as `phases[]` entries
+(`{"name":…,"status":…}`) — observability only; the ledger never alters what
+`check-impl` runs or its human output. The phases, in order:
+
+`compile`, `first-pass-tests`, `seedcheck-build`, `seedcheck-smoke`,
+`seedcheck-tests`, `stage3-build`, `fixed-point`.
+
+Per-phase status is derived from the human banners `check-impl` prints (the same
+marker set the top-level `phase` field keys off):
+
+- A phase the run advanced **past** (a later phase's start banner appeared) is
+  `pass` — control reaching a later phase proves the earlier ones completed.
+- The **last-reached** phase mirrors the top-level verdict: `fail` on a failure,
+  `warn` on the `fixed-point` nondeterminism mismatch, else `pass`.
+- Phases that were **never reached** (the run stopped earlier) are `skipped`.
+
+`compile` is the first thing `check-impl` runs, so it is always reached. The
+`seedcheck-smoke` phase (the hello-world viability step) can fail
+**independently** of the build and test phases — a `seedcheck-smoke` `fail`
+marks `seedcheck-tests`, `stage3-build`, and `fixed-point` `skipped`. The
+`fixed-point` `stage2 != stage3` mismatch is the lone phase `warn`: it pairs
+with top-level `status:"warn"` / `failure:"nondeterminism"` and **exit 0**.
+
+```json
+{"schema_version":"sailfin-make/1","target":"check","status":"warn","failure":"nondeterminism","phase":"fixed-point","first_error":null,"report":"build/agent-report.check.json","phases":[{"name":"compile","status":"pass"},{"name":"first-pass-tests","status":"pass"},{"name":"seedcheck-build","status":"pass"},{"name":"seedcheck-smoke","status":"pass"},{"name":"seedcheck-tests","status":"pass"},{"name":"stage3-build","status":"pass"},{"name":"fixed-point","status":"warn"}]}
+```
 
 ## Implementation
 

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -217,8 +217,9 @@ json_val() {
 # Map the wrapped target to the tool JSON artifact the Makefile captured under
 # the same JSON=1 gate: the BuildReport from #1120 (compile/rebuild), the test
 # jsonl from #1121 (test*), the check-fast envelope from #1122 (check-fast).
-# Echoes the path, or empty for a target with no single-tool artifact (today
-# only `check`, whose seven-phase ledger is issue F).
+# Echoes the path, or empty for a target with no single-tool artifact. `check`
+# has none but is handled separately by compose_check_phases (#1124); an empty
+# result here therefore means an unexpected target outside the wrapped set.
 tool_artifact_path() {
 	case "$TARGET" in
 		compile | rebuild) printf '%s' "build/native/.build-report.json" ;;
@@ -293,19 +294,85 @@ artifact_looks_intact_no_jq() {
 	return 0
 }
 
-# Compose the one-element phases[] array (#1123) from the captured tool
-# artifact. Echoes a JSON array literal:
+# The ordered seven-phase ledger for `make check` (#1124, epic #1056 Phase 2).
+PHASES_CHECK="compile first-pass-tests seedcheck-build seedcheck-smoke seedcheck-tests stage3-build fixed-point"
+
+# Compose the seven-phase `make check` ledger (#1124). Echoes a JSON array of
+# seven `{"name":<phase>,"status":<s>}` entries in pipeline order. Each phase's
+# status is derived from the human banners `check-impl` prints (the same marker
+# set `detect_check_phase` keys off), with phases after the failing/last-reached
+# one marked `skipped`:
+#   - phases the run advanced PAST (a later phase's start banner appeared) -> pass
+#   - the last-reached phase -> mirrors the verdict: fail / warn / pass
+#   - phases never reached -> skipped
+# `compile` is the first thing check-impl runs, so it is always reached.
+# The fixed-point `stage2 != stage3` mismatch is the lone `warn` (exit 0),
+# and seedcheck-smoke fails independently of the build/test phases.
+compose_check_phases() {
+	# Reached flags per phase, parallel to PHASES_CHECK. compile is unconditional.
+	local r_compile=1 r_fptests=0 r_scbuild=0 r_scsmoke=0 r_sctests=0 r_s3build=0 r_fixed=0
+	out_has '\[check\] running test suite on first-pass binary' && r_fptests=1
+	out_has 'proceeding to seedcheck build|verifying seed selfhost \(stage2\)' && r_scbuild=1
+	out_has 'validating seedcheck binary can run programs' && r_scsmoke=1
+	out_has 'running test suite with seedcheck binary' && r_sctests=1
+	out_has 'building stage3 for fixed-point' && r_s3build=1
+	out_has 'comparing stage2 vs stage3' && r_fixed=1
+
+	local reached=("$r_compile" "$r_fptests" "$r_scbuild" "$r_scsmoke" "$r_sctests" "$r_s3build" "$r_fixed")
+
+	# Latest reached phase (1-based). compile guarantees at least 1.
+	local last=1 i
+	for i in 0 1 2 3 4 5 6; do
+		[ "${reached[$i]}" -eq 1 ] && last=$((i + 1))
+	done
+
+	# The last-reached phase mirrors the verdict; nondeterminism is the warn.
+	local last_status="pass"
+	if [ "$STATUS" = "fail" ]; then
+		last_status="fail"
+	elif [ "$STATUS" = "warn" ]; then
+		last_status="warn"
+	fi
+
+	local names=($PHASES_CHECK)
+	local out="[" first=1 idx pstatus
+	for i in 0 1 2 3 4 5 6; do
+		idx=$((i + 1))
+		if [ "$idx" -lt "$last" ]; then
+			pstatus="pass"
+		elif [ "$idx" -eq "$last" ]; then
+			pstatus="$last_status"
+		else
+			pstatus="skipped"
+		fi
+		[ "$first" -eq 1 ] || out="${out},"
+		first=0
+		out="${out}{\"name\":$(json_val "${names[$i]}"),\"status\":$(json_val "$pstatus")}"
+	done
+	printf '%s]' "$out"
+}
+
+# Compose the phases[] array. `check` gets the seven-phase ledger (#1124);
+# every other wrapped target gets the one-element entry (#1123) composed from
+# the captured tool artifact:
 #   - non-test target, artifact present + parseable:
 #       [{"name":<target>,"status":<s>,"report":<artifact>}]
 #   - test target, jsonl present with a summary event:
 #       [{"name":<target>,"status":<s>,"passed":N,"failed":N,"report":<jsonl>}]
-#   - `check` (no single-tool artifact): a synthetic single entry
-#       [{"name":"check","status":<s>}] — issue F expands this to seven phases.
 #   - artifact expected but missing/unparseable: "[]" (graceful degrade).
+#   - no tool artifact and not `check` (unexpected target): a synthetic single
+#       entry [{"name":<target>,"status":<s>}].
 # Phase status mirrors the verdict: "fail" when STATUS is fail, else "pass"
-# (a `warn` target — check's nondeterminism — ran every phase, so the phase
-# itself is "pass"; the warn signal lives on the top-level status).
+# (a `warn` target — check's nondeterminism — ran every phase, so the
+# single-tool phase itself is "pass"; the warn signal lives on the top-level
+# status).
 compose_phases() {
+	# `make check`'s seven-phase ledger supersedes the single synthetic entry.
+	if [ "$TARGET" = "check" ]; then
+		compose_check_phases
+		return
+	fi
+
 	local phase_status="pass"
 	[ "$STATUS" = "fail" ] && phase_status="fail"
 	local name_json status_json
@@ -315,9 +382,8 @@ compose_phases() {
 	local artifact
 	artifact="$(tool_artifact_path)"
 
-	# No single-tool artifact (today: `check`). Emit a synthetic one-element
-	# phase from the verdict so the report is never empty; issue F grows this
-	# into the seven-phase ledger.
+	# No single-tool artifact and not `check` (unexpected target). Emit a
+	# synthetic one-element phase from the verdict so the report is never empty.
 	if [ -z "$artifact" ]; then
 		printf '[{"name":%s,"status":%s}]' "$name_json" "$status_json"
 		return


### PR DESCRIPTION
## Summary
- `JSON=1 make check`'s report (`build/agent-report.check.json`) now carries an ordered seven-element `phases[]` ledger — `compile`, `first-pass-tests`, `seedcheck-build`, `seedcheck-smoke`, `seedcheck-tests`, `stage3-build`, `fixed-point` — each with a `pass`/`fail`/`warn`/`skipped` status, derived from the human banners `check-impl` already prints (the same marker set the top-level `phase` keys off).
- Phases the run advanced *past* are `pass`; the last-reached phase mirrors the verdict (`fail` / nondeterminism-`warn` / `pass`); unreached phases are `skipped`. `seedcheck-smoke` fails independently of build/test; the `fixed-point` `stage2 != stage3` mismatch is the lone phase `warn` (exit 0).
- **Observability only** — no `check-impl` phase logic or ordering changes, **zero `compiler/src` changes**. The new `phases[]` is only composed under the existing `JSON=1` report gate; `check`'s exit code, human output, and the seedcheck-promotion step are untouched.

Closes #1124

## Acceptance Criteria
- [x] `JSON=1 make check` (green tree) → `phases[]` has all seven names in order, each `status:"pass"` (trailing `skipped` only if a phase legitimately didn't run). *(verified via the synthetic green case)*
- [x] A forced seedcheck-tests failure marks `seedcheck-tests` `fail`, `stage3-build`+`fixed-point` `skipped`, top-level `failure:"test-failure"`, `phase:"seedcheck-tests"`.
- [x] A `stage2 != stage3` mismatch yields `fixed-point` `status:"warn"`, top-level `status:"warn"`/`failure:"nondeterminism"`, **exit 0**.
- [x] `check`'s human output and the seedcheck-promotion step unchanged (no Makefile/`check-impl` change — de-scope lever taken: status-only ledger, no per-phase test-count env threading).

## Verification
```bash
# New regression test drives agent_report.sh with synthetic check banners,
# exercising the exact derivation paths in milliseconds (no 20-min make check):
$ bash compiler/tests/e2e/test_check_phase_ledger.sh
[test] PASS: green check: seven phases in order, all pass
[test] PASS: seedcheck-tests fail: that phase fail, trailing skipped
[test] PASS: nondeterminism: fixed-point warn, top-level warn, exit 0
[test] check phase ledger: 3 passed, 0 failed

# Green-tree ledger shape (issue's jq check passes):
$ jq -e '[.phases[].name]==["compile","first-pass-tests","seedcheck-build","seedcheck-smoke","seedcheck-tests","stage3-build","fixed-point"]' build/agent-report.check.json
true
```
The new test auto-runs under `make test-e2e-sh` (it's discovered by the `compiler/tests/e2e/test_*.sh` glob and tolerates the harness-passed binary arg).

## Files Changed
- `scripts/agent_report.sh` — `compose_check_phases()` + route `check` through the ledger
- `compiler/tests/e2e/test_check_phase_ledger.sh` — new regression coverage
- `docs/reference/make-result-schema.md` — seven-phase ledger section

## Notes
- **De-scope lever taken** (per the issue's "if M creeps" guidance): the ledger is status-only — no `SAILFIN_TEST_PHASE` env threading and **no Makefile change**, so the two nested `make test` artifacts stay as-is. The ACs and the verification `jq` only assert phase `name`+`status`, all satisfied.
- No `compiler/src`/`.sfn` files touched, so the self-host invariant and `sfn fmt` gate are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FgDJjEZCU12nDtJqnWC3h)_