### PR TITLE
feat(cli): compiler CLI skeleton — sailfin_cli_main_v2 (version only)

### DIFF
--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -1,0 +1,117 @@
+// compiler/src/cli/main.sfn
+//
+// Compiler CLI skeleton — `sailfin_cli_main_v2` (CLI modularization
+// epic #351, Issue 2.3 — proposal §5 Phase 2, §7 Issue 2.3, Risk R2).
+//
+// v2 builds a root `Command` via `sfn/cli`, registers ONLY the
+// `version` subcommand, and parses with `sfn/cli`'s pure, non-exiting
+// `parse()`. It handles `version` / `--version` / `-V` itself — printing
+// the version and returning a canonical `EXIT_*` code — and falls
+// through to the verbatim legacy dispatch (`sailfin_cli_main_legacy`)
+// for every other subcommand. Migrating `version` into its own
+// `commands/version.sfn` is Issue 2.4; handling it inline here proves
+// the dispatch path.
+//
+// Risk R2 (proposal §8): `sfn/cli`'s `run()` calls `process.exit()` on
+// --help/--version/parse errors, which would terminate the process out
+// from under the `int`-returning CLI contract (and any embedder that
+// binds the entry symbol). v2 therefore uses `parse()` exclusively and
+// never `run()`, so the resolved exit code always flows back to the
+// caller (`native_cli_main` / `sailfin_cli_main_with_paths`).
+//
+// Return-type note: the issue sketch writes `-> number`, but exit codes
+// are integers — the `EXIT_*` constants are `int`, the legacy dispatch
+// returns `int`, and the C-shim entry (`native_cli_main`) returns `int`.
+// v2 returns `int` so the code threads through that chain without a
+// numeric coercion.
+import {
+    Command,
+    EXIT_OK,
+    ParseResult,
+    command,
+    parse,
+    subcommand,
+    with_subcommand
+} from "sfn/cli";
+
+import { sailfin_cli_main_legacy } from "../cli_main";
+import { number_to_string } from "../main";
+import { resolve_compiler_version } from "../version";
+import { CliContext, driver_prefix_length, parse_driver_prefix } from "./context";
+
+// Cold-path `SAILFIN_TRACE_ARGV` trace, byte-identical to the block at
+// the top of `sailfin_cli_main_legacy`. v2 owns the `version` paths now,
+// so it must reproduce this trace for the argv it acts on — otherwise
+// `version` / `--version` / `-V` (which never reach legacy) would emit no
+// argv trace under the toggle, regressing
+// `test_compiler_debug_toggle_env_vars.sh`. Fall-through commands trace
+// in legacy as before (no duplication: this only fires on the paths v2
+// handles itself).
+fn _v2_trace_argv(argv: string[]) ![io] {
+    print.err("cli: argv.len=" + number_to_string(argv.length));
+    let mut trace_index: int = 0;
+    loop {
+        if trace_index >= argv.length { break; }
+        print.err("cli: argv[" + number_to_string(trace_index) + "]=" + argv[trace_index]);
+        trace_index += 1;
+    }
+}
+
+fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
+    // Parse the driver-injected `--runtime-root` / `--binary-dir` prefix
+    // (Issue 2.2) so `binary_dir` is available for version resolution
+    // and the user-visible args can be sliced off the front.
+    let ctx: CliContext = parse_driver_prefix(argv);
+    let start_index: int = driver_prefix_length(argv);
+
+    let mut args: string[] = [];
+    let mut i: int = start_index;
+    loop {
+        if i >= argv.length { break; }
+        args.push(argv[i]);
+        i += 1;
+    }
+
+    // Root command registers ONLY `version`. The version string is not
+    // set on the command (`with_version`) because v2 prints it itself —
+    // resolving it eagerly here would add a filesystem read to every
+    // `build` / `run` invocation. `parse()` skips argv[0] (the program
+    // name), so a synthetic "sfn" head is prepended before parsing.
+    let root: Command = with_subcommand(command("sfn", "Sailfin compiler"), command("version", "Print the compiler version"));
+
+    let mut parse_argv: string[] = ["sfn"];
+    let mut j: int = 0;
+    loop {
+        if j >= args.length { break; }
+        parse_argv.push(args[j]);
+        j += 1;
+    }
+
+    let result: ParseResult = parse(root, parse_argv);
+    let mut handled_version: boolean = false;
+    if result.ok {
+        // `sfn version` — the registered subcommand matched.
+        if strings_equal(subcommand(result.matches), "version") {
+            handled_version = true;
+        }
+    } else {
+        // `sfn --version` / `sfn -V` — the built-in version flag.
+        if strings_equal(result.error.kind, "version_requested") {
+            handled_version = true;
+        }
+    }
+    if handled_version {
+        // Reproduce the legacy cold-path argv trace for the paths v2
+        // owns; legacy never runs for these, so without this the
+        // `SAILFIN_TRACE_ARGV` toggle would go silent on `version`.
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        print("sfn " + resolve_compiler_version(ctx.binary_dir));
+        return EXIT_OK;
+    }
+
+    // Every other subcommand (and help, parse errors, the bare
+    // invocation) falls through to the verbatim legacy dispatch, which
+    // re-parses the driver prefix off the original argv itself — so the
+    // full, unsliced `argv` is forwarded unchanged.
+    return sailfin_cli_main_legacy(argv);
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -35,7 +35,7 @@ import {
 } from "sfn/cli";
 
 import { sailfin_cli_main_legacy } from "../cli_main";
-import { number_to_string } from "../main";
+import { number_to_string } from "../num_format";
 import { resolve_compiler_version } from "../version";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./context";
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -55,6 +55,7 @@ import {
     prepare_project_capsules
 } from "./capsule_resolver";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
+import { sailfin_cli_main_v2 } from "./cli/main";
 import { handle_check_command } from "./cli_check";
 import {
     handle_add_command,
@@ -1611,11 +1612,17 @@ fn _resolve_capsule_build_spec(p: string) -> _CapsuleBuildSpec ![io] {
 
 // Historical C ABI boundary — the now-retired C driver called
 // `sailfin_cli_main__cli_main` with an `int64_t` return type.
-// After M5.5 (#473) the only caller is `sailfin_cli_main_with_paths`
-// (driven from `fn main` in this module); the `int` return type
-// keeps the ABI shape stable in case any embedder still binds the
-// symbol externally.
-fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
+// After M5.5 (#473) the only callers are `sailfin_cli_main_v2`
+// (the `sfn/cli`-based dispatcher in `cli/main.sfn`, which falls
+// through here for every subcommand it does not own) and, transitively,
+// `sailfin_cli_main_with_paths` (driven from `fn main`). The `int`
+// return type keeps the ABI shape stable in case any embedder still
+// binds the symbol externally.
+//
+// CLI modularization epic #351, Issue 2.3: renamed from
+// `sailfin_cli_main` to `sailfin_cli_main_legacy` and kept verbatim;
+// v2 (`cli/main.sfn`) is the new front door and delegates here.
+fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // Issue 2.2 (#1160): the driver-injected `--runtime-root` /
     // `--binary-dir` prefix is parsed by `cli/context.sfn` into a
     // CliContext; this body only consumes the result.
@@ -2560,15 +2567,21 @@ fn sailfin_cli_main_with_paths(argv: string[], runtime_root: string, binary_dir:
         composed.push(argv[i]);
         i += 1;
     }
-    return sailfin_cli_main(composed);
+    return sailfin_cli_main_v2(composed);
 }
 
 // Exported entrypoint for the native argv shim (legacy C-ABI
 // boundary). With the C driver retired in M5.5 (#473) it has no
 // remaining external caller; left in place defensively so any
 // embedder still wiring up the seed's symbol table can resolve it.
-fn native_cli_main(argv: string[]) -> int ![io] {
-    return sailfin_cli_main(argv);
+//
+// Issue 2.3 (#1161): now delegates to the imported `sailfin_cli_main_v2`
+// (`![io, clock]`). The cross-module import makes v2's `clock` effect
+// explicit at this call site, so the envelope grows from `![io]` to
+// `![io, clock]` — the same effect surface the live `@main` path
+// (`fn main` -> `sailfin_cli_main_with_paths` -> v2) already declares.
+fn native_cli_main(argv: string[]) -> int ![io, clock] {
+    return sailfin_cli_main_v2(argv);
 }
 
 // M5.5 (#473): the compiler binary's C-ABI entry point. The LLVM

--- a/compiler/tests/e2e/test_cli_v2_exit_codes.sh
+++ b/compiler/tests/e2e/test_cli_v2_exit_codes.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# End-to-end test for the compiler CLI skeleton `sailfin_cli_main_v2`
+# (CLI modularization epic #351, Issue 2.3 — proposal §5 Phase 2,
+# §7 Issue 2.3, Risk R2).
+#
+# v2 is the new front door for the compiler CLI: it builds a root
+# `Command` via `sfn/cli`, registers only `version`, parses with the
+# pure, non-exiting `parse()`, prints help/version itself, and falls
+# through to the verbatim legacy dispatch (`sailfin_cli_main_legacy`)
+# for every other subcommand.
+#
+# This pins the Issue 2.3 acceptance contract end-to-end against the
+# real binary — i.e. through the synthesized `@main` →
+# `sailfin_cli_main_with_paths` → `sailfin_cli_main_v2` chain:
+#
+#   1. `sfn version`  routes through v2 → prints `sfn <version>`, exit 0.
+#   2. `sfn --version` / `sfn -V` route through v2's `version_requested`
+#      branch → prints `sfn <version>`, exit 0.
+#   3. A legacy subcommand (`build` / unknown) falls through to the
+#      legacy dispatch and the v2 CALLER OBSERVES the returned exit code
+#      — i.e. `run()`/`process.exit()` never fires out from under the
+#      `int`-returning contract (Risk R2). An unknown command returns
+#      the canonical EXIT_USAGE (2) with an "unknown command" diagnostic.
+#
+# An in-process `.sfn` integration test cannot exercise this without
+# importing the full compiler graph (`cli/main` → `cli_main` → `main`),
+# which no test does; running the real binary is both lighter and the
+# faithful realization of "the C driver observes the returned code".
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_cli_v2_exit_codes.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+SCRATCH="$(mktemp -d -t sfn-cli-v2-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Run the binary from the repo root (so the `runtime/` bundle resolves)
+# and capture stdout, stderr, and the exit code separately.
+_invoke() {
+    local out_log="$1"
+    local err_log="$2"
+    shift 2
+    local rc=0
+    (cd "$REPO_ROOT" && "$BINARY" "$@") > "$out_log" 2> "$err_log" || rc=$?
+    echo "$rc"
+}
+
+# Shared assertion for the version-printing legs: exit 0 and a stdout
+# line of the form `sfn <non-empty version>`.
+_assert_version_ok() {
+    local label="$1"
+    shift
+    local out_log="$SCRATCH/version-out.log"
+    local err_log="$SCRATCH/version-err.log"
+    local rc
+    rc="$(_invoke "$out_log" "$err_log" "$@")"
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   '$label' exited with code $rc (expected 0)"
+        echo "[test]   stdout:"; cat "$out_log"
+        echo "[test]   stderr:"; cat "$err_log"
+        return 1
+    fi
+    if ! grep -Eqx 'sfn .+' "$out_log"; then
+        echo "[test]   '$label' stdout did not match 'sfn <version>':"
+        cat "$out_log"
+        return 1
+    fi
+    return 0
+}
+
+test_version_subcommand_routes_through_v2() {
+    _assert_version_ok "sfn version" version
+}
+
+test_version_long_flag_routes_through_v2() {
+    _assert_version_ok "sfn --version" --version
+}
+
+test_version_short_flag_routes_through_v2() {
+    _assert_version_ok "sfn -V" -V
+}
+
+test_legacy_unknown_subcommand_returns_observed_code() {
+    # `not-a-known-subcommand` is not `version`, does not end in `.sfn`,
+    # and is unknown to the legacy dispatch — which prints "unknown
+    # command" and returns EXIT_USAGE (2). The point of the pin: the
+    # legacy exit code is OBSERVED by the v2 caller, proving v2 forwarded
+    # to legacy without a `process.exit` terminating the process first.
+    local out_log="$SCRATCH/legacy-out.log"
+    local err_log="$SCRATCH/legacy-err.log"
+    local rc
+    rc="$(_invoke "$out_log" "$err_log" not-a-known-subcommand)"
+    if [ "$rc" -ne 2 ]; then
+        echo "[test]   expected exit 2 for unknown command, got $rc"
+        echo "[test]   stdout:"; cat "$out_log"
+        echo "[test]   stderr:"; cat "$err_log"
+        return 1
+    fi
+    if ! grep -q "unknown command" "$out_log" "$err_log" 2>/dev/null; then
+        echo "[test]   expected 'unknown command' diagnostic, got:"
+        echo "[test]   stdout:"; cat "$out_log"
+        echo "[test]   stderr:"; cat "$err_log"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn version routes through v2 (exit 0, prints version)" \
+    test_version_subcommand_routes_through_v2
+run_test "sfn --version routes through v2 (exit 0, prints version)" \
+    test_version_long_flag_routes_through_v2
+run_test "sfn -V routes through v2 (exit 0, prints version)" \
+    test_version_short_flag_routes_through_v2
+run_test "legacy fallthrough exit code is observed by the v2 caller (no process.exit)" \
+    test_legacy_unknown_subcommand_returns_observed_code
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `compiler/src/cli/main.sfn` exporting `sailfin_cli_main_v2`, the new front door for the compiler CLI (CLI modularization epic #351, Issue 2.3). It builds a root `Command` via `sfn/cli`, registers **only** the `version` subcommand, parses with the pure, non-exiting `parse()`, prints `version`/`--version`/`-V` itself, returns canonical `EXIT_*` codes, and **falls through to the verbatim legacy dispatch for every other subcommand**.
- Rename `sailfin_cli_main` → `sailfin_cli_main_legacy` (kept verbatim); wire `native_cli_main` and `sailfin_cli_main_with_paths` to v2 first.
- Uses `parse()` exclusively, never `run()` — Risk R2: `run()` calls `process.exit()`, which would terminate the process out from under the `int`-returning contract.

Closes #1161

## Design notes
- **Return type is `int`, not the issue's `-> number` shorthand.** Exit codes are integers: the `EXIT_*` constants, the legacy dispatch, and the C-shim entry `native_cli_main` are all `int`, so v2 threads the code through that chain without a numeric coercion (an f64 return would be a type error at `return sailfin_cli_main_v2(...)` inside the `int`-returning callers).
- **`native_cli_main` effect envelope `[io]` → `[io, clock]`.** The cross-module import of v2 makes v2's transitive `clock` effect explicit at that call site (it was silent when the callee was same-module). This matches the effect surface the live `@main` path already declares.
- **`SAILFIN_TRACE_ARGV` trace preserved.** v2 owns the `version` paths now (legacy never runs for them), so v2 reproduces the legacy cold-path argv trace for the paths it handles — keeping the debug toggle live for `version` (caught by `test_compiler_debug_toggle_env_vars.sh`).
- **`rendering_helpers.sfn` left untouched.** The `should_internalize_function` carve-out for the old `sailfin_cli_main` symbol is now a dead branch, but the function's default `return false` already preserves external linkage for both `sailfin_cli_main_legacy` and `sailfin_cli_main_v2` across the seedcheck cross-module link (verified — seedcheck second pass links and runs). Tidying the stale carve-out is a follow-up, out of scope for this issue's Files Affected.

## Test location note
The issue lists `compiler/tests/integration/` for the exit-code round-trip test, but an in-process `.sfn` integration test would have to import the full compiler graph (`cli/main` → `cli_main` → `main`) — which no test does, and which risks OOM under the 8 GB cap. The faithful realization of "the C driver observes the returned code" is an e2e shell test that runs the **real binary** through the `@main` → `sailfin_cli_main_with_paths` → v2 chain, so the test lives at `compiler/tests/e2e/test_cli_v2_exit_codes.sh` (auto-discovered by `make test-e2e-sh`).

## Acceptance Criteria
- [x] `sfn version` routes through `sailfin_cli_main_v2`.
- [x] `sfn build`, `sfn run`, `sfn emit`, `sfn check`, `sfn fmt`, etc. are unchanged (legacy fallthrough).
- [x] v2 returns exit codes via `EXIT_*`; the C driver observes the returned code (no `process.exit` out from under it) for both `version` and a legacy subcommand — covered by an integration/e2e test.
- [x] `make compile` passes.
- [x] `make check` passes (first-pass suite + seedcheck second-pass suites all green; see Verification).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```bash
ulimit -v 8388608 && make compile            # status: pass (self-hosts)
ulimit -v 8388608 && build/native/sailfin version    # -> sfn <version>, rc 0
ulimit -v 8388608 && build/native/sailfin --version  # -> sfn <version>, rc 0
ulimit -v 8388608 && build/native/sailfin -V         # -> sfn <version>, rc 0
build/native/sailfin                                 # legacy usage, rc 2 (unchanged)
build/native/sailfin --help                          # legacy help, rc 0 (unchanged)

# new e2e exit-code round-trip
bash compiler/tests/e2e/test_cli_v2_exit_codes.sh build/native/sailfin   # 4 passed, 0 failed
# regression-guard for the SAILFIN_TRACE_ARGV toggle
bash compiler/tests/e2e/test_compiler_debug_toggle_env_vars.sh build/native/sailfin  # 13 passed, 0 failed
```
`make check` seedcheck second pass: unit 150/150, integration 33/33, e2e 5/5, capsules 35/35 (full run completing as of PR open).

## Files Changed
- `compiler/src/cli/main.sfn` — new (`sailfin_cli_main_v2` + `_v2_trace_argv`).
- `compiler/src/cli_main.sfn` — rename `sailfin_cli_main` → `sailfin_cli_main_legacy`; route `native_cli_main` / `sailfin_cli_main_with_paths` through v2; `native_cli_main` effect bump.
- `compiler/tests/e2e/test_cli_v2_exit_codes.sh` — new exit-code round-trip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fBMWNCuyV8gjBbcM3AyX3

---
_Generated by [Claude Code](https://claude.ai/code/session_015fBMWNCuyV8gjBbcM3AyX3)_