### PR TITLE
process: encode C↔Sailfin symbol-flip coexistence audit; move design agents to Fable 5

### DIFF
--- a/.claude/agents/compiler-architect.md
+++ b/.claude/agents/compiler-architect.md
@@ -2,7 +2,7 @@
 name: compiler-architect
 description: Opus-powered architect for designing compiler features, refactors, and fixes that account for self-hosting constraints, the full pipeline, and the 1.0 roadmap. Use when you need a forward-thinking plan before implementing.
 tools: Read, Grep, Glob, Bash, Write
-model: opus
+model: fable
 effort: high
 maxTurns: 30
 color: purple
@@ -85,6 +85,23 @@ and seed cuts). Apply these:
   call to a C API often needs a frontend primitive that does not exist yet
   (e.g. taking a function's address for a `pthread_create` start routine).
   Surface a missing primitive as an explicit predecessor, not a surprise.
+- **Audit C↔Sailfin symbol-flip coexistence — expressibility is not enough.**
+  "Can Sailfin express a real body?" is only half the question for any flip of
+  a `runtime/sfn/**` symbol during the C→Sailfin migration window. The other
+  half is the **link-time coexistence picture**, because the C and Sailfin
+  runtimes link into the same binary until `sailfin_runtime.c` is deleted. For
+  every flipped symbol, run the audit in `.claude/rules/c-sailfin-migration.md`:
+  who *defines* it (a bare `sfn_*` is often C-defined with only a `_sfn_`
+  infix façade on the Sailfin side), who *calls* it (C-internal callers + the
+  `static`-ify implication), whether it's prototyped in a `.h` (header-edit +
+  Files-Affected expansion), whether it shares a **mutable struct/header layout**
+  with the other runtime (the #1205-class heap-corruption hazard — arena handle
+  #1309, array header+canary #1316), and whether the **emitted ABI** matches the
+  Sailfin body's signature (an `OwnedBuf`-vs-`SfnString` mismatch is real design
+  work, not a rename). The grooming under-scope this exists to prevent: framing a
+  link-ownership flip (which touches `sailfin_runtime.c` + `.h`) as a 2-file
+  rename, and missing a divergent shared-struct layout. The readiness signal is
+  the `nm` relink gate in that rule, not the prose of a closed "ported" issue.
 
 ## Reference Documents
 

--- a/.claude/agents/compiler-architect.md
+++ b/.claude/agents/compiler-architect.md
@@ -1,6 +1,6 @@
 ---
 name: compiler-architect
-description: Opus-powered architect for designing compiler features, refactors, and fixes that account for self-hosting constraints, the full pipeline, and the 1.0 roadmap. Use when you need a forward-thinking plan before implementing.
+description: Fable 5-powered architect for designing compiler features, refactors, and fixes that account for self-hosting constraints, the full pipeline, and the 1.0 roadmap. Use when you need a forward-thinking plan before implementing.
 tools: Read, Grep, Glob, Bash, Write
 model: fable
 effort: high

--- a/.claude/agents/seed-stabilizer.md
+++ b/.claude/agents/seed-stabilizer.md
@@ -2,7 +2,7 @@
 name: seed-stabilizer
 description: Diagnoses compiler bugs affecting self-hosting correctness and build performance (miscompilation, LLVM IR errors, memory/perf regressions). Use when builds fail, produce wrong output, or regress in speed/memory. Requires deep IR analysis — use Opus.
 tools: Read, Grep, Glob, Bash
-model: opus
+model: fable
 effort: high
 maxTurns: 25
 color: red

--- a/.claude/agents/seed-stabilizer.md
+++ b/.claude/agents/seed-stabilizer.md
@@ -1,6 +1,6 @@
 ---
 name: seed-stabilizer
-description: Diagnoses compiler bugs affecting self-hosting correctness and build performance (miscompilation, LLVM IR errors, memory/perf regressions). Use when builds fail, produce wrong output, or regress in speed/memory. Requires deep IR analysis — use Opus.
+description: Diagnoses compiler bugs affecting self-hosting correctness and build performance (miscompilation, LLVM IR errors, memory/perf regressions). Use when builds fail, produce wrong output, or regress in speed/memory. Requires deep IR analysis — runs on Fable 5.
 tools: Read, Grep, Glob, Bash
 model: fable
 effort: high

--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -66,6 +66,30 @@ instead of as a planned predecessor). If the probe fails, the prerequisite
 is a **frontend issue that must be groomed first** — make it an explicit
 `Blocked by` / `Required in pinned seed` predecessor, not a surprise.
 
+### C↔Sailfin symbol-flip coexistence (gate)
+
+Expressibility (the probe above) is only half the question for any issue
+that **flips a `runtime/sfn/**` symbol from its C body to Sailfin** during
+the migration window (epic #1308). The C and Sailfin runtimes link into the
+same binary until `sailfin_runtime.c` is deleted, so a flip is a *link-time
+symbol-ownership change*, not a rename — and the trap is framing it as a
+2-file edit when it touches `sailfin_runtime.c` + a header, or missing a
+divergent shared-struct layout (the #1205-class heap-corruption hazard).
+
+Before any such issue goes `claude-ready`, run the audit in
+`.claude/rules/c-sailfin-migration.md` for each flipped symbol — who
+defines it (a bare `sfn_*` is often C-defined with only a `_sfn_` infix
+façade), who calls it (C-internal callers → `static`-ify + header edit),
+whether it shares a mutable struct/header layout with the other runtime
+(arena handle #1309, array header #1316), and whether the emitted ABI
+matches the Sailfin body (an `OwnedBuf`-vs-`SfnString` mismatch is an
+architect decision, not a rename). Expand **Files Affected** to the honest
+set (`sailfin_runtime.c` + `.h` for a link-ownership flip), add the `nm`
+relink gate to **Acceptance Criteria**, and flag any layout hazard for an
+ASAN interleave test. This is the under-scope that the compiler-architect
+must catch during Phase 2 decomposition — do not let "ported to Sailfin"
+prose stand in for the verified relink gate.
+
 ### Don't over-decompose: bundle a capability with its single consumer
 
 Splitting is not free. Prefer **one issue/PR** for a compiler capability plus

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -266,6 +266,46 @@ Read the full issue body to extract:
 
 ---
 
+## Phase 2.5: SCOPE PRE-FLIGHT (runtime symbol-flip issues)
+
+If the issue flips a `runtime/sfn/**` symbol from its C body to Sailfin —
+any `area:runtime` issue that "ports" / "de-trampolines" / "flips" an
+`sfn_*` / `sailfin_runtime_*` / `sailfin_adapter_*` symbol during the
+C→Sailfin migration (epic #1308) — **validate the issue's scope against
+reality before writing code.** This catches the Files-Affected gap and the
+shared-struct layout hazard in seconds rather than mid-implementation, and
+lets you proceed confidently when the scope *is* right. Run the audit in
+`.claude/rules/c-sailfin-migration.md` for each flipped symbol:
+
+```bash
+# Who defines it, who calls it, is it in a header? (per symbol S)
+grep -cE "\bS\s*\(" runtime/native/src/sailfin_runtime.c   # C definition + callers
+grep -nE "\bS\b" runtime/native/include/sailfin_runtime.h  # header prototype?
+grep -rnE "fn S\b" runtime/sfn                              # Sailfin definition (bare vs _sfn_ infix)
+```
+
+Then reconcile against the issue body:
+
+- **Files Affected mismatch** — if the symbol is C-defined and the registry
+  emits the bare name (a link-ownership flip), the issue MUST list
+  `runtime/native/src/sailfin_runtime.c` (and `sailfin_runtime.h` if the
+  symbol is prototyped there). If it lists only the `runtime/sfn/**` file,
+  the scope is wrong — pause via the Phase 3 scope-adjustment path below.
+- **Shared-struct layout hazard** — if the symbol reads/writes a struct or
+  header convention the *other* runtime also touches (arena handle #1309,
+  array header+canary #1316), confirm the issue carries a no-corruption /
+  ASAN-interleave acceptance criterion. If it doesn't, pause.
+- **Emitted-ABI mismatch** — if the registry row's `return_type` (in
+  `compiler/src/llvm/runtime_helpers.sfn`) differs from the Sailfin body's
+  signature (e.g. `{i8*, i64}` vs `OwnedBuf`), that's an architect decision,
+  not a pickup — pause and escalate.
+
+If the audit confirms the scope, proceed. If it surfaces a gap, use the
+Phase 3 scope-adjustment mechanism (comment, `needs-grooming`, resync) —
+do not silently expand the Files Affected set or invent a layout fix.
+
+---
+
 ## Phase 3: DISPATCH TO WORKFLOW
 
 Based on the issue's `type:*` label, follow the appropriate workflow. Use the issue body as the brief — don't redo the design work the architect already produced during grooming.

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -279,9 +279,9 @@ lets you proceed confidently when the scope *is* right. Run the audit in
 
 ```bash
 # Who defines it, who calls it, is it in a header? (per symbol S)
-grep -cE "\bS\s*\(" runtime/native/src/sailfin_runtime.c   # C definition + callers
-grep -nE "\bS\b" runtime/native/include/sailfin_runtime.h  # header prototype?
-grep -rnE "fn S\b" runtime/sfn                              # Sailfin definition (bare vs _sfn_ infix)
+grep -cE "S[[:space:]]*\(" runtime/native/src/sailfin_runtime.c   # C definition + callers
+grep -nw S runtime/native/include/sailfin_runtime.h              # header prototype?
+grep -rnE "fn S[ (]" runtime/sfn                                  # Sailfin definition (bare vs _sfn_ infix)
 ```
 
 Then reconcile against the issue body:

--- a/.claude/rules/c-sailfin-migration.md
+++ b/.claude/rules/c-sailfin-migration.md
@@ -11,16 +11,16 @@ Files Affected list or the "just rename it" framing as correct.
 
 For symbol `S` (e.g. `sfn_str_concat`, `sfn_arena_alloc`):
 
-1. **Who defines it?** `grep -nE '^\s*[A-Za-z_].*\bS\s*\(' runtime/native/src/*.c`
-   and `grep -rnE 'fn S\b' runtime/sfn`. A bare `sfn_*` that the registry
+1. **Who defines it?** `grep -nE '^[[:space:]]*[A-Za-z_].*S[[:space:]]*\(' runtime/native/src/*.c`
+   and `grep -rnE 'fn S[ (]' runtime/sfn`. A bare `sfn_*` that the registry
    emits is frequently **C-defined** with only a `sfn_<mod>_sfn_*` infix
    proof-of-life on the Sailfin side — the "port" is a façade.
-2. **Who calls it?** `grep -cE '\bS\s*\(' runtime/native/src/sailfin_runtime.c`.
+2. **Who calls it?** `grep -cE 'S[[:space:]]*\(' runtime/native/src/sailfin_runtime.c`.
    If the C runtime calls `S` internally (count > its definition count),
    `static`-ifying the C copy gives that caller a private static copy
    while emitted code binds to the Sailfin definition — usually fine, but
    never silently delete a C body with live internal callers.
-3. **Header collision?** `grep -nE '\bS\b' runtime/native/include/*.h`. If
+3. **Header collision?** `grep -nw S runtime/native/include/*.h`. If
    `S` is prototyped in a header, `static`-ifying the C definition collides
    with the `extern` prototype — the `.h` must be edited too. **Add both
    `.c` and `.h` to Files Affected.**
@@ -62,8 +62,13 @@ would pass: zero the `c-sources`/`ll-sources` in
 confirm no undefined symbols:
 
 ```bash
-nm -u build/sailfin/*.o | grep -E '(sfn_|sailfin_runtime_|sailfin_adapter_)' \
-  | sort -u | comm -12 - <(<symbols the C sources define>)   # → expected empty
+# symbols the Sailfin-compiled objects still demand:
+nm -u build/sailfin/*.o \
+  | grep -oE 'sfn_[a-z0-9_]+|sailfin_(runtime|adapter)_[a-z0-9_]+' | sort -u > /tmp/undef.txt
+# symbols the C runtime sources define:
+grep -rhoE 'sfn_[a-z0-9_]+|sailfin_(runtime|adapter)_[a-z0-9_]+' \
+  runtime/native/src/sailfin_runtime.c runtime/native/src/sailfin_arena.c | sort -u > /tmp/cdefs.txt
+comm -12 /tmp/undef.txt /tmp/cdefs.txt   # → expected empty
 ```
 
 Until that intersection is empty, the C runtime is still load-bearing —

--- a/.claude/rules/c-sailfin-migration.md
+++ b/.claude/rules/c-sailfin-migration.md
@@ -1,0 +1,71 @@
+Porting a runtime symbol from C to Sailfin during the C→Sailfin
+migration window (epic #1308 and any `runtime/sfn/**` flip) is **not** a
+mechanical rename. The C runtime and the Sailfin runtime are linked into
+the **same binary** until `sailfin_runtime.c` / `sailfin_arena.c` are
+deleted, so every flip is a link-time symbol-ownership change with
+coexistence hazards. Audit every such issue against the checklist below —
+at grooming time, and again as a pickup pre-flight — before treating the
+Files Affected list or the "just rename it" framing as correct.
+
+## The audit (run for each symbol being flipped)
+
+For symbol `S` (e.g. `sfn_str_concat`, `sfn_arena_alloc`):
+
+1. **Who defines it?** `grep -nE '^\s*[A-Za-z_].*\bS\s*\(' runtime/native/src/*.c`
+   and `grep -rnE 'fn S\b' runtime/sfn`. A bare `sfn_*` that the registry
+   emits is frequently **C-defined** with only a `sfn_<mod>_sfn_*` infix
+   proof-of-life on the Sailfin side — the "port" is a façade.
+2. **Who calls it?** `grep -cE '\bS\s*\(' runtime/native/src/sailfin_runtime.c`.
+   If the C runtime calls `S` internally (count > its definition count),
+   `static`-ifying the C copy gives that caller a private static copy
+   while emitted code binds to the Sailfin definition — usually fine, but
+   never silently delete a C body with live internal callers.
+3. **Header collision?** `grep -nE '\bS\b' runtime/native/include/*.h`. If
+   `S` is prototyped in a header, `static`-ifying the C definition collides
+   with the `extern` prototype — the `.h` must be edited too. **Add both
+   `.c` and `.h` to Files Affected.**
+4. **Shared-struct layout hazard (the #1205-class landmine)?** If `S`
+   reads or writes a struct/handle/header that the *other* runtime also
+   reads or writes, the two layouts must be **byte-identical**. The arena
+   handle (C `SfnArena` 40 bytes / 5 fields vs Sailfin `Arena` 24 bytes /
+   3 fields — #1309) and the array header+canary convention
+   (`SailfinPtrArray`, magic/capacity 2-word prefix — #1316) are the known
+   cases. A divergent shared layout is a heap-corruption hazard; gate it
+   behind an ASAN interleave test (see `.claude/rules/compiler-safety.md`
+   for the sanitizer-leg rules). Values passed by value/buffer
+   (`i8*`, `SfnString {i8*,i64}`, callbacks) carry **no** layout hazard.
+5. **Emitted-ABI match?** Compare the registry row's `return_type` /
+   `parameter_types` (`compiler/src/llvm/runtime_helpers.sfn`) against the
+   Sailfin body's signature. A mismatch (e.g. registry emits
+   `{i8*, i64}` + arena, the infix body returns `OwnedBuf`) is **real
+   design work**, not a rename — flag it for an architect decision, since
+   changing the emitted ABI ripples into every call site's lowering.
+
+## The three flip mechanisms (classify each symbol)
+
+1. **C defines AND emission targets the bare symbol** → link-ownership
+   flip: define in Sailfin, `static`-ify the C body, drop the header
+   prototype. Touches `runtime/native/src/sailfin_runtime.c` (+ `.h`) —
+   not just the `runtime/sfn/**` file. (string/print/env/arena/array families.)
+2. **Emission target ≠ C-internal symbol** (e.g. `sfn_fs_*` is
+   Sailfin-only while C uses `sailfin_adapter_fs_*` internally) → clean:
+   replace the Sailfin façade body with a real one; no C edit; the C
+   symbol retires when the file is deleted (#822). Files Affected is the
+   `runtime/sfn/**` file alone.
+3. **Additive frontend** (e.g. `extern var`) → no coexistence concern.
+
+## The readiness gate
+
+A runtime-flip issue is correctly scoped only when the relink experiment
+would pass: zero the `c-sources`/`ll-sources` in
+`runtime/native/capsule.toml`, `make clean-build && make compile`, and
+confirm no undefined symbols:
+
+```bash
+nm -u build/sailfin/*.o | grep -E '(sfn_|sailfin_runtime_|sailfin_adapter_)' \
+  | sort -u | comm -12 - <(<symbols the C sources define>)   # → expected empty
+```
+
+Until that intersection is empty, the C runtime is still load-bearing —
+"ported to Sailfin" in an audit or a closed issue does **not** mean the C
+body is dead. Verify, don't trust the prose.


### PR DESCRIPTION
## Summary

While grooming epic **#1308** (retire the C runtime), the decomposition under-scoped the arena/string/array port issues. Root cause: the compiler-architect's feasibility gate probes only *expressibility* ("can Sailfin express a real body?") and never the **dual-runtime link-time coexistence** picture. The C and Sailfin runtimes link into the same binary until `sailfin_runtime.c` is deleted, so each flip is a *link-ownership* change — and the gate missed that a flip touches `sailfin_runtime.c` + a header (not just the `runtime/sfn/**` file) and that the arena handle has a **40-vs-24-byte shared-struct layout hazard** (#1205-class heap corruption, surfaced on #1309). The implementing agent caught it at the design gate; this PR encodes the failure mode so grooming catches it first.

## Changes

- **New rule `.claude/rules/c-sailfin-migration.md`** (the keystone — auto-loads into every agent): the 3-mechanism symbol-flip taxonomy, the 5-point coexistence audit (who-defines / who-calls / header / shared-layout / emitted-ABI), the two hazard classes, and the `nm` relink readiness gate.
- **`compiler-architect`**: adds the coexistence audit to Decomposition Discipline, alongside the existing FFI-expressibility probe.
- **`groom`**: adds a C↔Sailfin symbol-flip coexistence gate before `claude-ready`.
- **`pickup`**: adds a Phase 2.5 scope pre-flight for runtime symbol-flip issues — validates Files Affected + layout/ABI against reality before coding, pausing via the existing scope-adjustment path on mismatch (catches gaps in seconds, not mid-implementation).
- **`compiler-architect` + `seed-stabilizer`**: switch `model: opus → fable` (`claude-fable-5`) for the high-stakes design and IR-diagnosis roles.

## Context

Companion to the #1308 grooming: #1309 was re-scoped to Option A (layout-match) after the design-gate catch, and #1310/#1312/#1314/#1315/#1316/#1318 had Files-Affected gaps corrected. This PR prevents the same class of miss on the next runtime-migration epic.

## Verification

Documentation/config only — no compiler source touched, so no self-host impact. `model: fable` resolves to `claude-fable-5` (verified against the model catalog). The rule and gates are prose contracts consumed by the grooming/pickup workflows.

https://claude.ai/code/session_01KzuWZhemK9th2NWEsNN2SG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzuWZhemK9th2NWEsNN2SG)_