### PR TITLE
fix(runtime): size embedded pthread mutex for macOS arm64 (#1265)

### DIFF
--- a/runtime/sfn/concurrency/channel.sfn
+++ b/runtime/sfn/concurrency/channel.sfn
@@ -45,8 +45,9 @@ struct PthreadMutex {
     _opaque7: i64;
 }
 
-// Opaque storage for a `pthread_cond_t`.  48 bytes on Linux x86_64 —
-// six 8-byte slots.
+// Opaque storage for a `pthread_cond_t`.  48 bytes on both supported
+// targets (Linux x86_64 glibc and macOS arm64) — six 8-byte slots, so
+// unlike the mutex it needs no max-sizing.
 struct PthreadCond {
     _opaque0: i64;
     _opaque1: i64;

--- a/runtime/sfn/concurrency/channel.sfn
+++ b/runtime/sfn/concurrency/channel.sfn
@@ -29,14 +29,20 @@
 // ── Externs (re-declared inline) ─────────────────────────────────
 // Declared inline rather than imported from pthread.sfn / libc.sfn,
 // matching the scheduler.sfn precedent (#306).
-// Opaque storage for a `pthread_mutex_t`.  40 bytes on Linux x86_64 —
-// five 8-byte slots.  Opaque to Sailfin; libpthread owns the bytes.
+// Opaque storage for a `pthread_mutex_t`.  64 bytes — eight 8-byte slots,
+// sized to the larger macOS arm64 layout (`pthread_mutex_t` = 64 B; Linux
+// glibc uses only the first 40, the slack is never read).  Under-sizing to
+// 40 B overran the embedded handle on macOS arm64, corrupting heap metadata
+// under parallel load (#1265).  Opaque to Sailfin; libpthread owns the bytes.
 struct PthreadMutex {
     _opaque0: i64;
     _opaque1: i64;
     _opaque2: i64;
     _opaque3: i64;
     _opaque4: i64;
+    _opaque5: i64;
+    _opaque6: i64;
+    _opaque7: i64;
 }
 
 // Opaque storage for a `pthread_cond_t`.  48 bytes on Linux x86_64 —
@@ -59,8 +65,8 @@ struct PthreadCond {
 // all cursor / count reads and writes; the conditions park
 // blocked producers / consumers.
 //
-// Linux x86_64 layout: six i64s (48 B) + PthreadMutex (40 B)
-//   + two PthreadCond (96 B) = 184 bytes.
+// Layout (max-sized handles): six i64s (48 B) + PthreadMutex (64 B)
+//   + two PthreadCond (96 B) = 208 bytes, + `closed` i64 = 216 bytes.
 struct Channel {
     buffer_addr: i64;
     capacity: i64;
@@ -100,21 +106,21 @@ extern fn pthread_cond_broadcast(c: * PthreadCond) -> i32;
 extern fn pthread_cond_destroy(c: * PthreadCond) -> i32;
 
 // ── Layout helpers ────────────────────────────────────────────────
-// Channel struct size: 184 bytes.
-fn _sfn_channel_struct_size() -> i64 { return 184; }
+// Channel struct size without the trailing `closed` flag: 208 bytes.
+fn _sfn_channel_struct_size() -> i64 { return 208; }
 
-// Byte offset of the `closed` field.  Six i64s (48) + PthreadMutex
-// (40) + two PthreadCond (96) = offset 184 — wait, `closed` is the
-// LAST field appended after the two conds.  The struct layout is:
-//   [0..48)   six i64 cursors
-//   [48..88)  PthreadMutex (40 B)
-//   [88..136) not_empty PthreadCond (48 B)
-//   [136..184) not_full PthreadCond (48 B)
-//   [184..192) closed i64
-// Total: 192 bytes.
-fn _sfn_channel_struct_size_full() -> i64 { return 192; }
+// Byte offset of the `closed` field.  `closed` is the LAST field,
+// appended after the two conds.  With the max-sized 64-byte mutex
+// (#1265) the struct layout is:
+//   [0..48)    six i64 cursors
+//   [48..112)  PthreadMutex (64 B)
+//   [112..160) not_empty PthreadCond (48 B)
+//   [160..208) not_full PthreadCond (48 B)
+//   [208..216) closed i64
+// Total: 216 bytes.
+fn _sfn_channel_struct_size_full() -> i64 { return 216; }
 
-fn _sfn_channel_closed_offset() -> i64 { return 184; }
+fn _sfn_channel_closed_offset() -> i64 { return 208; }
 
 // ── sfn_channel_create ────────────────────────────────────────────
 // Allocates a channel handle and its element buffer.  `capacity` is
@@ -316,9 +322,9 @@ fn sfn_channel_destroy(ch: * u8) -> void {
 // minimal extern surface needed here (same inline-redeclaration
 // discipline as the scheduler).
 //
-// Task byte size on Linux x86_64: four i64s + PthreadCond (48) +
-// PthreadMutex (40) = 120 bytes.
-fn _sfn_task_struct_size_ch() -> i64 { return 120; }
+// Task byte size (max-sized handles): four i64s (32) + PthreadCond (48) +
+// PthreadMutex (64) = 144 bytes.  Mirrors scheduler.sfn's Task.
+fn _sfn_task_struct_size_ch() -> i64 { return 144; }
 
 fn sfn_spawn_task(fn_ptr: * u8) -> * u8 {
     // Allocate the task via malloc.

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -87,9 +87,10 @@ struct PthreadMutex {
     _opaque7: i64;
 }
 
-// Opaque storage for a `pthread_cond_t`. 48 bytes on Linux x86_64
-// (glibc) — six 8-byte slots. Opaque to Sailfin; libpthread owns
-// the bytes via a `* PthreadCond` view passed to `pthread_cond_*`.
+// Opaque storage for a `pthread_cond_t`. 48 bytes on both supported
+// targets (Linux x86_64 glibc and macOS arm64) — six 8-byte slots, so
+// unlike the mutex it needs no max-sizing. Opaque to Sailfin; libpthread
+// owns the bytes via a `* PthreadCond` view passed to `pthread_cond_*`.
 struct PthreadCond {
     _opaque0: i64;
     _opaque1: i64;

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -57,28 +57,34 @@
 // is expressed as a run of 8-byte `i64` slots whose total size
 // equals the platform `sizeof`.
 //
-// Sizes below are for **Linux x86_64 (glibc)**, the supported
-// self-hosting build target:
-//   - `pthread_mutex_t` = 40 bytes -> 5 i64 slots
-//   - `pthread_cond_t`  = 48 bytes -> 6 i64 slots
-// For reference, macOS arm64 differs:
-//   - `pthread_mutex_t` = 64 bytes (8-byte sig + 56-byte opaque)
-//   - `pthread_cond_t`  = 48 bytes (8-byte sig + 40-byte opaque)
-// A platform-conditional split (per §2.9 Q7) is deferred until
-// Sailfin grows `cfg`-style conditional compilation; this
-// skeleton sizes for the build platform and documents the macOS
-// values here. The handles are opaque: only libpthread reads or
-// writes their bytes, so the slot names are deliberately generic.
-// Opaque storage for a `pthread_mutex_t`. 40 bytes on Linux x86_64
-// (glibc) — five 8-byte slots. Never read field-by-field from
-// Sailfin; the bytes belong to libpthread, reached through a
-// `* PthreadMutex` view passed to `pthread_mutex_*`.
+// The two self-hosting build targets disagree on `pthread_mutex_t`:
+//   - Linux x86_64 (glibc): `pthread_mutex_t` = 40 bytes, `pthread_cond_t` = 48 bytes
+//   - macOS arm64 (LP64):   `pthread_mutex_t` = 64 bytes (8-byte sig + 56-byte
+//     opaque), `pthread_cond_t` = 48 bytes (8-byte sig + 40-byte opaque)
+// A platform-conditional split (per §2.9 Q7) is deferred until Sailfin
+// grows `cfg`-style conditional compilation. Until then the opaque storage
+// is sized to the **maximum** across both targets so neither platform's
+// `pthread_*_init` overruns the embedded handle: mutex -> 64 bytes (8 slots,
+// covering macOS; the 24-byte slack on Linux is never read), cond -> 48 bytes
+// (6 slots, identical on both). Under-sizing the mutex to 40 bytes overran the
+// `Task` allocation by 24 bytes on macOS arm64, corrupting heap metadata and
+// faulting a later `malloc` inside the allocator under parallel load (#1265).
+// The handles are opaque: only libpthread reads or writes their bytes, so the
+// slot names are deliberately generic.
+// Opaque storage for a `pthread_mutex_t`. 64 bytes — eight 8-byte slots,
+// sized to the larger macOS arm64 layout (Linux glibc uses only the first
+// 40). Never read field-by-field from Sailfin; the bytes belong to
+// libpthread, reached through a `* PthreadMutex` view passed to
+// `pthread_mutex_*`.
 struct PthreadMutex {
     _opaque0: i64;
     _opaque1: i64;
     _opaque2: i64;
     _opaque3: i64;
     _opaque4: i64;
+    _opaque5: i64;
+    _opaque6: i64;
+    _opaque7: i64;
 }
 
 // Opaque storage for a `pthread_cond_t`. 48 bytes on Linux x86_64
@@ -101,8 +107,8 @@ struct PthreadCond {
 // atomic intrinsics (0 = pending, 1 = complete). `cond` / `mutex`
 // are embedded by value: the awaiter blocks on `cond` under
 // `mutex` until the worker sets `done` and signals (§2.6.3).
-// Linux x86_64 layout: four i64s (32 B) + PthreadCond (48 B) +
-// PthreadMutex (40 B) = 120 bytes.
+// Layout (max-sized handles): four i64s (32 B) + PthreadCond (48 B) +
+// PthreadMutex (64 B) = 144 bytes.
 struct Task {
     fn_ptr: i64;
     ctx: i64;
@@ -231,11 +237,11 @@ extern fn atoi(s: * u8) -> i32;
 // mutex, so the atomic ordering is stronger than required but never
 // wrong.
 //
-// `TaskQueue` byte size on Linux x86_64 (glibc): five `i64` cursors
-// (40 B) + `PthreadMutex` (40 B) + two `PthreadCond` (96 B) = 176
+// `TaskQueue` byte size (max-sized handles): five `i64` cursors
+// (40 B) + `PthreadMutex` (64 B) + two `PthreadCond` (96 B) = 200
 // bytes. This constant is the single layout dependency the
 // allocator path encodes; it must track the struct above.
-fn _sfn_taskqueue_struct_size() -> i64 { return 176; }
+fn _sfn_taskqueue_struct_size() -> i64 { return 200; }
 
 // Largest ring capacity whose byte size (`cap * 8`) still fits in a
 // positive `i64`: floor((2^63 - 1) / 8) = 0x0FFF_FFFF_FFFF_FFFF. A
@@ -484,10 +490,10 @@ fn sfn_scheduler_resolve_thread_count() -> i64 {
 // `Task.result`, sets `Task.done` with a seq_cst atomic store, and
 // signals `Task.cond`. The done flag + cond/mutex live by value in the
 // `Task` (see the struct header) so no extra allocation is needed.
-// `Task` byte size on Linux x86_64 (glibc): four i64s (32 B) +
-// PthreadCond (48 B) + PthreadMutex (40 B) = 120 bytes. Tracks the
+// `Task` byte size (max-sized handles): four i64s (32 B) +
+// PthreadCond (48 B) + PthreadMutex (64 B) = 144 bytes. Tracks the
 // struct above; the allocator path is the only layout dependency.
-fn _sfn_task_struct_size() -> i64 { return 120; }
+fn _sfn_task_struct_size() -> i64 { return 144; }
 
 // Byte offset of `Task.done` (field 4) — three leading i64s precede it.
 // `done` is reached by offset arithmetic rather than `& task.done`

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -51,7 +51,7 @@
 //
 // v0 limitations (follow-up waves): (1) per-connection `Task`
 // handles are fire-and-forget — never `sfn_task_join`ed or
-// destroyed — so each connection leaks one 120-byte `Task`. Reaping
+// destroyed — so each connection leaks one 144-byte `Task`. Reaping
 // fire-and-forget tasks needs a scheduler-side completion sweep
 // (separate issue); the connection `ctx` pair IS freed by the
 // worker. (2) No keep-alive (`Connection: close` semantics, one


### PR DESCRIPTION
## Summary

Fixes the async scheduler `SIGSEGV` in `sfn_task_create` under parallel test load on macOS arm64 (#1265).

**Root cause:** the scheduler/channel runtimes embed `pthread_mutex_t` / `pthread_cond_t` **by value**, sized for Linux x86_64 glibc (`pthread_mutex_t` = 40 B, 5 i64 slots). On macOS arm64 (LP64), `pthread_mutex_t` is **64 B** (8-byte sig + 56-byte opaque). So `pthread_mutex_init` / `_lock` wrote 24 bytes past the embedded handle. In `Task`, `mutex` is the trailing field, so the overrun ran past the `malloc` block and corrupted heap metadata — faulting a later `malloc` inside macOS 26's `mfm_alloc` under concurrent task creation. Load-dependent, reproduced on the stock seed, passed serially — all matching the report.

## Fix

Size the opaque pthread storage to the **max across both targets** (mutex → 64 B / 8 slots; cond stays 48 B / 6 slots, identical on both). Harmless slack on Linux; avoids the `cfg`-conditional split deferred to §2.9 Q7. Dependent allocation constants and the `Channel.closed` offset (which shifts with the larger mutex) updated to match.

| File | Change |
|---|---|
| `scheduler.sfn` | `PthreadMutex` 5→8 slots; `Task` 120→144; `TaskQueue` 176→200 |
| `channel.sfn` | `PthreadMutex` 5→8 slots; `Channel` full 192→216; `closed` offset 184→208; `Task_ch` 120→144 |
| `serve.sfn` | stale 120-byte `Task` doc comment → 144 |

`done_offset` (24) is unaffected — it precedes the embedded handles.

## Validation (macOS 26 arm64)

- Affected async/atomic family (31 tests) run **5×** under `sfn test --jobs 6`: **31/31 pass every run, zero crashes** (was 4–7/family segfaulting).
- `sfn fmt --check` clean; `sfn check` passes; `make compile` self-hosts clean.

Closes #1265