### PR TITLE
refactor(runtime): port env getenv/home_dir to Sailfin (C7/R7, #1312)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1083,8 +1083,9 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "string_starts_with");
     helpers = append_unique_effect(helpers, "process.run");
     helpers = append_unique_effect(helpers, "process.exit");
-    // `env.get` / `env.home` lower to `sailfin_runtime_getenv` /
-    // `sailfin_runtime_home_dir`; without explicit declare-tracking,
+    // `env.get` / `env.home` lower to the bare `sfn_getenv` / `sfn_home_dir`
+    // SfnString aggregate-ABI symbols (now Sailfin-defined in
+    // `runtime/sfn/io.sfn` — C7/R7, #1312); without explicit declare-tracking,
     // modules that consume them produce IR that clang rejects with
     // "use of undefined value" (see the env-var workaround note in
     // `compiler/src/effect_gate.sfn` — same root cause, surfacing as

--- a/compiler/tests/e2e/env_value_abi_test.sfn
+++ b/compiler/tests/e2e/env_value_abi_test.sfn
@@ -1,0 +1,106 @@
+// End-to-end test for the C7/R7 env flip (#1308, issue #1312): `env.get` /
+// `env.home` are now real Sailfin bodies in `runtime/sfn/io.sfn` returning the
+// `{i8*, i64}` SfnString aggregate by value (the M1.A.2 `SfnString` return
+// spelling). This is the load-bearing correctness proof: it builds a fixture
+// that reads an env var and prints it, runs it with the var set, and asserts
+// the value round-trips. A truncated aggregate return (the data pointer or the
+// length landing in the wrong SysV register) would surface here as a garbage /
+// wrong-length print — the exact failure the boxed-struct ABI was created to
+// avoid, which this narrow two-eightbyte INTEGER-class return is immune to.
+//
+// Native (no-bash) replacement-class test per epic #842 /
+// `.claude/rules/no-bash-e2e.md`. Build-and-run isolation mirrors
+// `sailfin_main_entry_test.sfn`: the fixture is written into a fresh
+// `with_tmp_dir` (so `sfn build` does not auto-discover
+// `runtime/native/capsule.toml`'s `main`), and the nested build's env is
+// threaded explicitly — `PATH` (clang + linker), `HOME`/`TMPDIR`, and
+// `SAILFIN_TEST_SCRATCH` (routes the `program.ll` build-cache dir per-
+// invocation under the parallel pool, #1333). The fixture's own env (the var
+// under test) is passed to the *run*, not the build.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-env-abi-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// Build `src` in a temp dir, run it with `run_env`, stash captured stdout to
+// `out_marker`, and return the run's exit code (or `-100` on build failure).
+fn _build_and_run(src: string, run_env: string[], out_marker: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, src);
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], run_env);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+// `env.get(name)` of a SET variable round-trips its full value through the
+// `{i8*, i64}` aggregate return — the core ABI proof.
+test "env-abi: env.get returns the full value of a set variable" ![io] {
+    let marker = _marker("get");
+    let src = "fn main() -> void ![io] { let v: string = env.get(\"SFN_ENV_ABI_TEST\"); print.info(v); }";
+    let exit = _build_and_run(src, ["SFN_ENV_ABI_TEST=roundtrip-sentinel-value"], marker);
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // Full value present (not truncated by a bad length register).
+    assert find(out, "roundtrip-sentinel-value", 0) >= 0;
+}
+
+// `env.get(name)` of an UNSET variable is the empty string (len 0) — the miss
+// path returns the `{emptyptr, 0}` aggregate, not garbage.
+test "env-abi: env.get of an unset variable is empty" ![io] {
+    let marker = _marker("miss");
+    let src = "fn main() -> void ![io] { let v: string = env.get(\"SFN_ENV_ABI_DEFINITELY_UNSET\"); print.info(\"[\" + v + \"]\"); }";
+    let exit = _build_and_run(src, [], marker);
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // The bracketed empty value prints as `[info] []` — nothing between.
+    assert find(out, "[]", 0) >= 0;
+}
+
+// `env.home()` returns `$HOME` when set — exercises the second flipped symbol
+// (the `["ptr"]`-only descriptor) through the same aggregate return ABI.
+test "env-abi: env.home returns HOME" ![io] {
+    let marker = _marker("home");
+    let src = "fn main() -> void ![io] { let h: string = env.home(); print.info(h); }";
+    let exit = _build_and_run(src, ["HOME=/sfn/env/abi/home"], marker);
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert find(out, "/sfn/env/abi/home", 0) >= 0;
+}

--- a/compiler/tests/unit/runtime_io_skeleton_test.sfn
+++ b/compiler/tests/unit/runtime_io_skeleton_test.sfn
@@ -45,9 +45,10 @@ test "lowering: runtime/sfn/io.sfn lowers the imported libc write call" ![io] {
 // assertions that lived in the retired `test_runtime_io_extended.sh`
 // (migrated to native sfn/test per epic #842). Lowers the REAL io.sfn
 // in-process and pins the new ownership: io.sfn now defines the bare
-// `sfn_print*` symbols directly (native `write(2)` bodies), keeps the
-// surviving `_sfn_` infix exports, and must NOT define the still-C-owned
-// `sfn_getenv` / `sfn_home_dir` canonical names (their flip is C7).
+// `sfn_print*` symbols directly (native `write(2)` bodies) and keeps the
+// surviving Sailfin exports. (The bare `sfn_getenv` / `sfn_home_dir`
+// canonical names are now ALSO Sailfin-defined — C7/R7, #1312 — asserted
+// in the dedicated env test below.)
 test "lowering: io.sfn defines the bare native sfn_print* family" ![io] {
     let source = fs.readFile("runtime/sfn/io.sfn");
     let program = parse_program(source);
@@ -62,25 +63,29 @@ test "lowering: io.sfn defines the bare native sfn_print* family" ![io] {
     assert _contains(ir, "define void @sfn_print_error(");
     // Surviving Sailfin exports (prelude import + baselines).
     assert _contains(ir, "define void @sfn_print_sfn(");
-    assert _contains(ir, "@sfn_getenv_sfn(");
-    assert _contains(ir, "@sfn_home_dir_sfn(");
     assert _contains(ir, "@sfn_write_fd(");
 }
 
-test "lowering: io.sfn still forwards env reads to the C entrypoints (C7 not flipped)" ![io] {
+test "lowering: io.sfn defines the bare native env readers (C7/R7 flipped)" ![io] {
     let source = fs.readFile("runtime/sfn/io.sfn");
     let program = parse_program(source);
     let native = emit_native_text_with_module_name(program, "runtime/sfn/io");
     let ir = lower_to_llvm_ir_from_text(native, "runtime/sfn/io");
 
-    // getenv / home_dir are NOT flipped to native yet (C7 of #1308):
-    // io.sfn's `sfn_getenv_sfn` / `sfn_home_dir_sfn` forward to the C
-    // `sailfin_runtime_*` trampolines, so the bare canonical names stay
-    // C-owned and io.sfn defines no colliding native body. (The bare
-    // `@sfn_getenv` / `@sfn_home_dir` appear only as registry-preamble
-    // `declare`s, so an absence check on them would be a false negative.)
-    assert _contains(ir, "@sailfin_runtime_getenv");
-    assert _contains(ir, "@sailfin_runtime_home_dir");
+    // C7/R7 of #1308 (issue #1312): `env.get` / `env.home` are now real
+    // Sailfin bodies. io.sfn defines the bare canonical `sfn_getenv` /
+    // `sfn_home_dir` with the `{i8*, i64}` SfnString aggregate return ABI
+    // (the M1.A.2 `SfnString` return spelling) — the symbols user emission
+    // calls against. The two-eightbyte name aggregate arrives as a
+    // `(data, len)` scalar pair, so the param list is `(i8*, i64, i8*)`.
+    assert _contains(ir, "define {i8*, i64} @sfn_getenv(");
+    assert _contains(ir, "define {i8*, i64} @sfn_home_dir(");
+    // The retired proof-of-life forwarders and their C trampoline externs
+    // are gone (their `sailfin_runtime_*` C bodies retire with #822).
+    assert ! _contains(ir, "@sfn_getenv_sfn(");
+    assert ! _contains(ir, "@sfn_home_dir_sfn(");
+    assert ! _contains(ir, "@sailfin_runtime_getenv");
+    assert ! _contains(ir, "@sailfin_runtime_home_dir");
 }
 
 test "lowering: io.sfn immediate-codepoint guard routes to the C decoders" ![io] {

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -475,7 +475,8 @@ survives until process exit. This is why per-module compiler RAM reaches
 |---|---|---|
 | `sailfin_runtime_sha256_hex` | ✅ (ported) | SHA-256 reimplemented in pure Sailfin in `capsules/sfn/crypto/src/mod.sfn` (M3, #816); the `crypto.sha256` intrinsic now resolves to the capsule symbol. C body in `sailfin_sha256.c` (~150 lines) stays linked for seed compat until M3.9 deletes it. |
 | `sailfin_runtime_base64_encode` | ✅ | Separate file `sailfin_base64.c` |
-| `sailfin_runtime_getenv` / `home_dir` / `read_file_bytes` | ✅ | Used by `sfn/os` and package manager |
+| `sailfin_runtime_getenv` / `home_dir` / `read_file_bytes` | ✅ | Single-pointer (`i8*`) trampolines. `getenv`/`home_dir` are now the legacy path only; the canonical aggregate readers flipped to Sailfin (next row). Stay exported for seed-built `i8*`-ABI IR; retire under #822. |
+| `sfn_getenv` / `sfn_home_dir` (`env.get` / `env.home`) | ✅ | **#1312 (epic #1308 C7/R7):** the `{i8*, i64}` SfnString aggregate-ABI readers are **real Sailfin bodies** in `runtime/sfn/io.sfn` over libc `getenv`; the C bodies are **deleted** (header protos dropped) — no internal C caller remained, so the nm/relink gate is clean. Enabled by the M1.A.2 by-value small-aggregate return (`SfnString` return spelling → `{i8*, i64}`, `type_mapping.sfn`, #1339) — its first consumer. Seed cut to `0.7.0-alpha.34` carries the capability so the seed compiles io.sfn correctly. Immediate-codepoint `name` decoded via `sfn_str_from_codepoint` (retires with #822). |
 
 ## Bootstrap-Era Defensive Scaffolding
 

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -434,16 +434,13 @@ extern "C"
     // Environment & path helpers.
     char *sailfin_runtime_getenv(const char *name);
     char *sailfin_runtime_home_dir(void);
-    /* M2.8b (#726): SfnString aggregate ABI for `env.get` / `env.home`.
-     * The compiler's runtime_helpers.sfn descriptors carry
-     * `parameter_types: ["{i8*, i64}", "ptr"]` / `["ptr"]` and
-     * `return_type: "{i8*, i64}"`; the call-site dispatch in
-     * `core_call_lowering.sfn` splices `ptr @sfn_default_arena` as
-     * the trailing arg (mirrors `sfn_str_concat` from #714). Bodies
-     * NUL-marshal the name through the arena, call `getenv`, and
-     * wrap the libc result via `sfn_str_from_cstr` + `sfn_str_len`. */
-    SfnString sfn_getenv(SfnString name, SfnArena **arena_slot);
-    SfnString sfn_home_dir(SfnArena **arena_slot);
+    /* M2.8b (#726): the `{i8*, i64}` SfnString aggregate-ABI env readers
+     * `sfn_getenv` / `sfn_home_dir` (`env.get` / `env.home`) moved to
+     * `runtime/sfn/io.sfn` (C7/R7 of #1308, issue #1312). The C bodies and
+     * these prototypes are removed together; emitted `call {i8*, i64}
+     * @sfn_getenv(...)` now binds to the Sailfin definition. The legacy
+     * single-pointer trampolines above stay (seed-built `i8*` ABI; retire
+     * with #822). */
     char *sailfin_runtime_read_file_bytes(const char *path, int64_t *out_length);
 
     // Misc stubs.

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -8285,99 +8285,16 @@ char *sailfin_runtime_home_dir(void)
     return strdup(home);
 }
 
-/* M2.8b (#726): SfnString aggregate ABI for `env.get` / `env.home`.
- * The runtime_helpers.sfn descriptors carry
- * `parameter_types: ["{i8*, i64}", "ptr"]` (env.get) /
- * `parameter_types: ["ptr"]` (env.home) and
- * `return_type: "{i8*, i64}"`. The compiler's call-site dispatch
- * splices `ptr @sfn_default_arena` as the trailing arg (mirrors
- * `sfn_str_concat` from #714); the bodies below NUL-marshal the
- * name through the arena and wrap the libc result via
- * `sfn_str_from_cstr` + `sfn_str_len`. The legacy
- * `sailfin_runtime_getenv` / `sailfin_runtime_home_dir` entrypoints
- * stay exported above so seed-built IR (which still emits the legacy
- * `i8*` ABI) keeps linking through the 2-pass self-host build. */
-SfnString sfn_getenv(SfnString name, SfnArena **arena_slot)
-{
-    SfnString result = {NULL, 0};
-    if (name.data == NULL || name.len <= 0)
-        return result;
-
-    /* Resolve arena — mirrors `sfn_str_concat`'s slot/fallback gate. */
-    SfnArena *arena;
-    if (arena_slot != NULL && *arena_slot != NULL)
-    {
-        arena = *arena_slot;
-    }
-    else
-    {
-        arena = sfn_arena_global();
-        if (arena_slot != NULL && *arena_slot == NULL)
-        {
-            *arena_slot = arena;
-        }
-    }
-
-    /* Decode pre-M1.A.2 tagged immediate-codepoint inputs into a
-     * stack buffer before the memcpy, mirroring `sfn_str_concat`'s
-     * handling: single-codepoint "strings" (e.g. literal `"X"`) are
-     * lowered to `((uint64_t)codepoint << 32)` rather than a real
-     * pointer; dereferencing `name.data` directly would segfault.
-     * `_utf8_encode` writes 1-4 UTF-8 bytes for the codepoint and
-     * the byte length matches what `sfn_str_len` returned at the
-     * call site. */
-    unsigned char name_imm_buf[5] = {0};
-    const char *name_data = name.data;
-    uint32_t name_cp = 0;
-    if (_is_immediate_codepoint_string(name.data, &name_cp))
-    {
-        _utf8_encode(name_cp, name_imm_buf);
-        name_data = (const char *)name_imm_buf;
-    }
-
-    /* NUL-marshal `name` into the arena so getenv() sees a clean C
-     * string regardless of the aggregate's NUL invariant. Today's
-     * SfnString.data is NUL-terminated (literal lowering writes a
-     * trailing 0; arena-routed concat preserves it), but the spec'd
-     * invariant only covers `len` bytes — copying through the arena
-     * keeps the contract independent of the data slot's terminator. */
-    size_t nlen = (size_t)name.len;
-    char *cname = (char *)sfn_arena_alloc(arena, nlen + 1, 1);
-    if (cname == NULL)
-        return result;
-    if (nlen > 0)
-        memcpy(cname, name_data, nlen);
-    cname[nlen] = '\0';
-
-    const char *val = getenv(cname);
-    if (val == NULL)
-        return result;
-
-    /* Wrap the libc-owned pointer via `sfn_str_from_cstr` (identity
-     * bridge in the M2.4a wave). `getenv()` guarantees a
-     * NUL-terminated buffer stable until the next mutating call on
-     * the same key, so the aggregate's data slot keeps the
-     * literal/concat NUL-termination invariant. Length recovered via
-     * `sfn_str_len` (the `native_signature` flip from M2.4a routes
-     * through `sailfin_runtime_string_length` for safe walking). */
-    const char *wrapped = sfn_str_from_cstr(val);
-    result.data = (char *)wrapped;
-    result.len = sfn_str_len(wrapped);
-    return result;
-}
-
-SfnString sfn_home_dir(SfnArena **arena_slot)
-{
-#if defined(_WIN32)
-    static const char k_home_name[] = "USERPROFILE";
-#else
-    static const char k_home_name[] = "HOME";
-#endif
-    SfnString name;
-    name.data = (char *)k_home_name;
-    name.len = (int64_t)(sizeof(k_home_name) - 1);
-    return sfn_getenv(name, arena_slot);
-}
+/* sfn_getenv / sfn_home_dir: the `{i8*, i64}` SfnString aggregate-ABI env
+ * readers (`env.get` / `env.home`) are now defined in `runtime/sfn/io.sfn`
+ * (C7/R7 of #1308, issue #1312). The C bodies are deleted (not static-ified):
+ * there is no remaining internal C caller — the only one was sfn_home_dir
+ * calling sfn_getenv, and both flip together — so the migration-rule
+ * "live-internal-caller" carve-out does not apply, and deleting keeps the
+ * nm/relink gate clean. The header prototypes are dropped in lockstep
+ * (sailfin_runtime.h). The legacy single-pointer `sailfin_runtime_getenv` /
+ * `sailfin_runtime_home_dir` trampolines above stay exported (seed-built IR
+ * on the legacy `i8*` ABI still links through them; they retire with #822). */
 
 char *sailfin_runtime_read_file_bytes(const char *path, int64_t *out_length)
 {

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -45,9 +45,23 @@
 //      (`sfn_log_execution`, `sfn_print_sfn`) likewise stay on the C
 //      entrypoints (their `* u8` arg has no length to drive `write`).
 //
-//   2. The `sfn_getenv_sfn` / `sfn_home_dir_sfn` proof-of-life family.
-//      These still forward to the `sailfin_runtime_{getenv,home_dir}` C
-//      entrypoints — their flip is C7 of #1308, not this issue.
+//   2. The bare `sfn_getenv` / `sfn_home_dir` env readers — the canonical
+//      symbols the compiler emits `call`s against for `env.get` / `env.home`
+//      (registered in `runtime_helpers.sfn` with the `{i8*, i64}` SfnString
+//      aggregate ABI). As of C7/R7 of the C→Sailfin runtime-retirement epic
+//      (#1308, issue #1312) these are **real native bodies** over libc
+//      `getenv` — no longer C trampolines. The prior C definitions
+//      (`SfnString sfn_getenv(SfnString, SfnArena**)` / `sfn_home_dir`) are
+//      deleted in the same change (no internal C caller remained); this
+//      module's TU is now the sole definition site. They return the
+//      `{i8*, i64}` aggregate by value: the
+//      `SfnString` return spelling routes the definition onto that ABI
+//      (M1.A.2), and the by-value name aggregate arrives as a `(data, len)`
+//      two-scalar pair — the same register classification the print family
+//      uses. The retired proof-of-life `sfn_getenv_sfn` / `sfn_home_dir_sfn`
+//      forwarders (and their `sailfin_runtime_{getenv,home_dir}` externs) are
+//      removed; the C `sailfin_runtime_{getenv,home_dir}` trampolines retire
+//      with #822.
 //
 // Linkage: this file is listed in `runtime/native/capsule.toml`'s
 // `sfn-sources` array; `_compile_runtime_sfn_sources` in
@@ -83,9 +97,20 @@ extern fn sailfin_runtime_print_warn(msg: * u8) -> void;
 
 extern fn sailfin_runtime_print_error(msg: * u8) -> void;
 
-extern fn sailfin_runtime_getenv(name: * u8) -> * u8;
+// libc `getenv` — the env-read primitive the native `sfn_getenv` /
+// `sfn_home_dir` bodies below call. Inlined (not imported) for the same
+// reason as `write` above: the isolated runtime-sfn emit only pre-stages the
+// platform symbols the seed snapshots, so any other libc surface must be
+// declared locally (the `arena.sfn` / `string.sfn` discipline).
+extern fn getenv(name: * u8) -> * u8;
 
-extern fn sailfin_runtime_home_dir() -> * u8;
+// `sfn_str_from_codepoint(cp)` — UTF-8 encodes a single codepoint into a
+// fresh NUL-terminated buffer. Used only on the pathological immediate-
+// codepoint `name` path (pre-M1.A.2 tagged pseudo-pointers). A C runtime
+// symbol on its own retirement track (R1 string family); the guard that
+// calls it — and this extern — retire with the immediate encoding
+// (#822 / #1136).
+extern fn sfn_str_from_codepoint(cp: i64) -> * u8;
 
 // stdout / stderr file descriptors — the `write(2)` targets for the
 // print family. Matches the C `_print_line` stream routing: raw/info to
@@ -208,18 +233,90 @@ fn sfn_print_error(data: * u8, len: i64) -> void ![io] {
 // (#822 / #1136).
 fn sfn_print_sfn(msg: * u8) -> void ![io] { sailfin_runtime_print_raw(msg); }
 
-// `sfn_getenv_sfn(name)` — environment-variable read. Still forwards to
-// the C `sailfin_runtime_getenv` (the aggregate-return + arena-threaded
-// flip is C7 of #1308). The user-emission hot path bypasses this
-// wrapper and lands on `@sfn_getenv` against the real aggregate ABI.
-fn sfn_getenv_sfn(name: * u8) -> * u8 ![io] {
-    return sailfin_runtime_getenv(name);
+// `_sfn_decode_immediate_name(data)` — decode a legacy immediate-codepoint
+// tagged pseudo-pointer (pre-M1.A.2) into a real NUL-terminated buffer.
+// Mirrors the C `sfn_getenv`'s `_is_immediate_codepoint_string` +
+// `_utf8_encode` guard: a single grapheme can arrive as `cp << 32` (low word
+// zero) or a near-null ASCII byte (`1..=0x7f`) rather than a real string
+// pointer; dereferencing it directly would segfault. The codepoint is the
+// raw value for the ASCII case and `raw >> 32` for the shifted case (the two
+// shapes `_sfn_is_immediate` accepts), and `sfn_str_from_codepoint` does the
+// UTF-8 encode. Pathological for env *names* (which are real strings in every
+// realistic path); the guard exists only so the native body matches the C
+// body's defensiveness. Retires with the immediate encoding (#822 / #1136).
+fn _sfn_decode_immediate_name(data: * u8) -> * u8 {
+    let raw: i64 = data as i64;
+    let mut cp: i64 = raw;
+    if raw > 127 { cp = raw >> 32; }
+    return sfn_str_from_codepoint(cp);
 }
 
-// `sfn_home_dir_sfn()` — `getenv("HOME")` (or `USERPROFILE` on Windows;
-// the C trampoline handles the platform fork). Same C7 deferral as
-// `sfn_getenv_sfn`.
-fn sfn_home_dir_sfn() -> * u8 ![io] { return sailfin_runtime_home_dir(); }
+// `sfn_getenv(name, arena)` — C7/R7 of the C→Sailfin runtime retirement
+// (#1308, issue #1312). The bare canonical symbol user emission targets for
+// `env.get` (`runtime_helpers.sfn`: `symbol: sfn_getenv`,
+// `return_type: "{i8*, i64}"`, `parameter_types: ["{i8*, i64}", "ptr"]`).
+// Replaces the C `SfnString sfn_getenv(SfnString, SfnArena**)` body, which is
+// deleted in the same change so the linker binds this definition.
+//
+// ABI: the `{i8*, i64}` name aggregate is passed by value, which the System V
+// / AAPCS classification of a two-eightbyte INTEGER struct splits into two
+// integer registers — identical to a `(data: * u8, len: i64)` pair (the same
+// coercion the print family relies on). So the parameters are two scalars +
+// the arena `ptr`, lowering to `define {i8*, i64} @sfn_getenv(i8*, i64, i8*)`
+// (the `SfnString` return spelling routes the definition onto the by-value
+// aggregate ABI — M1.A.2). The body returns a bare `* u8`; the return-path
+// coercion wraps it into the `{i8*, i64}` aggregate, recovering the length via
+// `sfn_str_len` — byte-identical to the C body's `sfn_str_from_cstr` +
+// `sfn_str_len` result wrapping.
+//
+// `arena` is unused: today's `SfnString.data` is always NUL-terminated
+// (literal lowering writes the trailing NUL; arena-routed concat preserves
+// it), so `name_data` is a valid C string and no arena-marshalled copy is
+// needed. The C body marshalled defensively against a future non-terminated
+// slice shape; when such a shape lands, re-introduce the arena copy here
+// (same condition under which the immediate guard above retires). The slot is
+// kept in the signature to match the emitted call ABI.
+fn sfn_getenv(name_data: * u8, name_len: i64, arena: * u8) -> SfnString ![io] {
+    if name_data as i64 == 0 {
+        let empty: string = "";
+        return empty;
+    }
+    if name_len <= 0 {
+        let empty_len: string = "";
+        return empty_len;
+    }
+    let mut cname: * u8 = name_data;
+    if _sfn_is_immediate(name_data) {
+        cname = _sfn_decode_immediate_name(name_data);
+    }
+    let val: * u8 = getenv(cname);
+    if val as i64 == 0 {
+        let empty_miss: string = "";
+        return empty_miss;
+    }
+    return val;
+}
+
+// `sfn_home_dir(arena)` — C7/R7 companion (`env.home`,
+// `runtime_helpers.sfn`: `symbol: sfn_home_dir`, `parameter_types: ["ptr"]`).
+// Replaces the deleted C `SfnString sfn_home_dir(SfnArena**)`. The C
+// body forked on `_WIN32` (`USERPROFILE`) vs POSIX (`HOME`); Sailfin has no
+// `cfg(target_os)` yet (#468), so this tries `HOME` first then falls back to
+// `USERPROFILE` — platform-agnostic and correct on both (Linux/macOS set
+// `HOME`; Windows sets `USERPROFILE`). Literals are bound to `string` locals
+// before the `* u8` cast — the proven env-read pattern (`arena.sfn` /
+// `rlimit.sfn`): the inline `getenv("…" as * u8)` form miscompiles under the
+// seed (the call is elided to a null store). Return ABI as `sfn_getenv`.
+fn sfn_home_dir(arena: * u8) -> SfnString ![io] {
+    let home: string = "HOME";
+    let val: * u8 = getenv(home as * u8);
+    if val as i64 != 0 { return val; }
+    let userprofile: string = "USERPROFILE";
+    let val2: * u8 = getenv(userprofile as * u8);
+    if val2 as i64 != 0 { return val2; }
+    let empty: string = "";
+    return empty;
+}
 
 // #925 (sub-issue of #390): `sfn_log_execution(value)` — the body the
 // `@logExecution` decorator lowers to (via


### PR DESCRIPTION
## What

Flips the bare `sfn_getenv` / `sfn_home_dir` `{i8*, i64}` SfnString aggregate-ABI env readers (`env.get` / `env.home`) from C to real Sailfin bodies in `runtime/sfn/io.sfn` over libc `getenv`. **C7/R7 of epic #1308** (C→Sailfin runtime retirement).

This is the consumer half of the work; its enabler — the M1.A.2 by-value small-aggregate return capability — landed in **#1339** and shipped in seed **0.7.0-alpha.34** (pinned by #1341).

## Changes

- **`runtime/sfn/io.sfn`** — real `sfn_getenv(name_data, name_len, arena) -> SfnString` and `sfn_home_dir(arena) -> SfnString`. The by-value name aggregate arrives as a `(data, len)` two-scalar pair (the print-family register-classification trick); the `SfnString` return spelling routes the definition onto the by-value `{i8*, i64}` ABI. The body returns a bare `* u8` and the return-path coercion wraps it (length via `sfn_str_len`) — byte-identical to the old C body's `sfn_str_from_cstr` + `sfn_str_len`. Immediate-codepoint `name` is decoded via `sfn_str_from_codepoint` (`_sfn_decode_immediate_name`; retires with #822). `home_dir` tries `HOME` then `USERPROFILE` (platform-agnostic; no `cfg(target_os)` yet, #468). The proof-of-life `sfn_getenv_sfn`/`sfn_home_dir_sfn` forwarders + their `sailfin_runtime_*` externs are removed.
- **`runtime/native/src/sailfin_runtime.c` / `include/sailfin_runtime.h`** — the C `sfn_getenv` / `sfn_home_dir` bodies + prototypes are **deleted** (not static-ified): no internal C caller remained — the only one was `sfn_home_dir`→`sfn_getenv`, and both flip together — so the migration-rule live-caller carve-out doesn't apply and deleting keeps the nm/relink gate clean. The single-pointer `sailfin_runtime_getenv`/`_home_dir` trampolines stay (seed-built `i8*`-ABI IR; retire with #822).
- **Tests** — `runtime_io_skeleton_test.sfn` updated to assert the flip (bare native `define {i8*, i64} @sfn_getenv` / `@sfn_home_dir`, façades gone); new `env_value_abi_test.sfn` e2e ABI roundtrip (full value round-trips with no truncation, miss → empty, home).
- **Docs** — `runtime_audit.md` env rows updated; `lowering_helpers.sfn` comment synced.

## Seed dependency

The seed compiles `runtime/sfn/io.sfn`, so this **requires a seed carrying the M1.A.2 capability**. The pinned seed is **0.7.0-alpha.34** (#1341); I verified it emits `define {i8*, i64}` for `-> SfnString`. (An earlier attempt against the alpha.33 seed broke the seedcheck precisely because that seed lacked the capability — the seed cut resolved it.)

## Validation

- ✅ Full native suite green (`make test`, 0 failures).
- ✅ **nm/relink gate clean** — `sfn_getenv`/`sfn_home_dir` gone from `sailfin_runtime.o`, now defined by io.sfn's object.
- ✅ Acceptance test `capsules/sfn/os/tests/env_from_current_test.sfn` (5/5), new e2e ABI roundtrip (3/3), updated io-skeleton test (5/5).
- ✅ env programs round-trip correctly (`env.get` set/miss, `env.home`) with no aggregate truncation.
- ℹ️ `make check`'s parallel test pool OOMs this constrained sandbox (each `--jobs` worker inherits the 8 GiB self-cap); the suite passes **serially**, and CI runs the full triple-pass gate with adequate resources. Second-gen self-host is sound by construction: both the seed and the first-pass binary carry the capability, so both emit a correct `{i8*, i64}` io.o.

Closes #1312. Part of epic #1308.

https://claude.ai/code/session_01XTX2JiQGWRuAS3oXRr9a2C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTX2JiQGWRuAS3oXRr9a2C)_