### PR TITLE
refactor(cli): migrate sfn init to sfn/cli

### DIFF
--- a/compiler/src/cli/commands/init.sfn
+++ b/compiler/src/cli/commands/init.sfn
@@ -1,0 +1,74 @@
+// compiler/src/cli/commands/init.sfn
+//
+// `init` subcommand (CLI modularization epic #351, Issue 3.1 — proposal
+// §5 Phase 3 item 1, §7). Migrates `sfn init` off the legacy
+// `cli_commands` handler onto the per-command `command_def()`/`run()`
+// pattern established by Issue 2.4 (`version`) and exercised by Issue 3.3
+// (`guillermo`).
+//
+// `init` takes no flags and no positionals, so `command_def()` is a bare
+// `command(...)`. The bare invocation scaffolds a new capsule (writes
+// `capsule.toml` + `src/main.sfn`); `run` reproduces the legacy handler's
+// behavior byte-for-byte and returns the same exit codes:
+//   - 0 — scaffolded a fresh capsule.
+//   - 1 — `capsule.toml` already exists here.
+// The usage error (2) for extra tokens is enforced by the v2 dispatch in
+// `cli/main.sfn`: `init` declares no args, so the parser surfaces any
+// trailing token as a non-ok parse and the dispatch returns 2 there — the
+// parser owns argument validation, matching the legacy `args.length != 1`
+// guard.
+//
+// Exit codes are integer literals, not the `sfn/cli` `EXIT_*` constants:
+// those are module-level `let` constants and have no cross-capsule import
+// value path today (they lower to a zero `internal global` in the
+// importing module — see the `_sfn_cli_link_gate` note in `cli_main.sfn`'s
+// `fn main`). `version`/`guillermo` only ever return `EXIT_OK`, so the
+// zero coincidentally matched; `init` is the first command needing 1/2, so
+// it must use literals to return them correctly.
+import { Command, Matches, command } from "sfn/cli";
+
+import { _get_env_cmd } from "../../cli_commands_utils";
+import { substring } from "../../string_utils";
+import { toml_generate } from "../../toml_parser";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `init`, registered on the v2 root via
+// `with_subcommand`. No args or flags — `init` is a bare subcommand.
+fn command_def() -> Command {
+    return command("init", "Scaffold a new capsule in the current directory");
+}
+
+// Scaffold a new capsule: write `capsule.toml` (name derived from the
+// current directory's basename) and a `src/main.sfn` stub. `matches` and
+// `ctx` are part of the per-command contract but unused here (init takes
+// no input). Byte-identical to the legacy `init` handler body.
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    if fs.exists("capsule.toml") {
+        print("capsule.toml already exists in this directory");
+        return 1;
+    }
+    let cwd = _get_env_cmd("PWD");
+    let mut pkg_name: string = "my-capsule";
+    if cwd.length > 0 {
+        let mut last_slash: int = -1;
+        let mut si: int = 0;
+        loop {
+            if si >= cwd.length { break; }
+            if substring(cwd, si, si + 1) == "/" { last_slash = si; }
+            si += 1;
+        }
+        if last_slash >= 0 {
+            if last_slash < cwd.length - 1 {
+                pkg_name = substring(cwd, last_slash + 1, cwd.length);
+            }
+        }
+    }
+    let toml_text = toml_generate(pkg_name, "0.1.0", "", "src/main.sfn");
+    fs.writeFile("capsule.toml", toml_text);
+    if !fs.exists("src") { fs.createDirectory("src", true); }
+    if !fs.exists("src/main.sfn") {
+        fs.writeFile("src/main.sfn", "fn main() ![io] {\n    print(\"Hello, Sailfin!\");\n}\n");
+    }
+    print("initialized capsule: " + pkg_name);
+    return 0;
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -38,6 +38,7 @@ import {
 import { sailfin_cli_main_legacy } from "../cli_main";
 import { number_to_string } from "../num_format";
 import { command_def as guillermo_command_def, run as guillermo_run } from "./commands/guillermo";
+import { command_def as init_command_def, run as init_run } from "./commands/init";
 import { command_def as version_command_def, run as version_run } from "./commands/version";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./context";
 
@@ -80,7 +81,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // resolving it eagerly here would add a filesystem read to every
     // `build` / `run` invocation. `parse()` skips argv[0] (the program
     // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def());
+    let root: Command = with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def());
 
     let mut parse_argv: string[] = ["sfn"];
     let mut j: int = 0;
@@ -100,6 +101,23 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
             if ctx.trace_argv { _v2_trace_argv(argv); }
             return guillermo_run(result.matches, ctx);
         }
+    }
+
+    // `sfn init` — the registered subcommand matched. `init` declares no
+    // args, so a clean parse (`result.ok`) is the bare invocation and
+    // dispatches to `init.run` (exit 0 scaffolded / 1 already-exists).
+    // Any trailing token makes the parse non-ok while still marking the
+    // `init` subcommand as descended; that is a usage error (exit 2),
+    // matching the legacy handler's `args.length != 1` guard — the parser
+    // owns argument validation, so the misuse never reaches `init.run`.
+    // The literal `2` (not `sfn/cli`'s `EXIT_USAGE`) is deliberate: the
+    // `EXIT_*` constants are module-level `let`s with no cross-capsule
+    // import value path today, so they lower to 0 here (see `init.sfn`).
+    if strings_equal(subcommand(result.matches), "init") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return init_run(result.matches, ctx); }
+        print("usage: sfn init");
+        return 2;
     }
 
     let mut handled_version: boolean = false;

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -98,7 +98,6 @@ import {
 import {
     toml_add_dependency,
     toml_add_dev_dependency,
-    toml_generate,
     toml_get_dependencies,
     toml_get_name,
     toml_get_string,
@@ -3532,41 +3531,6 @@ fn handle_add_command(args: string[]) -> int ![io] {
     return 0;
 }
 
-fn handle_init_command(args: string[]) -> int ![io] {
-    if args.length != 1 {
-        print("usage: sfn init");
-        return 2;
-    }
-    if fs.exists("capsule.toml") {
-        print("capsule.toml already exists in this directory");
-        return 1;
-    }
-    let cwd = _get_env_cmd("PWD");
-    let mut pkg_name: string = "my-capsule";
-    if cwd.length > 0 {
-        let mut last_slash: int = -1;
-        let mut si: int = 0;
-        loop {
-            if si >= cwd.length { break; }
-            if substring(cwd, si, si + 1) == "/" { last_slash = si; }
-            si += 1;
-        }
-        if last_slash >= 0 {
-            if last_slash < cwd.length - 1 {
-                pkg_name = substring(cwd, last_slash + 1, cwd.length);
-            }
-        }
-    }
-    let toml_text = toml_generate(pkg_name, "0.1.0", "", "src/main.sfn");
-    fs.writeFile("capsule.toml", toml_text);
-    if !fs.exists("src") { fs.createDirectory("src", true); }
-    if !fs.exists("src/main.sfn") {
-        fs.writeFile("src/main.sfn", "fn main() ![io] {\n    print(\"Hello, Sailfin!\");\n}\n");
-    }
-    print("initialized capsule: " + pkg_name);
-    return 0;
-}
-
 // `sfn lock`: materialize `workspace.lock` at the workspace root. Walks up
 // from the current directory for `workspace.toml`, resolves the member graph
 // into the flat lock-entry set (#1069), serializes it with the
@@ -3742,7 +3706,6 @@ export {
     handle_package_command,
     handle_add_command,
     handle_config_command,
-    handle_init_command,
     handle_lock_command,
     handle_login_command,
     handle_fmt_command

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -61,7 +61,6 @@ import {
     handle_add_command,
     handle_config_command,
     handle_fmt_command,
-    handle_init_command,
     handle_lock_command,
     handle_login_command,
     handle_package_command,
@@ -1961,7 +1960,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     if strings_equal(cmd, "-h") { _let10 = true; }
     if strings_equal(cmd, "--help") { _let10 = true; }
     let is_help = _let10;
-    let is_init = strings_equal(cmd, "init");
     let is_publish = strings_equal(cmd, "publish");
     let is_package = strings_equal(cmd, "package");
     let is_add = strings_equal(cmd, "add");
@@ -2744,8 +2742,8 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     }
 
     // ---- Package management commands ----
-    if is_init { return handle_init_command(args); }
-
+    // `sfn init` migrated to `sfn/cli` (epic #351, Issue 3.1) — handled
+    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     if is_publish { return handle_publish_command(args); }
 
     if is_package { return handle_package_command(args); }


### PR DESCRIPTION
## Summary
- Migrate `sfn init` off the legacy dispatch onto the per-command `command_def()`/`run()` pattern (CLI modularization epic #351, Issue 3.1 — proposal §5 Phase 3, §7), following the `version` (#1162) / `guillermo` exemplars.
- New `compiler/src/cli/commands/init.sfn` exports `command_def()` + `run(matches, ctx)`; scaffolds `capsule.toml` + `src/main.sfn` byte-identically to the old handler.
- Register `init.command_def()` on the v2 root and dispatch it; drop the legacy `init` arm and `handle_init_command` (plus its export and the now-unused `toml_generate` import).

Closes #1296

## Acceptance Criteria
- [x] `sfn init` in an empty dir scaffolds `capsule.toml` + `src/main.sfn` identically to today; re-running returns the same "already exists" exit code (1).
- [x] `compiler/src/cli/commands/init.sfn` exports `command_def()` + `run(matches, ctx)`; root built from `command_def()`.
- [x] Legacy path dead: `grep -rn handle_init_command compiler/src/` returns empty.
- [x] `make compile` passes.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.
- [ ] `make check` — running locally in a slow container at PR-open time; the CI gate is authoritative. (`make compile` self-host + full functional verification passed locally.)

## Verification
```
$ make compile
  ...status":"pass" (self-hosts)

# in a fresh temp dir, against build/native/sailfin:
$ sfn init        # exit 0
initialized capsule: <dir-basename>
$ sfn init        # exit 1
capsule.toml already exists in this directory
$ sfn init extra  # exit 2
usage: sfn init

$ sfn fmt --check <touched .sfn files>   # rc=0
$ grep -rn handle_init_command compiler/src/   # empty
```

## Implementation note
Exit codes use integer literals, **not** `sfn/cli`'s `EXIT_*` constants. Those are module-level `let` constants and have no cross-capsule import *value* path today — they lower to a zero `internal global` in the importing compiler module (see the `_sfn_cli_link_gate` note in `cli_main.sfn`'s `fn main`). `version`/`guillermo` only ever returned `EXIT_OK`, so the 0 coincidentally matched; `init` is the first migrated command that needs non-zero codes (1/2), so it must use literals to return them correctly. Worth a follow-up to make `sfn/cli` `EXIT_*` usable cross-capsule.

## Files Changed
- `compiler/src/cli/commands/init.sfn` — new
- `compiler/src/cli/main.sfn` — register + dispatch
- `compiler/src/cli_main.sfn` — drop legacy arm + import
- `compiler/src/cli_commands.sfn` — remove handler + export + unused import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016miWTyCQ2nfQmmZSPbsf6Z)_