### PR TITLE
refactor: collapse string.sfn's inlined OwnedBuf into the ownedbuf.sfn import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -966,6 +966,39 @@ rebuild-impl:
 			[ -f "$$manifest_path" ] || touch "$$manifest_path"; \
 		fi; \
 	done
+	@# #1289 (#1283 Gap 1): runtime/sfn/string.sfn imports OwnedBuf /
+	@# owned_buf_new / owned_buf_append from ./memory/ownedbuf. The
+	@# hand-rolled cross-windows RUNTIME_MODS loop (ci-cross-windows)
+	@# emits string.sfn standalone and, unlike #1288's
+	@# _compile_runtime_sfn_sources path, stages no sibling context of
+	@# its own — so without ownedbuf's `.sfn-asm` + layout-manifest staged
+	@# here the cold emit dies with "cannot resolve return type for call
+	@# to owned_buf_new". owned_buf_new returns OwnedBuf BY VALUE, so the
+	@# layout-manifest (the struct layout) is required alongside the fn
+	@# signature, not just the signature. Same staging shape as the
+	@# platform loop above; the rm forces a canonical NATIVE_OUT re-emit.
+	@rm -f build/native/import-context/runtime/sfn/memory/ownedbuf.sfn-asm build/native/import-context/runtime/sfn/memory/ownedbuf.layout-manifest
+	@mkdir -p build/native/import-context/runtime/sfn/memory
+	@set -e; \
+	ob_asm="build/native/import-context/runtime/sfn/memory/ownedbuf.sfn-asm"; \
+	ob_manifest="build/native/import-context/runtime/sfn/memory/ownedbuf.layout-manifest"; \
+	if [ ! -f "$$ob_asm" ]; then \
+		echo "[rebuild] staging runtime/sfn/memory/ownedbuf.sfn-asm..."; \
+		if ! $(NATIVE_OUT) emit --module-name "runtime/sfn/memory/ownedbuf" -o "$$ob_asm" native "runtime/sfn/memory/ownedbuf.sfn" >/dev/null; then \
+			echo "[rebuild][error] emit native failed for runtime/sfn/memory/ownedbuf.sfn" >&2; \
+			rm -f "$$ob_asm"; \
+			exit 1; \
+		fi; \
+		if [ ! -s "$$ob_asm" ]; then \
+			echo "[rebuild][error] emit native produced empty $$ob_asm" >&2; \
+			rm -f "$$ob_asm"; \
+			exit 1; \
+		fi; \
+	fi; \
+	if [ ! -f "$$ob_manifest" ]; then \
+		grep '^\.layout' "$$ob_asm" > "$$ob_manifest" 2>/dev/null || :; \
+		[ -f "$$ob_manifest" ] || touch "$$ob_manifest"; \
+	fi
 	@echo "[rebuild] built $(NATIVE_OUT)"
 
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -1059,7 +1059,7 @@ ci-cross-windows:
 	: "readlink reference once the MinGW stub is gone; Windows selects the"; \
 	: "GetModuleFileNameA leg instead. The rest are target-independent IR"; \
 	: "compiled for mingw. Each <module>:<source> pair is space-separated."; \
-	RUNTIME_MODS="prelude:runtime/prelude.sfn arena:runtime/sfn/memory/arena.sfn rc:runtime/sfn/memory/rc.sfn mem:runtime/sfn/memory/mem.sfn string:runtime/sfn/string.sfn array:runtime/sfn/array.sfn clock:runtime/sfn/clock.sfn io:runtime/sfn/io.sfn exception:runtime/sfn/exception.sfn type_meta:runtime/sfn/type_meta.sfn exec:runtime/sfn/platform/exec.sfn filesystem:runtime/sfn/adapters/filesystem.sfn http:runtime/sfn/adapters/http.sfn"; \
+	RUNTIME_MODS="prelude:runtime/prelude.sfn arena:runtime/sfn/memory/arena.sfn rc:runtime/sfn/memory/rc.sfn mem:runtime/sfn/memory/mem.sfn ownedbuf:runtime/sfn/memory/ownedbuf.sfn string:runtime/sfn/string.sfn array:runtime/sfn/array.sfn clock:runtime/sfn/clock.sfn io:runtime/sfn/io.sfn exception:runtime/sfn/exception.sfn type_meta:runtime/sfn/type_meta.sfn exec:runtime/sfn/platform/exec.sfn filesystem:runtime/sfn/adapters/filesystem.sfn http:runtime/sfn/adapters/http.sfn"; \
 	RUNTIME_OBJS=""; \
 	for pair in $$RUNTIME_MODS; do \
 		mod="$${pair%%:*}"; \

--- a/compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh
+++ b/compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh
@@ -114,7 +114,15 @@ ll-sources = ["ir/runtime_globals.ll"]
 # local / array index in the linked IR) now references them, so mem.sfn
 # is required too or the link fails with "undefined reference to
 # `sfn_mem_bounds_check`".
-sfn-sources = ["../sfn/test_marker.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/io.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/memory/mem.sfn"]
+# #1289 (#1283 Gap 1) collapsed string.sfn's inlined OwnedBuf/_str_buf_*
+# copy into an `import { OwnedBuf, owned_buf_new, owned_buf_append } from
+# "./memory/ownedbuf"`, so string.sfn is no longer self-contained:
+# ownedbuf.sfn must be listed (its `.sfn-asm` is staged by #1288 so
+# string.sfn's emit resolves the cross-module struct-returning call) and
+# arena.sfn must be listed (ownedbuf's `sfn_arena_sfn_*` externs resolve
+# to its defines at link). Without both, string.sfn's emit dies with
+# "cannot resolve return type for call to `owned_buf_new`".
+sfn-sources = ["../sfn/test_marker.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/io.sfn", "../sfn/memory/arena.sfn", "../sfn/memory/ownedbuf.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/memory/mem.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 prelude-entry = "../prelude.sfn"
@@ -150,8 +158,9 @@ EOF
     # `@sfn_to_debug_string` (string.sfn), and `@sfn_array_sfn_*`
     # (array.sfn). io.sfn additionally imports `./platform/libc`
     # (`write`), so libc.sfn must exist on disk for the consumer's
-    # `sfn emit` to resolve the extern. string.sfn / array.sfn have
-    # no imports.
+    # `sfn emit` to resolve the extern. array.sfn has no imports;
+    # string.sfn imports `./memory/ownedbuf` (#1289), so ownedbuf.sfn
+    # must exist on disk too (symlinked below).
     ln -s "$REPO_ROOT/runtime/sfn/io.sfn" "$ws/runtime/sfn/io.sfn"
     ln -s "$REPO_ROOT/runtime/sfn/string.sfn" "$ws/runtime/sfn/string.sfn"
     ln -s "$REPO_ROOT/runtime/sfn/array.sfn" "$ws/runtime/sfn/array.sfn"
@@ -161,6 +170,14 @@ EOF
     # its externs), so a bare symlink suffices.
     mkdir -p "$ws/runtime/sfn/memory"
     ln -s "$REPO_ROOT/runtime/sfn/memory/mem.sfn" "$ws/runtime/sfn/memory/mem.sfn"
+    # #1289 dep — string.sfn now imports `./memory/ownedbuf`
+    # (`OwnedBuf` / `owned_buf_new` / `owned_buf_append`). ownedbuf.sfn
+    # must be on disk for string.sfn's emit to resolve the import, and
+    # arena.sfn must be on disk + linked because ownedbuf's inline
+    # `sfn_arena_sfn_*` externs resolve to arena.sfn's defines. Both
+    # inline their own externs, so bare symlinks suffice.
+    ln -s "$REPO_ROOT/runtime/sfn/memory/arena.sfn" "$ws/runtime/sfn/memory/arena.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/memory/ownedbuf.sfn" "$ws/runtime/sfn/memory/ownedbuf.sfn"
 
     # The sfn-source under test. Tiny self-contained module.
     cat > "$ws/runtime/sfn/test_marker.sfn" <<'EOF'

--- a/compiler/tests/e2e/test_runtime_sfn_sources_struct_import.sh
+++ b/compiler/tests/e2e/test_runtime_sfn_sources_struct_import.sh
@@ -95,9 +95,13 @@ kind = "runtime"
 # Same shape as test_runtime_sfn_sources_link_consumer.sh's manifest
 # (see that file for why each real runtime module is required at
 # link time). The interesting entries are structlib/structuse.
+# arena.sfn + ownedbuf.sfn are required because string.sfn now imports
+# `./memory/ownedbuf` (#1289): ownedbuf.sfn so string's emit resolves
+# the cross-module struct-returning call, arena.sfn so ownedbuf's
+# `sfn_arena_sfn_*` externs resolve at link.
 c-sources = ["src/sailfin_arena.c", "src/sailfin_runtime.c"]
 ll-sources = ["ir/runtime_globals.ll"]
-sfn-sources = ["../sfn/structlib.sfn", "../sfn/structuse.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/io.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/memory/mem.sfn"]
+sfn-sources = ["../sfn/structlib.sfn", "../sfn/structuse.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/io.sfn", "../sfn/memory/arena.sfn", "../sfn/memory/ownedbuf.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/memory/mem.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 prelude-entry = "../prelude.sfn"
@@ -116,6 +120,11 @@ EOF
     ln -s "$REPO_ROOT/runtime/sfn/string.sfn" "$ws/runtime/sfn/string.sfn"
     ln -s "$REPO_ROOT/runtime/sfn/array.sfn" "$ws/runtime/sfn/array.sfn"
     ln -s "$REPO_ROOT/runtime/sfn/memory/mem.sfn" "$ws/runtime/sfn/memory/mem.sfn"
+    # #1289 — string.sfn imports `./memory/ownedbuf`; ownedbuf's inline
+    # `sfn_arena_sfn_*` externs resolve to arena.sfn at link. Both must
+    # be on disk for the emit + link to succeed.
+    ln -s "$REPO_ROOT/runtime/sfn/memory/arena.sfn" "$ws/runtime/sfn/memory/arena.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/memory/ownedbuf.sfn" "$ws/runtime/sfn/memory/ownedbuf.sfn"
     ln -s "$REPO_ROOT/runtime/sfn/platform/posix.sfn" "$ws/runtime/sfn/platform/posix.sfn"
     ln -s "$REPO_ROOT/runtime/sfn/platform/libc.sfn" "$ws/runtime/sfn/platform/libc.sfn"
 

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/memory/mem.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/platform/rlimit.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn", "../sfn/concurrency/scheduler.sfn", "../sfn/concurrency/future.sfn", "../sfn/concurrency/channel.sfn", "../sfn/concurrency/parallel.sfn", "../sfn/concurrency/serve.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/memory/mem.sfn", "../sfn/memory/ownedbuf.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/platform/rlimit.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn", "../sfn/concurrency/scheduler.sfn", "../sfn/concurrency/future.sfn", "../sfn/concurrency/channel.sfn", "../sfn/concurrency/parallel.sfn", "../sfn/concurrency/serve.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm", "-lpthread"]
 

--- a/runtime/sfn/memory/arena.sfn
+++ b/runtime/sfn/memory/arena.sfn
@@ -65,8 +65,10 @@
 // same reason `runtime/sfn/memory/rc.sfn`, `runtime/sfn/string.sfn`,
 // and `runtime/sfn/array.sfn` inline their externs: cross-module
 // extern resolution through the seed compiler hits the `cannot
-// resolve return type for call to …` fatal that issue #306 has not
-// closed yet, surfacing during emission. Inlining the three
+// resolve return type for call to …` fatal (the struct-return gap of
+// #1283 Gap 1; #1288 fixed the runtime-sfn-source emit path, but
+// de-inlining these C-ABI externs is separate follow-up work),
+// surfacing during emission. Inlining the three
 // declarations we need keeps this module self-contained for every
 // seed. Once the cross-module path lands, a follow-up PR flips
 // these to imports without touching the bodies. Note that libc

--- a/runtime/sfn/memory/ownedbuf.sfn
+++ b/runtime/sfn/memory/ownedbuf.sfn
@@ -60,8 +60,10 @@
 // Why inline `extern fn` declarations rather than imports? The same
 // reason `arena.sfn` / `rc.sfn` / `string.sfn` inline theirs:
 // cross-module extern resolution through the seed compiler still
-// hits the issue-#306 `cannot resolve return type for call to …`
-// fatal. The `sfn_arena_sfn_alloc` / `sfn_arena_sfn_realloc`
+// hits the `cannot resolve return type for call to …` fatal (the
+// struct-return gap of #1283 Gap 1; #1288 fixed the
+// runtime-sfn-source emit path, but de-inlining these C-ABI externs
+// is separate follow-up work). The `sfn_arena_sfn_alloc` / `sfn_arena_sfn_realloc`
 // declarations match the export signatures in
 // `runtime/sfn/memory/arena.sfn` exactly; linking this module
 // therefore requires the arena module (or the C arena's namesakes

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -36,51 +36,30 @@
 // annotations attach to *adapters* that wrap these primitives,
 // never to the primitives themselves.
 //
+// #1289 / #1283 Gap 1: `OwnedBuf` and its grow-at-tip constructor /
+// append (`owned_buf_new` / `owned_buf_append`) come from the canonical
+// `./memory/ownedbuf` module rather than being inlined here. The inline
+// copy #1217 (Phase R1) shipped existed only because the
+// runtime-sfn-source emit path could not resolve a cross-module
+// struct-returning call — the `OwnedBuf` aggregate return died at
+// `core_call_emission.sfn` with `cannot resolve return type for call
+// to …` (an inline `extern fn` can't carry the struct either — C-ABI
+// only, E0805). #1288 taught `_compile_runtime_sfn_sources` to stage
+// sibling runtime modules' `.sfn-asm` into the import-context the
+// lowering consults, so the call now resolves; with a seed containing
+// #1288 pinned, this consumer collapses the duplication. `concat` /
+// `append` therefore route growth through `ownedbuf.sfn`'s arena
+// externs (`sfn_arena_sfn_*`); `ownedbuf.sfn` and `arena.sfn` are
+// linked alongside this module via `runtime/native/capsule.toml`'s
+// `sfn-sources`.
+import { OwnedBuf, owned_buf_new, owned_buf_append } from "./memory/ownedbuf";
+
 // Why inline the libc externs? The same reason `arena.sfn` does:
 // the released seed compiler snapshots `runtime/sfn/platform/libc.sfn`
 // at build time. Inlining keeps this module self-contained for
 // every seed, regardless of which libc declarations have shipped.
 // Once the seed catches up, a follow-up PR can flip these to a
 // cross-module import without touching the bodies.
-//
-// #1217 (Phase R1): `OwnedBuf` is inlined here — definition
-// byte-identical to `runtime/sfn/memory/ownedbuf.sfn:112-117` (four-slot
-// i64 layout, the `_addr` discipline) — and the grow/append move logic
-// is reproduced through the private `_str_buf_*` helpers below. It is
-// NOT imported from ownedbuf.sfn: the runtime-sfn-source emit path
-// (`_compile_runtime_sfn_sources` in cli_main.sfn) emits each runtime
-// module standalone and does NOT thread a sibling runtime module's
-// signatures, so a cross-module call whose return type is the `OwnedBuf`
-// aggregate hits `cannot resolve return type for call to …` at
-// `core_call_emission.sfn:368` (an inline `extern fn` can't carry the
-// struct either — externs are C-ABI-only, E0805). This is the #999
-// class of bug, but in an emit path #999's fix did not cover; tracked
-// at #1283 (NOT the closed, unrelated #306). Same-module calls to
-// `_str_buf_new` / `_str_buf_append` resolve fine, and those helpers
-// route growth through the **C** arena externs (`sfn_arena_alloc` /
-// `sfn_arena_realloc`, like `sfn_arena_global`) — the always-linked
-// production allocator — NOT the Sailfin `sfn_arena_sfn_*` exports, so
-// string.sfn stays self-contained for every seed and link set (it is
-// not guaranteed that `arena.sfn` is linked wherever string.sfn is; the
-// synthetic-workspace link test pins exactly that). The LLVM `%OwnedBuf
-// = type { i64, i64, i64, i64 }` aggregate unifies at link with
-// ownedbuf.sfn's. Once #1283 lands, the inline struct + `_str_buf_*`
-// duplication collapses to a single import.
-struct OwnedBuf {
-    ptr_addr: i64;
-    len: i64;
-    cap: i64;
-    arena_addr: i64;
-}
-
-extern fn malloc(size: usize) -> * u8;
-
-extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
-
-extern fn sfn_arena_alloc(arena: * u8, size: usize, align: usize) -> * u8;
-
-extern fn sfn_arena_realloc(arena: * u8, ptr: * u8, old_size: usize, new_size: usize, align: usize) -> * u8;
-
 extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
 
 extern fn memchr(s: * u8, c: i32, n: usize) -> * u8;
@@ -174,7 +153,7 @@ extern fn sfn_int_to_str(value: i64) -> * u8;
 // discipline every other runtime module follows, e.g.
 // `runtime/sfn/memory/arena.sfn`'s mark/rewind). Under
 // `SAILFIN_USE_ARENA=0` (ASAN / diagnostics), `concat` therefore passes
-// `arena_addr = 0` and `_str_buf_new` falls back to libc storage. Both
+// `arena_addr = 0` and `owned_buf_new` falls back to libc storage. Both
 // are C-ABI (`-> * u8` / `-> bool`), so they stay inline externs (same
 // discipline as the libc externs above).
 extern fn sfn_arena_global() -> * u8;
@@ -248,129 +227,51 @@ fn sfn_str_sfn_from_cstr(s: * u8) -> * u8 { return s; }
 // (M1.A.2 hasn't landed). The user-emission hot path bypasses
 // this wrapper entirely and lands on the C entrypoint
 // `sfn_str_concat`, which has the real arena ABI.
-// `_str_buf_new(arena_addr, initial_cap)` / `_str_buf_append(self,
-// suffix_addr, suffix_len)` — #1217 (Phase R1): same-module copies of
-// `owned_buf_new` / `owned_buf_append` (ownedbuf.sfn), reproduced here
-// because string.sfn cannot make the cross-module struct-returning call
-// (#1283 — see the OwnedBuf header above). They are the move
-// substrate `sfn_str_sfn_append` / `_concat` build on: `_str_buf_append`
-// consumes `self` (a unique `OwnedBuf`) and returns the (possibly
-// relocated) buffer, routing growth through the C-ABI arena externs
-// (`sfn_arena_realloc` grow-if-at-tip, or `malloc` + `memcpy` when
-// libc-backed). The raw extern interior sits behind `unsafe` per §5.1;
-// the unique-owner move-return stays in checked code. Soundness of the
-// in-place grow-at-tip is the caller's unique ownership, which the
-// checker proves at every `sfn_str_sfn_append` / `_concat` call site.
-fn _str_buf_new(arena_addr: i64, initial_cap: i64) -> OwnedBuf {
-    let mut cap: i64 = 0;
-    let mut ptr_addr: i64 = 0;
-    if initial_cap > 0 {
-        let stepped: i64 = (initial_cap + 7) / 8;
-        cap = stepped * 8;
-        unsafe {
-            if arena_addr != 0 {
-                let storage: * u8 = sfn_arena_alloc(arena_addr as * u8, cap as usize, 8 as usize);
-                ptr_addr = storage as i64;
-            } else {
-                let heap: * u8 = malloc(cap as usize);
-                ptr_addr = heap as i64;
-            }
-        }
-        if ptr_addr == 0 { cap = 0; }
-    }
-    return OwnedBuf {
-        ptr_addr: ptr_addr,
-        len: 0,
-        cap: cap,
-        arena_addr: arena_addr
-    };
-}
-
-fn _str_buf_append(self: OwnedBuf, suffix_addr: i64, suffix_len: i64) -> OwnedBuf {
-    if suffix_addr == 0 { return self; }
-    if suffix_len <= 0 { return self; }
-    let needed: i64 = self.len + suffix_len;
-    if needed < self.len { return self; }
-    let mut ptr_addr: i64 = self.ptr_addr;
-    let mut cap: i64 = self.cap;
-    if needed > cap {
-        let mut new_cap: i64 = cap + cap;
-        if new_cap < needed { new_cap = needed; }
-        if new_cap < 16 { new_cap = 16; }
-        let stepped: i64 = (new_cap + 7) / 8;
-        new_cap = stepped * 8;
-        if new_cap < needed { return self; }
-        unsafe {
-            if self.arena_addr != 0 {
-                let grown: * u8 = sfn_arena_realloc(self.arena_addr as * u8, ptr_addr as * u8, cap as usize, new_cap as usize, 8 as usize);
-                if grown as i64 == 0 { return self; }
-                ptr_addr = grown as i64;
-            } else {
-                let fresh: * u8 = malloc(new_cap as usize);
-                if fresh as i64 == 0 { return self; }
-                if ptr_addr != 0 {
-                    if self.len > 0 {
-                        memcpy(fresh, ptr_addr as * u8, self.len as usize);
-                    }
-                }
-                ptr_addr = fresh as i64;
-            }
-        }
-        cap = new_cap;
-    }
-    unsafe {
-        let dst_addr: i64 = ptr_addr + self.len;
-        memcpy(dst_addr as * u8, suffix_addr as * u8, suffix_len as usize);
-    }
-    return OwnedBuf {
-        ptr_addr: ptr_addr,
-        len: needed,
-        cap: cap,
-        arena_addr: self.arena_addr
-    };
-}
-
-// #1217 (Phase R1): `concat` now returns an owned `OwnedBuf` (proposal
+//
+// #1217 (Phase R1): `concat` returns an owned `OwnedBuf` (proposal
 // §5.1 "concat returns owned") built by appending both operands into a
-// fresh buffer. The result is the unique owner of its bytes, so the
-// chained-append grow-at-tip the architect spec describes is sound by
-// construction — no aliasing of either input's storage (the #1205
-// hazard class). Storage is the process-global arena when arena mode is
-// on, gated on `sfn_arena_enabled()` so the `SAILFIN_USE_ARENA=0`
-// opt-out (ASAN / diagnostics) is honored — when disabled, `arena_addr`
-// is `0` and `_str_buf_new` falls back to libc-backed storage. Params
-// are unchanged (`* u8`, `* u8`) — the byte lengths are recovered via
-// the local `sfn_str_sfn_len`. The two `_str_buf_append` calls are
-// same-module moves of the unique buffer (consume-and-return); the raw
-// extern interior they route through sits behind `unsafe` inside the
-// helper.
+// fresh buffer via the canonical `owned_buf_new` / `owned_buf_append`
+// (imported from `./memory/ownedbuf` — #1289 collapsed the inlined
+// `_str_buf_*` copy once #1288's sibling-staging let the cross-module
+// `OwnedBuf`-returning call resolve). The result is the unique owner of
+// its bytes, so the chained-append grow-at-tip the architect spec
+// describes is sound by construction — no aliasing of either input's
+// storage (the #1205 hazard class). Storage is the process-global arena
+// when arena mode is on, gated on `sfn_arena_enabled()` so the
+// `SAILFIN_USE_ARENA=0` opt-out (ASAN / diagnostics) is honored — when
+// disabled, `arena_addr` is `0` and `owned_buf_new` falls back to
+// libc-backed storage. Params are unchanged (`* u8`, `* u8`) — the byte
+// lengths are recovered via the local `sfn_str_sfn_len`. The two
+// `owned_buf_append` calls are moves of the unique buffer
+// (consume-and-return); the raw extern interior they route through sits
+// behind `unsafe` inside `ownedbuf.sfn`.
 fn sfn_str_sfn_concat(a: * u8, b: * u8) -> OwnedBuf {
     let a_len: i64 = sfn_str_sfn_len(a);
     let b_len: i64 = sfn_str_sfn_len(b);
     let mut arena_addr: i64 = 0;
     if sfn_arena_enabled() { arena_addr = sfn_arena_global() as i64; }
     let total: i64 = a_len + b_len;
-    let buf: OwnedBuf = _str_buf_new(arena_addr, total);
-    let grown: OwnedBuf = _str_buf_append(buf, a as i64, a_len);
-    return _str_buf_append(grown, b as i64, b_len);
+    let buf: OwnedBuf = owned_buf_new(arena_addr, total);
+    let grown: OwnedBuf = owned_buf_append(buf, a as i64, a_len);
+    return owned_buf_append(grown, b as i64, b_len);
 }
 
 // `sfn_str_sfn_append(buf, suffix_addr, suffix_len)` — #1217 (Phase
-// R1): the append hot path, now a **move** over `OwnedBuf` (proposal
-// §5.1 "`sfn_str_sfn_append` takes/returns `OwnedBuf` (move)"). It
-// consumes the unique `buf`, appends `suffix_len` bytes from
-// `suffix_addr`, and returns the (possibly relocated) buffer —
-// delegating to the same-module `_str_buf_append`, which routes growth
-// through the arena's grow-if-at-tip realloc. Because the caller's `buf`
-// is the unique live owner (the ownership checker proves it; no alias),
-// the in-place grow-at-tip is sound — this is the structural close of
-// the #1205 aliasing hazard. The delegation is a same-module move (not
-// an extern), so it stays in checked code; the raw extern interior sits
-// behind `unsafe` inside `_str_buf_append`. The compiler has no callers
-// of `string.append` yet (the descriptor row is symbol-parking), so the
-// signature flip breaks no call site.
+// R1): the append hot path, a **move** over `OwnedBuf` (proposal §5.1
+// "`sfn_str_sfn_append` takes/returns `OwnedBuf` (move)"). It consumes
+// the unique `buf`, appends `suffix_len` bytes from `suffix_addr`, and
+// returns the (possibly relocated) buffer — delegating to the canonical
+// `owned_buf_append` (imported from `./memory/ownedbuf`), which routes
+// growth through the arena's grow-if-at-tip realloc. Because the
+// caller's `buf` is the unique live owner (the ownership checker proves
+// it; no alias), the in-place grow-at-tip is sound — this is the
+// structural close of the #1205 aliasing hazard. The delegation routes
+// through `ownedbuf.sfn`; the raw extern interior sits behind `unsafe`
+// there. The compiler has no callers of `string.append` yet (the
+// descriptor row is symbol-parking), so the signature flip breaks no
+// call site.
 fn sfn_str_sfn_append(buf: OwnedBuf, suffix_addr: i64, suffix_len: i64) -> OwnedBuf {
-    return _str_buf_append(buf, suffix_addr, suffix_len);
+    return owned_buf_append(buf, suffix_addr, suffix_len);
 }
 
 // M2.5 (#403) wave-2 trampolines — UTF-8 + numeric formatting.


### PR DESCRIPTION
## Summary

- Removes the #1217 cross-module-resolution workaround in `runtime/sfn/string.sfn`: the inlined `OwnedBuf` struct and the private `_str_buf_new`/`_str_buf_append` copies of `ownedbuf.sfn`'s grow-at-tip logic are deleted in favor of `import { OwnedBuf, owned_buf_new, owned_buf_append } from "./memory/ownedbuf"`.
- The duplication existed only because the runtime-sfn-source emit path could not resolve a cross-module struct-returning call (the `OwnedBuf` aggregate return died at `core_call_emission.sfn` with `cannot resolve return type for call to …`; an inline `extern fn` can't carry a struct return either — E0805). **#1288** (PR #1290, pinned in seed `v0.7.0-alpha.33`) taught `_compile_runtime_sfn_sources` to stage sibling runtime modules' `.sfn-asm` into the import-context the lowering consults, so the call now resolves.
- Stale `#306` citations describing this struct-return gap in `ownedbuf.sfn` / `arena.sfn` are corrected to `#1283`/`#1288`. Other modules' `#306` extern-inlining notes are intentionally left untouched (separate work).

Closes #1289

### Seed freshness (Phase 1.5)
`#1288` confirmed present in the pinned seed `v0.7.0-alpha.33` — the seed's `compiler/src/cli_main.sfn` contains the staging symbols `rt-import-context` and `_runtime_obj_key_with_sibling_deps` introduced by PR #1290 (the merge SHA is also dated ~20 min before the seed cut).

## Acceptance Criteria

- [x] `string.sfn` contains no `OwnedBuf` struct definition and no `_str_buf_*` functions; the grow-at-tip logic exists only in `ownedbuf.sfn`
- [x] `make compile` self-hosts from the pinned seed (proves the seed resolves the cross-module struct return)
- [x] `make test` green (string/append/concat regression tests unchanged and passing; e2e-sh 121/121)
- [x] No remaining `#306` citation in `string.sfn` / `ownedbuf.sfn` / `arena.sfn` that describes the cross-module struct-return gap
- [x] `sfn fmt --check` clean on touched `.sfn` files

## Verification

```bash
ulimit -v 8388608 && make compile          # pass (self-hosts from v0.7.0-alpha.33)
ulimit -v 8388608 && make test-e2e-sh      # e2e-sh: 121/121 passed, 0 failed
build/native/sailfin fmt --check runtime/sfn/string.sfn \
  runtime/sfn/memory/ownedbuf.sfn runtime/sfn/memory/arena.sfn   # clean
grep -n "#306" runtime/sfn/string.sfn \
  runtime/sfn/memory/ownedbuf.sfn runtime/sfn/memory/arena.sfn   # none
```

## Files Changed

Per the issue's scope:
- `runtime/native/capsule.toml` — add `../sfn/memory/ownedbuf.sfn` to `sfn-sources`
- `runtime/sfn/string.sfn` — import from `./memory/ownedbuf`; delete the inlined struct, the `_str_buf_*` helpers, and the now-orphaned `malloc`/`memcpy`/`sfn_arena_alloc`/`sfn_arena_realloc` externs; route `concat`/`append` through `owned_buf_new`/`owned_buf_append`
- `runtime/sfn/memory/ownedbuf.sfn`, `runtime/sfn/memory/arena.sfn` — `#306` → `#1283`/`#1288` citation fix

Beyond the issue's listed Files Affected, but **necessary** because `string.sfn` is no longer self-contained (it now has a sibling dependency on `ownedbuf.sfn`, which in turn needs `arena.sfn` at link):
- `Makefile` — add `ownedbuf` to the cross-windows `RUNTIME_MODS` list. This is forced by `test_cross_windows_runtime_modules.sh`, the guard that pins manifest↔Makefile `sfn-sources` parity.
- `compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh`, `..._struct_import.sh` — add `arena.sfn` + `ownedbuf.sfn` to the synthetic-workspace `sfn-sources` and symlink them; without the sibling on disk, `string.sfn`'s emit fails with `cannot resolve return type for call to owned_buf_new`.

## Notes for review

- The `concat`/`append` storage path now routes through `ownedbuf.sfn`'s `sfn_arena_sfn_*` externs (the Sailfin arena) instead of the inlined `sfn_arena_*` (the C arena). In the runtime-native capsule, `arena.sfn`, `ownedbuf.sfn`, and `string.sfn` are linked together, so the symbols resolve. No behavior change to `append`/`concat` semantics (the #1217 deliverable is unchanged).
- `slice → Slice` (Gap 2 of #1283) is out of scope and stays on `#1283`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXLuwsTTP8e5HuA8WD11MR)_