### PR TITLE
parser: handle trailing comma in call argument lists

### DIFF
--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -935,6 +935,21 @@ fn parse_call_arguments(state: ExpressionTokens) -> CallArgumentsParseResult {
         let separator = expression_tokens_peek(current);
         if symbol_matches(separator, ",") {
             current = expression_tokens_advance(current);
+            if expression_tokens_is_at_end(current) {
+                return CallArgumentsParseResult {
+                    state: state,
+                    arguments: [],
+                    success: false
+                };
+            }
+            // Allow a trailing comma: `f(a, b,)` ends the argument list at
+            // the `)` following the separator rather than parsing a bogus
+            // empty argument (which silently miscompiled — see #1357).
+            let after_comma = expression_tokens_peek(current);
+            if symbol_matches(after_comma, ")") {
+                current = expression_tokens_advance(current);
+                break;
+            }
             continue;
         }
         if symbol_matches(separator, ")") {

--- a/compiler/tests/unit/parser_call_trailing_comma_test.sfn
+++ b/compiler/tests/unit/parser_call_trailing_comma_test.sfn
@@ -1,0 +1,68 @@
+// Unit tests for trailing commas in call argument lists (issue #1357).
+//
+// Before the fix, `parse_call_arguments` unconditionally looped back to
+// parse another argument after consuming a separator `,`. A trailing
+// comma — `add(2, 3,)` — therefore ran the expression parser against the
+// closing `)`, which silently produced a bogus extra argument instead of
+// a diagnostic. The call then miscompiled (the last real argument was
+// effectively dropped/zeroed), so `add(2, 3,)` returned `0` while
+// `add(2, 3)` returned `5`. The miscompile survived `sfn fmt`, which
+// collapses a multi-line call onto one line but keeps the trailing comma.
+//
+// The fix makes a trailing comma close the argument list: after a
+// separator `,`, a following `)` ends the args. `add(2, 3,)` now parses
+// to a `Call` with exactly the two real arguments — identical to
+// `add(2, 3)`.
+import { Expression } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+// Initializer of the first top-level `let` in `source`, asserted to be a
+// `Call` so a structural change fails here with a clear message.
+fn first_call_initializer(source: string) -> Expression ![io] {
+    let program = parse_program(source);
+    let stmt = program.statements[0];
+    assert stmt.variant == "VariableDeclaration";
+    let init = stmt.initializer;
+    assert init != null;
+    assert init.variant == "Call";
+    return init;
+}
+
+// -------------------------------------------------------------------
+// A trailing comma does not add a bogus argument: `add(2, 3,)` parses
+// to a `Call` with exactly two arguments.
+// -------------------------------------------------------------------
+test "call trailing comma: does not add a bogus last argument" ![io] {
+    let expr = first_call_initializer("let x = add(2, 3,);");
+    assert expr.arguments.length == 2;
+    assert expr.arguments[0].variant == "NumberLiteral";
+    assert expr.arguments[1].variant == "NumberLiteral";
+}
+
+// -------------------------------------------------------------------
+// `add(2, 3,)` parses identically to `add(2, 3)` — same argument count
+// and shapes.
+// -------------------------------------------------------------------
+test "call trailing comma: parses identically to no trailing comma" ![io] {
+    let with_comma = first_call_initializer("let x = add(2, 3,);");
+    let without_comma = first_call_initializer("let x = add(2, 3);");
+    assert with_comma.arguments.length == without_comma.arguments.length;
+    assert with_comma.arguments.length == 2;
+}
+
+// -------------------------------------------------------------------
+// A single-argument trailing comma — `f(a,)` — keeps the one argument.
+// -------------------------------------------------------------------
+test "call trailing comma: single argument keeps its one argument" ![io] {
+    let expr = first_call_initializer("let x = f(a,);");
+    assert expr.arguments.length == 1;
+    assert expr.arguments[0].variant == "Identifier";
+}
+
+// -------------------------------------------------------------------
+// No regression: a call without a trailing comma keeps its arguments.
+// -------------------------------------------------------------------
+test "call trailing comma: ordinary call is unaffected" ![io] {
+    let expr = first_call_initializer("let x = add(2, 3);");
+    assert expr.arguments.length == 2;
+}


### PR DESCRIPTION
## Summary
- A trailing comma in a call (`f(a, b,)`) silently miscompiled: `parse_call_arguments` consumed the separator `,` and unconditionally looped back to parse another argument against the closing `)`, producing a bogus extra argument with no diagnostic. The call evaluated to the wrong value (`add(2, 3,)` → `0`, vs `add(2, 3)` → `5`), and the miscompile survived `sfn fmt` (which collapses a multi-line call onto one line but keeps the trailing comma).
- Fix: after a separator `,`, a following `)` now closes the argument list, so a trailing comma lowers correctly. The `sfn fmt` behavior is now purely cosmetic — no formatter change needed (issue scoped this as "decide during impl").

Closes #1357

## Acceptance Criteria
- [x] `add(2, 3,)` evaluates identically to `add(2, 3)` (repro returns exit `5`)
- [x] No silent miscompile: `sailfin check` parses the call correctly (2 args)
- [x] Regression test under `compiler/tests/unit/parser_call_trailing_comma_test.sfn` pinning correct lowering (4 tests)
- [x] Self-hosts (`make compile`) and `sfn fmt --check` clean

## Verification
```bash
# repro (was exit 0 before, now 5):
$ build/native/sailfin run tc.sfn   # let x = add(2, 3,); return x;
exit=5
$ build/native/sailfin run tc2.sfn  # control: add(2, 3)
exit=5

$ build/native/sailfin test compiler/tests/unit/parser_call_trailing_comma_test.sfn
PASS  (all 4 tests passed)

# parser + call-dispatch unit tests: all PASS
# make compile: exit 0 (self-host holds)
# sfn fmt --check on touched files: clean
```

## Files Changed
- `compiler/src/parser/expressions.sfn` — trailing-comma handling in `parse_call_arguments`
- `compiler/tests/unit/parser_call_trailing_comma_test.sfn` — regression test (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc4khnsaVhDLnQEL4BKH26)_