### PR TITLE
Add build/test/fmt-write MCP tools and steer agents to them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,17 @@ and `make check` are different tools, not fast/slow versions of the same one:
 Don't burn `make check` to discover a type or effect error `sfn check` would have
 caught in seconds. (Use `build/native/sailfin check <path>` if `sfn` is not on `PATH`.)
 
+**MCP tools (agentic clients).** When running as an MCP client (e.g. Claude Code
+with the `sailfin` server registered in `.mcp.json`), prefer the `sailfin_*` tools
+for the inner loop instead of shelling out: `sailfin_check` / `sailfin_diagnostics`
+(fast static analysis, JSON envelope), `sailfin_fmt_write` + `sailfin_fmt_check`
+(format then verify a touched file), `sailfin_build` (build a `.sfn` file or capsule),
+and `sailfin_test` (a targeted suite dir or a single `_test.sfn` file, with `-k` to
+run one named test). Each is a pure passthrough to one `sailfin` subcommand. They
+do **not** replace `make compile` (the compiler self-host needs seed + extern
+pre-staging the tools deliberately don't replicate) or `make check` — use those
+for the self-host invariant and the full gate. See `tools/mcp-server/README.md`.
+
 ## Compiler Pipeline
 
 `compiler/src/` follows this flow:

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -10,11 +10,19 @@ Part of the "AI agents are users" strategy described in [`CLAUDE.md`](../../CLAU
 |---|---|---|
 | `sailfin_version` | `sailfin version` | Smoke test — returns the compiler version. Fails loudly if `build/native/sailfin` is missing. |
 | `sailfin_check` | `sailfin check <path>` | Type + effect check a single `.sfn` file. Fast feedback during edits. |
+| `sailfin_diagnostics` | `sailfin check --json <path>` | Same analysis as `sailfin_check`, returned as the `sailfin-check/1` JSON envelope for programmatic consumption. |
 | `sailfin_emit_native` | `sailfin emit native <path>` | Emit `.sfn-asm` intermediate representation. Use for emit-stage diagnosis. |
 | `sailfin_emit_llvm` | `sailfin emit llvm <path>` | Emit LLVM IR. Use for lowering-stage or linker diagnosis. |
 | `sailfin_fmt_check` | `sailfin fmt --check <path>` | Report formatting differences without rewriting. |
+| `sailfin_fmt_write` | `sailfin fmt --write <path>` | Reformat a file or directory in place (canonical). Run before committing to satisfy the CI `fmt --check` gate. |
+| `sailfin_build` | `sailfin build <file>` / `-p <capsule>` | Build a single `.sfn` file or a capsule to a native binary. **Not** the compiler self-host (see below). |
+| `sailfin_test` | `sailfin test <path> [-k <name>] [--jobs N] [--json]` | Run a targeted suite directory or a single `_test.sfn` file. `path` required. |
 
-Every tool runs under a 60-second timeout, and the compiler self-applies its 8 GiB memory budget on Linux (see the [`compiler-safety` rule](../../.claude/rules/compiler-safety.md)); paths that resolve outside the workspace root are refused.
+**Design rule:** every tool is a *pure passthrough* to one `sailfin` subcommand — no build/test orchestration lives in the server. In particular, `sailfin_build` does **not** self-host the compiler: that build needs seed resolution and extern pre-staging (`make rebuild`), and the tool deliberately does not replicate it. Use `make compile` for the self-host build until that orchestration folds into the driver.
+
+`sailfin_test` requires a `path` on purpose — agents target one file or one suite (e.g. `compiler/tests/unit`) rather than the full serial suite, which can take ~45 min and is intentionally not exposed as a single call. The broad `compiler/tests/integration` and `compiler/tests/e2e` directories can still take several minutes.
+
+Timeouts: `sailfin_build` and `sailfin_test` run under a 10-minute budget, `sailfin_fmt_write` under 2 minutes, and the analysis/emit tools under 60 seconds. The compiler self-applies its 8 GiB memory budget on Linux (see the [`compiler-safety` rule](../../.claude/rules/compiler-safety.md)); paths that resolve outside the workspace root are refused.
 
 ## Build
 
@@ -52,7 +60,8 @@ npx @modelcontextprotocol/inspector node tools/mcp-server/dist/index.js
 
 Future tools to consider as the compiler grows:
 
-- `sailfin_diagnostics` — once the compiler emits `--json` diagnostics, expose a structured form that agents can parse and act on without text scraping.
 - `sailfin_effect_trace` — return the transitive effect set for a function, so agents can auto-complete `![...]` annotations.
-- `sailfin_test` — invoke focused tests. Currently deferred to the `test-runner` subagent for safety.
-- `sailfin_run` — capability-gated program execution. Requires the capability-manifest plumbing to ship first.
+- `sailfin_run` — capability-gated program execution. Requires the capability-manifest plumbing to ship first; executing a `.sfn` must honor its declared effect manifest, so this is a security surface, not a convenience wrapper.
+- A native `sfn mcp` subcommand — bundle this server into the compiler binary so `sfn mcp` Just Works after install, replacing the standalone Node wrapper.
+
+Shipped since the first cut: `sailfin_diagnostics` (`--json` envelope), `sailfin_fmt_write`, `sailfin_build`, and `sailfin_test` (targeted suites + `-k` single-test filter).

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -9,9 +9,17 @@
 //   - sailfin_emit_native     — emit .sfn-asm IR
 //   - sailfin_emit_llvm       — emit LLVM IR
 //   - sailfin_fmt_check       — formatting diagnostics (no rewrite)
+//   - sailfin_fmt_write       — reformat in place (canonical)
+//   - sailfin_build           — build a .sfn file / capsule to a binary
+//   - sailfin_test            — run a targeted suite or single test
 //
 // Every tool goes through runSailfin(), which enforces the timeout
 // and keeps invocations inside the workspace.
+//
+// Design rule: every tool is a *pure passthrough* to a single `sailfin`
+// subcommand. No build/test orchestration lives here — e.g. compiler
+// self-host (seed resolution + extern pre-staging) stays in `make
+// compile`, and sailfin_build deliberately does not replicate it.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -97,6 +105,67 @@ const pathSchema = z
   .string()
   .min(1)
   .describe("Path to a .sfn file, relative to the Sailfin workspace root.");
+
+const buildFileSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Path to a single .sfn file to build, relative to the workspace root. Mutually exclusive with `project`.",
+  );
+
+const projectSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Path to a Sailfin capsule directory (containing capsule.toml), relative to the workspace root. Built via `-p`. Mutually exclusive with `path`.",
+  );
+
+const testPathSchema = z
+  .string()
+  .min(1)
+  .describe(
+    "Path to a test suite directory (e.g. compiler/tests/unit) or a single _test.sfn file, relative to the workspace root. Required — target one file or one suite, not the whole tree.",
+  );
+
+const nameFilterSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Only run tests whose name contains this substring (maps to `-k`). Use to run a single named test.",
+  );
+
+const jobsSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(256)
+  .optional()
+  .describe(
+    "Max concurrent per-file test children (maps to `--jobs`). Each child is a full compiler invocation under its own 8 GiB cap, so size to available RAM. Defaults to serial (1).",
+  );
+
+const jsonSchema = z
+  .boolean()
+  .optional()
+  .describe("Emit machine-readable output instead of human text (--json).");
+
+const fmtWritePathSchema = z
+  .string()
+  .min(1)
+  .describe(
+    "Path to a .sfn file or directory to reformat in place, relative to the workspace root.",
+  );
+
+// Cold builds (especially macOS) and broad test suites take minutes, not
+// seconds — give them headroom over runSailfin's 60s default. Both block
+// the MCP channel for their duration, which is why sailfin_test requires a
+// path (no accidental whole-tree run) and sailfin_build is per-target.
+const BUILD_TIMEOUT_MS = 600_000; // 10 min
+const TEST_TIMEOUT_MS = 600_000; // 10 min
+const FMT_WRITE_TIMEOUT_MS = 120_000; // 2 min — dir-wide fmt touches many files
 
 server.registerTool(
   "sailfin_version",
@@ -243,6 +312,86 @@ server.registerTool(
     const out = await withResolvedPath(userPath, async (abs) => {
       const result = await runSailfin(["fmt", "--check", abs]);
       return formatResult("sailfin fmt --check", result);
+    });
+    return out as ToolResult;
+  },
+);
+
+server.registerTool(
+  "sailfin_fmt_write",
+  {
+    title: "Format-write a .sfn file or directory",
+    description:
+      "Run `sailfin fmt --write` against a .sfn file or directory, reformatting in place. Formatting is canonical and zero-config. Pair with sailfin_fmt_check: run this to fix the drift the check reports before committing (CI runs `fmt --check` and fails on unformatted files).",
+    inputSchema: { path: fmtWritePathSchema },
+  },
+  async ({ path: userPath }) => {
+    const out = await withResolvedPath(userPath, async (abs) => {
+      const result = await runSailfin(["fmt", "--write", abs], {
+        timeoutMs: FMT_WRITE_TIMEOUT_MS,
+      });
+      return formatResult("sailfin fmt --write", result);
+    });
+    return out as ToolResult;
+  },
+);
+
+server.registerTool(
+  "sailfin_build",
+  {
+    title: "Build a Sailfin file or capsule to a binary",
+    description:
+      "Compile a Sailfin source file or capsule to a native binary via `sailfin build`. Provide exactly one of `path` (a single .sfn file) or `project` (a capsule directory, built via -p). Optionally `json` for machine-readable output. Pure passthrough — this does NOT self-host the compiler itself: the self-host build needs seed resolution + extern pre-staging that lives in `make compile`, and this tool deliberately does not replicate it. Runs under a 10-minute timeout (cold builds take minutes).",
+    inputSchema: { path: buildFileSchema, project: projectSchema, json: jsonSchema },
+  },
+  async ({ path: userPath, project, json }) => {
+    const hasPath = typeof userPath === "string" && userPath.length > 0;
+    const hasProject = typeof project === "string" && project.length > 0;
+    if (hasPath === hasProject) {
+      return errorResult(
+        "sailfin_build: provide exactly one of `path` (a .sfn file) or `project` (a capsule directory).",
+      );
+    }
+    const target = (hasPath ? userPath : project) as string;
+    const out = await withResolvedPath(target, async (abs) => {
+      const args = hasProject ? ["build", "-p", abs] : ["build", abs];
+      if (json) {
+        args.push("--json");
+      }
+      const result = await runSailfin(args, { timeoutMs: BUILD_TIMEOUT_MS });
+      return formatResult("sailfin build", result);
+    });
+    return out as ToolResult;
+  },
+);
+
+server.registerTool(
+  "sailfin_test",
+  {
+    title: "Run a targeted Sailfin test suite or single test",
+    description:
+      "Run a Sailfin test suite directory (e.g. compiler/tests/unit) or a single _test.sfn file via `sailfin test <path>`. Optionally pass `name` to run only tests whose name contains it (-k), `jobs` for parallelism (--jobs), and `json` for the jsonl event stream (--json). `path` is required so an agent targets one file or one suite — the broad suites (compiler/tests/integration, compiler/tests/e2e) can take many minutes, and the full serial suite is intentionally not exposed as one call. Runs under a 10-minute timeout.",
+    inputSchema: {
+      path: testPathSchema,
+      name: nameFilterSchema,
+      jobs: jobsSchema,
+      json: jsonSchema,
+    },
+  },
+  async ({ path: userPath, name, jobs, json }) => {
+    const out = await withResolvedPath(userPath, async (abs) => {
+      const args = ["test", abs];
+      if (typeof name === "string" && name.length > 0) {
+        args.push("-k", name);
+      }
+      if (typeof jobs === "number") {
+        args.push("--jobs", String(jobs));
+      }
+      if (json) {
+        args.push("--json");
+      }
+      const result = await runSailfin(args, { timeoutMs: TEST_TIMEOUT_MS });
+      return formatResult("sailfin test", result);
     });
     return out as ToolResult;
   },

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -111,10 +111,10 @@ const buildFileSchema = z
   .min(1)
   .optional()
   .describe(
-    "Path to a single .sfn file to build, relative to the workspace root. Mutually exclusive with `project`.",
+    "Path to a single .sfn file to build, relative to the workspace root. Mutually exclusive with `capsule`.",
   );
 
-const projectSchema = z
+const capsuleSchema = z
   .string()
   .min(1)
   .optional()
@@ -341,20 +341,20 @@ server.registerTool(
   {
     title: "Build a Sailfin file or capsule to a binary",
     description:
-      "Compile a Sailfin source file or capsule to a native binary via `sailfin build`. Provide exactly one of `path` (a single .sfn file) or `project` (a capsule directory, built via -p). Optionally `json` for machine-readable output. Pure passthrough — this does NOT self-host the compiler itself: the self-host build needs seed resolution + extern pre-staging that lives in `make compile`, and this tool deliberately does not replicate it. Runs under a 10-minute timeout (cold builds take minutes).",
-    inputSchema: { path: buildFileSchema, project: projectSchema, json: jsonSchema },
+      "Compile a Sailfin source file or capsule to a native binary via `sailfin build`. Provide exactly one of `path` (a single .sfn file) or `capsule` (a capsule directory, built via -p). Optionally `json` for machine-readable output. Pure passthrough — this does NOT self-host the compiler itself: the self-host build needs seed resolution + extern pre-staging that lives in `make compile`, and this tool deliberately does not replicate it. Runs under a 10-minute timeout (cold builds take minutes).",
+    inputSchema: { path: buildFileSchema, capsule: capsuleSchema, json: jsonSchema },
   },
-  async ({ path: userPath, project, json }) => {
+  async ({ path: userPath, capsule, json }) => {
     const hasPath = typeof userPath === "string" && userPath.length > 0;
-    const hasProject = typeof project === "string" && project.length > 0;
-    if (hasPath === hasProject) {
+    const hasCapsule = typeof capsule === "string" && capsule.length > 0;
+    if (hasPath === hasCapsule) {
       return errorResult(
-        "sailfin_build: provide exactly one of `path` (a .sfn file) or `project` (a capsule directory).",
+        "sailfin_build: provide exactly one of `path` (a .sfn file) or `capsule` (a capsule directory).",
       );
     }
-    const target = (hasPath ? userPath : project) as string;
+    const target = (hasPath ? userPath : capsule) as string;
     const out = await withResolvedPath(target, async (abs) => {
-      const args = hasProject ? ["build", "-p", abs] : ["build", abs];
+      const args = hasCapsule ? ["build", "-p", abs] : ["build", abs];
       if (json) {
         args.push("--json");
       }

--- a/tools/mcp-server/test/smoke.test.ts
+++ b/tools/mcp-server/test/smoke.test.ts
@@ -136,18 +136,21 @@ async function withServer<T>(
   }
 }
 
-test("tools/list exposes all six tools with correct names", async () => {
+test("tools/list exposes all nine tools with correct names", async () => {
   const workspace = makeStubWorkspace();
   await withServer(workspace, async (client) => {
     const resp = await client.request("tools/list");
     const result = resp.result as { tools: Array<{ name: string }> };
     const names = result.tools.map((t) => t.name).sort();
     assert.deepEqual(names, [
+      "sailfin_build",
       "sailfin_check",
       "sailfin_diagnostics",
       "sailfin_emit_llvm",
       "sailfin_emit_native",
       "sailfin_fmt_check",
+      "sailfin_fmt_write",
+      "sailfin_test",
       "sailfin_version",
     ]);
   });
@@ -386,6 +389,121 @@ test("sailfin_diagnostics flags isError when envelope does not parse", async () 
     assert.equal(
       result.structuredContent!.raw_stdout,
       "this is not JSON at all",
+    );
+  });
+});
+
+test("sailfin_fmt_write passes through to the compiler and reports ok", async () => {
+  const workspace = makeStubWorkspace({ stdoutBody: "formatted foo.sfn" });
+  await writeStubSfn(workspace, "foo.sfn");
+  await withServer(workspace, async (client) => {
+    const resp = await client.request("tools/call", {
+      name: "sailfin_fmt_write",
+      arguments: { path: "foo.sfn" },
+    });
+    const result = resp.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent?: { exit: number };
+    };
+    assert.notEqual(result.isError, true);
+    assert.ok(result.content[0].text.includes("formatted foo.sfn"));
+    assert.equal(result.structuredContent!.exit, 0);
+  });
+});
+
+test("sailfin_build requires exactly one of path or project", async () => {
+  const workspace = makeStubWorkspace();
+  await withServer(workspace, async (client) => {
+    // Neither provided.
+    const neither = await client.request("tools/call", {
+      name: "sailfin_build",
+      arguments: {},
+    });
+    const neitherResult = neither.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+    assert.equal(neitherResult.isError, true);
+    assert.ok(
+      neitherResult.content[0].text.includes("exactly one of"),
+      `expected mutual-exclusion error, got: ${neitherResult.content[0].text}`,
+    );
+
+    // Both provided.
+    const both = await client.request("tools/call", {
+      name: "sailfin_build",
+      arguments: { path: "foo.sfn", project: "compiler" },
+    });
+    const bothResult = both.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+    assert.equal(bothResult.isError, true);
+    assert.ok(bothResult.content[0].text.includes("exactly one of"));
+  });
+});
+
+test("sailfin_build with a single file passes through to the compiler", async () => {
+  const workspace = makeStubWorkspace({ stdoutBody: "built foo" });
+  await writeStubSfn(workspace, "foo.sfn");
+  await withServer(workspace, async (client) => {
+    const resp = await client.request("tools/call", {
+      name: "sailfin_build",
+      arguments: { path: "foo.sfn" },
+    });
+    const result = resp.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent?: { exit: number };
+    };
+    assert.notEqual(result.isError, true);
+    assert.ok(result.content[0].text.includes("built foo"));
+    assert.equal(result.structuredContent!.exit, 0);
+  });
+});
+
+test("sailfin_test passes a suite path through and surfaces failures", async () => {
+  const workspace = makeStubWorkspace({
+    exitCode: 1,
+    stdoutBody: "",
+    stderrBody: "1 test failed in unit",
+  });
+  // The stub ignores argv; a directory path still resolves inside the
+  // workspace, which is all the wrapper guards on.
+  mkdirSync(path.join(workspace, "compiler", "tests", "unit"), {
+    recursive: true,
+  });
+  await withServer(workspace, async (client) => {
+    const resp = await client.request("tools/call", {
+      name: "sailfin_test",
+      arguments: { path: "compiler/tests/unit", name: "parses", jobs: 2 },
+    });
+    const result = resp.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent?: { exit: number; stderr: string };
+    };
+    assert.equal(result.isError, true, "non-zero test exit surfaces as isError");
+    assert.ok(result.content[0].text.includes("1 test failed in unit"));
+    assert.equal(result.structuredContent!.exit, 1);
+  });
+});
+
+test("sailfin_test rejects a path outside the workspace", async () => {
+  const workspace = makeStubWorkspace();
+  await withServer(workspace, async (client) => {
+    const resp = await client.request("tools/call", {
+      name: "sailfin_test",
+      arguments: { path: "../../etc" },
+    });
+    const result = resp.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+    assert.equal(result.isError, true);
+    assert.ok(
+      result.content[0].text.includes("Refusing path outside workspace"),
     );
   });
 });

--- a/tools/mcp-server/test/smoke.test.ts
+++ b/tools/mcp-server/test/smoke.test.ts
@@ -433,7 +433,7 @@ test("sailfin_build requires exactly one of path or project", async () => {
     // Both provided.
     const both = await client.request("tools/call", {
       name: "sailfin_build",
-      arguments: { path: "foo.sfn", project: "compiler" },
+      arguments: { path: "foo.sfn", capsule: "compiler" },
     });
     const bothResult = both.result as {
       content: Array<{ type: string; text: string }>;


### PR DESCRIPTION
## Why

The Sailfin MCP server exposed six **file-scoped analysis** tools (`version`, `check`, `diagnostics`, `emit_native`, `emit_llvm`, `fmt_check`) but none of the verbs an agent actually reaches for — build, test, format-write. So agentic clients fell back to `make`/`sfn` and never used MCP. This is the "AI agents are users" gap: the tools were a strict subset of the inner loop, framed for the rare single-module debugging case.

## What

Three new tools, each a **pure passthrough to one `sailfin` subcommand** (no orchestration baked into the server):

| Tool | Invocation |
|---|---|
| `sailfin_build` | `sailfin build <file>` or `-p <capsule>` (exactly one of `path`/`project`) |
| `sailfin_test` | `sailfin test <path> [-k <name>] [--jobs N] [--json]` |
| `sailfin_fmt_write` | `sailfin fmt --write <path>` |

### Design constraints honored
- **No build/test logic in the tool.** `sailfin_build` deliberately does **not** self-host the compiler — that build needs seed resolution + `runtime/sfn/platform/*` extern pre-staging that lives in `make rebuild` (`Makefile:787-839`), and the tool does not replicate it. `make compile` stays the self-host path until that orchestration folds into the driver.
- **No accidental 45-min run.** `sailfin_test` requires a `path` so an agent targets one `_test.sfn` file or one suite dir (e.g. `compiler/tests/unit`); `-k` runs a single named test. The full serial suite is intentionally not a single call.
- **Timeouts:** build/test 10 min (cold builds take minutes), fmt-write 2 min, analysis/emit unchanged at 60s. Workspace path-jail and the 8 GiB self-cap still apply.

### Docs / discoverability
The real reason agents ignored MCP was that nothing pointed at it. Added a `CLAUDE.md` note steering MCP clients to the `sailfin_*` inner loop (while keeping `make compile`/`make check` as the self-host + full-gate authorities), and refreshed `tools/mcp-server/README.md` (tool table, design rule, roadmap — `sailfin_run` and a native `sfn mcp` subcommand remain the open items).

## Testing
- `npm run build` + `npm test` in `tools/mcp-server/` — **13/13 smoke tests pass**, covering the three new tools, the `sailfin_build` path/project mutual-exclusion guard, and the `sailfin_test` workspace-boundary guard.
- No `.sfn` files touched — TypeScript + Markdown only, so the self-host invariant and `sfn fmt` gate are unaffected.

https://claude.ai/code/session_018HU8u1N8P8x2KFHsPrgJrF

---
_Generated by [Claude Code](https://claude.ai/code/session_018HU8u1N8P8x2KFHsPrgJrF)_