### PR TITLE
feat(compiler): add `extern var NAME: TYPE;` for C-ABI globals (#1313)

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -274,6 +274,12 @@ enum Statement {
         unsafe: boolean;
         decorators: Decorator[];
     },
+    ExternVarDeclaration {
+        name: string;
+        type_annotation: TypeAnnotation;
+        name_span: SourceSpan?;
+        decorators: Decorator[];
+    },
     StructDeclaration {
         name: string;
         name_span: SourceSpan?;

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -248,6 +248,12 @@ fn emit_statement_declarations(state: NativeState, statement: Statement) -> Stat
             handled: true
         };
     }
+    if statement.variant == "ExternVarDeclaration" {
+        return StatementDispatchResult {
+            state: emit_extern_var(state, statement.name, statement.type_annotation, statement.decorators),
+            handled: true
+        };
+    }
     if statement.variant == "StructDeclaration" {
         return StatementDispatchResult {
             state: emit_struct(state, statement),
@@ -377,6 +383,17 @@ fn emit_extern_function(state: NativeState, signature: FunctionSignature, unsafe
     current = emit_signature_metadata(current, signature);
     current = emit_parameter_metadata(current, signature.parameters);
     return state_emit_line(current, ".endfn");
+}
+
+// Emit a top-level `extern var NAME: TYPE;` as a `.extern-var NAME : TYPE`
+// directive. The native-IR parser collects it as an extern module binding
+// (`NativeBinding { is_extern: true }`), which lowers to an
+// `@NAME = external global <ty>` declaration whose references auto-load.
+fn emit_extern_var(state: NativeState, name: string, type_annotation: TypeAnnotation, decorators: Decorator[]) -> NativeState {
+    let mut current = emit_decorators(state, decorators);
+    let mut line: string = ".extern-var " + name;
+    line = append_optional_type_annotation(line, type_annotation);
+    return state_emit_line(current, line);
 }
 
 fn emit_throw(state: NativeState, statement: Statement) -> NativeState {

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -93,6 +93,35 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
     }
     if llvm_type.length == 0 { llvm_type = "double"; }
 
+    // `extern var NAME: TYPE;` (#1313): bind a C-ABI global symbol
+    // (e.g. libc `environ`). Emit `@NAME = external global <ty>` with the
+    // verbatim symbol name (no `@global.` prefix, no `internal` linkage,
+    // no initializer) and register a `LocalBinding` pointing at it so a
+    // reference auto-loads through the same `find_local_binding` ->
+    // `load_local_operand` path as any module global.
+    if binding.is_extern {
+        let extern_symbol = "@" + sanitize_symbol(name);
+        let mut extern_preamble: string[] = [];
+        extern_preamble.push(extern_symbol + " = external global " + llvm_type);
+        let extern_local = LocalBinding {
+            name: name,
+            pointer: extern_symbol,
+            llvm_type: llvm_type,
+            type_annotation: effective_type_annotation,
+            ownership: null,
+            consumed: false,
+            scope_id: scope_id,
+            scope_depth: 0,
+            allocation_kind: "arena",
+            init_sentinel: ""
+        };
+        return BindingLoweringResult {
+            preamble_lines: extern_preamble,
+            locals: [extern_local],
+            needs_init: false
+        };
+    }
+
     let mut preamble_lines: string[] = [];
     let mut needs_init: boolean = false;
 

--- a/compiler/src/native_ir.sfn
+++ b/compiler/src/native_ir.sfn
@@ -175,6 +175,7 @@ struct NativeBinding {
     name: string;
     mutable: boolean;
     is_thread_local: boolean;
+    is_extern: boolean;
     type_annotation: string;
     value: string?;
 }

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -25,6 +25,7 @@ import { gather_instruction, parse_instruction } from "./native_ir_parser_instru
 import { parse_decimal_number } from "./native_ir_utils_layout";
 import {
     line_looks_like_parameter_entry,
+    parse_binding_components,
     parse_decorator_name,
     parse_function_name,
     parse_import_entry,
@@ -170,6 +171,17 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                     diagnostics.push("unable to parse decorator directive: "
                         + line);
                 } else { pending_decorators.push(decorator_name); }
+            }
+            index += 1;
+            continue;
+        }
+        if starts_with(line, ".extern-var ") {
+            if pending_decorators.length > 0 { pending_decorators = []; }
+            if include_top_level_bindings {
+                let parsed = parse_binding_components(trim_text(strip_prefix(line, ".extern-var ")));
+                bindings.push(NativeBinding {
+                    name: parsed.name, mutable: false, is_thread_local: false, is_extern: true, type_annotation: parsed.type_annotation, value: null
+                });
             }
             index += 1;
             continue;
@@ -440,6 +452,7 @@ fn binding_from_instruction(instruction: NativeInstruction) -> NativeBinding {
         name: instruction.name,
         mutable: instruction.mutable,
         is_thread_local: instruction.is_thread_local,
+        is_extern: false,
         type_annotation: instruction.type_annotation,
         value: instruction.value
     };

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -985,6 +985,50 @@ fn parse_extern_function(initial_parser: Parser, starts_with_unsafe: boolean, de
     return StatementParseResult { parser: parser, statement: statement };
 }
 
+// Parse `extern var NAME: TYPE;` (optionally `unsafe extern var ...`).
+// Declares a reference to a C-ABI global symbol (e.g. libc `environ`).
+// The type annotation is validated against the same accept-list as
+// `extern fn` signatures (E0801–E0805) in `check_extern_var`.
+fn parse_extern_var(initial_parser: Parser, starts_with_unsafe: boolean, decorators: Decorator[]) -> StatementParseResult {
+    let mut parser: Parser = initial_parser;
+    parser = skip_trivia(parser);
+    if starts_with_unsafe { parser = consume_keyword(parser, "unsafe"); }
+
+    parser = skip_trivia(parser);
+    parser = consume_keyword(parser, "extern");
+
+    parser = skip_trivia(parser);
+    parser = consume_keyword(parser, "var");
+
+    parser = skip_trivia(parser);
+    let name_token = parser_peek_raw(parser);
+    let name = identifier_text(name_token);
+    let name_span = source_span_from_tokens([name_token]);
+    parser = parser_advance_raw(parser);
+
+    parser = skip_trivia(parser);
+    let sep_result = consume_annotation_separator(parser);
+    if sep_result.found { parser = sep_result.parser; } else {
+        let arrow_result = consume_return_type_separator(parser);
+        if arrow_result.found { parser = arrow_result.parser; }
+    }
+
+    let capture = collect_until(skip_trivia(parser), [";"]);
+    parser = capture.parser;
+    let type_text = trim_text(tokens_to_text(capture.tokens));
+
+    parser = skip_trivia(parser);
+    parser = consume_symbol(parser, ";");
+
+    let statement = Statement.ExternVarDeclaration {
+        name: name,
+        type_annotation: TypeAnnotation { text: type_text },
+        name_span: name_span,
+        decorators: decorators
+    };
+    return StatementParseResult { parser: parser, statement: statement };
+}
+
 // ============================================================================
 // Struct Declaration
 // ============================================================================

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -18,6 +18,7 @@ import {
     parse_enum,
     parse_export,
     parse_extern_function,
+    parse_extern_var,
     parse_function,
     parse_import,
     parse_interface,
@@ -161,11 +162,19 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
         }
     }
     if identifier_matches(token, "extern") {
+        let after_extern = skip_trivia(parser_advance_raw(parser));
+        if identifier_matches(parser_peek_raw(after_extern), "var") {
+            return parse_extern_var(parser, false, decorators);
+        }
         return parse_extern_function(parser, false, decorators);
     }
     if identifier_matches(token, "unsafe") {
         let lookahead = skip_trivia(parser_advance_raw(parser));
         if identifier_matches(parser_peek_raw(lookahead), "extern") {
+            let after_extern = skip_trivia(parser_advance_raw(lookahead));
+            if identifier_matches(parser_peek_raw(after_extern), "var") {
+                return parse_extern_var(parser, true, decorators);
+            }
             return parse_extern_function(parser, true, decorators);
         }
         if identifier_matches(parser_peek_raw(lookahead), "fn") {
@@ -451,6 +460,7 @@ export {
     // Function declaration
     parse_function,
     parse_extern_function,
+    parse_extern_var,
 
     // Struct declaration
     parse_struct,

--- a/compiler/src/prelude_scan.sfn
+++ b/compiler/src/prelude_scan.sfn
@@ -75,6 +75,11 @@ fn prelude_global_names_from_source(source: string) -> string[] {
             names.push(unsafe_extern_name);
             continue;
         }
+        let extern_var_name = _ps_name_after_prefix(line, "extern var ");
+        if extern_var_name.length > 0 {
+            names.push(extern_var_name);
+            continue;
+        }
         if substring(line, 0, 4) == "let " {
             let mut start = 4;
             // `let mut <name>` — skip the qualifier so the bound name is

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -31,6 +31,7 @@ import {
     append_symbol,
     check_enum_variants,
     check_extern_signature,
+    check_extern_var,
     check_fn_reference_raw,
     check_function_signature,
     check_interface_members,
@@ -304,6 +305,9 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
     if statement.variant == "ExternFunctionDeclaration" {
         return register_symbol(statement.signature.name, "extern function", statement.signature.name_span, existing, signature_is_generic(statement.signature), signature_is_c_abi(statement.signature));
     }
+    if statement.variant == "ExternVarDeclaration" {
+        return register_symbol(statement.name, "extern variable", statement.name_span, existing);
+    }
     if statement.variant == "StructDeclaration" {
         return register_symbol(statement.name, "struct", statement.name_span, existing);
     }
@@ -413,6 +417,21 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         loop {
             if _ci >= _sig_diags.length { break; }
             diagnostics.push(_sig_diags[_ci]);
+            _ci += 1;
+        }
+        return ScopeResult {
+            bindings: registration.bindings,
+            diagnostics: diagnostics
+        };
+    }
+    if statement.variant == "ExternVarDeclaration" {
+        let registration = register_local_symbol(bindings, statement.name, "extern variable", statement.name_span, scope_start);
+        let mut diagnostics = registration.diagnostics;
+        let _var_diags = check_extern_var(statement.name, statement.type_annotation);
+        let mut _ci: int = 0;
+        loop {
+            if _ci >= _var_diags.length { break; }
+            diagnostics.push(_var_diags[_ci]);
             _ci += 1;
         }
         return ScopeResult {

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -878,6 +878,30 @@ fn check_extern_signature(signature: FunctionSignature) -> Diagnostic[] {
     return diagnostics;
 }
 
+// Validate an `extern var NAME: TYPE;` declaration's type against the
+// same C-ABI accept-list as extern fn signatures (E0801–E0805). An
+// extern var binds a libc global symbol (e.g. `environ`), so its type
+// must be a concrete C-ABI type with storage — `void` is rejected the
+// same way it is in parameter position (a variable has storage; `void`
+// has none). `* * u8` (for `environ`) is on the accept-list.
+fn check_extern_var(name: string, type_annotation: TypeAnnotation?) -> Diagnostic[] {
+    let mut diagnostics: Diagnostic[] = [];
+    if type_annotation == null {
+        diagnostics.push(make_extern_var_missing_type_diagnostic(name));
+        return diagnostics;
+    }
+    let type_text = trim_text(type_annotation.text);
+    if type_text.length == 0 {
+        diagnostics.push(make_extern_var_missing_type_diagnostic(name));
+        return diagnostics;
+    }
+    let kind = classify_extern_parameter_type(type_text);
+    if !strings_equal(kind, "ok") {
+        diagnostics.push(make_extern_var_type_diagnostic(name, type_text, kind));
+    }
+    return diagnostics;
+}
+
 // Classify an extern type-annotation string used for a function
 // *parameter*. Returns one of:
 //   "ok"          — accepted by the v0 C-ABI rule set.
@@ -1419,6 +1443,35 @@ fn make_extern_parameter_type_diagnostic(fn_name: string, parameter_name: string
         message: "extern fn `" + fn_name + "` parameter `" + parameter_name
             + "` type `"
             + type_text
+            + "` is not C-ABI-compatible. "
+            + hint,
+        file_path: "",
+        primary: null,
+        suggestion: null
+    };
+}
+
+fn make_extern_var_missing_type_diagnostic(name: string) -> Diagnostic {
+    return Diagnostic {
+        code: "E0805",
+        severity: "error",
+        message: "extern var `" + name + "` is missing a type annotation."
+            + " Extern globals have no initializer for inference; the"
+            + " declaration must commit to a concrete C-ABI type"
+            + " (e.g. `* * u8` for libc `environ`).",
+        file_path: "",
+        primary: null,
+        suggestion: null
+    };
+}
+
+fn make_extern_var_type_diagnostic(name: string, type_text: string, kind: string) -> Diagnostic {
+    let code = extern_diagnostic_code_for(kind);
+    let hint = extern_type_hint_for(kind, type_text);
+    return Diagnostic {
+        code: code,
+        severity: "error",
+        message: "extern var `" + name + "` type `" + type_text
             + "` is not C-ABI-compatible. "
             + hint,
         file_path: "",

--- a/compiler/tests/e2e/extern_var_emit_test.sfn
+++ b/compiler/tests/e2e/extern_var_emit_test.sfn
@@ -1,0 +1,96 @@
+// End-to-end test for `extern var NAME: TYPE;` LLVM emission (#1313).
+//
+// `extern var` declares a reference to a C-ABI global symbol (e.g. libc
+// `environ`). It must lower to an `@NAME = external global <ty>` module
+// declaration that reuses the *verbatim* C symbol name — no `@global.`
+// module-global mangling, no `internal` linkage — and a reference must
+// emit a real `load` from that global (not an elided value). `* * u8`
+// collapses to the opaque `i8*` pointer (the existing pointer-mapping
+// rule); the `environ` consumer in `runtime/sfn/process.sfn` then walks
+// it via pointer arithmetic.
+//
+// Driven through `sfn emit llvm` as a subprocess (the production lowering
+// path) rather than an in-process `lower_to_llvm_ir_from_text` call.
+//
+// NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]` and
+// so cannot be called from an `![io]` test like these; assert on the
+// captured `.ll` text with `sfn/strings` predicates instead. (#842.)
+import { contains, split } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Whether any single line of `text` contains both `a` and `b` (the
+// faithful stand-in for `grep -E "a.*b"` over one line).
+fn _has_line_with_both(text: string, a: string, b: string) -> bool {
+    let lines = split(text, "\n");
+    let mut i = 0;
+    loop {
+        if i >= lines.length { break; }
+        if contains(lines[i], a) && contains(lines[i], b) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _emit_llvm(source: string, tag: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let src = dir + "/sfn-externvar-" + tag + ".sfn";
+    let ll = dir + "/sfn-externvar-" + tag + ".ll";
+    fs.writeFile(src, source);
+    if fs.exists(ll) { fs.deleteFile(ll); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", ll, "llvm", src], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    if !fs.exists(ll) { return ""; }
+    let ir = fs.readFile(ll);
+    fs.deleteFile(ll);
+    fs.deleteFile(src);
+    return ir;
+}
+
+fn _probe() -> string {
+    return "extern var environ: * * u8;\n" + "fn read_environ() -> * * u8 {\n"
+        + "    return environ;\n"
+        + "}\n";
+}
+
+test "extern-var: emits `@environ = external global` on the verbatim symbol" ![io] {
+    let ir = _emit_llvm(_probe(), "decl");
+    assert ir.length > 0;
+    assert contains(ir, "@environ = external global");
+    // Never the `@global.`-mangled module-global form, never `internal`.
+    assert ! contains(ir, "@global.environ");
+    assert ! contains(ir, "@environ = internal");
+}
+
+test "extern-var: a reference emits a real load from the global" ![io] {
+    let ir = _emit_llvm(_probe(), "load");
+    assert ir.length > 0;
+    // The reference is not elided — it loads from `@environ`.
+    assert _has_line_with_both(ir, "load", "@environ");
+}

--- a/compiler/tests/unit/parser_extern_var_test.sfn
+++ b/compiler/tests/unit/parser_extern_var_test.sfn
@@ -1,0 +1,46 @@
+// Unit tests for `extern var NAME: TYPE;` parsing (#1313).
+//
+// `extern var` declares a reference to a C-ABI global symbol (e.g. libc
+// `environ`). The parser dispatches on `extern` + lookahead `var` to
+// `parse_extern_var`, producing a `Statement.ExternVarDeclaration`. These
+// tests pin the dispatch (including the `unsafe extern var` form), the
+// node shape, and that the sibling `extern fn` path is untouched.
+import { parse_program } from "../../src/parser/mod";
+import { index_of } from "../../src/string_utils";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+test "parser: parses `extern var environ: * * u8;`" ![io] {
+    let program = parse_program("extern var environ: * * u8;");
+    assert program.statements.length == 1;
+    let stmt = program.statements[0];
+    assert stmt.variant == "ExternVarDeclaration";
+    assert stmt.name == "environ";
+    assert _contains(stmt.type_annotation.text, "u8");
+    assert _contains(stmt.type_annotation.text, "*");
+}
+
+test "parser: parses `unsafe extern var environ: * * u8;`" ![io] {
+    let program = parse_program("unsafe extern var environ: * * u8;");
+    assert program.statements.length == 1;
+    let stmt = program.statements[0];
+    assert stmt.variant == "ExternVarDeclaration";
+    assert stmt.name == "environ";
+}
+
+test "parser: a scalar extern var parses with a non-empty type" ![io] {
+    let program = parse_program("extern var errno: i32;");
+    assert program.statements.length == 1;
+    let stmt = program.statements[0];
+    assert stmt.variant == "ExternVarDeclaration";
+    assert stmt.name == "errno";
+    assert _contains(stmt.type_annotation.text, "i32");
+}
+
+test "parser: `extern fn` still dispatches to a function declaration" ![io] {
+    let program = parse_program("extern fn malloc(size: usize) -> * u8;");
+    assert program.statements.length == 1;
+    assert program.statements[0].variant == "ExternFunctionDeclaration";
+}

--- a/compiler/tests/unit/typecheck_extern_var_test.sfn
+++ b/compiler/tests/unit/typecheck_extern_var_test.sfn
@@ -1,0 +1,63 @@
+// Unit tests for `extern var NAME: TYPE;` typechecker registration (#1313).
+//
+// `extern var` binds a libc global; its type is validated against the same
+// C-ABI accept-list as `extern fn` signatures (`check_extern_var` reuses
+// `classify_extern_parameter_type`, so the same E0801–E0805 codes apply).
+// `* * u8` (for libc `environ`) is on the accept-list; non-C-ABI types and
+// `void` (a variable has storage; `void` has none) are rejected.
+import { parse_program } from "../../src/parser/mod";
+import { typecheck_diagnostics } from "../../src/typecheck";
+import { Diagnostic } from "../../src/typecheck_types";
+
+fn _has_code(diagnostics: Diagnostic[], code: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= diagnostics.length { break; }
+        if strings_equal(diagnostics[i].code, code) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+test "extern var: accepts `extern var environ: * * u8;`" ![io] {
+    let program = parse_program("extern var environ: * * u8;");
+    let diagnostics = typecheck_diagnostics(program);
+    assert diagnostics.length == 0;
+}
+
+test "extern var: accepts a scalar `extern var errno: i32;`" ![io] {
+    let program = parse_program("extern var errno: i32;");
+    let diagnostics = typecheck_diagnostics(program);
+    assert diagnostics.length == 0;
+}
+
+test "extern var: rejects string type (E0801)" ![io] {
+    let program = parse_program("extern var bad: string;");
+    let diagnostics = typecheck_diagnostics(program);
+    assert _has_code(diagnostics, "E0801");
+}
+
+test "extern var: rejects array type (E0802)" ![io] {
+    let program = parse_program("extern var bad: i32[];");
+    let diagnostics = typecheck_diagnostics(program);
+    assert _has_code(diagnostics, "E0802");
+}
+
+test "extern var: rejects legacy `number` (E0805)" ![io] {
+    let program = parse_program("extern var bad: number;");
+    let diagnostics = typecheck_diagnostics(program);
+    assert _has_code(diagnostics, "E0805");
+}
+
+test "extern var: rejects bare `void` (E0805)" ![io] {
+    let program = parse_program("extern var bad: void;");
+    let diagnostics = typecheck_diagnostics(program);
+    assert _has_code(diagnostics, "E0805");
+}
+
+test "extern var: a reference to the global resolves in scope (no undefined-symbol)" ![io] {
+    let source = "extern var environ: * * u8;\nfn read_environ() -> * * u8 { return environ; }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert diagnostics.length == 0;
+}


### PR DESCRIPTION
## What

Adds `extern var NAME: TYPE;` so Sailfin can reference a libc global symbol (e.g. `environ`), mirroring the existing `extern fn` pipeline end to end. This is **F1** of epic #1308 — the one genuine frontend gap blocking the `get_environ` C→Sailfin flip.

- **parser** (`declarations.sfn`/`mod.sfn`): `parse_extern_var` + dispatch on `extern`/`unsafe extern` followed by `var`
- **ast**: `ExternVarDeclaration` node
- **typecheck**: symbol registration + `check_extern_var` reusing the `extern fn` C-ABI accept-list (E0801–E0805); `void` rejected (a variable has storage)
- **emit_native**: `.extern-var NAME : TYPE` IR directive
- **native_ir**: `is_extern` on `NativeBinding`; parse the directive into an extern module binding
- **lowering** (`module_globals.sfn`): emits `@NAME = external global <ty>` on the **verbatim** C symbol (no `@global.` mangling, no `internal` linkage) and registers a module-global `LocalBinding`, so a reference auto-loads through the existing `find_local_binding` → `load_local_operand` path
- **prelude_scan**: recognize `extern var` for E0420 resolution

## Tests (native, not bash)

- `parser_extern_var_test.sfn` — node shape, `unsafe extern var`, `extern fn` regression
- `typecheck_extern_var_test.sfn` — accepts `* * u8`; rejects string (E0801), array (E0802), `number`/void (E0805); in-scope reference resolves
- `extern_var_emit_test.sfn` (e2e, subprocess `sfn emit llvm`) — pins `@environ = external global i8*` (verbatim symbol, no `@global.`/`internal`) + a real `load`

Golden IR for the probe:
```llvm
@environ = external global i8*
define i8* @read_environ__probe() {
  %t0 = load i8*, i8** @environ
  ...
```

## Self-hosting

`make compile` ✅ — `compiler/src` does not use `extern var`, so the pinned seed builds the new compiler cleanly. `sfn fmt --check` clean on all touched files.

## ⚠️ Scope: consumer deferred behind a seed cut

The issue claimed "Required in pinned seed: None," bundling the `runtime/sfn/process.sfn` `get_environ` consumer. **This is empirically false:** the pinned seed (`0.7.0-alpha.34`) cannot parse `extern var`, and it is the *seed* that compiles `process.sfn` (it is in the runtime capsule's `sfn-sources`) during `sfn build -p compiler`. Bundling the consumer breaks `make compile`/self-hosting — the exact "verify the readiness gate, don't trust the prose" hazard from `.claude/rules/c-sailfin-migration.md`.

So the `get_environ` flip lands in a **follow-up** after this feature is released and a new seed is pinned (the epic's own C9 seed-cut pattern):
1. merge this PR → release an alpha prerelease (old seed builds feature-only source) → the released compiler understands `extern var`
2. `/pin-seed` to that version
3. follow-up PR: `extern var environ: * * u8;` + `get_environ` in `process.sfn` + the seed bump — now buildable

Part of #1308. Advances #1313 (does not close it — the consumer + seed bump complete it).

https://claude.ai/code/session_01XdsqmJuWbHjohjQX2BMmr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdsqmJuWbHjohjQX2BMmr2)_