### PR TITLE
fix: resolve cross-module struct-returning calls between runtime sfn-sources

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -70,14 +70,17 @@ import {
     handle_test_command
 } from "./cli_commands";
 import {
+    _atomic_rename_into_place,
     _env_flag,
     _legacy_flag_file,
+    _mktemp_sibling_cmd,
     _resolve_linker,
     _sha256_of_file_cmd,
     _shell_read_cmd,
     _shell_single_quote_arg
 } from "./cli_commands_utils";
 import { emit_llvm_with_retry, emit_parse_nonneg_int } from "./emit_helpers";
+import { resolve_import_module_slug_for_module } from "./llvm/imports";
 import {
     compile_to_llvm_file_with_module,
     compile_to_llvm_with_module,
@@ -89,6 +92,7 @@ import {
     print_native_text_with_module_gated,
     write_native_text_file_with_module_gated
 } from "./main";
+import { parse_native_imports_for_import } from "./native_ir_api";
 import { RuntimeCapsuleArtifacts, runtime_capsule_from_root } from "./runtime_capsule_resolver";
 import {
     toml_get_build_kind,
@@ -1093,7 +1097,31 @@ struct RuntimeEmitResult {
     stats: CacheStats;
 }
 
-fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string, shared_cache_root: string) -> RuntimeEmitResult ![io] {
+// #1288: fold staged sibling-dep content into the runtime object
+// cache key. The emitted `.ll`/`.o` of a module with sibling imports
+// depends on those siblings' signatures/layouts, so editing a
+// sibling (e.g. a future `ownedbuf.sfn`) must bust the cached `.o`
+// of every module that imports it — otherwise the link silently
+// reuses a stale-ABI object. Modules without a `.import-deps`
+// sidecar keep the base key byte-for-byte (the pre-#1288 contract).
+// An unhashable dep returns "" so the caller falls back to the
+// always-recompile path, mirroring `runtime_object_cache_key`.
+fn _runtime_obj_key_with_sibling_deps(base_key: string, ctx_root: string, slug: string) -> string ![io] {
+    if base_key.length == 0 { return ""; }
+    let deps = _read_import_deps(ctx_root, slug);
+    let mut key = base_key;
+    let mut i: int = 0;
+    loop {
+        if i >= deps.length { break; }
+        let dep_hash = _sha256_of_file_cmd(deps[i]);
+        if dep_hash.length == 0 { return ""; }
+        key = key + "\n" + dep_hash;
+        i += 1;
+    }
+    return key;
+}
+
+fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string, shared_cache_root: string, ctx_root: string) -> RuntimeEmitResult ![io] {
     let mut stats = empty_cache_stats();
     let slug = module_name_from_path(src);
     let ll_path = _path_join(out_dir, cap_prefix + _path_basename(src)
@@ -1113,7 +1141,7 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
     // surfacing as `Undefined symbols ... link failed` (#969). This
     // mirrors the `_clang_compile_runtime_capsule_objects` c-source
     // path so the sfn-source + prelude emit invalidates identically.
-    let key = runtime_object_cache_key(src, opt_flag);
+    let key = _runtime_obj_key_with_sibling_deps(runtime_object_cache_key(src, opt_flag), ctx_root, slug);
     if key.length == 0 { stats.invalid_keys = stats.invalid_keys + 1; }
     let shared_suffix = cap_prefix + _path_basename(src) + opt_flag;
     if _runtime_obj_cache_hit(obj_path, key) {
@@ -1134,10 +1162,19 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
     // for the child; everything else inherits from the parent (PATH,
     // HOME, PWD, etc.). The shell-quote escaping protects against
     // paths that contain spaces or shell metacharacters.
+    // #1288: `--import-context` points at the private rt-import-context
+    // root. A module with a staged `.import-deps` sidecar threads its
+    // sibling sfn-source signatures into the emit
+    // (`compile_to_llvm_file_with_module_imports`, #957/#999); a module
+    // without one — including the `prelude-entry`, which shares this
+    // emit path but is never staged — reads an absent sidecar, gets an
+    // empty dep list, and degrades to the exact pre-#1288 legacy emit.
     let cmd = "SAILFIN_TRACE_EMIT= SAILFIN_SKIP_TYPECHECK= SAILFIN_TRACE_TEST_RUNNER= SAILFIN_DUMP_TEST_SOURCES= SAILFIN_NO_LEGACY_PROBE=1 "
         + _shell_single_quote_arg(self_path)
         + " emit --module-name "
         + _shell_single_quote_arg(slug)
+        + " --import-context "
+        + _shell_single_quote_arg(ctx_root)
         + " -o "
         + _shell_single_quote_arg(ll_path)
         + " llvm "
@@ -1162,6 +1199,185 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
         _runtime_obj_shared_cache_publish(shared_cache_root, key, obj_path, shared_suffix);
     }
     return RuntimeEmitResult { obj_path: obj_path, stats: stats };
+}
+
+// #1288 (Gap 1 of #1283): root of the PRIVATE import-context tree
+// for runtime sfn-source emits, sibling to the runtime `.o` cache
+// under `out_dir` (`build/sailfin` by default, work-dir aware).
+//
+// Deliberately NOT the shared cwd-relative
+// `build/native/import-context/` tree: artifacts staged there are
+// consulted by `collect_imported_module_context_for_module`'s
+// on-disk lookup during EVERY emit in that cwd. The prelude imports
+// the runtime modules (`runtime/prelude.sfn` → `./sfn/array`,
+// `./sfn/string`, …), so publishing runtime `.sfn-asm` into the
+// shared tree makes the prelude's lowering load those entries and
+// render imported-signature `declare`s that conflict with the
+// runtime-helper descriptor declares it also emits (e.g.
+// `declare i8* @sfn_array_push_string(i8*, i8*)` vs the
+// descriptor's `{ i8**, i64, i64 }*` form — clang then rejects the
+// IR with "invalid redefinition"). A private root threaded
+// explicitly via `--import-context` reaches exactly the sfn-source
+// child emits and nothing else.
+fn _runtime_sfn_ctx_root(out_dir: string) -> string {
+    return _path_join(out_dir, "rt-import-context");
+}
+
+// Stage one runtime sfn-source's native `.sfn-asm` into the private
+// import-context root so a SIBLING sfn-source importing a
+// struct-returning fn (e.g. `string.sfn` → `./memory/ownedbuf`)
+// resolves the callee's signature via the #957/#999 threading
+// (`--import-context` → `.import-deps` →
+// `compile_to_llvm_file_with_module_imports`). This is the
+// runtime-emit-path mirror of the resolver's capsule staging; the
+// Makefile's #812 loop provides on-disk artifacts for the four
+// `runtime/sfn/platform/*` extern modules only, which is why
+// `clock.sfn → ./platform/posix` worked while a struct-returning
+// sibling import died at `core_call_emission.sfn`'s "cannot resolve
+// return type" fatal. A pointer/i64-returning callee can be worked
+// around with an inline `extern fn`; a struct-by-value return
+// cannot (E0805) — staging, not per-module duplication, is the fix.
+// No `.layout-manifest` sidecar is needed on this path: the struct
+// shape travels inside the threaded native text.
+//
+// Content-keyed with the #632-style `.key` sidecar so warm builds
+// skip the child emit, and published via temp + atomic rename
+// (#1011) so a concurrent reader never observes a torn artifact.
+// The `native` emit stage is import-context-free by design (#906),
+// so staging order across the sfn-sources list does not matter.
+fn _stage_one_runtime_sfn_import_context(self_path: string, src: string, ctx_root: string) -> boolean ![io] {
+    let slug = module_name_from_path(src);
+    let asm_path = ctx_root + "/" + slug + ".sfn-asm";
+    let key = runtime_object_cache_key(src, "");
+    if _runtime_obj_cache_hit(asm_path, key) { return true; }
+    _ensure_dir(_dirname(asm_path));
+    let staged = _mktemp_sibling_cmd(asm_path);
+    let mut emit_target: string = asm_path;
+    if staged.length > 0 { emit_target = staged; }
+    // Same env-clearing `sh -c` contract as `_emit_runtime_sfn_to_obj`
+    // (see the race-safety note on `_compile_runtime_sfn_sources`).
+    // `--no-resolve-gate` (#906): this is a build-internal per-module
+    // NATIVE emit with no import context of its own, so the lowering
+    // dry-run gate would falsely reject the very cross-module calls
+    // this staging exists to resolve; the build's LLVM emit stage
+    // owns fail-closed.
+    let cmd = "SAILFIN_TRACE_EMIT= SAILFIN_SKIP_TYPECHECK= SAILFIN_TRACE_TEST_RUNNER= SAILFIN_DUMP_TEST_SOURCES= SAILFIN_NO_LEGACY_PROBE=1 "
+        + _shell_single_quote_arg(self_path)
+        + " emit --module-name "
+        + _shell_single_quote_arg(slug)
+        + " --no-resolve-gate -o "
+        + _shell_single_quote_arg(emit_target)
+        + " native "
+        + _shell_single_quote_arg(src);
+    let rc = process.run(["sh", "-c", cmd]);
+    if rc != 0 {
+        print("sfn build: failed to stage runtime sfn-source import-context for "
+            + src
+            + " (child exit="
+            + number_to_string(rc)
+            + ")");
+        if staged.length > 0 { process.run(["rm", "-f", staged]); }
+        return false;
+    }
+    // Empty-output probe, mirroring the Makefile #812 staging's
+    // `[ -s "$asm_path" ]` guard.
+    let probe = fs.readFile(emit_target);
+    if probe.length == 0 {
+        print("sfn build: staged runtime sfn-source import-context is empty for "
+            + src);
+        if staged.length > 0 { process.run(["rm", "-f", staged]); }
+        return false;
+    }
+    if staged.length > 0 {
+        if !_atomic_rename_into_place(staged, asm_path) {
+            print("sfn build: failed to publish runtime sfn-source import-context for "
+                + src);
+            process.run(["rm", "-f", staged]);
+            return false;
+        }
+    }
+    _runtime_obj_cache_record(asm_path, key);
+    return true;
+}
+
+// Write a module's `.import-deps` sidecar (one staged sibling
+// `.sfn-asm` path per line — the exact shape `_read_import_deps`
+// parses and the resolver's `_cr_stage_import_deps` writes). Only
+// imports that resolve to a STAGED SIBLING sfn-source are listed;
+// platform extern modules (`./platform/posix`, …) are not
+// sfn-sources, keep riding the on-disk #812 artifacts, and a module
+// with no sibling imports gets no sidecar at all — its child emit
+// then degrades to the exact pre-#1288 legacy path.
+fn _write_runtime_sfn_import_deps(asm_path: string, slug: string, ctx_root: string, staged_slugs: string[]) -> void ![io] {
+    let deps_path = ctx_root + "/" + slug + ".import-deps";
+    let asm_text = fs.readFile(asm_path);
+    let entries = parse_native_imports_for_import(asm_text);
+    let mut deps: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= entries.length { break; }
+        if entries[i].kind == "import" {
+            let dep_slug = resolve_import_module_slug_for_module(entries[i].module, slug);
+            let mut si: int = 0;
+            loop {
+                if si >= staged_slugs.length { break; }
+                if staged_slugs[si] == dep_slug {
+                    deps = deps + ctx_root + "/" + dep_slug + ".sfn-asm\n";
+                    break;
+                }
+                si += 1;
+            }
+        }
+        i += 1;
+    }
+    if deps.length == 0 {
+        // No sibling imports: drop any stale sidecar from a previous
+        // build so the emit can't thread context the module no longer
+        // declares.
+        if fs.exists(deps_path) { fs.deleteFile(deps_path); }
+        return;
+    }
+    fs.writeFile(deps_path, deps);
+}
+
+// Stage import-context artifacts + `.import-deps` sidecars for EVERY
+// sfn-source across the runtime capsules before any of them is
+// emitted to LLVM. Runs inside `_compile_runtime_sfn_sources` (and
+// therefore inside its `SAILFIN_DISABLE_RUNTIME_SFN_SOURCES` gate).
+// Fail-closed: a staging failure aborts the link the same way an
+// emit failure does — a missing sibling artifact would otherwise
+// surface later as the far less actionable "cannot resolve return
+// type" fatal in whichever module imports it.
+fn _stage_runtime_sfn_import_context(self_path: string, runtime_capsules: RuntimeCapsuleArtifacts[], ctx_root: string) -> boolean ![io] {
+    let mut staged_slugs: string[] = [];
+    let mut staged_asm_paths: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= runtime_capsules.length { break; }
+        let cap = runtime_capsules[i];
+        let mut si: int = 0;
+        loop {
+            if si >= cap.sfn_sources.length { break; }
+            let src = cap.sfn_sources[si];
+            if !_stage_one_runtime_sfn_import_context(self_path, src, ctx_root) {
+                return false;
+            }
+            let slug = module_name_from_path(src);
+            staged_slugs.push(slug);
+            staged_asm_paths.push(ctx_root + "/" + slug + ".sfn-asm");
+            si += 1;
+        }
+        i += 1;
+    }
+    // Second pass (all siblings now staged): derive each module's
+    // sibling deps from its own `.import` entries.
+    let mut di: int = 0;
+    loop {
+        if di >= staged_slugs.length { break; }
+        _write_runtime_sfn_import_deps(staged_asm_paths[di], staged_slugs[di], ctx_root, staged_slugs);
+        di += 1;
+    }
+    return true;
 }
 
 fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string, shared_cache_root: string) -> RuntimeLinkInputs ![io] {
@@ -1206,6 +1422,12 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
             + "\")");
         return _failed_runtime_link_inputs();
     }
+    // #1288: stage every sfn-source's import-context artifacts FIRST
+    // so each module's llvm emit below can resolve sibling imports.
+    let ctx_root = _runtime_sfn_ctx_root(out_dir);
+    if !_stage_runtime_sfn_import_context(self_path, runtime_capsules, ctx_root) {
+        return _failed_runtime_link_inputs();
+    }
     let mut i: int = 0;
     loop {
         if i >= runtime_capsules.length { break; }
@@ -1215,7 +1437,7 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
         loop {
             if si >= cap.sfn_sources.length { break; }
             let src = cap.sfn_sources[si];
-            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag, shared_cache_root);
+            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag, shared_cache_root, ctx_root);
             stats = merge_cache_stats(stats, emit.stats);
             if emit.obj_path.length == 0 {
                 return _failed_runtime_link_inputs();
@@ -1298,7 +1520,11 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
             let cap = runtime_capsules[pi];
             if cap.prelude_entry.length > 0 {
                 let cap_prefix = _runtime_obj_prefix(cap.capsule_name);
-                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag, shared_cache_root);
+                // #1288: the prelude is never staged, so it has no
+                // `.import-deps` sidecar — the threaded context root
+                // is inert here and the prelude keeps its legacy
+                // descriptor-based emit byte-for-byte (#940 Risk R2).
+                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag, shared_cache_root, _runtime_sfn_ctx_root(out_dir));
                 stats = merge_cache_stats(stats, prelude_emit.stats);
                 if prelude_emit.obj_path.length == 0 {
                     return _failed_runtime_link_inputs();

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1337,7 +1337,21 @@ fn _write_runtime_sfn_import_deps(asm_path: string, slug: string, ctx_root: stri
         if fs.exists(deps_path) { fs.deleteFile(deps_path); }
         return;
     }
-    fs.writeFile(deps_path, deps);
+    // #1011: a concurrent `--import-context` emit reads this sidecar;
+    // publish atomically (temp sibling + rename) so a peer never sees
+    // a partial dep list. Mirrors `_cr_stage_import_deps`'s publish,
+    // including its plain-write fallback when `mktemp` is unavailable.
+    let tmp = _mktemp_sibling_cmd(deps_path);
+    if tmp.length == 0 {
+        fs.writeFile(deps_path, deps);
+        return;
+    }
+    fs.writeFile(tmp, deps);
+    if !_atomic_rename_into_place(tmp, deps_path) {
+        print("sfn build: failed to publish runtime sfn-source import-deps for "
+            + slug);
+        process.run(["rm", "-f", tmp]);
+    }
 }
 
 // Stage import-context artifacts + `.import-deps` sidecars for EVERY

--- a/compiler/tests/e2e/test_runtime_sfn_sources_struct_import.sh
+++ b/compiler/tests/e2e/test_runtime_sfn_sources_struct_import.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# Issue #1288 (Gap 1 of #1283): regression test for cross-module
+# struct-returning calls between runtime sfn-sources.
+#
+# `_compile_runtime_sfn_sources` (compiler/src/cli_main.sfn) emits
+# each `sfn-sources` entry in an isolated child `sfn emit`. Before
+# #1288, no sibling sfn-source's `.sfn-asm` was staged into the
+# import-context tree, so a runtime module importing a
+# struct-returning fn from a sibling died during LLVM lowering with
+#   "cannot resolve return type for call to `<fn>` — callee
+#    signature is not known to the compiler"
+# (core_call_emission.sfn). Pointer/i64 externs could be worked
+# around with inline `extern fn`; a struct-by-value return cannot
+# (E0805) — which is why #1217 had to inline a copy of ownedbuf.sfn
+# into string.sfn. #1288 stages every sfn-source's `.sfn-asm` under a
+# PRIVATE root (`<out_dir>/rt-import-context/<slug>.sfn-asm`), writes
+# per-module `.import-deps` sidecars for sibling imports, and threads
+# the root into each child emit via `--import-context` (the #957/#999
+# mechanism), so sibling signatures resolve without publishing
+# anything into the shared cwd `build/native/import-context/` tree.
+# (Publishing there regresses every other emit in the cwd: the
+# prelude imports the runtime modules, and staged runtime artifacts
+# make its lowering render imported-signature declares that conflict
+# with its runtime-helper descriptor declares — clang then rejects
+# the prelude IR with "invalid redefinition".)
+#
+# The test (scaffolding modeled on
+# `test_runtime_sfn_sources_link_consumer.sh`):
+#   1. Builds a scratch workspace whose runtime capsule declares two
+#      synthetic sfn-sources: `structlib.sfn` (defines struct Pair +
+#      struct-returning pair_new/pair_shift) and `structuse.sfn`
+#      (imports them across the module boundary and wraps the result
+#      in an i64-returning probe fn).
+#   2. Runs `sfn build -p capsules/sfn/test-app`; the app calls the
+#      probe via a plain i64 extern and prints a marker.
+#   3. Asserts the build succeeds (it fails with the lowering fatal
+#      before #1288).
+#   4. Asserts the staged import-context artifacts exist.
+#   5. Asserts the consumer module's .ll resolved the imported
+#      signatures as `%Pair` (not a defaulted i8*).
+#   6. Runs the produced binary and asserts the probe value
+#      round-tripped through the cross-module struct returns.
+#   7. Asserts SAILFIN_DISABLE_RUNTIME_SFN_SOURCES=1 stages nothing.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_sfn_sources_struct_import.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+SCRATCH="$(mktemp -d -t sfn-rtsrc-struct-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+setup_workspace() {
+    local ws="$1"
+    rm -rf "$ws"
+    mkdir -p "$ws/runtime/native"
+    mkdir -p "$ws/runtime/sfn/platform" "$ws/runtime/sfn/memory"
+    mkdir -p "$ws/capsules/sfn/test-app/src"
+
+    cat > "$ws/workspace.toml" <<EOF
+[workspace]
+members = ["runtime/native", "capsules/sfn/test-app"]
+EOF
+
+    # Runtime capsule manifest. Mirrors the link-consumer test's
+    # dependency list (the real modules the prelude/link require)
+    # plus the two synthetic modules under test. structlib must be
+    # listed so its definitions link; structuse is the importing
+    # consumer whose emit exercises the staged sibling context.
+    cat > "$ws/runtime/native/capsule.toml" <<'EOF'
+[capsule]
+name = "sfn/runtime-native"
+version = "0.0.1"
+
+[capabilities]
+required = []
+
+[build]
+kind = "runtime"
+# Same shape as test_runtime_sfn_sources_link_consumer.sh's manifest
+# (see that file for why each real runtime module is required at
+# link time). The interesting entries are structlib/structuse.
+c-sources = ["src/sailfin_arena.c", "src/sailfin_runtime.c"]
+ll-sources = ["ir/runtime_globals.ll"]
+sfn-sources = ["../sfn/structlib.sfn", "../sfn/structuse.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/io.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/memory/mem.sfn"]
+include-dirs = ["include"]
+link-libs = ["-lm"]
+prelude-entry = "../prelude.sfn"
+EOF
+
+    # Mirror the repo's runtime/native tree + the real runtime
+    # modules the manifest references (symlinks, no copies).
+    ln -s "$REPO_ROOT/runtime/native/src" "$ws/runtime/native/src"
+    ln -s "$REPO_ROOT/runtime/native/include" "$ws/runtime/native/include"
+    ln -s "$REPO_ROOT/runtime/native/ir" "$ws/runtime/native/ir"
+    ln -s "$REPO_ROOT/runtime/prelude.sfn" "$ws/runtime/prelude.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/clock.sfn" "$ws/runtime/sfn/clock.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/exception.sfn" "$ws/runtime/sfn/exception.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/type_meta.sfn" "$ws/runtime/sfn/type_meta.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/io.sfn" "$ws/runtime/sfn/io.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/string.sfn" "$ws/runtime/sfn/string.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/array.sfn" "$ws/runtime/sfn/array.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/memory/mem.sfn" "$ws/runtime/sfn/memory/mem.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/platform/posix.sfn" "$ws/runtime/sfn/platform/posix.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/platform/libc.sfn" "$ws/runtime/sfn/platform/libc.sfn"
+
+    # The struct-defining sibling. Returned by value across the
+    # module boundary — the case an inline `extern fn` cannot
+    # express (E0805).
+    cat > "$ws/runtime/sfn/structlib.sfn" <<'EOF'
+// Synthetic runtime sfn-source for
+// `test_runtime_sfn_sources_struct_import.sh`: defines a struct and
+// struct-returning constructors, imported by structuse.sfn.
+struct Pair {
+    a: i64;
+    b: i64;
+}
+
+fn pair_new(a: i64, b: i64) -> Pair {
+    return Pair { a: a, b: b };
+}
+
+fn pair_shift(p: Pair, d: i64) -> Pair {
+    return Pair { a: p.a + d, b: p.b + d };
+}
+EOF
+
+    # The importing consumer. Before #1288 its llvm emit dies with
+    # "cannot resolve return type for call to `pair_new`".
+    cat > "$ws/runtime/sfn/structuse.sfn" <<'EOF'
+// Synthetic runtime sfn-source for
+// `test_runtime_sfn_sources_struct_import.sh`: makes cross-module
+// struct-returning calls into structlib.sfn and exposes an
+// i64-returning probe the app can reach via a plain extern.
+import { Pair, pair_new, pair_shift } from "./structlib";
+
+fn rt_struct_probe() -> i64 {
+    let p = pair_new(40, 2);
+    let q = pair_shift(p, 1);
+    return q.a * 100 + q.b;
+}
+EOF
+
+    cat > "$ws/capsules/sfn/test-app/capsule.toml" <<EOF
+[capsule]
+name = "sfn/test-app"
+version = "0.0.1"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "binary"
+entry = "src/main.sfn"
+
+[dependencies]
+"sfn/runtime-native" = "*"
+EOF
+
+    # pair_new(40,2) shifted by 1 → {41,3} → 41*100+3 = 4103.
+    cat > "$ws/capsules/sfn/test-app/src/main.sfn" <<'EOF'
+extern fn rt_struct_probe() -> i64;
+
+fn main() ![io] {
+    let probe = rt_struct_probe();
+    if probe == 4103 {
+        print.info("struct-roundtrip-ok");
+    } else {
+        print.info("struct-roundtrip-bad");
+    }
+}
+EOF
+}
+
+build_scratch_app() {
+    local ws="$1"
+    local log="$2"
+    local extra_env="${3:-}"
+    local rc=0
+    (cd "$ws" && env $extra_env "$BINARY" build -p capsules/sfn/test-app > "$log" 2>&1) || rc=$?
+    return $rc
+}
+
+test_struct_import_builds_and_roundtrips() {
+    local ws="$SCRATCH/ws-positive"
+    setup_workspace "$ws"
+    local log="$SCRATCH/ws-positive.log"
+    if ! build_scratch_app "$ws" "$log"; then
+        echo "[test]   sfn build failed for the synthetic workspace:"
+        if grep -q "cannot resolve return type" "$log"; then
+            echo "[test]   (the pre-#1288 'cannot resolve return type' fatal — sibling"
+            echo "[test]    import-context staging did not happen)"
+        fi
+        tail -40 "$log"
+        return 1
+    fi
+
+    # Staged private import-context artifacts for the synthetic
+    # modules. Deliberately NOT under build/native/import-context —
+    # see the header comment for the prelude-regression rationale.
+    local ctx="$ws/build/sailfin/rt-import-context/runtime/sfn"
+    for f in structlib.sfn-asm structuse.sfn-asm structuse.import-deps; do
+        if [ ! -f "$ctx/$f" ]; then
+            echo "[test]   expected staged import-context artifact missing: $ctx/$f"
+            ls -R "$ws/build/sailfin/rt-import-context" 2>/dev/null | head -30
+            return 1
+        fi
+    done
+    # The consumer's deps sidecar must point at the staged sibling asm.
+    if ! grep -q "rt-import-context/runtime/sfn/structlib.sfn-asm" "$ctx/structuse.import-deps"; then
+        echo "[test]   structuse.import-deps does not reference structlib.sfn-asm:"
+        cat "$ctx/structuse.import-deps"
+        return 1
+    fi
+    # The defining module has no sibling imports → no deps sidecar.
+    if [ -f "$ctx/structlib.import-deps" ]; then
+        echo "[test]   structlib unexpectedly has an .import-deps sidecar:"
+        cat "$ctx/structlib.import-deps"
+        return 1
+    fi
+    # Nothing may leak into the SHARED cwd-relative import-context
+    # tree (the prelude-regression vector).
+    if ls "$ws/build/native/import-context/runtime/sfn/"*.sfn-asm >/dev/null 2>&1; then
+        echo "[test]   runtime sfn-source artifacts leaked into the shared tree:"
+        ls "$ws/build/native/import-context/runtime/sfn/" | head -10
+        return 1
+    fi
+
+    # The consumer's emitted IR resolved the imported callees with the
+    # real %Pair signature (a defaulted signature would be i8*).
+    local use_ll="$ws/build/sailfin/sfn__runtime-native__structuse.sfn-O2.ll"
+    if [ ! -f "$use_ll" ]; then
+        echo "[test]   expected consumer .ll missing: $use_ll"
+        ls "$ws/build/sailfin/" 2>/dev/null | head -20
+        return 1
+    fi
+    if ! grep -qE "call %Pair\*? @pair_new" "$use_ll"; then
+        echo "[test]   structuse.ll did not resolve pair_new as %Pair-returning:"
+        grep -E "pair_new|pair_shift" "$use_ll" | head -10
+        return 1
+    fi
+
+    # End-to-end: the values survive the cross-module struct returns.
+    local app_bin="$ws/build/capsules/sfn/test-app/bin/test-app"
+    if [ ! -x "$app_bin" ]; then
+        echo "[test]   expected app binary missing: $app_bin"
+        find "$ws/build" -name 'test-app*' -type f 2>/dev/null | head -10
+        return 1
+    fi
+    local out
+    out="$("$app_bin" 2>&1)" || {
+        echo "[test]   app binary exited non-zero; output:"
+        printf '%s\n' "$out"
+        return 1
+    }
+    if ! printf '%s\n' "$out" | grep -q "struct-roundtrip-ok"; then
+        echo "[test]   app output did not contain struct-roundtrip-ok:"
+        printf '%s\n' "$out"
+        return 1
+    fi
+    return 0
+}
+
+test_disable_gate_skips_staging() {
+    local ws="$SCRATCH/ws-disabled"
+    setup_workspace "$ws"
+    local log="$SCRATCH/ws-disabled.log"
+    # The gated build is expected to fail (see the link-consumer
+    # test: post-#397 the prelude needs sfn-source symbols). This
+    # test only pins that the gate also short-circuits the #1288
+    # staging pass — no import-context artifacts for sfn-sources.
+    build_scratch_app "$ws" "$log" "SAILFIN_DISABLE_RUNTIME_SFN_SOURCES=1" || true
+    if [ -d "$ws/build/sailfin/rt-import-context" ]; then
+        echo "[test]   disable gate did NOT skip import-context staging:"
+        find "$ws/build/sailfin/rt-import-context" -type f 2>/dev/null | head -10
+        return 1
+    fi
+    return 0
+}
+
+run_test "runtime sfn-source struct import builds, stages context, and round-trips" \
+    test_struct_import_builds_and_roundtrips
+run_test "SAILFIN_DISABLE_RUNTIME_SFN_SOURCES skips import-context staging" \
+    test_disable_gate_skips_staging
+
+echo ""
+echo "[test] results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- `_compile_runtime_sfn_sources` now stages every runtime sfn-source's native `.sfn-asm` into a **private** `<out_dir>/rt-import-context/<slug>.sfn-asm` tree (content-keyed `.key` sidecar, temp + atomic-rename publish) before the per-module llvm emit loop, writes per-module `.import-deps` sidecars for staged-sibling imports (derived from each asm's `.import` entries), and threads the root into the child emits via `--import-context` — the existing #957/#999 mechanism. A runtime module importing a **struct-returning** fn from a sibling sfn-source now resolves the callee signature instead of dying at `core_call_emission.sfn`'s `cannot resolve return type` fatal (a struct-by-value return cannot fall back to an inline `extern fn` — E0805 — which is what forced #1217's inlined `OwnedBuf`/`_str_buf_*` copy in `string.sfn`).
- The runtime `.o` cache key folds sibling-dep asm hashes (`_runtime_obj_key_with_sibling_deps`), so editing a sibling busts every importer's cached object — no stale-ABI reuse.
- **Why a private root, not the shared `build/native/import-context/` tree:** the prelude imports the runtime modules (`./sfn/array`, `./sfn/string`, …). Publishing runtime `.sfn-asm` into the shared cwd tree makes every emit in that cwd — prelude included — render imported-signature declares that conflict with its runtime-helper descriptor declares (`declare i8* @sfn_array_push_string(i8*, i8*)` vs the descriptor's `{ i8**, i64, i64 }*` form → clang `invalid redefinition`). The first iteration of this change did exactly that and broke 24 e2e tests; the threaded private root reaches exactly the sfn-source child emits and nothing else. Modules without a `.import-deps` sidecar — including the `prelude-entry`, which shares this emit path — keep the byte-identical legacy emit.
- Staging emits pass `--no-resolve-gate` per the #906 contract for build-internal context-free native emits.

Closes #1288

## Acceptance Criteria

- [x] A runtime sfn-source importing a struct-returning fn from a sibling sfn-source builds and runs correctly via `sfn build` against a synthetic workspace (new e2e: `test_runtime_sfn_sources_struct_import.sh` — build success, `%Pair`-typed resolved declares, end-to-end value round-trip)
- [x] Staged artifacts asserted by the test (private `rt-import-context` root + `.import-deps` content; shared `build/native/import-context/` tree verified leak-free)
- [x] `SAILFIN_DISABLE_RUNTIME_SFN_SOURCES=1` still short-circuits (no staging, no objects)
- [x] `make compile` self-hosts; `make test` green (e2e-sh **120/120**; existing `test_runtime_sfn_sources_*` tests 4/4)
- [x] `sfn fmt --check` clean on touched `.sfn` files

## Verification

```bash
ulimit -v 8388608 && make compile     # pass (self-hosts)
ulimit -v 8388608 && make test        # pass (e2e-sh 120/120, unified runner green)
bash compiler/tests/e2e/test_runtime_sfn_sources_struct_import.sh build/native/sailfin   # 2/2
bash compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh build/native/sailfin   # 4/4
build/native/sailfin fmt --check compiler/src/cli_main.sfn   # clean
```

Pre-fix repro (validated manually): `sfn emit ... llvm` of a runtime module importing `pair_new(a, b) -> Pair` from a sibling fails with the lowering fatal; with the staged context it emits `declare %Pair* @pair_new(i64, i64)` matching the definition side's ABI exactly.

Reviewed by `code-reviewer` (opus): approve, no blocking findings — slug/dep resolution sound, fail-closed failure paths, cache-key invalidation chain correct, provably inert on the real compiler runtime today (no current runtime module imports a staged sibling, so pass-1/pass-2 runtime objects stay byte-identical).

## Files Changed

- `compiler/src/cli_main.sfn` — staging pass + `.import-deps` writer + `--import-context` threading + dep-aware cache key
- `compiler/tests/e2e/test_runtime_sfn_sources_struct_import.sh` — new regression test

## Follow-up

- #1289 (seed-gated): collapse `string.sfn`'s inlined `OwnedBuf`/`_str_buf_*` into the `./memory/ownedbuf` import once a seed containing this fix is pinned (pass 1 runs the seed's emit path).
- #1283 stays open tracking Gap 2 (`slice -> Slice`, blocked on #822 + M1.A.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtQzRq4yt3gdf1CwU66iJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtQzRq4yt3gdf1CwU66iJV)_