### PR TITLE
docs: commit strategic decision brief + correct backend-timeline framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,11 @@ When uncertain about feature status or semantics:
 3. **[sailfin.dev/roadmap](https://sailfin.dev/roadmap)** — active workstreams (`site/src/pages/roadmap.astro`)
 4. **`docs/runtime_audit.md`** — C→Sailfin runtime migration tracker
 5. **`docs/build-performance.md`** — build perf analysis + optimization plan
+6. **`docs/strategy/decision-brief.md`** — strategic overlay binding the internal
+   vision (the capstone `docs/proposals/capability-sealed-runtime.md`) to the
+   market: what's *proven now* (compile-time effects) vs. the *long-horizon seal*,
+   the now/later positioning split, and the seal-sufficient-vs-perf-parity fork.
+   Proposal docs win on architecture; the brief wins on positioning.
 
 Examples are compiler-only unless marked with future-syntax comments.
 

--- a/docs/proposals/capability-sealed-runtime.md
+++ b/docs/proposals/capability-sealed-runtime.md
@@ -166,7 +166,14 @@ This is further out than `llvm-independence.md` — it *depends* on it. The chai
 in order:
 
 1. **Finish C→Sailfin runtime** (Axis 1; M3 #390, M4 #965) — *in flight.*
-2. **Own the backend** (Track 8; `llvm-independence.md`) — vision; Stage 0 is small.
+2. **Own the backend — the *seal-sufficient* one** (Track 8; `llvm-independence.md`)
+   — vision; Stage 0 is small. Note the timeline correction in
+   `llvm-independence.md` §5: the seal needs a *correct, metadata-carrying,
+   syscall-gating* backend, **not** the perf-parity optimizer that is the genuine
+   long tail. The seal-sufficient target is agent-amenable and de-riskable by
+   differential testing against the existing LLVM backend, so this dependency is
+   plausibly quarters-scale, not the decade-scale arc the pre-LLM literature
+   assumed.
 3. **Own the syscall layer** (Axis 3; `llvm-independence.md` §8 Stage 4) — deepest piece.
 4. **Land the runtime object-capability model** (#934) — currently `priority:low`, post-1.0.
 5. **Carry capabilities through the scheduler** (extends #965) — the per-task context.
@@ -174,7 +181,9 @@ in order:
 
 Every step is already on the board or in this proposal set. The roadmap is
 *already pointed here* — this doc names the destination so the steps read as a
-journey rather than a pile.
+journey rather than a pile. The agentic era compresses the long pole (step 2):
+the perf tail is off this critical path; only correctness + metadata + the gate
+are.
 
 ---
 

--- a/docs/proposals/llvm-independence.md
+++ b/docs/proposals/llvm-independence.md
@@ -16,8 +16,13 @@ analysis + Track registry, #339), `docs/runtime_audit.md` /
 > dependent on LLVM/clang, the way Go owns its backend. It is a **long-term
 > health and performance** bet, deliberately separate from the in-flight
 > runtime rewrite (which eliminates C *source* but keeps LLVM and libc). It is
-> filed as a vision, not a plan: the actionable kernel (Stage 0) is small; the
-> rest is a decade-scale arc.
+> filed as a vision, not a plan: the actionable kernel (Stage 0) is small. The
+> rest is *not* the single decade-scale arc the pre-LLM tooling literature
+> assumed — see §5, which splits a **seal-sufficient backend** (correct +
+> metadata-carrying + syscall-gating, plausibly compressible to quarters with
+> agent-assisted work and a differential-testing oracle) from a **perf-parity
+> backend** (matching LLVM's optimizer — the genuine long tail, off the critical
+> path for the capability seal).
 
 ---
 
@@ -138,9 +143,19 @@ target. But the durable reasons tie to Sailfin's three differentiators:
 2. **Multi-arch, multi-format slog.** x86-64 + aarch64 each need instruction
    selection, register allocation, and ABI (SysV / AAPCS / Win64), plus
    ELF/Mach-O/COFF encoders, DWARF debug info, and unwind tables (`.eh_frame`).
-3. **We will be slower than `-O2` for years.** Every team that has done this
-   (Go, Zig's self-hosted backend, Cranelift) treated it as a decade-scale arc.
-   Matching LLVM throughput is not the near-term goal and should not be promised.
+3. **Perf parity with `-O2` is a long tail — but it is not the gate.** Matching
+   LLVM's optimizer throughput is genuinely hard and should not be promised as
+   near-term. The pre-LLM tooling literature (Go, Zig's self-hosted backend,
+   Cranelift) treated the *whole* effort as a decade-scale arc; that framing
+   conflates two distinct targets. A **seal-sufficient backend** — correct,
+   carrying capability metadata through lowering, gating syscalls, but *not*
+   perf-competitive — is the target on the critical path for the capability seal
+   (`capability-sealed-runtime.md`), and it is agent-amenable and de-riskable by
+   differential testing against the existing LLVM backend (a cheap correctness
+   oracle), which makes it plausibly a quarters-scale effort, not a decade. The
+   **perf-parity backend** is the long tail, the part agentic work helps least
+   with, and it is off the seal's critical path — required only for
+   general-purpose-language competitiveness.
 4. **Lost for free:** LLVM's sanitizers, LTO, PGO, and the entire optimization
    pipeline. The two-backend design (§6) is what keeps these available.
 

--- a/docs/strategy/decision-brief.md
+++ b/docs/strategy/decision-brief.md
@@ -1,4 +1,4 @@
-# Sailfin — Strategic Decision Brief (v2)
+# Sailfin — Strategic Decision Brief
 
 **Date:** 2026-06-14
 **Status:** Strategic overlay — agent context. Binds the internal vision (the
@@ -9,7 +9,7 @@ market positioning):** `docs/proposals/capability-sealed-runtime.md`,
 `docs/proposals/effect-validation.md`, `docs/proposals/model-engines-and-training.md`.
 
 > **What this is.** A strategic overlay for the Sailfin repo, written to be read
-> by a Claude Code agent operating in-tree (and by Michael). It does **not**
+> by a Claude Code agent operating in-tree. It does **not**
 > restate the internal vision — that already lives, better grounded, in the
 > proposal docs below. Its job is to (a) bind the internal vision to the external
 > market, (b) name the cross-cutting gaps, and (c) frame the open strategic fork.
@@ -46,11 +46,11 @@ market positioning):** `docs/proposals/capability-sealed-runtime.md`,
 
 ---
 
-## 3. The thesis (as it actually is — corrected from v1)
+## 3. The thesis
 
 Sailfin owns its stack on purpose, because **you cannot seal a binary you don't own**. The differentiated end-state, per `capability-sealed-runtime.md`: a native binary whose declared capabilities are enforced down to the syscall — proven-safe code runs at full native speed with no gate; code the type system can't see (FFI, plugins, generated/`eval`'d code) hits the owned syscall gate and is refused if it exceeds the grant. Plus the genuinely novel synthesis: **scoped, inherited, revocable capabilities per task** via the structured-concurrency scheduler — effects say *what*, capabilities say *how much*, structured concurrency says *for how long and to whom*. No mainstream language offers this.
 
-> v1 of this brief mis-framed Sailfin as a contract that "sits above and feeds someone else's runtime." That was wrong. Sailfin's reach-into-untrusted-code story is **its own runtime gate catching in-process foreign/generated code**, not emitting policy for an external enforcer. The emit-to-OPA/WASI/OTel idea survives only as a narrow *cross-process interop* option (Section 7), not the core.
+> A clarifying distinction: Sailfin's reach-into-untrusted-code story is **its own runtime gate catching in-process foreign/generated code**, not a contract that "sits above and feeds someone else's runtime" by emitting policy for an external enforcer. The emit-to-OPA/WASI/OTel idea survives only as a narrow *cross-process interop* option (Section 7), not the core.
 
 ---
 
@@ -94,7 +94,7 @@ For untrusted code running in *other* processes/runtimes (true foreign execution
 
 ---
 
-## 8. The fork (sharpened) — and the timeline correction
+## 8. The fork — and the timeline correction
 
 **Timeline (corrected).** Backend ownership is **not** a fixed decade-scale gate. The pre-LLM tooling literature (Go, Zig, Cranelift) treated a self-hosted backend as a decade-scale arc; agent-assisted compiler work plus a cheap correctness oracle (differential testing against the existing LLVM backend) changes that math. Split it:
 - **Seal-sufficient backend** — correct + carries capability metadata + gates syscalls; *not* perf-competitive with LLVM. On the critical path for the trust-substrate thesis. Agent-amenable and **plausibly compressible to quarters**, de-risked by differential testing against the existing LLVM backend (cheap correctness oracle). This is the target that matters.

--- a/docs/strategy/decision-brief.md
+++ b/docs/strategy/decision-brief.md
@@ -1,0 +1,135 @@
+# Sailfin — Strategic Decision Brief (v2)
+
+**Date:** 2026-06-14
+**Status:** Strategic overlay — agent context. Binds the internal vision (the
+proposal docs) to the external market. Referenced from `CLAUDE.md`.
+**Canonical architecture docs (these win on architecture; this brief wins on
+market positioning):** `docs/proposals/capability-sealed-runtime.md`,
+`docs/proposals/llvm-independence.md`, `docs/proposals/hierarchical-effects.md`,
+`docs/proposals/effect-validation.md`, `docs/proposals/model-engines-and-training.md`.
+
+> **What this is.** A strategic overlay for the Sailfin repo, written to be read
+> by a Claude Code agent operating in-tree (and by Michael). It does **not**
+> restate the internal vision — that already lives, better grounded, in the
+> proposal docs below. Its job is to (a) bind the internal vision to the external
+> market, (b) name the cross-cutting gaps, and (c) frame the open strategic fork.
+> Where this brief and the proposal docs conflict, the proposal docs win on
+> architecture; this brief wins on market positioning.
+>
+> **Canonical internal docs (read these first; do not duplicate them):**
+> - `docs/proposals/capability-sealed-runtime.md` — the capstone thesis (effects + capabilities + owned backend + owned syscall layer = a sealed binary). **This is the strategy.**
+> - `docs/proposals/llvm-independence.md` — the *how* of backend/syscall ownership.
+> - `docs/proposals/hierarchical-effects.md`, `docs/proposals/effect-validation.md` — effect-system depth.
+> - `docs/proposals/model-engines-and-training.md` — model-engine surface (relevant to the `![model]` gap below).
+> - `CLAUDE.md` — agent operating rules incl. the safety-claim discipline ("nothing is enforced today" unless it is).
+
+---
+
+## 1. How to use this brief (agent instructions)
+
+1. Read the canonical docs above + current repo state (effect checker, `compiler/src/llvm`, `runtime/sfn`, `effect_taxonomy.sfn`, `typecheck_types.sfn`).
+2. Audit against Section 6. Return findings before generating a backlog.
+3. Generate issues that advance Section 5 and remediate Section 4 gaps, citing files and the one-line strategic rationale per issue.
+4. Never make a runtime-enforcement claim that the code doesn't back (the seal is **vision**, not shipped). Preserve the safety-claim discipline.
+
+---
+
+## 2. Ground truth (verified against repo, June 2026)
+
+- **Identity:** "A systems language with compile-time capability enforcement." This is real and shipping, not aspirational.
+- **Enforced today (compile time):** `![io]`, `![net]`, `![clock]` are real gates; cross-module effect propagation (`E0402`); capsule capability cross-check via `capsule.toml` (`E0403`); structured diagnostics + fix-its; `sfn check --json` → `sailfin-check/1` envelope for the MCP server.
+- **Codegen:** still LLVM (`compiler/src/llvm`). No native backend in-tree beyond a test fixture. LLVM independence is a documented vision with a Stage-0 branch.
+- **Runtime:** C→Sailfin migration nearly complete (`runtime/sfn` ≈ 27 Sailfin files vs ~2 remaining C files). AOT-native execution, not a VM.
+- **Enforcement locus today:** compile-time only. Per `capability-sealed-runtime.md`, the manifest is currently "a lint, not a cage" — erased at codegen. Runtime/syscall enforcement is the **post-1.0 capstone vision**, gated on owning the backend then the syscall layer.
+
+**Discipline:** distinguish *compile-time proof* (real now) from *runtime seal* (vision). Never blur them externally.
+
+---
+
+## 3. The thesis (as it actually is — corrected from v1)
+
+Sailfin owns its stack on purpose, because **you cannot seal a binary you don't own**. The differentiated end-state, per `capability-sealed-runtime.md`: a native binary whose declared capabilities are enforced down to the syscall — proven-safe code runs at full native speed with no gate; code the type system can't see (FFI, plugins, generated/`eval`'d code) hits the owned syscall gate and is refused if it exceeds the grant. Plus the genuinely novel synthesis: **scoped, inherited, revocable capabilities per task** via the structured-concurrency scheduler — effects say *what*, capabilities say *how much*, structured concurrency says *for how long and to whom*. No mainstream language offers this.
+
+> v1 of this brief mis-framed Sailfin as a contract that "sits above and feeds someone else's runtime." That was wrong. Sailfin's reach-into-untrusted-code story is **its own runtime gate catching in-process foreign/generated code**, not emitting policy for an external enforcer. The emit-to-OPA/WASI/OTel idea survives only as a narrow *cross-process interop* option (Section 7), not the core.
+
+---
+
+## 4. External market reconciliation + gaps
+
+**Market position (corroborates and extends `capability-sealed-runtime.md` §1).** The AI-guardrail market has converged on *runtime* enforcement — sandboxes, microVMs, policy gates (OPA), runtime authorization (Cerbos, CodeIntegrity), and tracing (OpenTelemetry/MLflow). Capability-secure *portable execution* is owned by WASI (security-by-default, but a coarse VM boundary). Compile-time effect systems (Koka, Flix, Effekt — Effekt is capability-based) have the typing rigor but no AI framing, no productization, and static-only guarantees defeated by FFI. **The open lane** is exactly the one your doc names: type-proven *and* runtime-enforced, at native speed, on a runtime you own. That lane is real and currently unoccupied.
+
+**Gap 1 — `![model]` is scaffolded but not live (highest leverage).** `model` is in `effect_taxonomy.sfn` and partially wired in `typecheck_types.sfn`, but there's no call-site detector because no model-invoking surface ships yet. This is the one AI-specific effect, the piece with ~zero prior art, and the literal embodiment of the "why now." It is reachable on the **current LLVM stack** — it needs no backend/seal work. See Appendix A for a scoped issue.
+
+**Gap 2 — the best narrative is hidden.** README / `llms.txt` / site sell "compile-time enforcement, LLVM-native" — the *less* differentiated half. The capstone thesis (the seal; scoped/revocable per-task capabilities; the unoccupied lane) lives only in internal proposals. The positioning essay must surface the capstone, split into a **shippable-now half** (compile-time proof + `![model]`) and a **long-horizon half** (the seal), so the safety-claim discipline holds.
+
+**Gap 3 — sequencing.** The seal is gated on backend+syscall ownership; the *AI-era positioning* (compile-time proof for AI-generated code, model invocation as a tracked effect) is not. Decouple them: capture the timely positioning now on the current stack; let the seal be the long-horizon moat, not the thing the narrative waits on.
+
+---
+
+## 5. Near-term deliverables (all independent of the backend long pole)
+
+1. **Land `![model]` as a live effect** (Appendix A). Highest strategic leverage, no seal dependency.
+2. **Surface the capstone thesis publicly** — rework README/site framing to lead with the unoccupied lane, honestly split now/later. Feed `llms.txt` the corrected framing.
+3. **Positioning essay** — the capstone thesis, market-aware, now/later split. Names WASI / Capslock / static-only effect systems as the foils your doc already identified.
+4. **This brief committed + referenced from `CLAUDE.md`** as agent context.
+
+Deferred (the fork, Section 8): the seal-sufficient backend + syscall ownership.
+
+---
+
+## 6. Alignment audit questions
+
+- Is `![model]` a first-class, enforced effect — or still reserved? (Should be the headline AI primitive; currently the least-built.)
+- Do effect signatures + capability grants compose across module boundaries and (eventually) per task? (Compositionality is the whole reason to be compile-time.)
+- Does codegen *erase* effect/capability metadata, or is there any path to carry it through? (Metadata survival is the seal precondition — `llvm-independence.md` Track 8.)
+- Is the public framing (README/site/`llms.txt`) leading with the differentiated capstone, or with the commodity compile-time/LLVM story?
+- Does any in-flight work make a runtime-enforcement claim the code doesn't back? (Discipline violation — flag.)
+- Does any work chase perf-parity codegen *before* the seal-sufficient backend? (Wrong order if the goal is the trust substrate — see Section 8.)
+
+---
+
+## 7. Cross-process interop (demoted, optional)
+
+For untrusted code running in *other* processes/runtimes (true foreign execution, outside the Sailfin-owned process), the runtime gate doesn't reach. Only there might emitting to OPA/WASI/OTel matter. Treat as a future interop lane, not core, and not before the in-process seal exists.
+
+---
+
+## 8. The fork (sharpened) — and the timeline correction
+
+**Timeline (corrected).** Backend ownership is **not** a fixed decade-scale gate. The pre-LLM tooling literature (Go, Zig, Cranelift) treated a self-hosted backend as a decade-scale arc; agent-assisted compiler work plus a cheap correctness oracle (differential testing against the existing LLVM backend) changes that math. Split it:
+- **Seal-sufficient backend** — correct + carries capability metadata + gates syscalls; *not* perf-competitive with LLVM. On the critical path for the trust-substrate thesis. Agent-amenable and **plausibly compressible to quarters**, de-risked by differential testing against the existing LLVM backend (cheap correctness oracle). This is the target that matters.
+- **Perf-parity backend** — matching LLVM's optimizer. The genuine long tail, the part agentic work helps least with, and **off the critical path for the seal**. Only required if the goal is general-purpose-language competitiveness.
+
+**Two games:**
+- **Trust-substrate / influence (legacy).** Success = the seal exists end-to-end and the constructs (model-as-effect, scoped/revocable per-task capabilities) are real and reachable in the corpus. Needs only the *seal-sufficient* backend. Robust to competitors; risk is obscurity (addressed by Gaps 2–3).
+- **Competitive systems language (product).** Success = adoption *and* perf parity. Reintroduces the optimizer tail. Hard, and largely orthogonal to the seal's value.
+
+**Trigger:** the fork fires when the near-term deliverables (Section 5) are done and the next decision is whether to commit agent capacity to the seal-sufficient backend. Until then, do not let issue generation presuppose the perf-parity game.
+
+---
+
+## Appendix A — Scoped issue: land `![model]` as a live, enforced effect
+
+**Goal.** Promote `model` from reserved-in-taxonomy to a first-class enforced effect, at parity with `![io]`/`![net]`/`![clock]`, with no dependency on backend/seal work.
+
+**Context / files.** `compiler/src/effect_taxonomy.sfn` (already lists `model`), `compiler/src/typecheck_types.sfn` (partial `model` handling + `![model]` capability-gate diagnostic), the io/net/clock call-site detectors (the pattern to mirror), `capsule.toml` capability cross-check (`E0403`, should accept `model`), cross-module propagation (`E0402`, should propagate `model`). Read `docs/proposals/model-engines-and-training.md` for the intended model-invoking surface before fixing entry points.
+
+**Scope.**
+1. Define the model-invoking surface (inference/engine entry points per `model-engines-and-training.md`). If no such surface ships yet, land a minimal one behind `![model]` so the detector has real call sites.
+2. Add call-site detection mirroring io/net/clock: undeclared model invocation fails the build with a structured diagnostic + fix-it inserting `![model]`.
+3. Confirm cross-module propagation (`E0402`) and capsule cross-check (`E0403`) treat `model` identically to existing effects (likely free if the taxonomy is the single source of truth — verify, don't assume).
+4. Tests: positive (declared `![model]` compiles), negative (undeclared invocation fails with the new diagnostic), propagation, capsule-surface rejection.
+5. Docs: README "Effect system (enforced)" moves `model` from *reserved* to *enforced*; update `llms.txt`.
+
+**Acceptance.** A function invoking a model without `![model]` fails to compile with a fix-it; a capsule using `![model]` outside its declared surface fails with `E0403`; the AI-specific effect is demonstrably live on the current LLVM stack.
+
+**Non-goals.** No runtime/seal enforcement of `![model]` (that's the capstone). No model-engine implementation beyond the minimal surface needed to make the gate real.
+
+> **In-repo note (added on commit, 2026-06-14).** Appendix A's "land a minimal
+> model-invoking surface now" pushes against the locked CLAUDE.md principle that
+> AI is a post-1.0 `sfn/ai` library concern and the "don't ship unfinished safety
+> claims" rule. Per owner decision, the `![model]` work is **architect-gated**:
+> whether (and how minimal a surface) to land now is a `compiler-architect`
+> design-gate decision before any code, *not* a settled plan. The strategic
+> intent (`![model]` is the one AI-native differentiator, cheap on the current
+> stack) stands; the scoping does not bypass the design gate.

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -171,6 +171,8 @@ const postV1Platform: RoadmapCategory = {
 };
 
 const exploration: RoadmapItem[] = [
+  { label: "Capability-sealed runtime — effects enforced to the syscall boundary, scoped/revocable per-task capabilities (post-1.0 capstone vision)", status: "planned" },
+  { label: "Toolchain independence — seal-sufficient Sailfin-native backend (correct + metadata-carrying + syscall-gating), perf-parity backend as a separate long tail", status: "planned" },
   { label: "Structured concurrency — atomics, await, routine, channel, spawn, scheduler", status: "planned" },
   { label: "Effect system hardening — wire validate_effects() into compilation gate, hierarchical effects, polymorphism", status: "planned" },
   { label: "Phase 2 containers — closures with capture, generic constraints, drop emission", status: "planned" },


### PR DESCRIPTION
## What

Lands the **Strategic Decision Brief (v2)** as in-repo agent context and remediates the two cross-cutting findings it surfaces that are pure-docs.

### Changes
- **New: `docs/strategy/decision-brief.md`** — strategic overlay binding the capstone vision (`capability-sealed-runtime.md`) to the market: what's *proven now* (compile-time effects) vs. the *long-horizon seal*, the now/later positioning split, and the seal-sufficient-vs-perf-parity fork. Referenced from `CLAUDE.md`'s Source-of-Truth section. Appendix A carries an in-repo note recording the owner decision to **architect-gate** the `[model]` work.
- **Corrected backend-timeline framing** in `docs/proposals/llvm-independence.md` (header blurb + §5 Honest Costs) and `docs/proposals/capability-sealed-runtime.md` (§7 dependency chain): the pre-LLM tooling literature's "decade-scale arc" conflated two targets. Split the **seal-sufficient backend** (correct + metadata-carrying + syscall-gating; quarters-scale, agent-amenable, de-risked by differential testing against the existing LLVM backend) from the **perf-parity backend** (the genuine long tail, off the seal's critical path). The agentic era changed this math.
- **Promoted** capability-sealed-runtime + toolchain-independence to the roadmap's Backlog & Exploration (`site/src/pages/roadmap.astro`) so the long-horizon moat is visible.

## Audit basis
The brief was ground-truthed against the repo before any change. Verified: all five canonical proposal docs exist; `[model]` is taxonomy-reserved with **no** call-site detector (`effect_checker.sfn`); `E0402`/`E0403` are effect-agnostic (model propagates "for free"); codegen erases effect metadata (`emission.sfn:365` — a `;` comment only); public copy leads with the commodity compile-time/LLVM story. The brief is accurate on every checkable claim.

## Follow-up issues
- #1343 — Land `[model]` as a live, enforced effect (architect-gated; `needs-design`)
- #1344 — Surface the capability-seal thesis in public framing (README/site/llms.txt)
- #1345 — Write the positioning essay

## Notes
- Docs/`.astro`/`.md` only — no `.sfn` touched, so no self-host gate or `sfn fmt` applies.
- No runtime-enforcement claim is made that the code doesn't back; the seal is labeled vision throughout (safety-claim discipline preserved).

https://claude.ai/code/session_01EcUv9motXqWkSJcDnXoc4E

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcUv9motXqWkSJcDnXoc4E)_