### PR TITLE
feat(compiler): M1.A.2 by-value small-aggregate return (`SfnString` spelling) — enabler for #1312

### DIFF
--- a/compiler/src/llvm/type_mapping.sfn
+++ b/compiler/src/llvm/type_mapping.sfn
@@ -593,6 +593,7 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
     if starts_with(trimmed, "__closure__@") { return "{i8*, i8*}"; }
     if starts_with(trimmed, "fn(") { return "{i8*, i8*}"; }
     if starts_with(trimmed, "fn (") { return "{i8*, i8*}"; }
+    let normalized = unwrap_move_wrapper(trimmed);
     // Runtime-internal by-value `SfnString` aggregate ABI (M1.A.2). The bare
     // `{i8*, i64}` (data, len) two-eightbyte INTEGER-class struct is the
     // canonical SfnString layout (see `abi_hash.sfn`), returned/passed in
@@ -601,11 +602,12 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
     // parameter type `SfnString` in a runtime `.sfn` body routes the
     // *definition* onto that same by-value aggregate ABI instead of the boxed
     // `%T*` struct ABI below, so a Sailfin body can satisfy the call site
-    // without a C trampoline. Intercepted here, before the boxed-struct path,
-    // so it never becomes `%SfnString*`. Not a user-facing type — a runtime
-    // ABI spelling only.
-    if trimmed == "SfnString" { return "{i8*, i64}"; }
-    let normalized = unwrap_move_wrapper(trimmed);
+    // without a C trampoline. Checked on the move-unwrapped `normalized`
+    // spelling (so `move SfnString` and move-wrapped params/locals via
+    // `map_parameter_type` / `map_local_type` are caught too), before the
+    // boxed-struct path, so it never becomes `%SfnString*`. Not a user-facing
+    // type — a runtime ABI spelling only.
+    if normalized == "SfnString" { return "{i8*, i64}"; }
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
     if starts_with(normalized, "*") {

--- a/compiler/src/llvm/type_mapping.sfn
+++ b/compiler/src/llvm/type_mapping.sfn
@@ -511,6 +511,10 @@ fn map_type_annotation(annotation: string) -> string {
     if normalized == "u8" { _if314d = true; }
     if _if314d { return "i8"; }
     if normalized == "string" { return "i8*"; }
+    // Runtime-internal by-value `SfnString` aggregate spelling (M1.A.2) — see
+    // the matching guard in `map_return_type`. Keeps incidental field/local
+    // uses of `SfnString` consistent with the `{i8*, i64}` return/param ABI.
+    if normalized == "SfnString" { return "{i8*, i64}"; }
     if normalized == "void" { return "void"; }
     if normalized.length > 2 {
         let suffix = substring(normalized, normalized.length - 2, normalized.length);
@@ -589,6 +593,18 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
     if starts_with(trimmed, "__closure__@") { return "{i8*, i8*}"; }
     if starts_with(trimmed, "fn(") { return "{i8*, i8*}"; }
     if starts_with(trimmed, "fn (") { return "{i8*, i8*}"; }
+    // Runtime-internal by-value `SfnString` aggregate ABI (M1.A.2). The bare
+    // `{i8*, i64}` (data, len) two-eightbyte INTEGER-class struct is the
+    // canonical SfnString layout (see `abi_hash.sfn`), returned/passed in
+    // registers — the ABI the runtime-helper call sites already emit for
+    // `env.get` / `env.home` etc. (`runtime_helpers.sfn`). Naming the return /
+    // parameter type `SfnString` in a runtime `.sfn` body routes the
+    // *definition* onto that same by-value aggregate ABI instead of the boxed
+    // `%T*` struct ABI below, so a Sailfin body can satisfy the call site
+    // without a C trampoline. Intercepted here, before the boxed-struct path,
+    // so it never becomes `%SfnString*`. Not a user-facing type — a runtime
+    // ABI spelling only.
+    if trimmed == "SfnString" { return "{i8*, i64}"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.

--- a/compiler/tests/e2e/abi_value_return_test.sfn
+++ b/compiler/tests/e2e/abi_value_return_test.sfn
@@ -1,0 +1,86 @@
+// Regression test for the M1.A.2 by-value small-aggregate return capability
+// (prerequisite for the #1308 C7/R7 env flip #1312 and the string family's
+// `{i8*, i64}` canonical bodies).
+//
+// The compiler returns every *user* struct by pointer (`%T*`, the boxed-struct
+// ABI in `type_mapping.sfn`) to dodge an AArch64 aggregate-return legalizer
+// miscompile. A runtime body that must satisfy a by-value `{i8*, i64}` call
+// site therefore cannot just return a struct. The capability: a reserved
+// return/parameter type spelling `SfnString` that the type mappers map to the
+// literal `{i8*, i64}`, routing a Sailfin *definition* onto the existing
+// SfnString aggregate ABI — narrow (only the two-eightbyte INTEGER-class
+// `{i8*, i64}` shape) and opt-in (only the `SfnString` spelling). This pins:
+//   1. a `-> SfnString` function lowers to `define {i8*, i64} @…` returning the
+//      aggregate by value (the body returns a bare `* u8`; the return-path
+//      coercion wraps it), and
+//   2. the negative control — a `-> string` function STILL lowers to
+//      `define i8* @…`, never the aggregate (zero blast radius: `SfnString` is
+//      the only opt-in spelling).
+//
+// Native (no-bash) per `.claude/rules/no-bash-e2e.md`. Drives `sfn emit llvm`
+// over a tiny fixture and asserts on the emitted IR (frontend + lowering only,
+// no link), so it is fast and needs no clang/linker. `emit` writes the module
+// symbol with a `__<module>` suffix, so the assertions match the stable
+// `define <ret> @<name>` prefix, not an exact symbol.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `emit` neither links nor spawns clang, but `run_capture`'s empty array is the
+// *empty* environment; thread HOME/TMPDIR/SAILFIN_TEST_SCRATCH so the toolchain
+// has a writable scratch under the parallel pool. No PATH needed (no linker).
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// A unique scratch dir for this test (under the runner's per-file scratch when
+// present, else /tmp). `emit` writes IR to `-o` and keeps no `program.ll` build
+// cache, so a per-`tag` path is sufficient isolation under the parallel pool
+// (no `with_tmp_dir` — that fixture's closure must return `int`).
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/sfn-abi-value-return";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Emit LLVM IR for `source` and return it (or "EMIT_FAILED" on a non-zero exit).
+fn _emit_ir(tag: string, source: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let srcpath = dir + "/" + tag + ".sfn";
+    let outpath = dir + "/" + tag + ".ll";
+    fs.writeFile(srcpath, source);
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", outpath, "llvm", srcpath], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return "EMIT_FAILED"; }
+    return fs.readFile(outpath);
+}
+
+test "abi: SfnString return spelling lowers to a by-value {i8*, i64}" ![io] {
+    let ir = _emit_ir("agg", "fn agg(name_data: * u8, name_len: i64) -> SfnString ![io] { return name_data; }");
+    // Definition returns the aggregate by value (not `%SfnString*`).
+    assert find(ir, "define {i8*, i64} @agg", 0) >= 0;
+    // And the body's bare `* u8` return is wrapped into the aggregate.
+    assert find(ir, "ret {i8*, i64}", 0) >= 0;
+}
+
+test "abi: string return spelling still lowers to i8* (no regression)" ![io] {
+    let ir = _emit_ir("strctrl", "fn s(x: * u8) -> string ![io] { return x; }");
+    // `string` is unchanged — single pointer return.
+    assert find(ir, "define i8* @s", 0) >= 0;
+    // ...and never the by-value aggregate (proves `SfnString` is opt-in).
+    assert find(ir, "define {i8*, i64} @s", 0) < 0;
+}

--- a/compiler/tests/e2e/abi_value_return_test.sfn
+++ b/compiler/tests/e2e/abi_value_return_test.sfn
@@ -77,6 +77,15 @@ test "abi: SfnString return spelling lowers to a by-value {i8*, i64}" ![io] {
     assert find(ir, "ret {i8*, i64}", 0) >= 0;
 }
 
+test "abi: move-wrapped SfnString return still lowers to by-value {i8*, i64}" ![io] {
+    // The spelling is matched on the move-unwrapped form (`unwrap_move_wrapper`
+    // strips `Affine<…>` / `Linear<…>`), so a consume-and-return
+    // `-> Affine<SfnString>` takes the by-value path too — not the boxed `%T*`
+    // ABI it would fall into if matched before the unwrap.
+    let ir = _emit_ir("movecase", "fn mv(name_data: * u8, name_len: i64) -> Affine<SfnString> ![io] { return name_data; }");
+    assert find(ir, "define {i8*, i64} @mv", 0) >= 0;
+}
+
 test "abi: string return spelling still lowers to i8* (no regression)" ![io] {
     let ir = _emit_ir("strctrl", "fn s(x: * u8) -> string ![io] { return x; }");
     // `string` is unchanged — single pointer return.

--- a/docs/conventions/runtime-helpers.md
+++ b/docs/conventions/runtime-helpers.md
@@ -82,11 +82,11 @@ AArch64 aggregate-return legalizer miscompile), so a runtime body that must
 satisfy a by-value `{i8*, i64}` call site cannot just `return` a normal
 struct.
 
-The mechanism (M1.A.2, first landed by #1312): a reserved return/parameter
-type **spelling `SfnString`** that `map_return_type` / `map_type_annotation`
-intercept and map to the literal `{i8*, i64}`, routing the *definition* onto
-the by-value aggregate ABI without changing any other struct. It is narrow
-and opt-in by design:
+The mechanism (the M1.A.2 capability; its first consumer is the #1312 env
+flip): a reserved return/parameter type **spelling `SfnString`** that
+`map_return_type` / `map_type_annotation` intercept and map to the literal
+`{i8*, i64}`, routing the *definition* onto the by-value aggregate ABI without
+changing any other struct. It is narrow and opt-in by design:
 
 - **Return:** spell the return type `SfnString` (→ `define {i8*, i64} @f`).
   The body returns a bare `* u8`; the return-path coercion

--- a/docs/conventions/runtime-helpers.md
+++ b/docs/conventions/runtime-helpers.md
@@ -72,6 +72,39 @@ preamble's `render_runtime_helper_declarations` then emits a single
 `declare` per used target's effective symbol — no aliases, no
 per-target fallbacks.
 
+## Returning the `{i8*, i64}` aggregate from a Sailfin body (`SfnString`)
+
+A handful of helpers carry the `{i8*, i64}` SfnString aggregate return ABI
+(`env.get` / `env.home`; the string family's `{i8*,i64}` canonical bodies
+will follow). The compiler returns every *user* struct by pointer (`%T*`,
+the "boxed-struct ABI" in `type_mapping.sfn` — deliberate, to dodge an
+AArch64 aggregate-return legalizer miscompile), so a runtime body that must
+satisfy a by-value `{i8*, i64}` call site cannot just `return` a normal
+struct.
+
+The mechanism (M1.A.2, first landed by #1312): a reserved return/parameter
+type **spelling `SfnString`** that `map_return_type` / `map_type_annotation`
+intercept and map to the literal `{i8*, i64}`, routing the *definition* onto
+the by-value aggregate ABI without changing any other struct. It is narrow
+and opt-in by design:
+
+- **Return:** spell the return type `SfnString` (→ `define {i8*, i64} @f`).
+  The body returns a bare `* u8`; the return-path coercion
+  (`coerce_pointer_or_struct`) wraps it into `{i8*, i64}`, recovering the
+  length via `sfn_str_len`. A `string`-typed return still maps to `i8*` —
+  `SfnString` is the only spelling that opts in.
+- **Parameter:** a by-value `{i8*, i64}` argument classifies as two INTEGER
+  eightbytes, identical to a `(data: * u8, len: i64)` scalar pair (the print
+  family's trick). Take the two scalars, not an `SfnString` param — the body
+  has no struct fields to read.
+- `SfnString` is a **runtime-internal ABI spelling, not a user-facing
+  type** — keep it out of the language spec; it appears only in
+  `runtime/sfn/*.sfn` bodies whose descriptor carries `{i8*, i64}`.
+- Safe only for ≤16B, all-INTEGER-class aggregates (`{i8*, i64}` is exactly
+  that). Do **not** generalize to other shapes via a layout heuristic — that
+  re-exposes the boxed-ABI's AArch64 hazard. A second by-value shape, if ever
+  needed, is a deliberate new decision.
+
 ## When the registry is the wrong tool
 
 The runtime helper registry is for descriptors that:


### PR DESCRIPTION
## What

Adds a narrow, opt-in compiler capability for a Sailfin function **definition** to return (and accept) the `{i8*, i64}` SfnString aggregate **by value**, instead of the default boxed `%T*` struct ABI. A reserved return/parameter type spelling **`SfnString`** is intercepted in `map_return_type` / `map_type_annotation` (`compiler/src/llvm/type_mapping.sfn`) and mapped to the literal `{i8*, i64}`, routing the definition onto the already-plumbed SfnString aggregate ABI that the runtime-helper call sites (`env.get`/`env.home`, and the string family) already emit.

This is the untracked **"M1.A.2"** capability (#1283 Gap 2) — the prerequisite enabler for the C7/R7 env flip (#1312) and the string-family C-runtime retirement under epic #1308.

## Why this is separate from the env flip (#1312)

I implemented the full env flip first, but the complete `make check` gate exposed a **seed-boundary** problem the original "no seed cut" plan missed:

- `make compile` uses the **pinned seed** to compile `runtime/sfn/io.sfn`.
- The seed has no `SfnString` guard, so it lowers `-> SfnString` to `define i8* @sfn_getenv` (single pointer), while the call sites expect `{i8*, i64}`.
- That ABI mismatch is baked into the seed-built first-pass runtime and **corrupts the seedcheck** — `make check` failed at `seedcheck-smoke` (deterministic 3/3; the seed has **zero** spellings mapping to `{i8*, i64}`, so it physically cannot compile the consumer correctly).

The first-pass passed all suites (116/116 e2e-sh) only because test binaries are *recompiled* by the capability-bearing first-pass compiler — masking the seed-built runtime breakage until the second generation. This is exactly epic #1308's **C9 seed-gate**, now shown to apply to #1312.

**So the env consumer must land after a seed cut carrying this capability.** This PR is that gated enabler.

## Scope (deliberately minimal + safe)

- Only the literal `SfnString` spelling opts in; `string` still maps to `i8*` and every other struct still boxes to `%T*`. **Zero blast radius** — nothing in-tree spells `SfnString`, so the guard is **dormant during self-host** (it never fires while the compiler compiles itself).
- Only the two-eightbyte INTEGER-class `{i8*, i64}` shape (returned in registers — the legalizer-stable case, **not** the general aggregate return the boxed-struct ABI guards against on AArch64). Not generalized via a layout heuristic.
- `SfnString` is a **runtime-internal ABI spelling, not a user-facing type** — documented in `docs/conventions/runtime-helpers.md`, kept out of the language spec.

## Validation

- ✅ `make check` passes — **fixed point** reached (stage2 == stage3 IR), seedcheck promoted.
- ✅ New `compiler/tests/e2e/abi_value_return_test.sfn`: pins `-> SfnString` → `define {i8*, i64}` + `ret {i8*, i64}`, and the negative control `-> string` → `define i8*` (never the aggregate).
- ✅ `sfn fmt --check` clean on all touched `.sfn`.

## Files

- `compiler/src/llvm/type_mapping.sfn` — the `SfnString` → `{i8*, i64}` guard (return + param + annotation mappers).
- `compiler/tests/e2e/abi_value_return_test.sfn` — capability regression + no-regression control (native `sfn/test`, no bash).
- `docs/conventions/runtime-helpers.md` — documents the `SfnString` ABI spelling.

## Follow-up (the env flip, #1312)

The env consumer (io.sfn `sfn_getenv`/`sfn_home_dir` bodies + C-runtime deletion) is **fully implemented and validated** against a capability-bearing compiler — unit (`runtime_io_skeleton_test`), e2e ABI roundtrip, and the issue's named acceptance test (`env_from_current_test`) all passed; the nm/relink gate is clean. It will land in a follow-up **after**:
1. this PR merges,
2. a seed is cut carrying the capability, and
3. `.seed-version` is pinned to it (`/pin-seed`).

The validated consumer patch + seed-cut steps will be posted to #1312.

Refs #1308, #1283. Unblocks #1312 (pending seed cut). Does **not** close #1312 (the env flip lands in the follow-up).

https://claude.ai/code/session_01XTX2JiQGWRuAS3oXRr9a2C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTX2JiQGWRuAS3oXRr9a2C)_