### PR TITLE
feat(http): HTTP/1.1 wire layer for sfn/http capsule (Wave 1, epic #1321)

### DIFF
--- a/capsules/sfn/http/capsule.toml
+++ b/capsules/sfn/http/capsule.toml
@@ -1,6 +1,6 @@
 [capsule]
 name = "sfn/http"
-version = "0.2.1"
+version = "0.3.0"
 description = "HTTP client and server for Sailfin"
 
 [dependencies]

--- a/capsules/sfn/http/src/mod.sfn
+++ b/capsules/sfn/http/src/mod.sfn
@@ -2,45 +2,30 @@
 //
 // Provides a unified API for making HTTP requests and serving HTTP responses.
 // All operations require the `net` effect; server operations also require `io`.
+//
+// Internal layout — this barrel re-exports the public surface. Sources live in:
+//   - types.sfn  Request, Response, ServerConfig
+//   - wire.sfn   parse_request, serialize_response, header, query_param,
+//                reason_phrase, response, response_with_status,
+//                json_response, not_found
+//   - mod.sfn    client (get, post) + serve (server entry point)
+//
+// Build-out tracked by epic #1321; design in docs/proposals/sfn-http-capsule.md.
 // ---- Types ----
-struct Request {
-    method: string;
-    path: string;
-    headers: string[];
-    body: string;
-}
+export { Request, Response, ServerConfig } from "./types";
 
-struct Response {
-    status: int;
-    headers: string[];
-    body: string;
-}
-
-struct ServerConfig {
-    port: int;
-    host: string;
-}
-
-// ---- Response helpers ----
-fn response(body: string) -> Response {
-    return Response { status: 200, headers: [], body: body };
-}
-
-fn response_with_status(status: int, body: string) -> Response {
-    return Response { status: status, headers: [], body: body };
-}
-
-fn json_response(body: string) -> Response {
-    return Response {
-        status: 200,
-        headers: ["Content-Type: application/json"],
-        body: body
-    };
-}
-
-fn not_found(body: string = "Not Found") -> Response {
-    return Response { status: 404, headers: [], body: body };
-}
+// ---- Wire layer + response builders ----
+export {
+    parse_request,
+    serialize_response,
+    header,
+    query_param,
+    reason_phrase,
+    response,
+    response_with_status,
+    json_response,
+    not_found
+} from "./wire";
 
 // ---- Client ----
 fn get(url: string) -> string ![net] {
@@ -54,7 +39,7 @@ fn post(url: string, body: string) -> string ![net] {
 }
 
 // ---- Server ----
-fn serve(handler: any, config: any?) -> void ![io, net] {
+fn serve(handler: any, config: any? = null) -> void ![io, net] {
     // Start an HTTP server that dispatches requests to the handler function.
     //
     // Usage:

--- a/capsules/sfn/http/src/types.sfn
+++ b/capsules/sfn/http/src/types.sfn
@@ -1,0 +1,33 @@
+// sfn/http — shared wire types.
+//
+// `Request` / `Response` / `ServerConfig` live here (not in `mod.sfn`) so
+// the wire layer (`wire.sfn`) and the barrel (`mod.sfn`) can both depend on
+// them without an import cycle — the same `types.sfn` split `sfn/cli` uses.
+// Re-exported from `mod.sfn` as part of the public surface.
+// An inbound HTTP request, as parsed from the raw request bytes by
+// `wire.parse_request`. `query` is the raw query string after `?` (no
+// percent-decoding in v0); `headers` are raw "Name: value" lines.
+struct Request {
+    method: string;
+    path: string;
+    query: string;
+    headers: string[];
+    body: string;
+}
+
+// An outbound HTTP response. `headers` are raw "Name: value" lines;
+// `wire.serialize_response` adds `Content-Length` and `Connection: close`
+// and drops any header carrying a CR or LF (injection guard).
+struct Response {
+    status: int;
+    headers: string[];
+    body: string;
+}
+
+// Server bind configuration. v0 honors `port` only — the runtime binds
+// `INADDR_ANY`, so `host` is carried for forward-compatibility but not yet
+// enforced (see docs/proposals/sfn-http-capsule.md §2).
+struct ServerConfig {
+    port: int;
+    host: string;
+}

--- a/capsules/sfn/http/src/wire.sfn
+++ b/capsules/sfn/http/src/wire.sfn
@@ -1,0 +1,284 @@
+// sfn/http — HTTP/1.1 wire layer (pure Sailfin, no runtime/socket deps).
+//
+// Marshals between raw HTTP/1.1 bytes (NUL-terminated strings at the ABI)
+// and the typed `Request` / `Response` structs:
+//   - `parse_request(raw)`      raw request bytes  -> Request
+//   - `serialize_response(rsp)` Response           -> raw response bytes
+//   - `header(req, name)`       case-insensitive header lookup -> string?
+//   - `query_param(req, name)`  query-string lookup -> string?
+//
+// This is Wave 1 of the sfn/http build-out (epic #1321). It is consumed by
+// the Wave 2 `serve` trampoline but ships and tests standalone — it touches
+// no runtime, compiler, or socket code.
+//
+// v0 scope (matches docs/proposals/sfn-http-capsule.md §3.4): text bodies
+// only, no percent-decoding of paths/queries, no chunked decoding, no
+// multi-line (obs-fold) header continuation. Header names are matched
+// case-insensitively (RFC 7230 §3.2); values are returned trimmed.
+import { Request, Response } from "./types";
+
+// ── private helpers ───────────────────────────────────────────────
+// Minimal base-10 int formatter (the prelude exposes no int->string
+// intrinsic to capsules yet; mirrors sfn/cli's `_int_to_string`).
+fn _int_to_string(value: int) -> string {
+    if value == 0 { return "0"; }
+    let table = "0123456789";
+    let mut n = value;
+    let mut negative = false;
+    if n < 0 {
+        negative = true;
+        n = 0 - n;
+    }
+    let mut digits = "";
+    loop {
+        if n == 0 { break; }
+        let d = n - (n / 10) * 10;
+        digits = substring(table, d, d + 1) + digits;
+        n = n / 10;
+    }
+    if negative { return "-" + digits; }
+    return digits;
+}
+
+// Strip ASCII spaces and tabs from both ends (header field values are
+// `OWS`-padded). Newlines are not expected mid-field after line splitting.
+fn _trim(value: string) -> string {
+    let mut start = 0;
+    let mut end = value.length;
+    loop {
+        if start >= end { break; }
+        let ch = grapheme_at(value, start);
+        if strings_equal(ch, " ") || strings_equal(ch, "\t") {
+            start = start + 1;
+            continue;
+        }
+        break;
+    }
+    loop {
+        if end <= start { break; }
+        let ch = grapheme_at(value, end - 1);
+        if strings_equal(ch, " ") || strings_equal(ch, "\t") {
+            end = end - 1;
+            continue;
+        }
+        break;
+    }
+    return substring(value, start, end);
+}
+
+// Drop a single trailing carriage return (lines are split on '\n').
+fn _strip_cr(line: string) -> string {
+    let n = line.length;
+    if n > 0 && strings_equal(grapheme_at(line, n - 1), "\r") {
+        return substring(line, 0, n - 1);
+    }
+    return line;
+}
+
+// True if `s` contains a CR or LF — used to reject header-injection
+// attempts before a user-supplied header is written to the wire.
+fn _has_crlf(s: string) -> boolean {
+    return find_char(s, "\r", 0) >= 0 || find_char(s, "\n", 0) >= 0;
+}
+
+// ASCII-lowercase (A–Z only) for case-insensitive header-name matching.
+fn _ascii_lower(value: string) -> string {
+    let mut out = "";
+    let mut i = 0;
+    loop {
+        if i >= value.length { break; }
+        let ch = grapheme_at(value, i);
+        let code = char_code(ch);
+        if code >= 65 && code <= 90 { out = out + char_from_code(code + 32); } else {
+            out = out + ch;
+        }
+        i = i + 1;
+    }
+    return out;
+}
+
+// ── reason phrases ────────────────────────────────────────────────
+// Reason phrase for the common status codes; unknown codes get the
+// generic `"Status"` (a valid HTTP/1.1 reason phrase).
+fn reason_phrase(status: int) -> string {
+    if status == 200 { return "OK"; }
+    if status == 201 { return "Created"; }
+    if status == 202 { return "Accepted"; }
+    if status == 204 { return "No Content"; }
+    if status == 301 { return "Moved Permanently"; }
+    if status == 302 { return "Found"; }
+    if status == 304 { return "Not Modified"; }
+    if status == 400 { return "Bad Request"; }
+    if status == 401 { return "Unauthorized"; }
+    if status == 403 { return "Forbidden"; }
+    if status == 404 { return "Not Found"; }
+    if status == 405 { return "Method Not Allowed"; }
+    if status == 409 { return "Conflict"; }
+    if status == 500 { return "Internal Server Error"; }
+    if status == 501 { return "Not Implemented"; }
+    if status == 502 { return "Bad Gateway"; }
+    if status == 503 { return "Service Unavailable"; }
+    return "Status";
+}
+
+// ── request parsing ───────────────────────────────────────────────
+// Parse raw HTTP/1.1 request bytes into a `Request`. Tolerant of a
+// missing final blank line and of bare-LF line endings (CR is stripped
+// when present). `method`/`path`/`query` come from the request line;
+// `headers` are the raw "Name: value" lines up to the blank-line
+// terminator; `body` is whatever follows it (GET-shaped in v0 — the
+// runtime does not yet drain Content-Length; see Wave 3 / #1324).
+fn parse_request(raw: string) -> Request {
+    let total = raw.length;
+
+    // Request line: up to the first '\n'.
+    let line_nl = find_char(raw, "\n", 0);
+    let mut line_end = total;
+    if line_nl >= 0 { line_end = line_nl; }
+    let request_line = _strip_cr(substring(raw, 0, line_end));
+
+    let mut method = "";
+    let mut target = "";
+    let sp1 = find_char(request_line, " ", 0);
+    if sp1 >= 0 {
+        method = substring(request_line, 0, sp1);
+        let sp2 = find_char(request_line, " ", sp1 + 1);
+        if sp2 >= 0 { target = substring(request_line, sp1 + 1, sp2); } else {
+            target = substring(request_line, sp1 + 1, request_line.length);
+        }
+    } else { method = request_line; }
+
+    // Split the target into path and raw query on the first '?'.
+    let mut path = target;
+    let mut query = "";
+    let q = find_char(target, "?", 0);
+    if q >= 0 {
+        path = substring(target, 0, q);
+        query = substring(target, q + 1, target.length);
+    }
+
+    // Header lines until the blank line; the remainder is the body.
+    let mut headers: string[] = [];
+    let mut body = "";
+    let mut cursor = total;
+    if line_nl >= 0 { cursor = line_nl + 1; }
+    loop {
+        if cursor >= total { break; }
+        let nl = find_char(raw, "\n", cursor);
+        let mut end = total;
+        if nl >= 0 { end = nl; }
+        let line = _strip_cr(substring(raw, cursor, end));
+        let mut next = total;
+        if nl >= 0 { next = nl + 1; }
+        if line.length == 0 {
+            body = substring(raw, next, total);
+            break;
+        }
+        headers.push(line);
+        if nl < 0 { break; }
+        cursor = next;
+    }
+
+    return Request {
+        method: method,
+        path: path,
+        query: query,
+        headers: headers,
+        body: body
+    };
+}
+
+// ── response serialization ────────────────────────────────────────
+// Serialize a `Response` into a full HTTP/1.1 response. The status line
+// uses `reason_phrase(rsp.status)`; user headers are emitted verbatim
+// EXCEPT any containing a CR or LF, which are dropped (header-injection
+// guard). `Content-Length` (from the body's length) and `Connection:
+// close` are always appended. v0 is text bodies only.
+fn serialize_response(rsp: Response) -> string {
+    let mut out = "HTTP/1.1 " + _int_to_string(rsp.status) + " " + reason_phrase(rsp.status)
+        + "\r\n";
+    let mut i = 0;
+    loop {
+        if i >= rsp.headers.length { break; }
+        let h = rsp.headers[i];
+        if !_has_crlf(h) { out = out + h + "\r\n"; }
+        i = i + 1;
+    }
+    out = out + "Content-Length: " + _int_to_string(rsp.body.length) + "\r\n";
+    out = out + "Connection: close\r\n";
+    out = out + "\r\n";
+    out = out + rsp.body;
+    return out;
+}
+
+// ── accessors ─────────────────────────────────────────────────────
+// Case-insensitive header lookup. Returns the trimmed value of the first
+// matching `Name: value` header, or null if absent.
+fn header(req: Request, name: string) -> string? {
+    let target = _ascii_lower(name);
+    let mut i = 0;
+    loop {
+        if i >= req.headers.length { break; }
+        let h = req.headers[i];
+        let colon = find_char(h, ":", 0);
+        if colon >= 0 {
+            let hname = _ascii_lower(_trim(substring(h, 0, colon)));
+            if strings_equal(hname, target) {
+                return _trim(substring(h, colon + 1, h.length));
+            }
+        }
+        i = i + 1;
+    }
+    return null;
+}
+
+// Look up a query-string parameter by exact (case-sensitive) key. Returns
+// the raw value (no percent-decoding in v0), an empty string for a
+// valueless key (`?flag`), or null if the key is absent.
+fn query_param(req: Request, name: string) -> string? {
+    let q = req.query;
+    let total = q.length;
+    let mut cursor = 0;
+    loop {
+        if cursor >= total { break; }
+        let amp = find_char(q, "&", cursor);
+        let mut end = total;
+        if amp >= 0 { end = amp; }
+        let pair = substring(q, cursor, end);
+        let eq = find_char(pair, "=", 0);
+        if eq >= 0 {
+            let key = substring(pair, 0, eq);
+            if strings_equal(key, name) {
+                return substring(pair, eq + 1, pair.length);
+            }
+        } else {
+            if strings_equal(pair, name) { return ""; }
+        }
+        if amp < 0 { break; }
+        cursor = amp + 1;
+    }
+    return null;
+}
+
+// ── response builders ─────────────────────────────────────────────
+// Convenience constructors for the common responses. Moved here from
+// `mod.sfn` so the typed `Response` surface lives beside its serializer.
+fn response(body: string) -> Response {
+    return Response { status: 200, headers: [], body: body };
+}
+
+fn response_with_status(status: int, body: string) -> Response {
+    return Response { status: status, headers: [], body: body };
+}
+
+fn json_response(body: string) -> Response {
+    return Response {
+        status: 200,
+        headers: ["Content-Type: application/json"],
+        body: body
+    };
+}
+
+fn not_found(body: string = "Not Found") -> Response {
+    return Response { status: 404, headers: [], body: body };
+}

--- a/capsules/sfn/http/src/wire.sfn
+++ b/capsules/sfn/http/src/wire.sfn
@@ -81,6 +81,21 @@ fn _has_crlf(s: string) -> boolean {
     return find_char(s, "\r", 0) >= 0 || find_char(s, "\n", 0) >= 0;
 }
 
+// True if `h` is a framing header the serializer owns. `serialize_response`
+// always emits its own `Content-Length` and `Connection: close`, so a
+// user-supplied copy would produce duplicate/conflicting framing headers —
+// a response-smuggling footgun (proxies disagree on first-vs-last). These
+// (and `Transfer-Encoding`, which conflicts with explicit `Content-Length`
+// framing) are dropped from `rsp.headers`.
+fn _is_reserved_header(h: string) -> boolean {
+    let colon = find_char(h, ":", 0);
+    let mut name = h;
+    if colon >= 0 { name = substring(h, 0, colon); }
+    let lower = _ascii_lower(_trim(name));
+    return strings_equal(lower, "content-length") || strings_equal(lower, "connection")
+        || strings_equal(lower, "transfer-encoding");
+}
+
 // ASCII-lowercase (A–Z only) for case-insensitive header-name matching.
 fn _ascii_lower(value: string) -> string {
     let mut out = "";
@@ -191,9 +206,11 @@ fn parse_request(raw: string) -> Request {
 // ── response serialization ────────────────────────────────────────
 // Serialize a `Response` into a full HTTP/1.1 response. The status line
 // uses `reason_phrase(rsp.status)`; user headers are emitted verbatim
-// EXCEPT any containing a CR or LF, which are dropped (header-injection
-// guard). `Content-Length` (from the body's length) and `Connection:
-// close` are always appended. v0 is text bodies only.
+// EXCEPT any containing a CR or LF (header-injection guard) or naming a
+// framing header the serializer owns — `Content-Length`, `Connection`,
+// `Transfer-Encoding` (response-smuggling guard, see `_is_reserved_header`).
+// `Content-Length` (from the body's length) and `Connection: close` are
+// always appended. v0 is text bodies only.
 fn serialize_response(rsp: Response) -> string {
     let mut out = "HTTP/1.1 " + _int_to_string(rsp.status) + " " + reason_phrase(rsp.status)
         + "\r\n";
@@ -201,7 +218,7 @@ fn serialize_response(rsp: Response) -> string {
     loop {
         if i >= rsp.headers.length { break; }
         let h = rsp.headers[i];
-        if !_has_crlf(h) { out = out + h + "\r\n"; }
+        if !_has_crlf(h) && !_is_reserved_header(h) { out = out + h + "\r\n"; }
         i = i + 1;
     }
     out = out + "Content-Length: " + _int_to_string(rsp.body.length) + "\r\n";

--- a/capsules/sfn/http/tests/wire_test.sfn
+++ b/capsules/sfn/http/tests/wire_test.sfn
@@ -66,6 +66,20 @@ test "serialize_response: drops headers carrying CR or LF (injection guard)" {
     assert strings_equal(out, expected);
 }
 
+test "serialize_response: drops user-supplied framing headers (smuggling guard)" {
+    // User-supplied Content-Length / Connection / Transfer-Encoding must not
+    // reach the wire — the serializer owns framing. The case-insensitive,
+    // OWS-padded copies below are all dropped; X-Keep survives.
+    let rsp = Response {
+        status: 200,
+        headers: ["content-length: 999", "Connection: keep-alive", "Transfer-Encoding: chunked", "X-Keep: yes"],
+        body: "abc"
+    };
+    let out = serialize_response(rsp);
+    let expected = "HTTP/1.1 200 OK\r\nX-Keep: yes\r\nContent-Length: 3\r\nConnection: close\r\n\r\nabc";
+    assert strings_equal(out, expected);
+}
+
 test "reason_phrase: known codes mapped, unknown falls back to Status" {
     assert strings_equal(reason_phrase(200), "OK");
     assert strings_equal(reason_phrase(500), "Internal Server Error");

--- a/capsules/sfn/http/tests/wire_test.sfn
+++ b/capsules/sfn/http/tests/wire_test.sfn
@@ -1,0 +1,104 @@
+// Tests for the sfn/http wire layer (Wave 1 of epic #1321):
+// parse_request / serialize_response / header / query_param.
+//
+// Pure parse/serialize coverage — no runtime, socket, or serve path is
+// exercised here (that is Wave 2). Serialization is asserted by exact
+// string equality because the output is deterministic.
+import {
+    Request,
+    Response,
+    parse_request,
+    serialize_response,
+    header,
+    query_param,
+    reason_phrase,
+    not_found
+} from "../src/mod";
+
+test "parse_request: GET request line, path, query, and headers" {
+    let raw = "GET /search?q=sail&n=2 HTTP/1.1\r\nHost: localhost\r\nAccept: */*\r\n\r\n";
+    let req = parse_request(raw);
+    assert strings_equal(req.method, "GET");
+    assert strings_equal(req.path, "/search");
+    assert strings_equal(req.query, "q=sail&n=2");
+    assert strings_equal(req.body, "");
+    assert req.headers.length == 2;
+    assert strings_equal(req.headers[0], "Host: localhost");
+    assert strings_equal(req.headers[1], "Accept: */*");
+}
+
+test "parse_request: POST carries the body after the blank line" {
+    let raw = "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello";
+    let req = parse_request(raw);
+    assert strings_equal(req.method, "POST");
+    assert strings_equal(req.path, "/submit");
+    assert strings_equal(req.query, "");
+    assert strings_equal(req.body, "hello");
+    assert req.headers.length == 2;
+}
+
+test "parse_request: bare path with no query yields an empty query" {
+    let req = parse_request("GET / HTTP/1.1\r\n\r\n");
+    assert strings_equal(req.path, "/");
+    assert strings_equal(req.query, "");
+    assert req.headers.length == 0;
+}
+
+test "serialize_response: status line, custom header, framing (exact bytes)" {
+    let rsp = Response {
+        status: 404,
+        headers: ["X-Custom: yes"],
+        body: "nope"
+    };
+    let out = serialize_response(rsp);
+    let expected = "HTTP/1.1 404 Not Found\r\nX-Custom: yes\r\nContent-Length: 4\r\nConnection: close\r\n\r\nnope";
+    assert strings_equal(out, expected);
+}
+
+test "serialize_response: drops headers carrying CR or LF (injection guard)" {
+    let rsp = Response {
+        status: 200,
+        headers: ["Evil: a\r\nInjected: b"],
+        body: "hi"
+    };
+    let out = serialize_response(rsp);
+    let expected = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi";
+    assert strings_equal(out, expected);
+}
+
+test "reason_phrase: known codes mapped, unknown falls back to Status" {
+    assert strings_equal(reason_phrase(200), "OK");
+    assert strings_equal(reason_phrase(500), "Internal Server Error");
+    assert strings_equal(reason_phrase(599), "Status");
+}
+
+test "header: case-insensitive lookup returns the trimmed value" {
+    let req = parse_request("GET / HTTP/1.1\r\nHost:   example.com  \r\nX-Token: abc\r\n\r\n");
+    let host = header(req, "HOST");
+    assert host != null;
+    if host != null { assert strings_equal(host, "example.com"); }
+    let token = header(req, "x-token");
+    assert token != null;
+    if token != null { assert strings_equal(token, "abc"); }
+    assert header(req, "x-missing") == null;
+}
+
+test "query_param: keyed lookup, valueless key, and absent key" {
+    let req = parse_request("GET /p?a=1&flag&b=two HTTP/1.1\r\n\r\n");
+    let a = query_param(req, "a");
+    assert a != null;
+    if a != null { assert strings_equal(a, "1"); }
+    let b = query_param(req, "b");
+    assert b != null;
+    if b != null { assert strings_equal(b, "two"); }
+    let flag = query_param(req, "flag");
+    assert flag != null;
+    if flag != null { assert strings_equal(flag, ""); }
+    assert query_param(req, "missing") == null;
+}
+
+test "not_found: default body and 404 status" {
+    let rsp = not_found();
+    assert rsp.status == 404;
+    assert strings_equal(rsp.body, "Not Found");
+}

--- a/docs/proposals/sfn-http-capsule.md
+++ b/docs/proposals/sfn-http-capsule.md
@@ -1,0 +1,250 @@
+# Proposal: `sfn/http` — typed HTTP server/client surface
+
+Status: **approved** (design gate cleared 2026-06-13) — groomed into a tracking epic + Wave 1–4 issues
+Decisions locked at the gate: handler API = return-based `fn(Request) -> Response`; v0 handlers
+**restricted to top-level named functions** (closures documented + best-effort diagnostic, per
+open question 2); `ServerConfig.host` dropped from the v0 signature.
+Depends on: M4 epic #965 (closed 2026-06-12) — Sailfin-native scheduler + `sfn_serve`
+Related: `runtime/sfn/concurrency/serve.sfn` (raw server), `runtime/sfn/adapters/http.sfn`
+(raw client), `capsules/sfn/http/src/mod.sfn` (typed stubs), #1308 / #1318 (string-ABI
+reshaping — deliberately not touched), #1220 (move semantics — designed-around).
+
+## 1. Goal
+
+Turn the `sfn/http` capsule into a real, typed HTTP/1.1 server (and incrementally
+client) surface so users can write web servers in native Sailfin:
+
+```sfn
+import { serve, Request, Response, response, not_found } from "http";
+
+fn handler(req: Request) -> Response {
+    if req.path == "/" { return response("Welcome to Sailfin!"); }
+    return not_found();
+}
+
+fn main() ![net, io] {
+    serve(handler, 8080);
+}
+```
+
+This is the "follow-up wave" the `serve.sfn` header (lines 24–36) explicitly names:
+the `fn(Request) -> Response` struct-marshalling layer on top of the proven raw
+`fn(* u8) -> * u8` runtime ABI.
+
+## 2. Handler API decision
+
+**Chosen: return-based `fn(req: Request) -> Response`** (Deno.serve / Cloudflare
+Workers `fetch` shape).
+
+Rationale:
+
+- **Single marshalling boundary.** The runtime ABI is one value in, one value out
+  (`* u8` request bytes → `* u8` response bytes). A return-based handler maps onto it
+  1:1; an Express-style `fn(req, res)` mutation API would need a mutable `res` object
+  threaded across the boundary and a "did the handler respond?" protocol.
+- **No mutable aliasing.** A shared mutable `res` is exactly the #1205-class aliasing
+  shape the ownership floor (#1209) exists to forbid, and it fights #1220
+  (channel-send/spawn as moves). Value-return composes with moves; mutation does not.
+- **Boring syntax / LLM-friendly.** `Request -> Response` is the dominant modern
+  convention (Deno, Workers, Bun, Go's `http.Handler` is morally request→write-once).
+  LLMs generate it reliably.
+- **Methods-on-structs not required.** `res.send(...)` needs method dispatch on a
+  capsule struct; free functions (`response(...)`, `json_response(...)`) need nothing
+  new.
+
+Reconciling the three in-tree shapes:
+
+| Shape | Disposition |
+|---|---|
+| runtime `fn(* u8) -> * u8` | Stays as the substrate. Untyped `serve(handle, 8080)` with a `fn(string) -> string` handler keeps working (pinned by `test_runtime_serve.sh`). |
+| capsule `fn(Request) -> Response` | Becomes the real, typed public API. `serve(handler: fn(Request) -> Response, port: int)` replaces the `any`-typed stub. |
+| `examples/web/http-server.sfn` Express-style `fn(req, res)` + `{ port: 8080 }` | Rewritten to the return-based form in the same PR that ships typed `serve` (Wave 2). The Express shape never worked (serve was a print stub) so there is no compat concern. |
+
+`ServerConfig` is **dropped from the v0 signature** (kept as a type only if trivially
+useful later): the runtime binds `INADDR_ANY` unconditionally, so a `host` field would
+be parsed-but-not-enforced — exactly what we don't ship. v0 is `serve(handler, port:
+int = 8080)`; `ServerConfig { port, host }` returns when host binding is real.
+
+## 3. Architecture
+
+### 3.1 Where things live
+
+- **All marshalling lives in the capsule** (`capsules/sfn/http/src/`), in plain
+  high-level Sailfin (`string`, `string[]`, structs). No retyping of runtime
+  descriptors, no arena threading, no interaction with #1318's `OwnedBuf` reshaping.
+  This works because Sailfin strings are NUL-terminated `i8*` at the ABI
+  (`sfn_str_to_cstr` / `from_cstr` are identity bridges, `runtime/sfn/string.sfn:202`),
+  so a trampoline typed `fn(raw: string) -> string` *is* the runtime's
+  `fn(* u8) -> * u8` — proven by the pinned e2e probe `fn handle(req: string) -> string`
+  in `compiler/tests/e2e/test_runtime_serve.sh`.
+- **One additive runtime entrypoint** (`runtime/sfn/concurrency/serve.sfn`):
+  `sfn_serve_framed(handler: * u8, port: i32)` — identical accept loop, but the
+  handler's return is the **full pre-framed HTTP response** (status line + headers +
+  body) sent verbatim; `null` → `500`. This is what makes `Response.status` and
+  `Response.headers` real instead of parsed-but-ignored (today `_serve_send_response`
+  always frames `200 OK`). It is a **new Sailfin-only symbol** — migration-mechanism 3
+  (additive), no C definition, no header, no shared-struct layout, no
+  `c-sailfin-migration` coexistence audit needed.
+- **One small compiler change** (`compiler/src/llvm/expression_lowering/native/core.sfn:1415`):
+  the bespoke `serve(` lowering text-matches **any** call spelled `serve(...)` and
+  lowers it straight to `@sfn_serve(handler, port)`. An imported capsule `serve` would
+  be silently hijacked (its typed handler bitcast to a raw handler, its config arg
+  truncated to i32). Fix: gate the bespoke path on `serve` **not** resolving to a
+  user-defined/imported function (consult the `functions` map already in scope; fall
+  through to generic call lowering when found). Bare `serve(handle, 8080)` with no
+  import is unaffected, so the pinned e2e stays green.
+
+### 3.2 Data flow
+
+```
+user: serve(handler, 8080)                              [capsule serve, ![net, io]]
+  └─ stores handler code-pointer in module global  let mut _handler_addr: i64
+     (the future.sfn `_sfn_g_queue_addr` pattern)
+  └─ extern call: sfn_serve_framed(_sfn_http_trampoline as ... as * u8, port as i32)
+
+runtime: accept → pool worker → dispatch (fn(* u8) -> * u8)
+  └─ _sfn_http_trampoline(raw: string) -> string        [capsule, top-level fn]
+       ├─ parse_request(raw)      -> Request            [capsule wire.sfn]
+       ├─ user handler(Request)   -> Response           (called via * fn cast from _handler_addr)
+       └─ serialize_response(rsp) -> string             [full HTTP/1.1 bytes]
+
+runtime: send verbatim, Connection: close, close(fd)
+```
+
+### 3.3 Request population (v0 honesty)
+
+`_serve_recv_request` reads only to the `\r\n\r\n` terminator (GET-shaped v0), so:
+
+- **v0 (Wave 2):** `method`, `path` (query split off), `query` (raw string),
+  `headers: string[]` ("Name: value" lines), `body` = whatever trailed the terminator
+  in the final chunk — documented as **unreliable; GET-only support**.
+- **Wave 3 (runtime, additive):** `_serve_recv_request` drains `Content-Length` bytes
+  after the terminator (capped, e.g. 1 MiB) → `body` becomes real, POST ships. No ABI
+  change.
+
+### 3.4 Response serialization (capsule `wire.sfn`)
+
+- Status line from `Response.status` with a small reason-phrase table (200, 201, 204,
+  301, 302, 400, 401, 403, 404, 405, 500, 502, 503; default `"Status"`).
+- User headers emitted as-is **after CR/LF rejection** (any header string containing
+  `\r` or `\n` is dropped — header-injection guard).
+- `Content-Length` computed from `body.length`; `Connection: close` appended.
+- Text bodies only in v0 (strings are NUL-terminated; embedded-NUL binary bodies are
+  out of scope and documented).
+
+### 3.5 Handler-value restriction (v0)
+
+The handler slot stores a **bare code pointer** (i64) and the trampoline calls it via a
+`* fn` cast — the same env-less indirect-call shape `sfn_serve` itself uses. Closures
+(`{fn_ptr, env}`, #689) have a different representation, so **v0 requires a top-level
+named function as the handler** (documented; same restriction the raw `serve` has
+today). Closure-handler support is a follow-up (store the full fn value / add an
+env-aware dispatch) and is listed as an open question below.
+
+## 4. Scope cut
+
+| Surface | v0 (this proposal) | Follow-up | Out (post-1.0) |
+|---|---|---|---|
+| Typed `serve(fn(Request) -> Response, port)` | yes (Wave 2) | — | — |
+| Status codes + headers honored on the wire | yes (`sfn_serve_framed`) | — | — |
+| Request: method, path, query, headers | yes | — | — |
+| Request body (POST) | no — documented GET-only | Wave 3 (Content-Length drain) | — |
+| Header/query accessors (`header(req, n)`, `query_param(req, n)`) | yes (Wave 1, pure capsule) | — | — |
+| Typed client (`fetch`-style → `Response` with status/headers) | no — `get`/`post` body-string wrappers stay | Wave 4 (needs additive `sfn_http_request_raw` returning the full raw response) | — |
+| Routing (`Router`) | no — handler-side `if req.path == ...` idiom | post-v0 capsule work (blocked on closure-handler story) | — |
+| Keep-alive | no (`Connection: close`) | runtime follow-up | — |
+| Closure handlers | no (top-level fn only, documented) | follow-up | — |
+| `ServerConfig.host` binding | dropped from v0 API | with host-bind runtime support | — |
+| TLS, DNS, chunked, redirects | — | — | out (matches client v0 limits) |
+| Per-response buffer free / Task reaping | no — documented leak (same class as the existing fire-and-forget Task leak) | request-scoped arena follow-up (ties to ownership/arena work) | — |
+
+Stage1 readiness: everything in the v0 column is enforced end-to-end (status/headers
+actually hit the wire; the GET-only body limit is documented, not implied-working).
+
+## 5. Sequencing (pickable issues)
+
+**Wave 1 — `sfn/http` wire layer (S).** Pure capsule, no deps, first mergeable PR.
+- `capsules/sfn/http/src/wire.sfn`: `parse_request(raw: string) -> Request`,
+  `serialize_response(rsp: Response) -> string`, `header(req, name) -> string?`,
+  `query_param(req, name) -> string?`; path/query split; CR/LF header guard;
+  reason-phrase table.
+- `capsules/sfn/http/tests/wire_test.sfn` unit tests (parse a canned GET/POST head,
+  round-trip a 404-with-headers response, injection guard).
+- No runtime, no compiler, no example changes. Independently shippable.
+
+**Wave 2 — typed `serve` vertical slice (M).** *The first user-visible slice.*
+Bundles the compiler gate with its single consumer (per decomposition discipline —
+splitting would add a PR with no standalone value; no seed cut needed because the
+compiler change and the capsule consumer land in one `make compile` pass and the
+compiler itself never calls `serve`).
+- Runtime: `sfn_serve_framed` in `runtime/sfn/concurrency/serve.sfn` (additive; reuse
+  `_serve_*` helpers; conn ctx grows a mode word or a second worker fn).
+- Compiler: gate the bespoke `serve(` lowering
+  (`compiler/src/llvm/expression_lowering/native/core.sfn:1415`) on `serve` not
+  resolving in `functions`.
+- Capsule: replace the `serve` stub in `mod.sfn` with the typed signature, handler
+  slot global, `_sfn_http_trampoline`, `extern fn sfn_serve_framed(...)`.
+- Example: rewrite `examples/web/http-server.sfn` to the return-based form.
+- e2e: new `compiler/tests/e2e/test_http_capsule_serve.sh` — loopback round-trip
+  asserting a non-200 status and a custom header arrive on the wire; plus an IR probe
+  that an *imported* `serve` does **not** lower to `@sfn_serve` directly.
+- Pre-flight verifications (cheap, before coding): (a) struct params/returns lower as
+  single pointers at the `* fn` cast boundary; (b) the `functions` map at
+  core.sfn:1415 contains imported capsule functions; (c) capsule sources accept
+  `extern fn` + `as * u8` casts like `runtime/sfn` modules do.
+
+**Wave 3 — POST body draining (S).**
+- Runtime: `_serve_recv_request` parses `Content-Length` and drains the body (cap ~1
+  MiB, over-cap → 500 path). No ABI change.
+- Capsule: none (wire.sfn already parses the body when present).
+- e2e: POST round-trip through the typed handler echoing `req.body`.
+- Docs: lift the GET-only caveat.
+
+**Wave 4 — typed client (S/M, optional for the server goal).**
+- Runtime (additive): `sfn_http_request_raw(method, url, headers, body) -> * u8`
+  returning the **full** raw response in `runtime/sfn/adapters/http.sfn` (shares the
+  existing socket helpers; same v0 limits: no TLS/DNS/chunked).
+- Capsule: `fetch(method, url, headers, body) -> Response ![net]` parsing via a
+  response-side twin of `wire.sfn`'s request parser. `get`/`post` wrappers unchanged.
+- e2e: loopback client↔server round-trip — the capsule talks to itself.
+
+Dependency order: 1 → 2 → 3; 4 after 1 (parallel to 2/3 in principle, but sequencing
+after 3 lets its e2e use the capsule server as the test peer).
+
+## 6. Risks / open questions
+
+1. **Bespoke-lowering gate regressions.** Text-matched lowerings are fragile; the gate
+   must not break bare `serve(h, port)` (pinned e2e) nor accidentally suppress the
+   bespoke path inside the capsule itself. Mitigation: the capsule never spells a call
+   `serve(...)` internally — it calls the `sfn_serve_framed` extern directly.
+2. **Closure handlers typecheck but crash** (a closure value bitcast to a bare code
+   pointer). **Resolved at the design gate (2026-06-13): ship v0 with the documented
+   top-level-function restriction + a best-effort diagnostic** ("serve handler must be a
+   top-level function"). Closure-handler support is a post-v0 follow-up (store the full
+   fn value / env-aware dispatch). Wave 2 is *not* blocked on closure-value plumbing.
+3. **Per-request allocations are never freed** (handler-built strings come from the
+   runtime allocator; the worker can't `free()` them). Same class as the documented
+   fire-and-forget Task leak. Acceptable for v0? The principled fix is a
+   request-scoped arena — flag for the ownership/arena track, not this epic.
+4. **Effect enforcement depth.** Extern fns must not declare effects
+   (`typecheck_types.sfn:1388`), so the `sfn_serve_framed` call inside the capsule is
+   effect-invisible; enforcement rides on the capsule `serve`'s own `![net, io]`
+   annotation (pinned by test). The general "externs are effect holes" gap is
+   pre-existing and out of scope here.
+5. **Single server per process** (one global handler slot; `sfn_serve*` never returns
+   and owns its pool). Matches the runtime's existing shape; document it.
+6. **Struct ABI assumption** (single-pointer structs across the `* fn` cast) is
+   load-bearing for Wave 2 — verify in pre-flight, escalate to the architect if
+   structs lower by-value anywhere on this path.
+
+## 7. Pipeline touchpoints
+
+| Stage | Files |
+|---|---|
+| Capsule | `capsules/sfn/http/src/mod.sfn`, `capsules/sfn/http/src/wire.sfn` (new), `capsules/sfn/http/capsule.toml` (version bump), `capsules/sfn/http/tests/wire_test.sfn` (new) |
+| Runtime (Sailfin) | `runtime/sfn/concurrency/serve.sfn` (Wave 2: `sfn_serve_framed`; Wave 3: body drain), `runtime/sfn/adapters/http.sfn` (Wave 4: `sfn_http_request_raw`) |
+| Runtime (C) | none — no symbol flips, no header edits, no shared-layout hazards |
+| Compiler | `compiler/src/llvm/expression_lowering/native/core.sfn` (~line 1415, Wave 2 gate only); `compiler/src/llvm/runtime_helpers.sfn` only if a `serve_framed` registry row is wanted for defense-in-depth (optional) |
+| Examples | `examples/web/http-server.sfn` (rewrite), `examples/README.md` (capabilities note) |
+| Tests | `compiler/tests/e2e/test_http_capsule_serve.sh` (new), `compiler/tests/e2e/test_runtime_serve.sh` (unchanged — must stay green), per-wave capsule unit tests |
+| Docs | `docs/status.md` (http capsule row), `site/src/content/docs/docs/reference/standard-library.md` (sfn/http section: API, v0 limits), `runtime/sfn/concurrency/serve.sfn` header comment (framed contract) |


### PR DESCRIPTION
## What

Wave 1 of the `sfn/http` build-out (epic #1321): the pure-Sailfin HTTP/1.1 **wire layer** that the typed `serve` path (Wave 2) will marshal through. Also includes the approved design proposal.

Unblocked by **M4 (#965, closed)** — the Sailfin-native scheduler + `sfn_serve` runtime substrate is in place; this layer is exactly the `fn(Request) -> Response` marshalling "follow-up wave" the `serve.sfn` header names.

## Changes

- **`src/types.sfn`** (new) — split `Request` / `Response` / `ServerConfig` out of `mod.sfn` (adds `Request.query`) so `wire.sfn` and the `mod.sfn` barrel share them without an import cycle (same `types.sfn` layout as `sfn/cli`).
- **`src/wire.sfn`** (new):
  - `parse_request(raw) -> Request` — request line, path/query split, header lines, body.
  - `serialize_response(rsp) -> string` — status line via `reason_phrase`, `Content-Length` + `Connection: close` framing, and a **CR/LF header-injection guard** (drops any header containing `\r`/`\n`).
  - `header(req, name) -> string?` (case-insensitive) and `query_param(req, name) -> string?` accessors.
  - Response builders (`response`, `json_response`, `not_found`, …) moved here beside the serializer.
- **`src/mod.sfn`** — reduced to a barrel re-exporting `types` + `wire`; client `get`/`post` and the `serve` stub unchanged (Wave 2 wires `serve`).
- **`tests/wire_test.sfn`** (new) — 9 unit tests.
- **`capsule.toml`** — `0.2.1` → `0.3.0`.
- **`docs/proposals/sfn-http-capsule.md`** — approved design (handler API = return-based `fn(Request) -> Response`; v0 restricted to top-level handlers; no C edits / no symbol flips).

## Scope

Pure capsule code — **no runtime, compiler, or socket changes**; the compiler self-host is untouched. POST body reliability (Wave 3), typed `serve` (Wave 2), and the typed client (Wave 4) are follow-ups.

## Verification

```
build/native/sailfin fmt --check capsules/sfn/http/src/*.sfn capsules/sfn/http/tests/wire_test.sfn   # clean
build/native/sailfin test capsules/sfn/http/tests/wire_test.sfn                                      # PASS (9/9)
make compile                                                                                          # green (compiler unaffected)
```

Implementation note: uses the registered string runtime helpers (`grapheme_at` / `substring` / `strings_equal` / `char_code` / `find_char`) — `char_at` is not lowerable from capsule code.

Closes #1322
Part of #1321

https://claude.ai/code/session_01UdmehmTwqCJTayy2PD1CTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdmehmTwqCJTayy2PD1CTP)_