### PR TITLE
feat(http): drain Content-Length POST bodies in serve

### DIFF
--- a/capsules/sfn/http/src/wire.sfn
+++ b/capsules/sfn/http/src/wire.sfn
@@ -141,8 +141,10 @@ fn reason_phrase(status: int) -> string {
 // missing final blank line and of bare-LF line endings (CR is stripped
 // when present). `method`/`path`/`query` come from the request line;
 // `headers` are the raw "Name: value" lines up to the blank-line
-// terminator; `body` is whatever follows it (GET-shaped in v0 — the
-// runtime does not yet drain Content-Length; see Wave 3 / #1324).
+// terminator; `body` is whatever follows it. The runtime drains the
+// `Content-Length` body before handing the raw request here (Wave 3 /
+// #1324), so `body` is reliable for POST/PUT; chunked encoding stays
+// out of scope (post-1.0).
 fn parse_request(raw: string) -> Request {
     let total = raw.length;
 

--- a/compiler/tests/e2e/test_http_capsule_serve.sh
+++ b/compiler/tests/e2e/test_http_capsule_serve.sh
@@ -86,6 +86,11 @@ fn handle(req: Request) -> Response {
     if strings_equal(req.path, "/secret") {
         return Response { status: 403, headers: ["X-Reason: nope"], body: "denied" };
     }
+    // Echo the drained request body back (Wave 3 / #1324): proves the
+    // runtime drains the Content-Length body before the handler runs.
+    if strings_equal(req.path, "/echo") {
+        return Response { status: 200, headers: ["X-Echo: 1"], body: req.body };
+    }
     return not_found();
 }
 
@@ -204,8 +209,213 @@ PYEOF
     return "$bad"
 }
 
+# ---- Behavioral: a POST Content-Length body is drained and reaches req.body ----
+# Wave 3 / #1324: the runtime drains the Content-Length body after the
+# header terminator, so a POST handler can read it via `req.body`. We
+# POST a non-trivial body to /echo and assert it round-trips verbatim.
+test_loopback_post_body() {
+    # The framed server never returns (one server per process), so start
+    # a fresh instance for this case and retire any prior one.
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+
+    local port
+    port="$(python3 - <<'PYEOF'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PYEOF
+)"
+    if [ -z "$port" ]; then
+        echo "[test]   could not allocate a free port"
+        return 1
+    fi
+
+    write_app "$port"
+    local srvlog="$SCRATCH/server_post.out"
+    "$BINARY" run "$APP/src/main.sfn" > "$srvlog" 2>&1 &
+    SERVER_PID=$!
+
+    local client="$SCRATCH/client_post.py"
+    cat > "$client" <<PYEOF
+import socket, sys, time
+port = ${port}
+# A body bigger than one TCP segment is convenient to exercise the
+# drain loop, but correctness only needs an exact Content-Length match.
+body = ("payload-" * 64) + "END"
+raw = (
+    "POST /echo HTTP/1.1\r\n"
+    "Host: localhost\r\n"
+    "Content-Length: %d\r\n"
+    "Connection: close\r\n"
+    "\r\n" % len(body.encode())
+) + body
+deadline = time.time() + 25
+data = None
+while time.time() < deadline:
+    try:
+        c = socket.create_connection(("127.0.0.1", port), timeout=2)
+    except OSError:
+        time.sleep(0.3)
+        continue
+    try:
+        c.sendall(raw.encode())
+        buf = b""
+        while True:
+            chunk = c.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+    finally:
+        c.close()
+    data = buf
+    break
+if data is None:
+    print("NO_RESPONSE", flush=True)
+    sys.exit(1)
+sys.stdout.write(data.decode("utf-8", "replace"))
+sys.stdout.flush()
+PYEOF
+
+    local out="$SCRATCH/client_post.out"
+    if ! python3 "$client" > "$out" 2>&1; then
+        echo "[test]   POST client never reached the server:"
+        cat "$out"
+        echo "[test]   --- server log ---"
+        cat "$srvlog"
+        return 1
+    fi
+
+    local bad=0
+    if ! grep -qE "^HTTP/1\.1 200 OK" "$out"; then
+        echo "[test]   expected '200 OK' for POST /echo, got:"
+        cat "$out"
+        bad=$((bad + 1))
+    fi
+    if ! grep -qE "^X-Echo: 1" "$out"; then
+        echo "[test]   expected header 'X-Echo: 1', got:"
+        cat "$out"
+        bad=$((bad + 1))
+    fi
+    # The echoed body must contain the start and end markers of what we
+    # sent — proof the full Content-Length body was drained, not truncated.
+    if ! grep -q "payload-payload-" "$out" || ! grep -q "END" "$out"; then
+        echo "[test]   echoed body did not round-trip the POST payload, got:"
+        cat "$out"
+        bad=$((bad + 1))
+    fi
+    if [ "$bad" -ne 0 ]; then
+        echo "[test]   --- server log ---"
+        cat "$srvlog"
+    fi
+    return "$bad"
+}
+
+# ---- Behavioral: an over-cap Content-Length is rejected with a 500, not a hang ----
+# Wave 3 / #1324: bodies over the 1 MiB cap are rejected up front (the
+# runtime returns null → the worker frames a 500 and closes) rather than
+# allocating unboundedly or blocking on recv.
+test_loopback_oversize_rejected() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+
+    local port
+    port="$(python3 - <<'PYEOF'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PYEOF
+)"
+    if [ -z "$port" ]; then
+        echo "[test]   could not allocate a free port"
+        return 1
+    fi
+
+    write_app "$port"
+    local srvlog="$SCRATCH/server_big.out"
+    "$BINARY" run "$APP/src/main.sfn" > "$srvlog" 2>&1 &
+    SERVER_PID=$!
+
+    local client="$SCRATCH/client_big.py"
+    cat > "$client" <<PYEOF
+import socket, sys, time
+port = ${port}
+# Declare a 2 MiB body (over the 1 MiB cap) but send only the header —
+# the server must reject on the declared length without waiting for the
+# body, so a tiny partial send is enough to read back the 500.
+header = (
+    "POST /echo HTTP/1.1\r\n"
+    "Host: localhost\r\n"
+    "Content-Length: 2000000\r\n"
+    "Connection: close\r\n"
+    "\r\n"
+).encode()
+deadline = time.time() + 25
+data = None
+while time.time() < deadline:
+    try:
+        c = socket.create_connection(("127.0.0.1", port), timeout=2)
+    except OSError:
+        time.sleep(0.3)
+        continue
+    try:
+        try:
+            c.sendall(header + b"partial-body")
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        buf = b""
+        try:
+            while True:
+                chunk = c.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+        except (ConnectionResetError, socket.timeout):
+            pass
+    finally:
+        c.close()
+    data = buf
+    break
+if data is None:
+    print("NO_RESPONSE", flush=True)
+    sys.exit(1)
+sys.stdout.write(data.decode("utf-8", "replace"))
+sys.stdout.flush()
+PYEOF
+
+    local out="$SCRATCH/client_big.out"
+    if ! python3 "$client" > "$out" 2>&1; then
+        echo "[test]   over-cap client never reached the server:"
+        cat "$out"
+        echo "[test]   --- server log ---"
+        cat "$srvlog"
+        return 1
+    fi
+
+    if ! grep -qE "^HTTP/1\.1 500" "$out"; then
+        echo "[test]   expected a 500 for an over-cap Content-Length, got:"
+        cat "$out"
+        echo "[test]   --- server log ---"
+        cat "$srvlog"
+        return 1
+    fi
+    return 0
+}
+
 run_test "imported serve lowers to the capsule fn, not the builtin @sfn_serve" test_gate_not_hijacked
 run_test "typed serve delivers custom status + headers on the wire" test_loopback_status_and_headers
+run_test "POST Content-Length body is drained and reaches req.body" test_loopback_post_body
+run_test "over-cap Content-Length is rejected with a 500" test_loopback_oversize_rejected
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/compiler/tests/e2e/test_http_capsule_serve.sh
+++ b/compiler/tests/e2e/test_http_capsule_serve.sh
@@ -278,7 +278,19 @@ while time.time() < deadline:
 if data is None:
     print("NO_RESPONSE", flush=True)
     sys.exit(1)
-sys.stdout.write(data.decode("utf-8", "replace"))
+text = data.decode("utf-8", "replace")
+sys.stdout.write(text)
+# Validate the echoed body EXACTLY (not just markers): split off the
+# response body after the header terminator and compare byte-for-byte
+# against what we sent. This is the Wave 3 acceptance criterion, so a
+# truncated or padded body must fail.
+sep = "\r\n\r\n"
+idx = text.find(sep)
+resp_body = text[idx + len(sep):] if idx >= 0 else ""
+if resp_body == body:
+    sys.stdout.write("\n__BODY_EXACT_MATCH__\n")
+else:
+    sys.stdout.write("\n__BODY_MISMATCH__ got=%r want=%r\n" % (resp_body, body))
 sys.stdout.flush()
 PYEOF
 
@@ -302,10 +314,10 @@ PYEOF
         cat "$out"
         bad=$((bad + 1))
     fi
-    # The echoed body must contain the start and end markers of what we
-    # sent — proof the full Content-Length body was drained, not truncated.
-    if ! grep -q "payload-payload-" "$out" || ! grep -q "END" "$out"; then
-        echo "[test]   echoed body did not round-trip the POST payload, got:"
+    # The echoed body must equal the sent body byte-for-byte — proof the
+    # full Content-Length body was drained, not truncated or padded.
+    if ! grep -q "__BODY_EXACT_MATCH__" "$out"; then
+        echo "[test]   echoed body did not round-trip the POST payload exactly, got:"
         cat "$out"
         bad=$((bad + 1))
     fi

--- a/docs/status.md
+++ b/docs/status.md
@@ -166,7 +166,7 @@ Capsules ship under `capsules/sfn/` and are imported by bare name
 | `sfn/time` | `"time"` | Shipped | `clock` | Sleep, monotonic timing, elapsed |
 | `sfn/cli` | `"cli"` | Shipped | `io` | Arg parsing, subcommands, help generation, terminal styling |
 | `sfn/test` | `"test"` | Partial | None (pure tier) / `io` | Assertions: legacy `assert_*` (`![io]`), `pure_assert_*`, free-function `expect_*` tier, snapshot tier (#977). Fluent `expect(x).to_be(y)` deferred on generic monomorphization + cross-module method-dispatch ABI |
-| `sfn/http` | `"sfn/http"` | Partial (Waves 1–2 shipped) | `net`, `io` | GET/POST client wrappers; pure-Sailfin wire layer (parse/serialize/accessors); typed HTTP/1.1 `serve` on the M4 runtime (`sfn_serve_framed`). v0 limits: blocking/single-process, no TLS, no keep-alive, POST body unreliable. Wave 3+ (TLS, keep-alive, routing) pending. (#1321, PR #1326 merged; #1328 in review) |
+| `sfn/http` | `"sfn/http"` | Partial (Waves 1–3 shipped) | `net`, `io` | GET/POST client wrappers; pure-Sailfin wire layer (parse/serialize/accessors); typed HTTP/1.1 `serve` on the M4 runtime (`sfn_serve_framed`); POST/PUT bodies drained via `Content-Length` (1 MiB cap). v0 limits: blocking/single-process, no TLS, no keep-alive, no chunked encoding. Wave 4+ (TLS, keep-alive, routing) pending. (#1321, PR #1326 merged; #1324 Content-Length drain) |
 | `sfn/net` | `"net"` | Stubbed | `net`, `io` | TCP/UDP socket API (pending runtime intrinsics) |
 | `sfn/sync` | `"sync"` | Stubbed | `io` | channel/parallel/spawn API (pending concurrency runtime) |
 | `sfn/tensor` | `"tensor"` | Shipped (CPU) | `gpu` (planned) | Tensor ops, matmul, transpose; no GPU dispatch yet |

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -202,22 +202,29 @@ fn _serve_send_all(fd: i32, buf: * u8, total: i64) -> bool {
 // where `header_end` is the offset just past the `\r\n\r\n`
 // terminator). Case-insensitive on the header name (RFC 7230 §3.2).
 // Returns the non-negative value, or -1 when no Content-Length header
-// is present in the head. The match must fall inside the header block
-// — a later occurrence (e.g. inside an already-buffered body) is
-// ignored via the offset guard. v0 takes the first match and does not
-// anchor to a line start, so a pathological header literally named to
-// embed `content-length:` could be misread; real clients do not do
-// this and the value is bounded by `max_body` regardless.
+// is present in the head.
+//
+// The search is anchored to a header-line start by matching the
+// CRLF-prefixed name `\r\ncontent-length:` — every header is preceded
+// by the CRLF that terminates the request line or the prior header, so
+// this matches only a real header field, never a `content-length:`
+// substring sitting inside another header's name or value (e.g.
+// `X: content-length: 999`). Without the anchor such a substring could
+// be misread and make the body-drain loop block on bytes the client
+// never sends (DoS / hang). The match must also begin inside the
+// header block: a match whose name starts at/after the blank-line
+// terminator (a body that happens to open with `content-length:`) is
+// rejected by the `off + 2 >= header_end` guard.
 fn _serve_content_length(buf: * u8, header_end: i64) -> i64 {
-    let needle: string = "content-length:";
+    let needle: string = "\r\ncontent-length:";
     let hit: * u8 = strcasestr(buf, needle as * u8);
     if hit as i64 == 0 { return 0 - 1; }
-    // Ignore a match that lands at/after the header terminator.
+    // `off` points at the CRLF; the header name starts at `off + 2`.
     let off: i64 = (hit as i64) - (buf as i64);
-    if off >= header_end { return 0 - 1; }
-    // The value starts after the 15-char "content-length:" token;
+    if off + 2 >= header_end { return 0 - 1; }
+    // The value starts after the 17-char "\r\ncontent-length:" token;
     // strtoll skips leading whitespace and parses the decimal length.
-    let value_ptr: * u8 = _serve_ptr_off(hit, 15);
+    let value_ptr: * u8 = _serve_ptr_off(hit, 17);
     return strtoll(value_ptr, null, 10);
 }
 

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -43,11 +43,12 @@
 // in place of the legacy `@sailfin_adapter_serve_start`.
 //
 // Scope: HTTP/1.1 only — NO TLS (post-1.0), and blocking accept —
-// NO async I/O (v0). Request parsing is minimal: the raw request
-// head is handed to the handler verbatim (GET-shaped v0; bodies are
-// read up to the header terminator). The response is always
-// `200 OK` with a `Content-Length`; a null handler return becomes a
-// `500`.
+// NO async I/O (v0). Request parsing is minimal: the raw request is
+// handed to the handler verbatim. `Content-Length` request bodies ARE
+// drained (capped at 1 MiB; over-cap → `500`), so POST/PUT handlers
+// see a reliable body; chunked transfer-encoding is out of scope
+// (post-1.0). The default `sfn_serve` response is always `200 OK` with
+// a `Content-Length`; a null handler return becomes a `500`.
 //
 // v0 limitations (follow-up waves): (1) per-connection `Task`
 // handles are fire-and-forget — never `sfn_task_join`ed or
@@ -89,6 +90,15 @@ extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
 extern fn strlen(s: * u8) -> usize;
 
 extern fn strstr(haystack: * u8, needle: * u8) -> * u8;
+
+// `strcasestr` (GNU/BSD libc) — case-insensitive `strstr`, used to
+// locate the `Content-Length` request header regardless of casing
+// (RFC 7230 §3.2 header names are case-insensitive). Present on both
+// targets (glibc + Darwin). `strtoll` parses the decimal value (the
+// `end` out-param is always passed `null`, mirroring `rlimit.sfn`).
+extern fn strcasestr(haystack: * u8, needle: * u8) -> * u8;
+
+extern fn strtoll(s: * u8, end: * u8, base: i32) -> i64;
 
 // ── BSD sockets (libc) ────────────────────────────────────────
 // `addr` is spelled `* u8` (the `net.sfn` opaque-handle policy:
@@ -187,26 +197,63 @@ fn _serve_send_all(fd: i32, buf: * u8, total: i64) -> bool {
     return true;
 }
 
-// `_serve_recv_request(fd)` — read the request head into a growing
-// libc buffer (doubling like `http.sfn`'s `_recv_all`), stopping
-// once the `\r\n\r\n` header terminator is seen, on EOF, or on a
-// `recv` error. Returns a NUL-terminated, caller-owned buffer (null
-// on OOM / error). v0 reads only up to the header terminator —
-// request bodies past the headers are not drained (GET-shaped v0).
+// `_serve_content_length(buf, header_end)` — extract the declared
+// `Content-Length` from the request head (bytes `[0, header_end)`,
+// where `header_end` is the offset just past the `\r\n\r\n`
+// terminator). Case-insensitive on the header name (RFC 7230 §3.2).
+// Returns the non-negative value, or -1 when no Content-Length header
+// is present in the head. The match must fall inside the header block
+// — a later occurrence (e.g. inside an already-buffered body) is
+// ignored via the offset guard. v0 takes the first match and does not
+// anchor to a line start, so a pathological header literally named to
+// embed `content-length:` could be misread; real clients do not do
+// this and the value is bounded by `max_body` regardless.
+fn _serve_content_length(buf: * u8, header_end: i64) -> i64 {
+    let needle: string = "content-length:";
+    let hit: * u8 = strcasestr(buf, needle as * u8);
+    if hit as i64 == 0 { return 0 - 1; }
+    // Ignore a match that lands at/after the header terminator.
+    let off: i64 = (hit as i64) - (buf as i64);
+    if off >= header_end { return 0 - 1; }
+    // The value starts after the 15-char "content-length:" token;
+    // strtoll skips leading whitespace and parses the decimal length.
+    let value_ptr: * u8 = _serve_ptr_off(hit, 15);
+    return strtoll(value_ptr, null, 10);
+}
+
+// `_serve_recv_request(fd)` — read a full request (head + body) into a
+// growing libc buffer (doubling like `http.sfn`'s `_recv_all`).
+// Returns a NUL-terminated, caller-owned buffer (null on OOM / error /
+// over-cap body, which the worker turns into a `500` + connection
+// close).
 //
-// A client that never sends the `\r\n\r\n` terminator must not be
-// able to force unbounded growth (DoS / OOM), so the header read is
-// capped at `max_request` bytes — once exceeded without a terminator
-// the request is rejected (buffer freed, null returned, which the
-// worker turns into a `500` + connection close).
+// Phase 1 reads until the `\r\n\r\n` header terminator, on EOF, or on
+// a `recv` error. A client that never sends the terminator must not be
+// able to force unbounded growth (slow-loris / unbounded-header DoS),
+// so the header read is capped at `max_header` bytes — once exceeded
+// without a terminator the request is rejected.
+//
+// Phase 2 honors `Content-Length`: any body bytes past the header
+// terminator are drained so `Request.body` is reliable for POST/PUT.
+// `recv` may already have buffered part (or all) of the body alongside
+// the headers, so only the shortfall is read. The body is capped at
+// `max_body` (1 MiB) — an over-cap declared length is rejected up front
+// (null → `500`) rather than risking an unbounded allocation or a hang.
+// Chunked transfer-encoding is out of scope (post-1.0); only an
+// explicit `Content-Length` body is drained.
 fn _serve_recv_request(fd: i32) -> * u8 {
-    let max_request: i64 = 65536;
+    let max_header: i64 = 65536;
+    let max_body: i64 = 1048576;
     let mut capacity: i64 = 4096;
     let mut len: i64 = 0;
     let mut buf: * u8 = malloc((capacity + 1) as usize);
     if buf as i64 == 0 { return null; }
     let chunk: i64 = 4096;
     let terminator: string = "\r\n\r\n";
+
+    // Phase 1 — read the header block. `header_end` is the offset just
+    // past the `\r\n\r\n` terminator, or -1 if EOF arrived first.
+    let mut header_end: i64 = 0 - 1;
     loop {
         if len + chunk > capacity {
             let new_cap: i64 = capacity * 2;
@@ -226,14 +273,64 @@ fn _serve_recv_request(fd: i32) -> * u8 {
         if n == 0 { break; }
         len = len + n;
         memset(_serve_ptr_off(buf, len), 0, 1 as usize);
-        // Stop as soon as the full header block has arrived.
-        if (strstr(buf, terminator as * u8) as i64) != 0 { break; }
+        let term_ptr: * u8 = strstr(buf, terminator as * u8);
+        if (term_ptr as i64) != 0 {
+            header_end = ((term_ptr as i64) - (buf as i64)) + 4;
+            break;
+        }
         // Reject a request that exceeds the header cap without a
         // terminator (slow-loris / unbounded-header DoS guard).
-        if len >= max_request {
+        if len >= max_header {
             free(buf);
             return null;
         }
+    }
+
+    // EOF before the headers completed: return what we have.
+    if header_end < 0 {
+        memset(_serve_ptr_off(buf, len), 0, 1 as usize);
+        return buf;
+    }
+
+    // Phase 2 — drain the Content-Length body, if any.
+    let content_length: i64 = _serve_content_length(buf, header_end);
+    if content_length <= 0 {
+        memset(_serve_ptr_off(buf, len), 0, 1 as usize);
+        return buf;
+    }
+    // Over-cap body: reject before allocating / blocking on recv.
+    if content_length > max_body {
+        free(buf);
+        return null;
+    }
+
+    let body_target: i64 = header_end + content_length;
+    loop {
+        if len >= body_target { break; }
+        if body_target > capacity {
+            let mut new_cap: i64 = capacity;
+            loop {
+                if new_cap >= body_target { break; }
+                new_cap = new_cap * 2;
+            }
+            let new_buf: * u8 = realloc(buf, (new_cap + 1) as usize);
+            if new_buf as i64 == 0 {
+                free(buf);
+                return null;
+            }
+            buf = new_buf;
+            capacity = new_cap;
+        }
+        let want: i64 = body_target - len;
+        let n: i64 = recv(fd, _serve_ptr_off(buf, len), want, 0);
+        if n < 0 {
+            free(buf);
+            return null;
+        }
+        // Client closed before sending the full declared body: return
+        // what arrived (the handler sees a short body rather than a hang).
+        if n == 0 { break; }
+        len = len + n;
     }
     memset(_serve_ptr_off(buf, len), 0, 1 as usize);
     return buf;

--- a/site/src/content/docs/docs/reference/standard-library.md
+++ b/site/src/content/docs/docs/reference/standard-library.md
@@ -971,7 +971,7 @@ fn submit(url: string, payload: string) -> string ![net] {
 ### v0 limitations
 
 - **HTTP/1.1 only, blocking accept, no TLS, no keep-alive** (`Connection: close` on every response).
-- **POST/PUT body unreliable** — request body draining for non-GET methods is a follow-up; do not rely on `Request.body` being populated in v0.
+- **`Content-Length` bodies only** — POST/PUT request bodies are drained via `Content-Length` (capped at 1 MiB; over-cap requests get a `500`), so `Request.body` is reliable. Chunked transfer-encoding is not decoded (post-1.0).
 - **`host` binding not enforced** — the server always binds `INADDR_ANY` regardless of `ServerConfig.host`.
 - **Per-request allocations are not freed** — a known leak; acceptable for short-lived or v0 servers but not production long-running processes.
 - **One server per process** — multiple concurrent `serve` calls in one process are not supported in v0.


### PR DESCRIPTION
## Summary

- `_serve_recv_request` now drains the `Content-Length` request body after the `\r\n\r\n` header terminator, so `Request.body` is reliable for POST/PUT handlers. No ABI change — the trampoline still receives the full raw request as a NUL-terminated string.
- Bodies are capped at **1 MiB**; an over-cap declared length is rejected up front (`null` → `500`) rather than risking an unbounded allocation or a `recv` hang. `recv` may already have buffered part/all of the body alongside the headers, so only the shortfall is read.
- `Content-Length` is parsed case-insensitively (`strcasestr` + `strtoll`), anchored to the header block via an offset guard. Chunked transfer-encoding stays out of scope (post-1.0).

Wave 3 of epic #1321. Design: `docs/proposals/sfn-http-capsule.md` §3.3, §5.

Closes #1324

## Acceptance Criteria

- [x] A POST handler reads the full request body via `req.body` (e2e `/echo` round-trip).
- [x] Over-cap bodies are rejected with a `500` (1 MiB cap), not a hang/overrun (e2e over-cap case).
- [x] POST e2e round-trip passes.
- [x] `sfn fmt --check` clean; `make compile` passes (self-hosts).

## Verification

```bash
make compile                                              # PASS — self-hosts with the change
sfn fmt --check runtime/sfn/concurrency/serve.sfn \
                capsules/sfn/http/src/wire.sfn            # PASS (exit 0)
bash compiler/tests/e2e/test_http_capsule_serve.sh build/native/sailfin
#   PASS: imported serve lowers to the capsule fn, not the builtin @sfn_serve
#   PASS: typed serve delivers custom status + headers on the wire
#   PASS: POST Content-Length body is drained and reaches req.body   (new)
#   PASS: over-cap Content-Length is rejected with a 500             (new)
#   4 passed, 0 failed
```

> **Note on `make check`:** the full gate surfaced **pre-existing, non-deterministic SIGSEGV crashes** in the atomics tests (`atomic_fence_test.sfn`, `atomic_load_store_test.sfn`, exit 139). These are unrelated to this change — reproduced in isolation with `serve.sfn` entirely uninvolved (2 crashes / 1 pass over 3 runs; the runner's own RETRY logic targets exactly this flake). This change touches only HTTP body draining and cannot affect atomics code paths. Worth a separate test-infra/flaky-crash issue.

## Files Changed

- `runtime/sfn/concurrency/serve.sfn` — `_serve_content_length` helper + Content-Length drain in `_serve_recv_request`; `strcasestr`/`strtoll` externs; header caveat lifted.
- `compiler/tests/e2e/test_http_capsule_serve.sh` — POST `/echo` round-trip + over-cap rejection cases; `/echo` route on the consumer handler.
- `capsules/sfn/http/src/wire.sfn`, `site/src/content/docs/docs/reference/standard-library.md`, `docs/status.md` — lift the "GET-only / body unreliable" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sb4dbBYeNktp56Bx8QPqjP)_