### PR TITLE
fix(lowering): innermost-only consumption at the return boundary (#1267)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -274,12 +274,15 @@ fn promote_local_to_rc(locals: LocalBinding[], name: string) -> LocalBinding[] {
 // Linear) remains post-1.0 and is out of scope here.
 // Mark ONLY the innermost (last) binding matching `name` as consumed,
 // mirroring the binding `find_local_binding` resolves and the one
-// `promote_local_to_rc` rewrites. `bindings_mark_local_consumed` (the
-// helper the return path uses) flips every same-named binding, which
-// would wrongly suppress the drop of an outer-scope local shadowed by
-// the escaping one — the outer value never crossed the boundary and its
-// owner-drop must still fire.
-fn _mark_last_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
+// `promote_local_to_rc` rewrites. `bindings_mark_local_consumed` flips
+// every same-named binding, which would wrongly suppress the drop of an
+// outer-scope local shadowed by the consumed/escaping one — the outer
+// value never crossed the boundary and its owner-drop must still fire.
+// Exported (issue #1267) so the return-boundary consumption in
+// `lower_return_instruction` and the assignment/let/bare-expression
+// consumption paths can mirror the same innermost-only resolution the
+// escape boundary already uses via `promote_escaping_local`.
+fn mark_last_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
     let mut target_index: int = -1;
     let mut scan: int = locals.length;
     loop {
@@ -332,7 +335,7 @@ fn promote_escaping_local(locals: LocalBinding[], name: string) -> LocalBinding[
         if binding.ownership.variant == "Borrow" { return locals; }
     }
     let promoted = promote_local_to_rc(locals, name);
-    return _mark_last_local_consumed(promoted, name);
+    return mark_last_local_consumed(promoted, name);
 }
 
 // Collect every identifier token in `text`, skipping string-literal

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -60,6 +60,7 @@ import {
     find_local_binding,
     infer_borrow_base_scope,
     make_lifetime_region_metadata,
+    mark_last_local_consumed,
     promote_escaping_locals_for_boundaries,
     promote_local_to_rc
 } from "./core_scopes";
@@ -262,7 +263,10 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
 
             if consumption != null {
                 if consumption.kind == "local" {
-                    current_locals = mark_local_consumed(current_locals, consumption.name);
+                    // Issue #1267: innermost-only consumption so a shadowed
+                    // outer local keeps its scope-exit drop when only the
+                    // inner same-named binding was moved by the RHS.
+                    current_locals = mark_last_local_consumed(current_locals, consumption.name);
                 } else if consumption.kind == "parameter" {
                     current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
                 }
@@ -361,7 +365,10 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
     current_temp = recover_temp_from_lines(current_lines, current_temp);
     if consumption != null {
         if consumption.kind == "local" {
-            current_locals = mark_local_consumed(current_locals, consumption.name);
+            // Issue #1267: innermost-only consumption (matches the escape
+            // boundary applied just below, which already resolves the last
+            // binding); a shadowed outer local keeps its scope-exit drop.
+            current_locals = mark_last_local_consumed(current_locals, consumption.name);
         } else if consumption.kind == "parameter" {
             current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
         }
@@ -694,7 +701,11 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     // be a use-after-free once `sfn_rc_release` becomes non-no-op.
     if consumption != null {
         if consumption.kind == "local" {
-            current_locals = mark_local_consumed(current_locals, consumption.name);
+            // Issue #1267: innermost-only consumption. Marking every
+            // same-named binding consumed would suppress the scope-exit
+            // drop of an outer local shadowed by the returned one (a leak);
+            // only the binding `find_local_binding` resolves was moved.
+            current_locals = mark_last_local_consumed(current_locals, consumption.name);
         } else if consumption.kind == "parameter" {
             current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
         }
@@ -719,7 +730,11 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
         if returned_local != null {
             if is_heap_type(returned_local.llvm_type) {
                 current_locals = promote_local_to_rc(current_locals, trimmed_return_expr);
-                current_locals = mark_local_consumed(current_locals, trimmed_return_expr);
+                // Issue #1267: consume the same innermost binding
+                // `promote_local_to_rc` just flipped. `mark_local_consumed`
+                // flipped every match, so a shadowed outer local lost its
+                // drop even though only the inner one was returned.
+                current_locals = mark_last_local_consumed(current_locals, trimmed_return_expr);
             }
         }
     }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -5,11 +5,15 @@ import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../nativ
 import { index_of } from "../../string_utils";
 import { analyze_value_ownership, detect_borrow_conflicts, lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
-import { append_local_binding, promote_escaping_locals_for_boundaries } from "../expression_lowering/native/core_scopes";
+import {
+    append_local_binding,
+    mark_last_local_consumed,
+    promote_escaping_locals_for_boundaries
+} from "../expression_lowering/native/core_scopes";
 import { is_heap_type } from "../expression_lowering/native/core_type_mapping";
 import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
 import { map_local_type } from "../expression_lowering/native/statement_type_mapping";
-import { find_local_binding, mark_local_consumed, mark_parameter_consumed } from "../expressions_bindings";
+import { find_local_binding, mark_parameter_consumed } from "../expressions_bindings";
 import { default_return_literal, format_local_pointer_name } from "../expressions_helpers";
 import {
     append_lifetime_region,
@@ -206,7 +210,11 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
 
     if consumption != null {
         if consumption.kind == "local" {
-            current_locals = mark_local_consumed(current_locals, consumption.name);
+            // Issue #1267: innermost-only consumption. A `let` initializer
+            // that moves a shadowed local must consume only the binding
+            // `find_local_binding` resolves; flipping every same-named match
+            // would suppress the outer binding's scope-exit drop (a leak).
+            current_locals = mark_last_local_consumed(current_locals, consumption.name);
         } else if consumption.kind == "parameter" {
             current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
         }

--- a/compiler/tests/unit/escape_promotion_test.sfn
+++ b/compiler/tests/unit/escape_promotion_test.sfn
@@ -19,7 +19,12 @@
 // Plus a few "predicate hygiene" cases for `is_heap_type` so future
 // changes to the predicate don't silently expand or shrink the heap-type
 // surface (over-match → use-after-free, under-match → leak).
-import { append_local_binding, find_local_binding, promote_local_to_rc } from "../../src/llvm/expression_lowering/native/core_scopes";
+import {
+    append_local_binding,
+    find_local_binding,
+    mark_last_local_consumed,
+    promote_local_to_rc
+} from "../../src/llvm/expression_lowering/native/core_scopes";
 import { is_heap_type } from "../../src/llvm/expression_lowering/native/core_type_mapping";
 import { LocalBinding, OwnershipInfo } from "../../src/llvm/types";
 
@@ -241,4 +246,68 @@ test "promote_local_to_rc: shadowed name only promotes the last match (mirrors f
     assert resolved != null;
     assert resolved.pointer == "%l_inner";
     assert resolved.allocation_kind == "rc";
+}
+
+// -----------------------------------------------------------------------------
+// mark_last_local_consumed — innermost-only consumption (issue #1267).
+//
+// `lower_return_instruction` marks the returned local consumed so
+// `emit_scope_drops` skips it. Before #1267 it used the all-matches
+// `bindings_mark_local_consumed`, which flipped EVERY same-named binding —
+// so returning an inner-scope shadow also suppressed the outer binding's
+// scope-exit drop even though the outer value never escaped (a leak). The
+// consumption must mirror `promote_local_to_rc` / `find_local_binding`:
+// resolve and flip only the innermost (last) match.
+// -----------------------------------------------------------------------------
+test "mark_last_local_consumed: shadowed name only consumes the last match" {
+    let outer = _make_binding_with_pointer("s", "i8*", "arena", "%l_outer");
+    let inner = _make_binding_with_pointer("s", "i8*", "arena", "%l_inner");
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, outer);
+    locals = append_local_binding(locals, inner);
+    let consumed = mark_last_local_consumed(locals, "s");
+    assert consumed.length == 2;
+    // Outer (older) binding keeps its scope-exit drop — it never escaped.
+    assert consumed[0].pointer == "%l_outer";
+    assert ! consumed[0].consumed;
+    // Inner (most-recent) binding is the one find_local_binding resolves,
+    // so it is the one marked consumed.
+    assert consumed[1].pointer == "%l_inner";
+    assert consumed[1].consumed;
+}
+
+test "mark_last_local_consumed: missing name leaves the array unchanged" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding_with_pointer("a", "i8*", "arena", "%l_a"));
+    locals = append_local_binding(locals, _make_binding_with_pointer("b", "i8*", "arena", "%l_b"));
+    let consumed = mark_last_local_consumed(locals, "missing");
+    assert consumed.length == 2;
+    assert ! consumed[0].consumed;
+    assert ! consumed[1].consumed;
+}
+
+test "return boundary: returning the inner shadow leaves the outer binding's drop intact (both axes)" {
+    // Composes the two helpers `lower_return_instruction` applies to a
+    // heap-typed bare-identifier return (`promote_local_to_rc` then
+    // `mark_last_local_consumed`) and pins that ONLY the innermost binding
+    // flips on BOTH axes. The outer same-named local — which was never
+    // returned — must keep `arena` AND stay unconsumed so its owner drop
+    // still fires at scope exit. This is the return-boundary analogue of the
+    // escape-boundary shadowing pin in escape_promotion_boundaries_test.sfn.
+    let outer = _make_binding_with_pointer("s", "i8*", "arena", "%l_outer");
+    let inner = _make_binding_with_pointer("s", "i8*", "arena", "%l_inner");
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, outer);
+    locals = append_local_binding(locals, inner);
+    let promoted = promote_local_to_rc(locals, "s");
+    let result = mark_last_local_consumed(promoted, "s");
+    assert result.length == 2;
+    // Outer (older) binding: untouched on both axes.
+    assert result[0].pointer == "%l_outer";
+    assert result[0].allocation_kind == "arena";
+    assert ! result[0].consumed;
+    // Inner (most-recent) binding: promoted AND consumed.
+    assert result[1].pointer == "%l_inner";
+    assert result[1].allocation_kind == "rc";
+    assert result[1].consumed;
 }


### PR DESCRIPTION
## Summary
- `lower_return_instruction` marked the returned local consumed via `mark_local_consumed` → `bindings_mark_local_consumed`, which flips `consumed = true` on **every** same-named `LocalBinding`. When an inner `let x` shadowed an outer `x` and the inner one was returned, the outer binding (which never escaped) was also marked consumed, suppressing its scope-exit owner drop — a leak. `promote_local_to_rc` already resolves innermost-only; consumption now mirrors it.
- Exported `mark_last_local_consumed` from `core_scopes.sfn` (formerly the internal `_mark_last_local_consumed` the M4 escape boundary already used) and routed the return-boundary consumption + escape-promotion block through it.
- **Audit result:** the other resolved-name consumption sites had the same shadowing exposure — the assignment and bare-expression paths in `statement.sfn` and the `let`-initializer path in `lowering/instructions_let.sfn`. All now use the innermost-only helper. `mark_parameter_consumed` sites are unaffected (parameters cannot shadow). _(This brings `lowering/instructions_let.sfn` into the change set — named in the issue's Scope `In:` audit directive though omitted from its Files Affected list.)_

Closes #1267

## Acceptance Criteria
- [x] returning an inner shadowed local leaves the outer same-named binding unconsumed (its scope-exit drop still fires)
- [x] unit test pins the shadowing semantics at the return boundary on both axes (allocation_kind and consumed)
- [x] `make compile` passes (self-hosts)
- [x] `make test` passes — see note below
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```text
make compile                       → self-host PASS
escape_promotion_test.sfn          → 17/17 PASS (3 new return-boundary shadowing pins)
unit        → 154/154 passed, 0 failed
integration →  35/35  passed, 0 failed
e2e         →  32/32  passed, 0 failed
capsules    →  36/36  passed, 0 failed
fmt --check → clean (core_scopes, statement, instructions_let, escape_promotion_test)
```

**Note on `make test`:** one full-suite run surfaced a flake in `test_runtime_helper_declare_integrity.sh` ("consumer sweep N differs from baseline", stray `0xE7` byte in emitted IR). This is the **known, documented non-deterministic heap corruption tracked by #892** in the C runtime's `sfn_str_eq` / concat-reuse path (`runtime/native/src/sailfin_runtime.c`) — the test's own header describes it as *"heap-layout/timing dependent (passes in isolation, fails under `make check` pressure)"* with that exact `0xE7` signature. It is a different subsystem from this change (drop-emission `consumed` flags in lowering). Confirmed non-deterministic: the failing sweep iteration moved across runs (17 → 20) with identical source, and a separate run passed it 99/99. Not a regression from this PR.

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core_scopes.sfn` — `_mark_last_local_consumed` → exported `mark_last_local_consumed`
- `compiler/src/llvm/expression_lowering/native/statement.sfn` — return / assignment / bare-expr consumption sites
- `compiler/src/llvm/lowering/instructions_let.sfn` — `let`-initializer consumption site
- `compiler/tests/unit/escape_promotion_test.sfn` — return-boundary shadowing pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z4q4DU91eDXNWn9XecUCY)_