### PR TITLE
docs: ownership E09xx fix-its + stance-reversal doc edits (E10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,8 +204,11 @@ When adding features or making design choices:
   is a library concern or post-1.0. Don't dilute the core with half-finished
   ownership, AI syntax, or GPU features.
 - **Don't ship unfinished safety claims.** "Parsed but not enforced" is worse than
-  absent — it teaches users to ignore the feature. Ownership, taint, and AI
-  constructs stay out of marketing until enforced end-to-end.
+  absent — it teaches users to ignore the feature. Taint and AI constructs stay
+  out of marketing until enforced end-to-end. **Exception:** runtime
+  ownership/aliasing enforcement *is* shipped end-to-end for the native runtime
+  (Phase R1, epic #1209), so it may be documented as enforced for that surface;
+  user-facing ownership stays previewed until Phase U.
 - **Libraries over keywords.** A keyword can never become a variable name. Only
   add keywords for constructs that can't be library functions. AI constructs
   (`model`, `prompt`, `tool`, `pipeline`) are migrating to the `sfn/ai` capsule;
@@ -235,9 +238,17 @@ Prefer the new forms where the parser already accepts them. Full plan:
 
 - No pipeline operator (`|>`) — use function calls
 - No currency literals — use numeric literals with comments (`0.05 // USD`)
-- `Affine<T>` / `Linear<T>` parsed but **not enforced** (post-1.0). The native
-  backend tracks some ownership metadata internally; no user-facing guarantees.
-  Sailfin's safety story is effects and capabilities, **not** borrow checking.
+- **Ownership/aliasing analysis** — a bounded unique-ownership / no-aliased-mutation
+  / no-use-after-free analysis is **enforced on the native runtime** for 1.0 as a
+  memory-safety floor (`ownership_checker.sfn`, epic #1209; closes the #1205
+  aliasing-corruption hazard structurally). It is **not a fourth pillar** — it is a
+  soundness requirement in the same category as type checking, not a marketed
+  differentiator; the three pillars stay effects, capabilities, concurrency.
+  `Affine<T>` / `Linear<T>` are enforced single-use where used (`E0901`/`E0907`);
+  `OwnedBuf` / `Slice` carry the runtime's owned-buffer surface. **User-facing
+  ownership and full borrow checking remain post-1.0** (Phase U). The model is a
+  deliberately **extensible floor** built upward from (D1 expansion mandate),
+  **not** a Rust-style borrow checker. See `reference/preview/ownership.md`.
 - `PII<T>` / `Secret<T>` parsed, no runtime enforcement (post-1.0)
 - `model` / `prompt` / `tool` / `pipeline` blocks emit metadata only (migrating
   to the `sfn/ai` capsule)

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -554,11 +554,21 @@ Implications for this audit:
    it once in C — as a temporary unblocker — or doing it once in Sailfin — as
    the real runtime primitive — should be a single decision, not two.
 2. **The compiler must gain real drop signals before a safe runtime is
-   possible.** Per `CLAUDE.md`, ownership types are deferred post-1.0; the
-   runtime instead relies on conservative drop emission keyed off
+   possible.** The runtime relies on conservative drop emission keyed off
    compiler-known allocation kinds (M1.5, epic #322). Until M1.5 ships,
    the runtime can't trust any drop the compiler claims to emit. This is
    the reason `SAILFIN_ENABLE_STRING_FREE` is off by default today.
+   **Stance update (epic #1209, D1/D9):** the broader "ownership types are
+   deferred post-1.0" framing no longer holds for the runtime surface. A
+   bounded unique-ownership / no-aliased-mutation / no-use-after-free
+   analysis is now **enforced on the native runtime** for 1.0
+   (`ownership_checker.sfn`) as the *structural* fix for the in-place
+   grow-at-tip aliasing corruption (#1205) — proving a buffer is uniquely
+   owned makes the in-place mutation sound rather than trusting a
+   compiler-emitted drop after the fact. Drop emission (M1.5) and ownership
+   enforcement are complementary: drops reclaim memory, ownership proves no
+   live alias is stomped. User-facing ownership and full borrow checking
+   remain post-1.0 (Phase U).
 3. **Files-as-GC is cheap to delete but expensive to replace.** ~336 dotfile
    references to `build/sailfin/.xxx` IPC temp paths remain. Every one of those
    is a latent allocation that needs a real drop when IPC goes away.
@@ -612,11 +622,18 @@ compiler features that do not exist in the current toolchain.
    (function return in v0; closure capture and channel send once those land).
    This supersedes the previous prereq pair (drop emission as a separate
    bullet, plus a "move/consume enforcement (or explicit removal)" bullet
-   for ownership types). Per `CLAUDE.md`, ownership types
-   (`Affine<T>` / `Linear<T>`) are **deferred post-1.0** — the runtime trusts
-   compiler-emitted drops keyed off allocation kind, not move-semantics
-   enforcement. See `docs/runtime_architecture.md` §3.1 for the seam
-   (`LocalBinding.allocation_kind` + `emit_scope_drops`) and #322 for the
+   for ownership types). **Stance update (epic #1209, D1):** for the runtime
+   surface specifically, ownership enforcement is **no longer deferred** — a
+   bounded unique-ownership / no-aliased-mutation / no-use-after-free analysis
+   (`ownership_checker.sfn`, the `E09xx` diagnostic family) is enforced on the
+   native runtime for 1.0 as the structural fix for #1205, and `Affine<T>` /
+   `Linear<T>` are enforced single-use where used (`E0901`/`E0907`). The
+   runtime now both trusts compiler-emitted drops keyed off allocation kind
+   **and** has its in-place mutation proven sound by unique ownership; the two
+   are complementary, not alternatives. User-facing ownership / full borrow
+   checking stay post-1.0 (Phase U). See `docs/runtime_architecture.md` §3.1
+   for the drop seam (`LocalBinding.allocation_kind` + `emit_scope_drops`),
+   `reference/preview/ownership.md` for the ownership model, and #322 for the
    sub-issue split.
 6. **`extern fn` with typed linker-resolved symbols.** ✅ **Shipped 2026-05-01.**
    The Sailfin runtime must reach platform syscalls (`pthread_create`,
@@ -751,11 +768,13 @@ Entrypoints that are C-based today and must be gone by 1.0:
 Reordered from the previous audit to reflect the April 2026 reality.
 
 - **M0 — Compiler prerequisites** (roadmap §0). Integer types, `Result<T, E>`,
-  closures-with-capture. Per `CLAUDE.md`, ownership enforcement
-  (`Affine<T>` / `Linear<T>`) is **deferred post-1.0**; the runtime instead
-  relies on conservative drop emission keyed off compiler-known allocation
-  kinds (M1.5). The runtime rewrite cannot produce a better runtime than
-  the compiler can describe.
+  closures-with-capture. The runtime relies on conservative drop emission keyed
+  off compiler-known allocation kinds (M1.5). **Stance update (epic #1209):**
+  bounded ownership/aliasing enforcement on the native runtime is **no longer
+  deferred** — it ships at 1.0 as the structural fix for #1205 (the
+  `E09xx` family in `ownership_checker.sfn`); only *user-facing* ownership and
+  full borrow checking remain post-1.0 (Phase U). The runtime rewrite cannot
+  produce a better runtime than the compiler can describe.
 - **M0.5 — Arena allocator in C** *(optional unblocker)*. If the compiler
   perf work needs a temporary memory-reclamation primitive before M1, it lives
   in the C runtime and is deleted at M3. Scope: bump allocator, reset per

--- a/site/src/content/docs/docs/reference/preview/ownership.md
+++ b/site/src/content/docs/docs/reference/preview/ownership.md
@@ -1,0 +1,173 @@
+---
+title: "Ownership & Aliasing"
+description: "Design preview — Sailfin's bounded ownership model: a runtime-enforced memory-safety floor for 1.0, and the deliberately extensible path beyond it."
+sidebar:
+  order: 3.5
+---
+
+Sailfin enforces a **bounded ownership / aliasing analysis** that proves the
+native runtime cannot corrupt memory through aliased in-place mutation or
+use-after-free. This page describes the *model* and its **intended expansion
+path**; for the precise per-phase enforcement status and worked diagnostic
+examples, see [Ownership Enforcement](/docs/reference/preview/ownership-enforcement/).
+
+## What it is — and what it is not
+
+Ownership checking is a **soundness floor on the implementation**, in the same
+category as type checking: the compiler rejects a use-after-move for the same
+reason it rejects passing a `string` where an `int` is expected. It is **not a
+fourth pillar.** Sailfin's three differentiators are unchanged:
+
+1. **Effect types** — compile-time capability enforcement.
+2. **Capability-based security** — capsule manifests + dependency auditing.
+3. **Structured concurrency** — planned (M4).
+
+We never describe Sailfin as "a borrow-checked language like Rust." We describe
+it as "a language whose runtime is memory-safe by construction." The analysis is
+enforced on the native runtime today; **user-facing ownership and full borrow
+checking are post-1.0** (Phase U, below).
+
+> **Why it exists.** A recurring, nondeterministic IR-corruption class
+> (issue #1205) traces to a single structural cause: an in-place buffer
+> mutation — the `grow-if-at-tip` `string_append` optimization — that assumes
+> a buffer is uniquely owned when a live alias may still exist. Patching each
+> aliasing call-site failed three times. Proving uniqueness fixes it
+> structurally: grow-at-tip stays, but only on values the compiler has proven
+> unique, so the corruption becomes *unrepresentable* rather than *patched*.
+
+## The 1.0 enforced subset (Option C)
+
+For values of a designated **uniquely-owned buffer type** and for affine values,
+the compiler proves there is **no live alias** at the point of in-place mutation
+or disposal. Concretely, a standalone `ownership_checker.sfn` pass — after
+effect-check, mirroring the effect checker's scope walk — tracks an **ownership
+state** per binding through the control-flow graph:
+
+- `Owned` — the binding uniquely owns its value; in-place mutation and drop are
+  legal here.
+- `Moved` — ownership transferred out (by rebinding, by passing to a call, by
+  `return`); any subsequent use is an error.
+- `Borrowed(shared)` — **reserved extension point** (not 1.0 surface; see
+  *Expansion path*).
+
+A value of an owned type (`OwnedBuf`, `Affine<T>`, `Linear<T>`) is *moved* when
+it is rebound (`let y = x;`), passed to a call (`f(x)`), or returned. The pass
+establishes three theorems: **unique ownership at mutation**, **no
+use-after-move**, and **no use-after-free**.
+
+### `OwnedBuf` / `Slice`
+
+The owned-buffer type family lives in `runtime/sfn/memory/ownedbuf.sfn`:
+
+- **`OwnedBuf`** — a unique, growable byte buffer. Assigning it moves it; taking
+  a second live reference is an error. In-place mutators (`append`, `grow`,
+  `set`) consume `self` and return the (possibly relocated) buffer, so
+  grow-at-tip is *sound by construction* — there is no other live binding to
+  stomp. Raw-pointer interior stays behind `unsafe { }`.
+- **`Slice`** — a non-owning, read-only byte view over an `OwnedBuf`. Views
+  cannot mutate or free; in the 1.0 subset their lifetimes are kept trivial
+  (function-local, no escape).
+
+```sfn
+fn consume(b: OwnedBuf) -> int { return 1; }
+
+fn ok(buf: OwnedBuf) -> int {
+    let inner = buf;        // moves buf into inner
+    return consume(inner);  // consumes inner; neither is used again
+}
+
+fn bad(buf: OwnedBuf) -> int {
+    let n = consume(buf);   // moves buf
+    return buf.length;      // E0901: use of moved value `buf`
+}
+```
+
+### `Affine<T>` / `Linear<T>`
+
+The existing `Affine<T>` / `Linear<T>` parse surface is now **load-bearing**
+where used:
+
+- `Affine<T>` is **at-most-once**: using it zero times is fine; a second use
+  after the move is `E0901`.
+- `Linear<T>` is **exactly-once**: in addition to the at-most-once rule, a
+  linear value **must be consumed** (moved, returned, passed to a call, or
+  freed) before it leaves scope. A linear value never consumed raises `E0907`.
+
+```sfn
+fn drop_it(v: Linear<int>) -> int { return 0; }          // E0907: linear `v` never consumed
+fn keep_it(v: Linear<int>) -> int { return drop_it(v); } // ok: `v` consumed by the call
+```
+
+Ordinary copyable values are unaffected, and **user code is unaffected at 1.0** —
+enforcement is runtime-scoped. Code that never names `OwnedBuf` / `unsafe` /
+enforced `Affine` compiles exactly as before.
+
+## The `unsafe` boundary
+
+Runtime code needs raw pointers and FFI (`malloc`/`free`/`memcpy`,
+`memcmp`/`strtod`, the libc/pthread surface). Constructing, dereferencing, doing
+pointer arithmetic on, or freeing a raw pointer is permitted **only** inside an
+`extern fn` body, an explicit `unsafe { … }` block, or an `unsafe fn`. The
+ownership checker does **not** analyze the interior of an `unsafe` region — that
+is the author's asserted responsibility. What it *does* enforce is the
+**boundary**: a raw pointer may not silently escape into safe code as an
+aliasable mutable handle (`E0906`). The unsound assumptions live in named,
+auditable `unsafe` regions, not diffused across every raw pointer.
+
+## Diagnostics — the `E09xx` family
+
+Each diagnostic carries the span of the offending use **plus** the span of the
+move/free that invalidated it (the two-span shape that makes use-after-move
+diagnostics actionable).
+
+| Code | Condition | Fix-it hint |
+|---|---|---|
+| `E0901` | Use of a moved value | *value moved here at `<span>`; clone it before the move, or restructure so the second use precedes the move* |
+| `E0902` | In-place mutation of a possibly-aliased buffer | *`<name>` may be aliased by `<other>` (created at `<span>`); take a unique `OwnedBuf`, or use the copying concat path* |
+| `E0903` | Use after free / after drop | *`<name>` was freed at `<span>`; do not use it after disposal* |
+| `E0904` | Second live reference to a unique value | *`<name>` is uniquely owned; this creates a second live binding — move it or take an explicit copy* |
+| `E0905` | Returning a reference that does not outlive the caller | *`<name>` is local to this function; return an owned value or copy into the caller's buffer* (Phase U) |
+| `E0906` | Raw-pointer escape into safe code outside an `unsafe` region | *raw-pointer escape requires the call site to be inside an `unsafe` block / the buffer to be released to FFI* |
+| `E0907` | Linear value never consumed | *`<name>` is `Linear<T>`; a linear value must be used exactly once — move it, return it, pass it to a call, or free it before it goes out of scope* |
+
+`E0901`–`E0904`, `E0906`, and `E0907` are enforced today on the runtime surface;
+`E0905` (return-of-local-reference) lands with borrowed-view lifetimes in
+Phase U. See [Ownership Enforcement](/docs/reference/preview/ownership-enforcement/)
+for the current per-phase status.
+
+## Expansion path (the model is a floor, not a ceiling)
+
+The 1.0 subset is the **first rung of a deliberately extensible model** — Sailfin
+will grow its ownership/borrowing story over time as a modern,
+agentic-development-era exploration of memory safety. **Sailfin does not have to
+be Rust.** The following are not "post-1.0 maybe"; they are the **named forward
+path**, and the type family and diagnostic surface are designed to widen
+*without a rewrite*:
+
+- **The `Borrowed` lattice state** and shared-borrow semantics are the planned
+  next widening — read-only sharing of an owned buffer without copying.
+- **`Slice` / view lifetimes** deepen toward borrowed-view lifetimes, at which
+  point `E0905` (return-of-local-reference) becomes enforceable for user code.
+- **Phase U — user-facing ownership.** `Affine<T>` / `Linear<T>` become enforced
+  for user code on opt-in; ordinary code stays unaffected unless it opts in.
+  Whole-language enforcement, shared `&T` / unique `&mut T` borrows, and any
+  lifetime syntax are all Phase U. When Phase U enforcement ships, this preview
+  is promoted to a numbered chapter in the
+  [Language Specification](/docs/reference/spec/).
+
+What the 1.0 subset deliberately does **not** do: no lifetime variables (`'a`),
+no lifetime elision, no shared `&` / unique `&mut` borrow syntax for arbitrary
+user types, no whole-program alias analysis, and no enforcement on raw pointers
+themselves (those stay in the `unsafe` / `extern` escape hatch). The
+unique-ownership guarantee comes from the *type*, not from inferring aliasing on
+raw pointers.
+
+## Relationship to the effect system
+
+The ownership checker and the effect checker are **orthogonal and
+complementary**, running back-to-back over the same scope structure. The effect
+checker answers *"is this code allowed to perform this capability?"*; the
+ownership checker answers *"is this memory access sound?"* Ownership introduces
+**no new effect atom** — the taxonomy stays locked at the canonical six
+(`clock`, `gpu`, `io`, `model`, `net`, `rand`). Ownership is a separate axis, not
+a seventh effect and not a fourth pillar.

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -153,7 +153,7 @@ const postV1Ai: RoadmapCategory = {
     { label: "Secret<T> / PII<T> taint tracking integrated with the effect system", status: "planned" },
     { label: "sfn lsp — language server for IDE integration", status: "planned" },
     { label: "sfn audit enhancements — transitive capability analysis, SBOM generation", status: "planned" },
-    { label: "User-facing ownership & full borrow checking (&T, &mut T, shared borrows, lifetimes — Phase U). The 1.0 runtime memory-safety floor (bounded unique-ownership/no-aliased-mutation analysis enforced on the native runtime, epic #1209, sequenced before the C-runtime deletion #822 and feeding M4 safe-sharing #965; closes #1205) already ships; this widens it to user code.", status: "planned" },
+    { label: "User-facing ownership & full borrow checking (&T, &mut T, shared borrows, lifetimes) — Phase U, widening the 1.0 runtime memory-safety floor (epic #1209) to user code.", status: "planned" },
   ],
 };
 

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -153,7 +153,7 @@ const postV1Ai: RoadmapCategory = {
     { label: "Secret<T> / PII<T> taint tracking integrated with the effect system", status: "planned" },
     { label: "sfn lsp — language server for IDE integration", status: "planned" },
     { label: "sfn audit enhancements — transitive capability analysis, SBOM generation", status: "planned" },
-    { label: "Ownership and borrowing enforcement (Affine<T>, Linear<T>, &T, &mut T)", status: "planned" },
+    { label: "User-facing ownership & full borrow checking (&T, &mut T, shared borrows, lifetimes — Phase U). The 1.0 runtime memory-safety floor (bounded unique-ownership/no-aliased-mutation analysis enforced on the native runtime, epic #1209, sequenced before the C-runtime deletion #822 and feeding M4 safe-sharing #965; closes #1205) already ships; this widens it to user code.", status: "planned" },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Lands the documentation half of the D1/D9 stance reversal (epic #1209, E10): runtime ownership/aliasing enforcement is a **1.0 memory-safety floor**, not a deferred post-1.0 feature and **not a fourth pillar**.
- Reframes `CLAUDE.md`, the roadmap, and `docs/runtime_audit.md` to the locked stance (enforced-on-runtime floor, extensible, user-facing borrowing still post-1.0).
- Adds the user-facing `reference/preview/ownership.md` chapter with the `E0901`–`E0907` fix-it table and the expansion path.

Closes #1219

## Context
E10 of epic #1209 (proposal `docs/proposals/borrow-checking-1.0.md` §4-bis). Both blockers are merged: **#1215** (E6 — `E0902`/`E0903` ownership rules) and **#1217** (E8 — Phase R1 arena+string migration), so the docs now describe shipped behavior. The `blocked` label on the issue was stale and has been cleared.

## Acceptance Criteria
- [x] `CLAUDE.md`, roadmap, and `runtime_audit.md` reflect the locked stance (enforced-on-runtime floor, not a pillar, extensible).
- [x] `reference/preview/ownership.md` exists and describes the model + expansion path (Borrowed state, slices/views, Phase U).
- [x] The `E09xx` family is documented with fix-its (`E0901`–`E0907` table).
- [x] No `.sfn` changes; `make compile`/`make check` unaffected.

## Verification
```bash
$ ls site/src/content/docs/docs/reference/preview/ownership.md
site/src/content/docs/docs/reference/preview/ownership.md
$ grep -n "borrow" CLAUDE.md
249:  ownership and full borrow checking remain post-1.0** (Phase U). The model is a
251:  **not** a Rust-style borrow checker. See `reference/preview/ownership.md`.
$ git status --short | grep -c '\.sfn$'
0   # no .sfn files changed
```

## Files Changed
- `CLAUDE.md` — Affine/Linear stance line + "don't ship unfinished safety claims" exception
- `site/src/pages/roadmap.astro` — ownership item reframed (1.0 floor vs post-1.0 borrowing)
- `docs/runtime_audit.md` — three stance-update notes superseding the "deferred post-1.0" framing
- `site/src/content/docs/docs/reference/preview/ownership.md` *(new)* — user-facing model + `E09xx` fix-its + expansion path

## Note for reviewers
The roadmap's 1.0 critical-path section renders dynamically from GitHub milestones (the ownership epic #1209 already surfaces under the "Memory Safety — Ownership & Aliasing Enforcement" milestone). The static edit reframes the post-1.0 borrowing item rather than blindly reordering `DISPLAY_ORDER` by milestone number; the "sequenced before #822, cross-link #1205/#965" intent is captured in that item's text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDsKSk1TAHFZFxSS8tHCwk)_