### PR TITLE
refactor(runtime): port arena core (create/alloc/global/enabled) to Sailfin

### DIFF
--- a/compiler/tests/e2e/test_owned_buf_grow_determinism.sh
+++ b/compiler/tests/e2e/test_owned_buf_grow_determinism.sh
@@ -137,11 +137,13 @@ extern int64_t owned_buf_byte_at(void *self, int64_t index);
 /* Runtime stubs the emitted IR references (same set as
  * test_owned_buf_roundtrip.sh). sfn_alloc_struct backs the boxed-struct
  * returns; plain malloc suffices because every box is fully initialized
- * by a whole-aggregate store before use. */
+ * by a whole-aggregate store before use.
+ *
+ * #1309: sfn_arena_enabled / sfn_arena_global are now defined in arena.ll
+ * (linked below), so stubbing them here would collide; the real defs
+ * reference sfn_alloc_struct, satisfied by the stub. */
 void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
 void sfn_type_register(void *desc) { (void)desc; }
-int sfn_arena_enabled(void) { return 0; }
-void *sfn_arena_global(void) { return NULL; }
 void *sfn_alloc_struct(int64_t size) { return malloc((size_t)size); }
 
 /* Read back the whole buffer and compare to expect[0..n). */

--- a/compiler/tests/e2e/test_owned_buf_roundtrip.sh
+++ b/compiler/tests/e2e/test_owned_buf_roundtrip.sh
@@ -234,21 +234,19 @@ extern int64_t slice_byte_at(void *slice, int64_t index);
  * test_runtime_memory_arena.sh — see its harness header for the
  * rationale on each). `sfn_alloc_struct` backs the boxed-struct
  * returns; a plain malloc suffices because every box is fully
- * initialized by a whole-aggregate store before use. */
+ * initialized by a whole-aggregate store before use.
+ *
+ * #1309: `sfn_arena_enabled` / `sfn_arena_global` are now DEFINED in
+ * arena.ll (they replaced the removed C namesakes), so stubbing them
+ * here would be a duplicate-symbol link error — the linked arena.ll
+ * provides them. They pull in `sfn_alloc_struct` (their probe literals)
+ * which the stub below satisfies. */
 void sailfin_runtime_mark_persistent(void *ptr) {
     (void)ptr;
 }
 
 void sfn_type_register(void *desc) {
     (void)desc;
-}
-
-int sfn_arena_enabled(void) {
-    return 0;
-}
-
-void *sfn_arena_global(void) {
-    return NULL;
 }
 
 void *sfn_alloc_struct(int64_t size) {

--- a/compiler/tests/e2e/test_runtime_memory_arena.sh
+++ b/compiler/tests/e2e/test_runtime_memory_arena.sh
@@ -152,21 +152,77 @@ test_no_bare_sfn_arena_define() {
         echo "[test]   $ll missing — test_emit_define_shape must run first"
         return 1
     fi
-    # Coexistence regression: the Sailfin module must NOT emit a
-    # bare `define ... @sfn_arena_create(` etc. — that name belongs
-    # to the C arena (`runtime/native/src/sailfin_arena.c`) and a
-    # collision would fail `make compile` at link time. The
-    # `sfn_arena_sfn_*` infix is the marker for Sailfin-emitted
-    # symbols. When M3 retires the C arena, this assertion goes
-    # away (the architect plan in #389 M2.2 calls this out).
+    # Coexistence regression (post-#1309). The arena *core* —
+    # `sfn_arena_create` / `sfn_arena_alloc` / `sfn_arena_global` /
+    # `sfn_arena_enabled` — is now Sailfin-owned (those C definitions
+    # were removed from `sailfin_arena.c`), so arena.sfn MUST emit bare
+    # `define`s for them (asserted positively below). The remaining
+    # still-C entry points — `sfn_arena_reset` / `sfn_arena_destroy` /
+    # `sfn_arena_realloc` (and `print_stats` / `mark` / `rewind`) —
+    # keep their C definitions, so arena.sfn must NOT emit bare
+    # `define`s for those names or `make compile` fails at link with a
+    # duplicate symbol. #822 retires the rest of the C arena and this
+    # split collapses.
     local found=0
-    for sym in sfn_arena_create sfn_arena_alloc sfn_arena_reset sfn_arena_destroy sfn_arena_realloc; do
+    for sym in sfn_arena_reset sfn_arena_destroy sfn_arena_realloc; do
         if grep -qE "^define .* @${sym}\(" "$ll"; then
             echo "[test]   collision risk: arena.sfn emits 'define ... @${sym}(', conflicts with C arena"
             found=$((found + 1))
         fi
     done
     return "$found"
+}
+
+test_bare_core_defines() {
+    # #1309: the four bare arena-core exports must be DEFINED by
+    # arena.sfn now that their C namesakes are gone — this is the link
+    # ownership the whole refactor turns on. Anchored at line start so
+    # a `call` site does not satisfy the assertion.
+    local ll="$SCRATCH/arena.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+    local missing=0
+    if ! grep -qE "^define i8\* @sfn_arena_create\(i64 " "$ll"; then
+        echo "[test]   missing 'define i8* @sfn_arena_create(i64 ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "^define i8\* @sfn_arena_alloc\(i8\* " "$ll"; then
+        echo "[test]   missing 'define i8* @sfn_arena_alloc(i8* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "^define i8\* @sfn_arena_global\(" "$ll"; then
+        echo "[test]   missing 'define i8* @sfn_arena_global()'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "^define i1 @sfn_arena_enabled\(" "$ll"; then
+        echo "[test]   missing 'define i1 @sfn_arena_enabled()'"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+test_arena_struct_is_40_bytes() {
+    # #1309 deciding constraint: the Sailfin `Arena` must be
+    # byte-identical to the C `SfnArena` (40 bytes / five i64 slots,
+    # `total_allocated@24` / `total_pages@32`) so the still-C
+    # `sfn_arena_realloc` / `print_stats` writing those offsets on the
+    # shared global handle stay in bounds. A regression that drops the
+    # two transition counters (24-byte handle) is a #1205-class heap
+    # corruption — caught here as an IR-shape mismatch before it can
+    # corrupt the heap.
+    local ll="$SCRATCH/arena.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+    if ! grep -qE "^%Arena = type \{ i64, i64, i64, i64, i64 \}" "$ll"; then
+        echo "[test]   Arena is not the 40-byte 5×i64 layout the C SfnArena requires:"
+        grep -E "^%Arena = type" "$ll" || echo "   (no %Arena type definition emitted)"
+        return 1
+    fi
+    return 0
 }
 
 test_lifecycle_roundtrip() {
@@ -244,20 +300,23 @@ void sfn_type_register(void *desc) {
     (void)desc;
 }
 
-/* #927: arena.sfn's mark/rewind pair reads the process-global arena
- * via the C `sfn_arena_enabled` / `sfn_arena_global`, so the emitted
- * arena.ll now `declare`s both. This lifecycle harness exercises only
- * the five core allocator entry points (mark/rewind have their own
- * roundtrip in test_runtime_memory_arena_mark.sh against the real C
- * arena), so a disabled-arena stub for `sfn_arena_enabled` and a NULL
- * `sfn_arena_global` keep the link self-contained — neither is reached
- * on the allocator path under test. */
-int sfn_arena_enabled(void) {
-    return 0;
-}
+/* #1309: arena.sfn now DEFINES `sfn_arena_enabled` and
+ * `sfn_arena_global` (they replaced the removed C namesakes), so the
+ * emitted arena.ll carries their bodies — providing stubs here would be
+ * a duplicate-symbol link error. This lifecycle harness exercises only
+ * the five `sfn_arena_sfn_*` infix entry points (which never reach the
+ * global handle or the arena-mode probe), so the real Sailfin
+ * definitions sit unused in the link; they pull in libc
+ * getenv/strcmp/write/abort, all resolved by the system C library. */
 
-void *sfn_arena_global(void) {
-    return NULL;
+/* #1309: those two functions build their probe literals (the env-var
+ * name; the OOM diagnostic) as SfnStrings via `sfn_alloc_struct`, so
+ * arena.ll now references it even though this harness never calls the
+ * functions. A calloc-backed stub satisfies the link (the
+ * interposed-`free` counter is unaffected — the infix entry points the
+ * harness exercises never call `sfn_alloc_struct`). */
+void *sfn_alloc_struct(long size_bytes) {
+    return calloc(1, (size_t)size_bytes);
 }
 
 int main(void) {
@@ -462,12 +521,257 @@ CHARNESS
     return 0
 }
 
+test_asan_no_corruption() {
+    # #1309 deciding constraint, end-to-end. Links the Sailfin arena
+    # (arena.ll: bare `sfn_arena_create` / `sfn_arena_alloc` that own
+    # the 40-byte handle) against the still-C `sailfin_arena.c`
+    # (`sfn_arena_realloc` / `sfn_arena_print_stats`) and exercises the
+    # cross-runtime path on a SHARED handle under AddressSanitizer. If
+    # the Sailfin `Arena` were the old 24-byte layout, the C side's
+    # instrumented reads/writes of `total_allocated@24` /
+    # `total_pages@32` would land in the malloc redzone and ASAN would
+    # report a heap-buffer-overflow. With the 40-byte match the run is
+    # clean. The IR-shape gate (test_arena_struct_is_40_bytes) catches
+    # the same regression statically; this is the dynamic proof.
+    local ll="$SCRATCH/arena.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping ASAN no-corruption gate"
+        return 0
+    fi
+
+    # ASAN reserves ~16 TB of virtual address space for its shadow at
+    # startup; any finite `ulimit -v` (or the compiler self-cap) aborts
+    # that reservation before main(). Skip — not fail — when capped; the
+    # static IR-shape gate still pins the layout. See
+    # `.claude/rules/compiler-safety.md`.
+    local vmem_cap
+    vmem_cap="$(ulimit -v 2>/dev/null || echo unlimited)"
+    if [ "$vmem_cap" != "unlimited" ]; then
+        echo "[test]   virtual-memory cap active (ulimit -v ${vmem_cap}) — ASAN shadow reservation cannot run; static 40-byte gate still passed"
+        return 0
+    fi
+
+    # Probe that the ASAN runtime (compiler-rt archives) is actually
+    # installed — many minimal toolchains ship clang without it. A
+    # missing sanitizer runtime is a SKIP, not a failure (the static
+    # 40-byte IR-shape gate already pins the layout); only a genuine
+    # `ERROR: AddressSanitizer` report below may fail the test. See
+    # `.claude/rules/compiler-safety.md`.
+    local probe="$SCRATCH/asan_probe.c"
+    echo 'int main(void){return 0;}' > "$probe"
+    if ! "$clang_bin" -fsanitize=address "$probe" -o "$SCRATCH/asan_probe" 2>"$SCRATCH/asan_probe.log"; then
+        echo "[test]   AddressSanitizer runtime unavailable (compiler-rt archives missing) — skipping; static 40-byte gate still passed"
+        return 0
+    fi
+
+    local harness="$SCRATCH/asan_harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* Cross-runtime no-corruption harness for #1309. The Sailfin arena
+ * owns create/alloc (40-byte handle); the C arena owns realloc/
+ * print_stats. Both touch the SAME handle. Under ASAN, a layout
+ * mismatch surfaces as a heap-buffer-overflow on the C side's access
+ * to total_allocated@24 / total_pages@32. */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Sailfin-defined (arena.ll). */
+extern void *sfn_arena_create(size_t default_page_size);
+extern void *sfn_arena_alloc(void *arena, size_t size, size_t align);
+/* C-defined (sailfin_arena.c) — operate on the shared handle. */
+extern void *sfn_arena_realloc(void *arena, void *ptr, size_t old_size,
+                               size_t new_size, size_t align);
+extern void sfn_arena_print_stats(void *arena);
+
+/* Stubs the emitted arena.ll references (see lifecycle harness). The
+ * Sailfin arena-mode probe / global builds SfnString literals via
+ * sfn_alloc_struct; a calloc-backed stub satisfies the link. */
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+void sfn_type_register(void *desc) { (void)desc; }
+void *sfn_alloc_struct(long size_bytes) { return calloc(1, (size_t)size_bytes); }
+
+int main(void) {
+    /* Sailfin create → 40-byte handle, total_allocated@24=0,
+     * total_pages@32=1. */
+    void *arena = sfn_arena_create(4096);
+    if (!arena) {
+        fprintf(stderr, "create returned NULL\n");
+        return 1;
+    }
+
+    /* Sailfin alloc bumps total_allocated@24 on the shared handle. */
+    uint8_t *p = (uint8_t *)sfn_arena_alloc(arena, 128, 8);
+    if (!p) {
+        fprintf(stderr, "alloc(128) returned NULL\n");
+        return 2;
+    }
+    memset(p, 0xAB, 128);
+
+    /* C realloc reads ptr/used and writes total_allocated@24 (grow-in-
+     * place: p is at the tip). C-instrumented access to offset 24 must
+     * be in-bounds → no ASAN report. */
+    uint8_t *p2 = (uint8_t *)sfn_arena_realloc(arena, p, 128, 256, 8);
+    if (!p2) {
+        fprintf(stderr, "realloc returned NULL\n");
+        return 3;
+    }
+    for (size_t i = 0; i < 128; i++) {
+        if (p2[i] != 0xAB) {
+            fprintf(stderr, "realloc lost bytes at %zu\n", i);
+            return 4;
+        }
+    }
+
+    /* C realloc copy-on-overflow path calls Sailfin sfn_arena_alloc
+     * (allocates a fresh page → writes total_pages@32 + total_allocated
+     * @24). Force it by allocating past the tip first. */
+    uint8_t *q = (uint8_t *)sfn_arena_alloc(arena, 64, 8);
+    if (!q) { return 5; }
+    uint8_t *p3 = (uint8_t *)sfn_arena_realloc(arena, p2, 256, 8192, 8);
+    if (!p3) { return 6; }
+
+    /* C print_stats reads total_allocated@24 and walks the page chain —
+     * the canonical cross-runtime read of the transition counters. */
+    sfn_arena_print_stats(arena);
+
+    return 0;
+}
+CHARNESS
+
+    local arena_c="$REPO_ROOT/runtime/native/src/sailfin_arena.c"
+    local inc="$REPO_ROOT/runtime/native/include"
+    local arena_obj="$SCRATCH/arena_ll.o"
+    local bin="$SCRATCH/asan_roundtrip"
+    local log="$SCRATCH/asan.log"
+    # Compile the Sailfin IR to a plain object first (no ASAN pass over
+    # machine-generated IR — the deciding access is the C side's read of
+    # the transition counters). ASAN interposes malloc globally, so the
+    # Sailfin-allocated 40-byte handle still gets redzones the
+    # instrumented C reads are checked against. -Wno-override-module:
+    # the .ll triple may not match the host.
+    if ! "$clang_bin" -Wno-override-module -c "$ll" -o "$arena_obj" 2>"$log"; then
+        echo "[test]   clang failed to compile arena.ll:"
+        cat "$log"
+        return 1
+    fi
+    # ASAN-instrument the C harness + the still-C arena; link the plain
+    # Sailfin object. SAILFIN_MEM_LIMIT=unlimited so the linked binary's
+    # own self-cap does not abort the shadow reservation.
+    if ! "$clang_bin" -fsanitize=address -Wno-override-module \
+        -I"$inc" "$harness" "$arena_c" "$arena_obj" -o "$bin" -lm 2>"$log"; then
+        echo "[test]   clang failed to build ASAN harness:"
+        cat "$log"
+        return 1
+    fi
+    if ! SAILFIN_MEM_LIMIT=unlimited ASAN_OPTIONS=detect_leaks=0 "$bin" >"$log" 2>&1; then
+        echo "[test]   ASAN no-corruption harness failed:"
+        cat "$log"
+        return 1
+    fi
+    if grep -q "ERROR: AddressSanitizer" "$log"; then
+        echo "[test]   AddressSanitizer reported a violation on the shared handle:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_arena_enabled_env_semantics() {
+    # #1309 regression coverage for the two subtlest fixes in the port:
+    #   (1) the re-entrancy guard — `sfn_arena_enabled` builds its
+    #       `SAILFIN_USE_ARENA` probe literals via `sfn_alloc_struct`,
+    #       which (like `mem.sfn`) calls back into `sfn_arena_enabled`;
+    #       without the provisional-state guard the very first call
+    #       recurses to a stack overflow. The harness's `sfn_alloc_struct`
+    #       below deliberately re-enters `sfn_arena_enabled` to reproduce
+    #       that path — a regression that drops the guard CRASHES here.
+    #   (2) the getenv-not-elided fix — the inline `getenv("…" as * u8)`
+    #       form miscompiles (call elided, result lowered to null), making
+    #       every env value read as "unset" (→ enabled). Asserting the
+    #       off-values flip to disabled pins the `string`-local form.
+    local ll="$SCRATCH/arena.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping env-semantics gate"
+        return 0
+    fi
+
+    local harness="$SCRATCH/env_harness.c"
+    cat > "$harness" <<'CHARNESS'
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+/* i1 return → declare _Bool so the upper bits of the return register
+ * are not read as garbage (an `int` decl makes every value read as
+ * nonzero/true). */
+extern _Bool sfn_arena_enabled(void);
+void sailfin_runtime_mark_persistent(void *p) { (void)p; }
+void sfn_type_register(void *d) { (void)d; }
+/* Mirror mem.sfn's sfn_alloc_struct: it consults sfn_arena_enabled to
+ * route arena-vs-calloc — exactly the re-entrancy the probe's
+ * provisional-state guard must survive. calloc keeps the harness
+ * self-contained; the point is to re-enter sfn_arena_enabled during its
+ * own first-call probe. Without the guard this recurses forever. */
+void *sfn_alloc_struct(long n) { (void)sfn_arena_enabled(); return calloc(1, (size_t)n); }
+int main(void) { printf("%d\n", sfn_arena_enabled() ? 1 : 0); return 0; }
+CHARNESS
+
+    local bin="$SCRATCH/env_probe"
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" -o "$bin" -lm 2>"$SCRATCH/env.log"; then
+        echo "[test]   clang failed to build env-semantics harness:"
+        cat "$SCRATCH/env.log"
+        return 1
+    fi
+
+    # Each row: "<label>|<env-spec>|<expected>". An empty env-spec means
+    # unset; "VAR=" means set-but-empty. A crash (no output / nonzero rc)
+    # is the recursion-guard regression signal.
+    local fails=0
+    _probe() { # $1=expected  $2.. = env assignment(s) (may be empty)
+        local expected="$1"; shift
+        local got
+        got="$(env -u SAILFIN_USE_ARENA "$@" "$bin" 2>/dev/null)" || {
+            echo "[test]   sfn_arena_enabled crashed (rc=$?) with [$*] — re-entrancy guard regression?"
+            fails=$((fails + 1)); return
+        }
+        if [ "$got" != "$expected" ]; then
+            echo "[test]   SAILFIN_USE_ARENA [$*]: got '$got', expected '$expected'"
+            fails=$((fails + 1))
+        fi
+    }
+    _probe 1                              # unset → on (default)
+    _probe 1 SAILFIN_USE_ARENA=1          # explicit on
+    _probe 1 SAILFIN_USE_ARENA=yes        # any other value → on
+    _probe 0 SAILFIN_USE_ARENA=           # empty → off
+    _probe 0 SAILFIN_USE_ARENA=0          # "0" → off
+    _probe 0 SAILFIN_USE_ARENA=false      # "false" → off
+    return "$fails"
+}
+
 run_test "sfn check runtime/sfn/memory/arena.sfn passes" test_check_clean
 run_test "sfn fmt --check runtime/sfn/memory/arena.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm produces define for every sfn_arena_sfn_* export" test_emit_define_shape
 run_test "sfn emit llvm declares libc malloc/free/memcpy trampolines" test_emit_libc_declares
-run_test "sfn emit llvm does not collide with C arena's sfn_arena_* exports" test_no_bare_sfn_arena_define
+run_test "sfn emit llvm defines bare arena-core exports (create/alloc/global/enabled)" test_bare_core_defines
+run_test "sfn emit llvm keeps Arena byte-identical to C SfnArena (40 bytes)" test_arena_struct_is_40_bytes
+run_test "sfn emit llvm does not collide with still-C sfn_arena_* exports" test_no_bare_sfn_arena_define
 run_test "create → alloc → realloc → reset → destroy exercises every entry point" test_lifecycle_roundtrip
+run_test "SAILFIN_USE_ARENA env semantics + probe recursion guard" test_arena_enabled_env_semantics
+run_test "ASAN: C realloc/print_stats on a Sailfin-created handle is corruption-free" test_asan_no_corruption
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/compiler/tests/e2e/test_runtime_memory_arena_mark.sh
+++ b/compiler/tests/e2e/test_runtime_memory_arena_mark.sh
@@ -10,9 +10,9 @@
 #
 #   1. emit shape — emitted IR carries a `define` for
 #                   `sfn_arena_sfn_mark` (→ double) and
-#                   `sfn_arena_sfn_rewind` (double →) plus a `declare`
-#                   for the C `sfn_arena_global` / `sfn_arena_enabled`
-#                   the bodies read.
+#                   `sfn_arena_sfn_rewind` (double →) plus a `define`
+#                   for `sfn_arena_global` / `sfn_arena_enabled` (now
+#                   Sailfin-owned, #1309) the bodies read.
 #   2. coexistence — the ported pair uses the module's `sfn_arena_sfn_*`
 #                    infix; assert it does NOT emit bare
 #                    `sfn_arena_mark` / `sfn_arena_rewind` (those names
@@ -76,16 +76,21 @@ test_emit_define_shape() {
     return "$missing"
 }
 
-test_emit_global_declares() {
+test_emit_global_defines() {
     local ll="$SCRATCH/arena.ll"
     if [ ! -f "$ll" ]; then
         echo "[test]   $ll missing — test_emit_define_shape must run first"
         return 1
     fi
+    # #1309: the global-arena handle + arena-mode probe that mark/rewind
+    # read are now DEFINED in arena.sfn (they replaced the removed C
+    # namesakes), so the bodies call the local Sailfin defs rather than
+    # an extern `declare`. A regression that reverts ownership to C
+    # (extern `declare` instead of `define`) trips this.
     local missing=0
     for sym in sfn_arena_enabled sfn_arena_global; do
-        if ! grep -qE "^declare .* @${sym}\(" "$ll"; then
-            echo "[test]   missing 'declare ... @${sym}(' in arena.ll"
+        if ! grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'define ... @${sym}(' in arena.ll"
             missing=$((missing + 1))
         fi
     done
@@ -161,11 +166,21 @@ extern void   sfn_arena_sfn_rewind(double encoded_mark);
 void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
 void sfn_type_register(void *meta) { (void)meta; }
 
-/* The Sailfin allocator bodies also declared in arena.ll reference
- * `malloc`/`free`/`memcpy`/`realloc` — all satisfied by libc. The
- * arena globals (`sfn_arena_enabled` / `sfn_arena_global`) come from
- * the linked sailfin_arena.c. We force arena mode on by setting the
- * env var before the first `sfn_arena_global()` call. */
+/* #1309: arena.sfn's `sfn_arena_enabled` / `sfn_arena_global` build
+ * their `SAILFIN_USE_ARENA` / probe literals via `sfn_alloc_struct`, so
+ * the emitted arena.ll references it. A calloc-backed stub satisfies the
+ * link; the mark/rewind roundtrip drives real allocations through the
+ * arena (`sfn_arena_alloc`) and never relies on this stub's bytes. */
+void *sfn_alloc_struct(long size_bytes) { return calloc(1, (size_t)size_bytes); }
+
+/* The Sailfin allocator bodies in arena.ll reference
+ * `malloc`/`free`/`memcpy` — all satisfied by libc. #1309 moved
+ * `sfn_arena_enabled` / `sfn_arena_global` / `sfn_arena_alloc` /
+ * `sfn_arena_create` INTO arena.ll (the C namesakes were removed); this
+ * harness links arena.ll for those and sailfin_arena.c for the still-C
+ * `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind`
+ * that share the same global handle. We force arena mode on by setting
+ * the env var before the first `sfn_arena_global()` call. */
 int main(void) {
     /* ---- DISABLED arena: mark→0.0, rewind inert (genuine no-op) ----
      * Run first, in a forked child that never enables the arena (the
@@ -272,7 +287,7 @@ CHARNESS
 }
 
 run_test "sfn emit llvm produces define for sfn_arena_sfn_mark / _rewind" test_emit_define_shape
-run_test "sfn emit llvm declares C arena globals (enabled/global)" test_emit_global_declares
+run_test "sfn emit llvm defines arena globals (enabled/global) in Sailfin" test_emit_global_defines
 run_test "ported pair does not collide with bare C arena mark/rewind" test_no_bare_c_arena_collision
 run_test "mark → alloc → rewind reclaims post-mark bump (real C arena)" test_mark_rewind_roundtrip
 

--- a/compiler/tests/e2e/test_runtime_sfn_sources_active.sh
+++ b/compiler/tests/e2e/test_runtime_sfn_sources_active.sh
@@ -20,12 +20,14 @@
 # manifest. With build.sh retired, the manifest is the sole
 # source of truth and the allowlist drift-check below is gone.
 #
-# The test asserts both the new (Sailfin) and the old (C)
-# symbol families are present. The C arena assertion guards
-# the M2 "both arenas link side-by-side" invariant — a future
-# patch that drops the C arena before M3 trips this assertion
-# (which is intentional: the C arena retires on a tracked PR,
-# not silently).
+# The test asserts the Sailfin `sfn_arena_sfn_*` infix family, the
+# bare arena-core exports that #1309 moved into Sailfin
+# (`sfn_arena_create`/`alloc`/`global`/`enabled`), and the remaining C
+# arena symbols (`reset`/`destroy`/`realloc`/`print_stats`/`mark`/
+# `rewind`) are all present. The remaining-C assertion guards the
+# "C arena still links for the not-yet-ported entry points" invariant —
+# a patch that drops them before #822 trips it (intentional: the C arena
+# retires on a tracked PR, not silently).
 
 set -euo pipefail
 
@@ -94,40 +96,63 @@ test_compiler_binary_exports_sfn_arena_sfn() {
     return "$missing"
 }
 
-# ---- Test: the compiler binary still exports the C arena symbols ----
+# ---- Test: the compiler binary still exports the remaining C arena symbols ----
 test_compiler_binary_keeps_c_arena_exports() {
-    # Coexistence invariant: M2.1 ships the Sailfin arena
-    # alongside the C arena, not as a replacement. The C arena
-    # remains the production allocator until M3 retires
-    # `runtime/native/src/sailfin_arena.c`. A patch that
-    # accidentally drops the C arena would silently route
-    # production through unfinished Sailfin stubs — this
-    # assertion catches that. Same defined-text-symbol regex as
-    # the Sailfin-export assertion above (` T ` / ` t `, with
-    # the optional macOS `_` prefix) so an undefined reference
-    # cannot pass for an export and Mach-O symbol mangling does
-    # not produce false negatives.
+    # Coexistence invariant. #1309 moved the arena *core* —
+    # `sfn_arena_create` / `sfn_arena_alloc` (+ the global handle /
+    # arena-mode probe) — into the Sailfin module, but the rest of the C
+    # arena (`reset` / `destroy` / `realloc`, plus `print_stats` / `mark`
+    # / `rewind`) stays the production implementation, operating on the
+    # same shared global handle, until #822 retires
+    # `runtime/native/src/sailfin_arena.c`. This asserts those still-C
+    # symbols remain exported: a patch that accidentally drops the
+    # remaining C arena before #822 — silently routing production through
+    # absent helpers — trips here. (create/alloc are checked as
+    # Sailfin-owned below; they must NOT be re-added to this C list.)
+    # Same defined-text-symbol regex as the Sailfin-export assertion
+    # above (` T ` / ` t `, optional macOS `_` prefix) so an undefined
+    # reference cannot pass for an export and Mach-O mangling does not
+    # produce false negatives.
     local nm_log
     nm_log="$(nm "$BINARY" 2>/dev/null || true)"
     local missing=0
-    for sym in sfn_arena_create sfn_arena_alloc sfn_arena_reset sfn_arena_destroy sfn_arena_realloc; do
+    for sym in sfn_arena_reset sfn_arena_destroy sfn_arena_realloc sfn_arena_print_stats sfn_arena_mark sfn_arena_rewind; do
         if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
-            echo "[test]   compiler binary missing C arena export: $sym (looked for ' T|t [_]${sym}' in nm output)"
+            echo "[test]   compiler binary missing still-C arena export: $sym (looked for ' T|t [_]${sym}' in nm output)"
             missing=$((missing + 1))
         fi
     done
     return "$missing"
 }
 
-# ---- Test: nm | grep sfn_arena matches at least the five spec names ----
+# ---- Test: the bare arena-core exports are Sailfin-owned (#1309) ----
+test_compiler_binary_exports_bare_arena_core() {
+    # #1309 headline: the bare `sfn_arena_create` / `sfn_arena_alloc` /
+    # `sfn_arena_global` / `sfn_arena_enabled` are now DEFINED by the
+    # Sailfin arena module (the C namesakes were removed), so the linker
+    # binds every caller — `sailfin_runtime.c`'s bare call sites and the
+    # `mem.sfn` externs — to the Sailfin definitions. They must be
+    # present as defined text symbols; a regression that fails to emit
+    # them (or re-adds the C defs as duplicates) breaks the link this
+    # asserts. Same defined-text-symbol regex as the other export checks.
+    local nm_log
+    nm_log="$(nm "$BINARY" 2>/dev/null || true)"
+    local missing=0
+    for sym in sfn_arena_create sfn_arena_alloc sfn_arena_global sfn_arena_enabled; do
+        if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
+            echo "[test]   compiler binary missing Sailfin arena-core export: $sym"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: nm | grep sfn_arena matches at least the spec name ----
 test_nm_grep_sfn_arena_spec_names() {
-    # The literal acceptance check from issue #394: every spec
-    # name in the architect's "exposes" list (`sfn_arena_create
-    # / alloc / reset / destroy / realloc`) is present in the
-    # compiler binary. Today both the C arena and the Sailfin
-    # module's distinct-but-prefixed exports satisfy this; the
-    # check stays valid through M3 because the C arena is the
-    # one keeping these specific names.
+    # The literal acceptance check from issue #394: the spec name
+    # `sfn_arena_alloc` is present in the compiler binary. Post-#1309 it
+    # is the Sailfin bare export that satisfies this (the C namesake was
+    # removed); the check stays valid through #822.
     local nm_log
     nm_log="$(nm "$BINARY" 2>/dev/null || true)"
     if ! grep -q "sfn_arena_alloc" <<< "$nm_log"; then
@@ -139,7 +164,8 @@ test_nm_grep_sfn_arena_spec_names() {
 
 run_test "runtime/native/capsule.toml sfn-sources lists the arena module" test_manifest_lists_arena
 run_test "compiler binary exports five sfn_arena_sfn_* Sailfin symbols" test_compiler_binary_exports_sfn_arena_sfn
-run_test "compiler binary still exports five sfn_arena_* C arena symbols" test_compiler_binary_keeps_c_arena_exports
+run_test "compiler binary exports bare arena-core (create/alloc/global/enabled) from Sailfin" test_compiler_binary_exports_bare_arena_core
+run_test "compiler binary still exports remaining C arena symbols (reset/destroy/realloc/...)" test_compiler_binary_keeps_c_arena_exports
 run_test "nm | grep sfn_arena_alloc matches at least one symbol (#394 spec)" test_nm_grep_sfn_arena_spec_names
 
 echo "[summary] $PASS passed, $FAIL failed"

--- a/compiler/tests/e2e/test_runtime_string_immediate.sh
+++ b/compiler/tests/e2e/test_runtime_string_immediate.sh
@@ -64,6 +64,7 @@ cat > "$HARNESS" <<'EOF'
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Canonical sfn_str_* trampoline ABI (runtime/native/src/sailfin_runtime.c). */
@@ -78,6 +79,26 @@ extern int64_t sfn_str_byte_at(const char *s, int64_t idx);
 extern int64_t sfn_str_find_byte(const char *s, int64_t byte_value, int64_t start_index);
 extern double sfn_str_codepoint(const char *s);
 extern double sfn_str_to_number(const char *s);
+
+/* #1309: the arena core (`sfn_arena_enabled` / `sfn_arena_global` /
+ * `sfn_arena_alloc`) moved from sailfin_arena.c into the Sailfin module
+ * runtime/sfn/memory/arena.sfn, so the C-only sources this fixture links
+ * (sailfin_runtime.c + sailfin_arena.c) no longer resolve them. This
+ * fixture targets the immediate-codepoint guards in the `sfn_str_*`
+ * trampolines, which are independent of the allocation strategy, so we
+ * provide minimal C stubs rather than pulling the Sailfin arena into a
+ * deliberately C-only test: `enabled`→false steers the runtime to its
+ * malloc/calloc fallback, and `alloc` is malloc-backed for any path that
+ * still reaches it. (The still-C realloc/reset/destroy/print_stats in
+ * sailfin_arena.c are guarded by `enabled()` and stay dormant here.) */
+bool sfn_arena_enabled(void) { return false; }
+void *sfn_arena_global(void) { static char dummy[64]; return dummy; }
+void *sfn_arena_alloc(void *arena, size_t size, size_t align)
+{
+    (void)arena;
+    (void)align;
+    return malloc(size);
+}
 
 static int failures = 0;
 

--- a/runtime/native/include/sailfin_arena.h
+++ b/runtime/native/include/sailfin_arena.h
@@ -1,15 +1,21 @@
 #pragma once
 
 /*
- * sailfin_arena.h — M0.5 bump allocator for the Sailfin runtime.
+ * sailfin_arena.h — bump allocator for the Sailfin runtime (transition).
  *
- * Temporary C implementation that will be replaced by a Sailfin-native
- * arena at M2/M3. See docs/runtime_architecture.md §4.4.
+ * As of #1309 the arena *core* — the process-global handle and the hot
+ * bump path (`sfn_arena_create`, `sfn_arena_alloc`, `sfn_arena_global`,
+ * `sfn_arena_enabled`) — lives in `runtime/sfn/memory/arena.sfn`. The
+ * declarations for those four stay below so C callers link against the
+ * Sailfin definitions; the C definitions here are
+ * `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind`,
+ * which operate on the same shared handle and retire in #822. See
+ * docs/runtime_architecture.md §4.4.
  *
- * When SAILFIN_USE_ARENA=1 is set in the environment, the runtime routes
- * all string and array allocations through a process-global arena. Memory
- * is freed in bulk at process exit (or per-module in a future long-lived
- * compiler process).
+ * When the arena is enabled (SAILFIN_USE_ARENA — unset/other → on;
+ * empty/"0"/"false" → off), the runtime routes all string and array
+ * allocations through a process-global arena. Memory is freed in bulk at
+ * process exit (or per-module in a long-lived compiler process).
  */
 
 #include <stddef.h>
@@ -42,7 +48,13 @@ extern "C"
 
     /* ---------- Lifecycle ---------- */
 
-    /* Create a new arena with the given default page size. */
+    /*
+     * Create a new arena with the given default page size.
+     *
+     * #1309: defined in runtime/sfn/memory/arena.sfn — this prototype
+     * stays so C callers (sailfin_runtime.c) link against the Sailfin
+     * definition. sailfin_arena.c no longer defines it.
+     */
     SfnArena *sfn_arena_create(size_t default_page_size);
 
     /* Reset all pages to used=0. Does NOT free backing pages. */
@@ -86,6 +98,11 @@ extern "C"
      * If the current page cannot fit, a new page is allocated
      * (max of default_page_size and size+align).
      * Returns NULL only on malloc failure.
+     *
+     * #1309: defined in runtime/sfn/memory/arena.sfn (the bare export
+     * forwards to `sfn_arena_sfn_alloc`); this prototype stays for C
+     * callers and for sfn_arena_realloc below. sailfin_arena.c no
+     * longer defines it.
      */
     void *sfn_arena_alloc(SfnArena *arena, size_t size, size_t align);
 
@@ -103,8 +120,15 @@ extern "C"
                             size_t new_size, size_t align);
 
     /* ---------- Global arena ---------- */
+    /*
+     * #1309: sfn_arena_enabled and sfn_arena_global are defined in
+     * runtime/sfn/memory/arena.sfn. These prototypes stay so C callers
+     * (sailfin_runtime.c) link against the Sailfin definitions;
+     * sailfin_arena.c no longer defines them or the lazy-singleton
+     * statics.
+     */
 
-    /* Returns true if arena mode is active (SAILFIN_USE_ARENA=1). */
+    /* Returns true if arena mode is active (SAILFIN_USE_ARENA semantics). */
     bool sfn_arena_enabled(void);
 
     /* Get the process-global arena (lazily created on first call). */

--- a/runtime/native/src/sailfin_arena.c
+++ b/runtime/native/src/sailfin_arena.c
@@ -1,45 +1,34 @@
 /*
- * sailfin_arena.c — M0.5 bump allocator for the Sailfin runtime.
+ * sailfin_arena.c — bump allocator for the Sailfin runtime (transition).
  *
- * Temporary C implementation (~200 lines). Will be replaced by a
- * Sailfin-native arena at M2/M3. See docs/runtime_architecture.md §4.4.
+ * As of #1309 the arena *core* — the process-global handle plus the hot
+ * bump path (`sfn_arena_create`, `sfn_arena_alloc`, `sfn_arena_global`,
+ * `sfn_arena_enabled`) — is owned by the Sailfin module
+ * `runtime/sfn/memory/arena.sfn`; those symbols are removed here so the
+ * linker binds every caller (this file's siblings, `sailfin_runtime.c`,
+ * and the `mem.sfn` externs) to the Sailfin definitions. What remains —
+ * `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind` —
+ * operates on the *same* shared global handle, which is byte-compatible
+ * across both runtimes (the Sailfin `Arena` mirrors `SfnArena`'s 40-byte
+ * layout). The rest of this file retires in #822. See
+ * docs/runtime_architecture.md §4.4.
  */
 
 #include "sailfin_arena.h"
 
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * `sfn_arena_alloc` is now defined in `runtime/sfn/memory/arena.sfn`
+ * (#1309); `sfn_arena_realloc` below calls it through the prototype in
+ * `sailfin_arena.h`, resolved at link time against the Sailfin object.
+ */
+
 /* ------------------------------------------------------------------ */
 /* Internal helpers                                                    */
 /* ------------------------------------------------------------------ */
-
-static inline size_t _align_up(size_t value, size_t align)
-{
-    /* align must be a non-zero power of two (all internal callers pass 8). */
-    return (value + align - 1) & ~(align - 1);
-}
-
-static SfnArenaPage *_page_create(size_t capacity)
-{
-    SfnArenaPage *page = (SfnArenaPage *)malloc(sizeof(SfnArenaPage));
-    if (!page)
-        return NULL;
-
-    page->data = (uint8_t *)malloc(capacity);
-    if (!page->data)
-    {
-        free(page);
-        return NULL;
-    }
-
-    page->capacity = capacity;
-    page->used = 0;
-    page->next = NULL;
-    return page;
-}
 
 static void _page_destroy(SfnArenaPage *page)
 {
@@ -53,29 +42,7 @@ static void _page_destroy(SfnArenaPage *page)
 /* Lifecycle                                                           */
 /* ------------------------------------------------------------------ */
 
-SfnArena *sfn_arena_create(size_t default_page_size)
-{
-    if (default_page_size == 0)
-        default_page_size = 1024 * 1024; /* 1 MiB default for compiler */
-
-    SfnArena *arena = (SfnArena *)malloc(sizeof(SfnArena));
-    if (!arena)
-        return NULL;
-
-    SfnArenaPage *first = _page_create(default_page_size);
-    if (!first)
-    {
-        free(arena);
-        return NULL;
-    }
-
-    arena->current = first;
-    arena->first = first;
-    arena->default_page_size = default_page_size;
-    arena->total_allocated = 0;
-    arena->total_pages = 1;
-    return arena;
-}
+/* sfn_arena_create: now defined in runtime/sfn/memory/arena.sfn (#1309). */
 
 void sfn_arena_reset(SfnArena *arena)
 {
@@ -141,69 +108,7 @@ void sfn_arena_destroy(SfnArena *arena)
 /* Allocation                                                          */
 /* ------------------------------------------------------------------ */
 
-void *sfn_arena_alloc(SfnArena *arena, size_t size, size_t align)
-{
-    if (!arena || size == 0)
-        return NULL;
-    if (align == 0)
-        align = 8;
-
-    SfnArenaPage *page = arena->current;
-    size_t offset = _align_up(page->used, align);
-
-    if (offset <= page->capacity && size <= page->capacity - offset)
-    {
-        page->used = offset + size;
-        arena->total_allocated += size;
-        return page->data + offset;
-    }
-
-    /* Current page too small — try to reuse downstream pages first.
-     *
-     * `sfn_arena_rewind` (Phase 5a) leaves zeroed pages attached
-     * after the rewind target so subsequent allocations can reuse
-     * the existing capacity instead of growing the page list. The
-     * old behavior allocated a fresh page on every overflow,
-     * leaking the rewound capacity behind the new page in the
-     * linked list. Walking forward here makes mark/rewind a true
-     * stack-discipline reuse. The walk is bounded by pages that
-     * survived the most-recent rewind; in steady state it's
-     * usually one hop. */
-    SfnArenaPage *candidate = page->next;
-    while (candidate)
-    {
-        size_t cand_offset = _align_up(candidate->used, align);
-        if (cand_offset <= candidate->capacity && size <= candidate->capacity - cand_offset)
-        {
-            candidate->used = cand_offset + size;
-            arena->current = candidate;
-            arena->total_allocated += size;
-            return candidate->data + cand_offset;
-        }
-        candidate = candidate->next;
-    }
-
-    /* No reusable downstream page — allocate a new one. */
-    size_t needed = size + align; /* worst-case alignment padding */
-    size_t page_size = arena->default_page_size;
-    if (needed > page_size)
-        page_size = needed;
-
-    SfnArenaPage *new_page = _page_create(page_size);
-    if (!new_page)
-        return NULL;
-
-    /* Insert new page after current and advance. */
-    new_page->next = page->next;
-    page->next = new_page;
-    arena->current = new_page;
-    arena->total_pages++;
-
-    offset = _align_up(new_page->used, align);
-    new_page->used = offset + size;
-    arena->total_allocated += size;
-    return new_page->data + offset;
-}
+/* sfn_arena_alloc: now defined in runtime/sfn/memory/arena.sfn (#1309). */
 
 void *sfn_arena_realloc(SfnArena *arena, void *ptr, size_t old_size,
                         size_t new_size, size_t align)
@@ -245,84 +150,18 @@ void *sfn_arena_realloc(SfnArena *arena, void *ptr, size_t old_size,
 }
 
 /* ------------------------------------------------------------------ */
-/* Global arena (lazy singleton)                                       */
+/* Global arena + arena-mode probe                                     */
 /* ------------------------------------------------------------------ */
-
-static SfnArena *_global_arena = NULL;
-static int _arena_enabled = -1; /* -1 = unchecked */
-static pthread_once_t _arena_enabled_once = PTHREAD_ONCE_INIT;
-static pthread_once_t _arena_global_once = PTHREAD_ONCE_INIT;
-
-static void _init_arena_enabled(void)
-{
-    /*
-     * Arena is on by default. End-user `sfn check`, `sfn test`, and
-     * any future `sfn vet`/`sfn fix`/`sfn lsp` invocation needs the
-     * arena (Phase 5a's mark/rewind primitive only reclaims memory
-     * when the arena is active) — without it the in-process multi-
-     * module loop hits the unfreed-allocations wall documented in
-     * `docs/build-performance.md` Root Cause 5 and SIGSEGVs at
-     * scale. `make compile` historically exported
-     * `SAILFIN_USE_ARENA=1` via the prior `scripts/build.sh` (since
-     * retired in Stage E PR7 / #383); this flip extends the same
-     * default to installed binaries so end users don't have to set
-     * the env var themselves.
-     *
-     * Opt-out: `SAILFIN_USE_ARENA=0` (or `""` or `"false"`) disables
-     * the arena and the runtime falls back to the malloc/owned-string-
-     * hash path. Useful for the `make test-arena` IR-equivalence harness
-     * and for diagnosing arena-vs-malloc divergences. The off-set
-     * matches the Sailfin-side `_env_flag` contract in
-     * `compiler/src/cli_commands_utils.sfn` so a single mental model
-     * applies across every `SAILFIN_*` toggle.
-     *
-     * Empty env: `SAILFIN_USE_ARENA=` (set but empty) is treated
-     * as opt-out, mirroring the `=0` case. This is a deliberate
-     * divergence from `unset` (which now means "take the default",
-     * i.e. arena ON): a script that explicitly clears the variable
-     * with `SAILFIN_USE_ARENA=` is signalling intent to disable,
-     * not "I have no opinion". `unset SAILFIN_USE_ARENA` is the
-     * way to ask for the default.
-     */
-    const char *env = getenv("SAILFIN_USE_ARENA");
-    if (env == NULL)
-    {
-        /* Unset: take the default. */
-        _arena_enabled = 1;
-        return;
-    }
-    if (env[0] == '\0' || strcmp(env, "0") == 0 || strcmp(env, "false") == 0)
-    {
-        /* Explicit opt-out: empty string, "0", or "false". */
-        _arena_enabled = 0;
-        return;
-    }
-    /* Any other value is opt-in (including the historical "1"). */
-    _arena_enabled = 1;
-}
-
-bool sfn_arena_enabled(void)
-{
-    pthread_once(&_arena_enabled_once, _init_arena_enabled);
-    return _arena_enabled == 1;
-}
-
-static void _init_global_arena(void)
-{
-    /* 4 MiB pages for the compiler — modules can be large. */
-    _global_arena = sfn_arena_create(4 * 1024 * 1024);
-    if (!_global_arena)
-    {
-        fprintf(stderr, "[sailfin-arena] fatal: failed to create global arena\n");
-        abort();
-    }
-}
-
-SfnArena *sfn_arena_global(void)
-{
-    pthread_once(&_arena_global_once, _init_global_arena);
-    return _global_arena;
-}
+/*
+ * `sfn_arena_enabled` (SAILFIN_USE_ARENA probe) and `sfn_arena_global`
+ * (lazy process-global handle), along with their backing statics and
+ * pthread_once init helpers, are now defined in
+ * `runtime/sfn/memory/arena.sfn` (#1309). The Sailfin
+ * `sfn_arena_enabled` preserves the exact env semantics documented
+ * there: unset → on (default); empty / "0" / "false" → off; anything
+ * else → on. `sfn_arena_global` creates a 4 MiB-page handle on first
+ * call and aborts with the same fd-2 diagnostic on OOM.
+ */
 
 /* ------------------------------------------------------------------ */
 /* Stats                                                               */

--- a/runtime/native/src/sailfin_arena.c
+++ b/runtime/native/src/sailfin_arena.c
@@ -160,7 +160,8 @@ void *sfn_arena_realloc(SfnArena *arena, void *ptr, size_t old_size,
  * `sfn_arena_enabled` preserves the exact env semantics documented
  * there: unset → on (default); empty / "0" / "false" → off; anything
  * else → on. `sfn_arena_global` creates a 4 MiB-page handle on first
- * call and aborts with the same fd-2 diagnostic on OOM.
+ * call and `abort()`s (bare, no diagnostic — printing one would
+ * re-enter sfn_alloc_struct → sfn_arena_global and recurse) on OOM.
  */
 
 /* ------------------------------------------------------------------ */

--- a/runtime/sfn/memory/arena.sfn
+++ b/runtime/sfn/memory/arena.sfn
@@ -16,8 +16,10 @@
 //   sfn_arena_sfn_destroy(arena)             → free pages + arena
 //   sfn_arena_sfn_realloc(arena, ptr, old, new, align) → grow-if-at-tip
 //
-// Layout. `Arena` is a 24-byte (three i64 slot) handle that owns a
-// chain of `ArenaPage` records. Each `ArenaPage` is a 32-byte (four
+// Layout. `Arena` is a 40-byte (five i64 slot) handle that owns a
+// chain of `ArenaPage` records — byte-identical to the C `SfnArena`
+// (#1309; see the `struct Arena` comment for why the dual-runtime
+// transition requires the match). Each `ArenaPage` is a 32-byte (four
 // i64 slot) header followed by a separately-malloc'd byte buffer.
 // Pointer-typed fields ride as `i64` slots — same workaround as
 // `runtime/sfn/memory/rc.sfn` and `runtime/sfn/exception.sfn` because
@@ -45,14 +47,20 @@
 // matching the C arena's contract documented in
 // `runtime_architecture.md` §2.1.1.
 //
-// Coexistence with the C arena. Sailfin exports use the `sfn_arena_sfn_*`
-// infix; the C arena exports the bare `sfn_arena_*` names. Both
-// families ship in every compiler binary today — the production
-// runtime keeps calling the C entry points. M3 retires the C arena
-// (flip the C namesakes to `static`, rename the Sailfin exports to
-// the bare form, and route every caller through the Sailfin module
-// in a single rollback-safe PR). Until then the dual-arena layout is
-// the proof-of-life for the M2 runtime/sfn link path.
+// Coexistence with the C arena. As of #1309 the arena *core* — the
+// process-global handle plus the hot bump path — is Sailfin-owned: the
+// bare `sfn_arena_create` / `sfn_arena_alloc` / `sfn_arena_global` /
+// `sfn_arena_enabled` exports below replace the C namesakes (now
+// removed from `sailfin_arena.c`), so the linker binds every caller
+// (the 29 bare `sailfin_runtime.c` call sites and the `mem.sfn`
+// externs) here. The `sfn_arena_sfn_*` infix family is retained for
+// `ownedbuf.sfn`'s externs and is the implementation the bare
+// `create`/`alloc` forward to. The still-C
+// `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind`
+// operate on the **same shared 40-byte global handle** — which is why
+// `Arena` mirrors the C `SfnArena` layout byte-for-byte. #822 deletes
+// the remaining C arena and shrinks the two transition-only counters
+// back out (40→24).
 //
 // Effects: none. Memory primitives sit below the I/O layer (same
 // discipline as `runtime/sfn/memory/rc.sfn` and the other
@@ -100,6 +108,18 @@ extern fn free(ptr: * u8) -> void;
 
 extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
 
+// libc helpers backing the process-global handle + arena-mode probe
+// ported from `sailfin_arena.c` in #1309. `getenv`/`strcmp` reproduce
+// `_init_arena_enabled`'s `SAILFIN_USE_ARENA` decision; `abort`
+// reproduces `_init_global_arena`'s fatal-on-OOM termination. Inlined
+// for the same cross-module extern-resolution reason as `malloc`/`free`
+// above.
+extern fn getenv(name: * u8) -> * u8;
+
+extern fn strcmp(a: * u8, b: * u8) -> i32;
+
+extern fn abort() -> void;
+
 // `ArenaPage` is the per-page bookkeeping header (32 bytes, four
 // i64 slots). `data_addr` points at the page's backing byte buffer
 // (malloc'd separately from this header). `capacity` is the buffer
@@ -114,14 +134,33 @@ struct ArenaPage {
     next_addr: i64;
 }
 
-// `Arena` is the public handle (24 bytes, three i64 slots).
+// `Arena` is the public handle (40 bytes, five i64 slots).
 // `current_addr` is the page that satisfies the next bump; `first_addr`
 // is the chain head (for reset and destroy walks); `default_page_size`
-// is the size of fresh pages spawned when the chain overflows.
+// is the size of fresh pages spawned when the chain overflows;
+// `total_allocated` is the running byte count handed out by `alloc`;
+// `total_pages` is the number of pages in the chain.
+//
+// The two trailing counters (`total_allocated`, `total_pages`) mirror
+// the C `SfnArena` layout exactly (`sailfin_arena.h:34-41`:
+// `current@0, first@8, default_page_size@16, total_allocated@24,
+// total_pages@32`). The handle is dereferenced by **both** runtimes
+// during the M2→M3 transition (#1309): the Sailfin `create`/`alloc`
+// now own the process-global handle while the still-C
+// `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind`
+// keep operating on it. A 24-byte Sailfin handle would let those C
+// helpers write `total_allocated`/`total_pages` past the allocation —
+// a #1205-class heap corruption — so the layout is byte-identical here
+// and the counters are maintained the way `sailfin_arena.c:157,200,
+// 75-76` do. The two extra fields shrink back out in #822 when the C
+// arena is deleted. The 40-byte layout is also the one the mark/rewind
+// port (below) already assumes.
 struct Arena {
     current_addr: i64;
     first_addr: i64;
     default_page_size: i64;
+    total_allocated: i64;
+    total_pages: i64;
 }
 
 // `_sfn_arena_align_up(value, align)` rounds `value` up to the next
@@ -181,7 +220,7 @@ fn sfn_arena_sfn_create(default_page_size: usize) -> * u8 {
     let mut page_size: i64 = default_page_size as i64;
     if page_size == 0 { page_size = 1048576; }
 
-    let arena_ptr: * u8 = malloc(24 as usize);
+    let arena_ptr: * u8 = malloc(40 as usize);
     if arena_ptr as i64 == 0 { return arena_ptr; }
 
     let first_ptr: * u8 = _sfn_arena_page_create(page_size);
@@ -194,6 +233,10 @@ fn sfn_arena_sfn_create(default_page_size: usize) -> * u8 {
     arena.current_addr = first_ptr as i64;
     arena.first_addr = first_ptr as i64;
     arena.default_page_size = page_size;
+    // Init the C-mirrored counters (sailfin_arena.c:75-76): one seed
+    // page, zero bytes handed out yet.
+    arena.total_allocated = 0;
+    arena.total_pages = 1;
     return arena_ptr;
 }
 
@@ -223,6 +266,7 @@ fn sfn_arena_sfn_alloc(arena: * u8, size: usize, align: usize) -> * u8 {
         let space: i64 = cap - offset;
         if size_i <= space {
             page.used = offset + size_i;
+            a.total_allocated = a.total_allocated + size_i;
             let result_addr: i64 = page.data_addr + offset;
             return result_addr as * u8;
         }
@@ -245,6 +289,7 @@ fn sfn_arena_sfn_alloc(arena: * u8, size: usize, align: usize) -> * u8 {
             if size_i <= cand_space {
                 candidate.used = cand_offset + size_i;
                 a.current_addr = candidate_addr;
+                a.total_allocated = a.total_allocated + size_i;
                 let cand_result_addr: i64 = candidate.data_addr + cand_offset;
                 return cand_result_addr as * u8;
             }
@@ -268,11 +313,149 @@ fn sfn_arena_sfn_alloc(arena: * u8, size: usize, align: usize) -> * u8 {
     new_page.next_addr = page.next_addr;
     page.next_addr = new_page_ptr as i64;
     a.current_addr = new_page_ptr as i64;
+    a.total_pages = a.total_pages + 1;
 
     let new_offset: i64 = _sfn_arena_align_up(new_page.used, align_i);
     new_page.used = new_offset + size_i;
+    a.total_allocated = a.total_allocated + size_i;
     let new_result_addr: i64 = new_page.data_addr + new_offset;
     return new_result_addr as * u8;
+}
+
+// ====================================================================
+// Bare-named arena core (#1309, C1 of epic #1308).
+//
+// The C `sfn_arena_create` / `sfn_arena_alloc` / `sfn_arena_global` /
+// `sfn_arena_enabled` are removed from `sailfin_arena.c`; these bare
+// Sailfin exports take over those symbol names so the linker binds
+// every caller — `sailfin_runtime.c`'s 29 bare call sites and the
+// `mem.sfn` externs — to the Sailfin definitions. The still-C
+// `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind`
+// keep operating on the **same shared 40-byte global handle** these
+// produce, so the layout-match above is the deciding correctness
+// constraint. The 24→40 shrink and the rest of the C arena retire in
+// #822.
+//
+// `create` and `alloc` are thin forwarders to the `sfn_arena_sfn_*`
+// infix bodies above (which own the bump discipline and the
+// C-mirrored counter upkeep) so there is a single implementation of
+// each. The infix family stays exported for `ownedbuf.sfn`'s externs.
+// `sfn_arena_create(default_page_size)` — bare-named entry point.
+// Forwards to `sfn_arena_sfn_create`, which allocates the 40-byte
+// handle and inits `total_allocated`/`total_pages`. Faithful to the C
+// `sfn_arena_create` (`sailfin_arena.c:56`).
+fn sfn_arena_create(default_page_size: usize) -> * u8 {
+    return sfn_arena_sfn_create(default_page_size);
+}
+
+// `sfn_arena_alloc(arena, size, align)` — bare-named entry point, the
+// hot-path bump allocator `mem.sfn`'s `sfn_alloc_struct` and 29
+// `sailfin_runtime.c` call sites route through. Forwards to
+// `sfn_arena_sfn_alloc`, which maintains `total_allocated`/`total_pages`
+// exactly as the C `sfn_arena_alloc` did (`sailfin_arena.c:144`).
+fn sfn_arena_alloc(arena: * u8, size: usize, align: usize) -> * u8 {
+    return sfn_arena_sfn_alloc(arena, size, align);
+}
+
+// Process-global arena handle (`_global_arena`) + arena-mode flag
+// (`_arena_enabled`), lazily initialised. `-1` = unchecked, `0` =
+// disabled, `1` = enabled; the address `0` for the global handle
+// doubles as "not yet created".
+//
+// **Thread-safety (known regression vs the C arena — deliberate).** The
+// C original guarded both lazy globals with `pthread_once`
+// (`sailfin_arena.c:253-254,306,323`). This port replaces that with an
+// unsynchronised check-and-set, matching every other lazy global in the
+// `runtime/sfn` layer (`mem.sfn:sfn_mem_get_field_buf_addr`,
+// `type_meta.sfn`'s registry, `future.sfn`'s scheduler globals) and the
+// single-threaded assumption `sfn_alloc_struct` already bakes in. That
+// holds for the compiler toolchain itself (compilation is
+// single-threaded) but NOT for emitted user binaries that spawn
+// `routine`/future threads: two threads racing the first allocation can
+// double-create the global arena or observe the provisional `0` mid-
+// probe. This is acceptable pre-1.0 — the structured-concurrency runtime
+// is not yet shipped (see CLAUDE.md "Deferred / Not Yet Shipped") — and
+// is the same exposure the rest of the `runtime/sfn` alloc path carries.
+// Re-introducing a `pthread_once`-equivalent is a concurrency-runtime
+// concern, tracked there, not part of this M2→M3 arena port.
+let mut _sfn_arena_enabled_state: i64 = -1;
+
+let mut _sfn_arena_global_addr: i64 = 0;
+
+// `sfn_arena_enabled()` — `SAILFIN_USE_ARENA` probe, faithful port of
+// `_init_arena_enabled` + `sfn_arena_enabled` (`sailfin_arena.c:256,
+// 304`). Unset → on (the default). Empty / `0` / `false` → off.
+// Anything else → on. Cached after the first probe. The empty-string
+// case uses `strcmp(env, "")` rather than a single-byte load — the
+// seed compiler's `* u8` byte-load gap (see the file header) makes the
+// `env[0] == '\0'` form unavailable here.
+fn sfn_arena_enabled() -> bool {
+    if _sfn_arena_enabled_state < 0 {
+        // Re-entrancy guard (the load-bearing subtlety of this port).
+        // A `string` / `* u8` literal lowers to an `sfn_alloc_struct`
+        // call that copies the bytes into freshly-allocated memory
+        // (verified in the emitted IR: `call i8* @sfn_alloc_struct(i64
+        // 18)` for "SAILFIN_USE_ARENA\0"). `sfn_alloc_struct` calls
+        // back here to choose arena-vs-calloc, so the env-probe
+        // literals below would recurse infinitely from the very first
+        // call (the startup `_sfn_default_arena_init` constructor).
+        // Publishing a provisional non-negative state BEFORE any
+        // allocation breaks the cycle: the re-entrant call sees
+        // `state >= 0` and returns immediately. Provisional `0`
+        // (disabled) routes the probe's own SfnString allocations
+        // through the libc `calloc` fallback rather than forcing the
+        // global arena into existence mid-probe.
+        _sfn_arena_enabled_state = 0;
+        // Bind each literal to a `string` local before the `as * u8`
+        // cast — the proven env-read pattern from `rlimit.sfn` /
+        // `http.sfn`. The inline form `getenv("…" as * u8)` miscompiles
+        // under the seed: the call is elided and its result lowered to a
+        // null store, so every env value reads as "unset". The `string`
+        // local materialises the `SfnString` (allocated via
+        // `sfn_alloc_struct` — safe now, the provisional state above
+        // routes it through the libc fallback) and the cast extracts its
+        // data pointer correctly.
+        let name: string = "SAILFIN_USE_ARENA";
+        let env: * u8 = getenv(name as * u8);
+        if env as i64 == 0 {
+            // Unset: take the default (arena on).
+            _sfn_arena_enabled_state = 1;
+        } else {
+            let empty: string = "";
+            let zero: string = "0";
+            let f: string = "false";
+            if strcmp(env, empty as * u8) == 0 { _sfn_arena_enabled_state = 0; } else if strcmp(env, zero as * u8) == 0 {
+                _sfn_arena_enabled_state = 0;
+            } else if strcmp(env, f as * u8) == 0 {
+                _sfn_arena_enabled_state = 0;
+            } else { _sfn_arena_enabled_state = 1; }
+        }
+    }
+    return _sfn_arena_enabled_state == 1;
+}
+
+// `sfn_arena_global()` — lazy process-global arena (4 MiB pages for the
+// compiler), faithful port of `_init_global_arena` + `sfn_arena_global`
+// (`sailfin_arena.c:310,321`). Creates the handle on first call;
+// `abort()`s if creation fails (the lowered call sites GEP+store into
+// the returned base with no null-check, so a silent NULL would surface
+// as a bare SIGSEGV — `abort` turns OOM into a clean SIGABRT).
+//
+// The C original printed "[sailfin-arena] fatal: …" before aborting,
+// but a message here is unshippable: emitting one builds an `SfnString`
+// via `sfn_alloc_struct`, which (arena enabled) re-enters
+// `sfn_arena_global` with `_sfn_arena_global_addr` still 0 and recurses
+// until the stack overflows — turning a clean OOM abort into a crash.
+// The bare `abort()` (SIGABRT) is the faithful, recursion-free signal.
+fn sfn_arena_global() -> * u8 {
+    if _sfn_arena_global_addr == 0 {
+        let created: * u8 = sfn_arena_sfn_create(4194304 as usize);
+        if created as i64 == 0 {
+            unsafe { abort(); }
+        }
+        _sfn_arena_global_addr = created as i64;
+    }
+    return _sfn_arena_global_addr as * u8;
 }
 
 // `sfn_arena_sfn_reset(arena)` zeroes the `used` cursor on every
@@ -292,6 +475,10 @@ fn sfn_arena_sfn_reset(arena: * u8) -> void {
         walker = p.next_addr;
     }
     a.current_addr = first_addr;
+    // Match the C arena's reset (sailfin_arena.c:87): the byte counter
+    // resets with the pages; the page chain (and `total_pages`) stays
+    // intact for reuse.
+    a.total_allocated = 0;
 }
 
 // `sfn_arena_sfn_destroy(arena)` frees every page in the chain and
@@ -354,6 +541,7 @@ fn sfn_arena_sfn_realloc(arena: * u8, ptr: * u8, old_size: usize, new_size: usiz
         if ptr_addr + old_size_i == tip_addr {
             if used + extra <= page.capacity {
                 page.used = used + extra;
+                a.total_allocated = a.total_allocated + extra;
                 return ptr;
             }
         }
@@ -416,12 +604,10 @@ fn sfn_arena_sfn_realloc(arena: * u8, ptr: * u8, old_size: usize, new_size: usiz
 // matching `runtime/native/include/sailfin_arena.h`. `_runtime_enter`
 // (a `static inline` call-sequence counter in the C runtime) has no
 // bearing on mark/rewind semantics and is intentionally not ported.
-// arena-mode probe + process-global arena handle, both exported from
-// `runtime/native/src/sailfin_arena.c`.
-extern fn sfn_arena_enabled() -> bool;
-
-extern fn sfn_arena_global() -> * u8;
-
+// arena-mode probe + process-global arena handle. As of #1309 both are
+// **defined above** in this module (the bare `sfn_arena_enabled` /
+// `sfn_arena_global` Sailfin exports that replaced the C namesakes), so
+// mark/rewind call them directly — no extern needed.
 // `sfn_arena_sfn_mark()` snapshots the global arena's current page +
 // used offset, encoded as `(page_index << 32) | used` cast to a
 // `number`. Returns `0.0` when the arena is disabled or has no current

--- a/runtime/sfn/memory/arena.sfn
+++ b/runtime/sfn/memory/arena.sfn
@@ -333,7 +333,7 @@ fn sfn_arena_sfn_alloc(arena: * u8, size: usize, align: usize) -> * u8 {
 // `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind`
 // keep operating on the **same shared 40-byte global handle** these
 // produce, so the layout-match above is the deciding correctness
-// constraint. The 24→40 shrink and the rest of the C arena retire in
+// constraint. The 40→24 shrink and the rest of the C arena retire in
 // #822.
 //
 // `create` and `alloc` are thin forwarders to the `sfn_arena_sfn_*`


### PR DESCRIPTION
## Summary
- Move the arena **core** — the process-global handle plus the hot bump path (`sfn_arena_create` / `sfn_arena_alloc` / `sfn_arena_global` / `sfn_arena_enabled`) — from C into `runtime/sfn/memory/arena.sfn`. The C namesakes are removed from `sailfin_arena.c`, so the linker binds every caller (`sailfin_runtime.c`'s 29 bare call sites + the `mem.sfn` externs) to the Sailfin definitions.
- Expand the Sailfin `Arena` struct to **40 bytes / 5×i64**, byte-identical to the C `SfnArena` (`total_allocated@24`, `total_pages@32`). The deciding constraint: the still-C `sfn_arena_realloc`/`reset`/`destroy`/`print_stats`/`mark`/`rewind` keep writing those offsets on the **shared** global handle, so a 24-byte Sailfin handle would corrupt the heap (#1205-class). The Sailfin `create`/`alloc` maintain the two counters exactly as the C did; they shrink back out in #822.

Closes #1309 (C1 of epic #1308).

### Two seed-compiler workarounds (documented in-code)
1. **Re-entrancy guard** — `sfn_arena_enabled` publishes a provisional cached state *before* reading `SAILFIN_USE_ARENA`. String literals lower to `sfn_alloc_struct` (SfnString construction), which calls back into `sfn_arena_enabled` to route arena-vs-calloc — an infinite recursion from the startup arena constructor without the guard.
2. **`getenv` elision** — the probe literals are bound to `let x: string` locals before the `as * u8` cast; the inline `getenv("…" as * u8)` form miscompiles under the seed (call elided, result lowered to a null store, so every env value reads as "unset").

The unsynchronised lazy-init replaces the C `pthread_once`; this matches the rest of the `runtime/sfn` alloc layer's single-thread assumption and is documented in-code as a known exposure deferred to the (not-yet-shipped) concurrency runtime.

## Acceptance Criteria
- [x] `make compile` self-hosts from the pinned seed (runtime-source only — no seed cut)
- [x] `make check` — first pass fully green (122/122 e2e-sh); seedcheck second pass was passing when the dev session was paused. **Re-run on CI for the authoritative full triple-pass.**
- [x] `nm`: the `arena.sfn` TU defines `sfn_arena_{create,alloc,global,enabled}`; `sailfin_arena.o` no longer defines them (references `sfn_arena_alloc` as `U`, resolved to Sailfin at link)
- [x] No-corruption gate: `%Arena = type { i64, i64, i64, i64, i64 }` (40-byte) IR-shape assertion + ASAN cross-runtime roundtrip (C `realloc`/`print_stats` on a Sailfin-created handle); ASAN leg skips cleanly when compiler-rt is absent, static gate always runs
- [x] `SAILFIN_USE_ARENA` on/off reproduce the C `_init_arena_enabled` semantics (unset/other → on; ``/`0`/`false` → off) — verified
- [x] `sfn fmt --check` clean on `runtime/sfn/memory/arena.sfn`

## Verification (local)
```
make compile                                   # self-hosts ✓
nm arena.sfn TU                                # defines the four ✓; C obj references U sfn_arena_alloc ✓
test_runtime_memory_arena.sh                   # 10/10 (incl. 40-byte shape, env semantics, ASAN gate) ✓
SAILFIN_USE_ARENA probe                        # unset/1/yes→on; ""/0/false→off ✓
cross-runtime: Sailfin create/alloc + C realloc/print_stats # clean (pages=2, total_allocated coherent) ✓
make check first pass                          # 122/122 e2e-sh ✓ (canary flake on one run, green on re-run)
```
The five sibling e2e harnesses that link the arena runtime were updated for the new symbol ownership (stubs removed where arena.ll now defines the symbol; `sfn_alloc_struct` stub added where arena.ll now references it; `declares`→`defines` assertions updated).

> Note: `test_runtime_helper_declare_integrity.sh` (the #892 non-deterministic-under-pressure canary) failed once under full-gate load then passed on re-run; my change does not touch its corruption mechanism (the `sfn_str_eq` sequence counter), so this is the test's documented pre-existing flakiness, not a regression.

## Files Changed
- `runtime/sfn/memory/arena.sfn` — 40-byte struct; counter upkeep; bare `create`/`alloc`/`global`/`enabled` exports + lazy singleton + env probe
- `runtime/native/src/sailfin_arena.c` — remove the 4 ported defs + statics/init helpers + orphaned `_align_up`/`_page_create`
- `runtime/native/include/sailfin_arena.h` — keep prototypes (C callers link to Sailfin defs); refresh stale top comment
- `compiler/tests/e2e/{test_runtime_memory_arena,_arena_mark,_owned_buf_roundtrip,_owned_buf_grow_determinism,_runtime_string_immediate,_runtime_sfn_sources_active}.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdT11xxmPW1yTAemPLxCNZ)_