### PR TITLE
fix(codegen): materialize cross-capsule let constants in the importer (#1368)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -117,7 +117,7 @@ import {
 import { build_type_context_with_recovery } from "./lowering_phase_types";
 import { recover_functions_for_lowering } from "./lowering_recovery";
 import { _parse_lowered_fn_string_constants, split_lines_local } from "./lowering_text_utils";
-import { lower_module_bindings_to_globals } from "./module_globals";
+import { lower_imported_bindings_to_globals, lower_module_bindings_to_globals } from "./module_globals";
 import { emit_type_descriptors } from "./type_descriptors";
 
 // Resolve the mangled call symbol for a lifecycle-hook function (#975).
@@ -661,6 +661,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     let imported_interfaces = imported_syms.interfaces;
     let imported_functions = imported_syms.functions;
     let imported_struct_methods = imported_syms.struct_methods;
+    let imported_bindings = imported_syms.bindings;
 
     if debug_lowering { print.err("emit-llvm: phase=imports"); }
 
@@ -848,6 +849,32 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         module_string_constants = _mg.string_constants;
         if _mg.diagnostics.length > 0 {
             diagnostics = extend_string_lines_checked(diagnostics, _mg.diagnostics, "module globals");
+        }
+    }
+    // #1368: materialise module-level `let` constants that imported capsules
+    // EXPORT as the importer's own value-carrying globals, and register a
+    // local binding for each, so a cross-capsule reference loads the
+    // producer's value instead of falling through to the zero-default
+    // recovery in statement lowering. Must run before `lower_all_functions`
+    // so function bodies see the imported-constant bindings in
+    // `module_global_locals`.
+    if imported_bindings.length > 0 {
+        let mut existing_global_names: string[] = [];
+        let mut _eg: int = 0;
+        loop {
+            if _eg >= module_global_locals.length { break; }
+            existing_global_names.push(module_global_locals[_eg].name);
+            _eg += 1;
+        }
+        let _ib = lower_imported_bindings_to_globals(imported_bindings, type_context, existing_global_names);
+        if _ib.preamble_lines.length > 0 {
+            module_preamble_lines = extend_string_lines(module_preamble_lines, _ib.preamble_lines);
+        }
+        let mut _ibl: int = 0;
+        loop {
+            if _ibl >= _ib.locals.length { break; }
+            module_global_locals.push(_ib.locals[_ibl]);
+            _ibl += 1;
         }
     }
     if trace { print.err("test llvm: module globals lowered"); }

--- a/compiler/src/llvm/lowering/lowering_phase_imports.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_imports.sfn
@@ -8,6 +8,7 @@
 // extend_native_functions) from the orchestrator's import set.
 import {
     LayoutManifest,
+    NativeBinding,
     NativeEnum,
     NativeFunction,
     NativeImport,
@@ -15,13 +16,16 @@ import {
     NativeStruct
 } from "../../native_ir";
 import {
+    parse_native_bindings_from_text,
     parse_native_enums_for_import,
     parse_native_functions_for_import,
+    parse_native_imports_for_import,
     parse_native_interfaces_for_import,
     parse_native_structs_for_import
 } from "../../native_ir_api";
 import { apply_layout_manifest_to_module } from "../imports";
-import { find_function_by_name_or_import } from "../rendering_helpers";
+import { collect_exported_symbol_names, find_function_by_name_or_import } from "../rendering_helpers";
+import { string_array_contains } from "../utils";
 import {
     extend_native_enums,
     extend_native_functions,
@@ -42,6 +46,33 @@ struct ImportedModuleSymbols {
     interfaces: NativeInterface[];
     functions: NativeFunction[];
     struct_methods: NativeFunction[];
+    bindings: NativeBinding[];
+}
+
+// Collect the module-level `let` constants an imported text EXPORTS (#1368).
+// Only exported bindings are surfaced: a producer's non-exported globals are
+// an implementation detail the importer must not materialise. The importer
+// value-inlines each exported constant into its own module
+// (`lower_imported_bindings_to_globals`), so the producer's value is read
+// directly with no cross-object link dependency.
+fn parse_single_import_exported_bindings(native_text: string) -> NativeBinding[] {
+    let mut exported: NativeBinding[] = [];
+    let all_bindings = parse_native_bindings_from_text(native_text);
+    if all_bindings.length == 0 { return exported; }
+    let exported_names = collect_exported_symbol_names(parse_native_imports_for_import(native_text));
+    if exported_names.length == 0 { return exported; }
+    let mut index: int = 0;
+    loop {
+        if index >= all_bindings.length { break; }
+        let binding = all_bindings[index];
+        index += 1;
+        if binding == null { continue; }
+        if binding.name == null { continue; }
+        if string_array_contains(exported_names, binding.name) {
+            exported.push(binding);
+        }
+    }
+    return exported;
 }
 
 // Parse imported interfaces from a single import text.
@@ -122,6 +153,7 @@ fn gather_imported_module_symbols(safe_imported_native_texts: string[], safe_imp
     let mut imported_interfaces: NativeInterface[] = [];
     let mut imported_functions: NativeFunction[] = [];
     let mut imported_struct_methods: NativeFunction[] = [];
+    let mut imported_bindings: NativeBinding[] = [];
 
     let manifest_count = safe_imported_manifests.length;
     let mut text_index: int = 0;
@@ -157,6 +189,13 @@ fn gather_imported_module_symbols(safe_imported_native_texts: string[], safe_imp
         imported_functions = extend_native_functions(imported_functions, applied_functions);
         let imported_methods = extract_import_struct_methods(applied_structs);
         imported_struct_methods = extend_native_functions(imported_struct_methods, imported_methods);
+        let exported_bindings = parse_single_import_exported_bindings(native_text);
+        let mut bi: int = 0;
+        loop {
+            if bi >= exported_bindings.length { break; }
+            imported_bindings.push(exported_bindings[bi]);
+            bi += 1;
+        }
         text_index += 1;
     }
 
@@ -176,6 +215,7 @@ fn gather_imported_module_symbols(safe_imported_native_texts: string[], safe_imp
         enums: imported_enums,
         interfaces: imported_interfaces,
         functions: imported_functions,
-        struct_methods: imported_struct_methods
+        struct_methods: imported_struct_methods,
+        bindings: imported_bindings
     };
 }

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -20,6 +20,7 @@ import {
     matches_case_insensitive,
     number_to_string,
     sanitize_symbol,
+    string_array_contains,
     trim_text
 } from "../utils";
 
@@ -29,6 +30,24 @@ fn module_global_symbol(name: string) -> string {
 
 fn module_init_symbol(module_name: string) -> string {
     return "@sailfin_module_init__" + sanitize_symbol(module_name);
+}
+
+// Map a binding's source type annotation to its LLVM type. Extracted from
+// `_process_one_binding` so the module-global lowering has a single
+// annotation→LLVM-type mapping (#1368).
+fn _binding_llvm_type(context: TypeContext, type_annotation: string) -> string {
+    let mut llvm_type: string = "";
+    if type_annotation == "string" { llvm_type = "i8*"; } else if type_annotation == "number" {
+        llvm_type = "double";
+    } else if type_annotation == "float" { llvm_type = "double"; } else if type_annotation == "boolean" {
+        llvm_type = "i1";
+    } else if type_annotation == "bool" { llvm_type = "i1"; } else if type_annotation == "i64" {
+        llvm_type = "i64";
+    } else if type_annotation == "i32" { llvm_type = "i32"; } else if type_annotation.length > 0 {
+        llvm_type = map_local_type(context, type_annotation);
+    }
+    if llvm_type.length == 0 { llvm_type = "double"; }
+    return llvm_type;
 }
 
 // Strip surrounding quotes from a string literal (e.g., `"hello"` -> `hello`).
@@ -80,18 +99,7 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
     }
     if type_annotation.length == 0 { return empty_result; }
     let global_name = module_global_symbol(name);
-    let mut llvm_type: string = "";
-    // Fast-path common primitive types
-    if type_annotation == "string" { llvm_type = "i8*"; } else if type_annotation == "number" {
-        llvm_type = "double";
-    } else if type_annotation == "float" { llvm_type = "double"; } else if type_annotation == "boolean" {
-        llvm_type = "i1";
-    } else if type_annotation == "bool" { llvm_type = "i1"; } else if type_annotation == "i64" {
-        llvm_type = "i64";
-    } else if type_annotation == "i32" { llvm_type = "i32"; } else if type_annotation.length > 0 {
-        llvm_type = map_local_type(context, type_annotation);
-    }
-    if llvm_type.length == 0 { llvm_type = "double"; }
+    let llvm_type = _binding_llvm_type(context, type_annotation);
 
     // `extern var NAME: TYPE;` (#1313): bind a C-ABI global symbol
     // (e.g. libc `environ`). Emit `@NAME = external global <ty>` with the
@@ -274,5 +282,93 @@ fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeCont
         locals: locals,
         string_constants: empty_string_constant_set(),
         diagnostics: []
+    };
+}
+
+// Result of materialising imported module-level `let` constants in the
+// importing module: the global definition preamble lines and the
+// `LocalBinding` entries that make a reference resolve + load (#1368).
+struct ImportedBindingLoweringResult {
+    preamble_lines: string[];
+    locals: LocalBinding[];
+}
+
+// Materialise the module-level `let` constants an imported capsule EXPORTS
+// as the importer's own value-carrying globals (#1368).
+//
+// A module-level `let` constant lowers to an `internal global` — invisible
+// across the link boundary — so a cross-capsule reference used to fall
+// through expression lowering to the zero-default recovery in statement
+// lowering and silently read back `0`. Rather than make the producer's
+// symbol external (which would still require linking the producer's object,
+// and a constant-only producer module is not pulled into the link),
+// constant-propagate the value across the import boundary: the importer
+// already parsed the producer's binding — value and all — so we re-lower it
+// here through `_process_one_binding`, emitting a self-contained
+// `@global.<name> = internal global <ty> <value>` plus a `LocalBinding`. A
+// reference then loads the producer-defined value with no cross-object
+// dependency.
+//
+// Only safe-to-duplicate constants flow through: immutable bindings with a
+// compile-time-constant initializer (`needs_init == false`). Mutable module
+// globals are genuine shared state — duplicating them would diverge per
+// importer — and runtime-initialized bindings would duplicate side effects,
+// so both are skipped (out of scope for #1368, which is constants). Names
+// already present in the importing module's own globals (`existing_names`)
+// and duplicate imported names are materialised once.
+fn lower_imported_bindings_to_globals(bindings: NativeBinding[], context: TypeContext, existing_names: string[]) -> ImportedBindingLoweringResult {
+    let scope_id = format_root_scope_id("module");
+    let mut preamble_lines: string[] = [];
+    let mut locals: LocalBinding[] = [];
+    let mut seen: string[] = [];
+    let mut e: int = 0;
+    loop {
+        if e >= existing_names.length { break; }
+        seen.push(existing_names[e]);
+        e += 1;
+    }
+    if bindings == null {
+        return ImportedBindingLoweringResult {
+            preamble_lines: preamble_lines,
+            locals: locals
+        };
+    }
+    let mut index: int = 0;
+    loop {
+        if index >= bindings.length { break; }
+        let binding = bindings[index];
+        index += 1;
+        if binding == null { continue; }
+        let name = binding.name;
+        if name == null { continue; }
+        if name.length == 0 { continue; }
+        // `extern var` C-ABI globals already declare themselves through the
+        // producer's own emission; only ordinary `let` constants flow here.
+        if binding.is_extern { continue; }
+        // Shared mutable state cannot be constant-propagated — skip it.
+        if binding.mutable { continue; }
+        if string_array_contains(seen, name) { continue; }
+        let result = _process_one_binding(binding, context, scope_id);
+        // A runtime-initialized binding would duplicate its init side effects
+        // (and its init helpers may not be imported) — only inline constants.
+        if result.needs_init { continue; }
+        if result.locals.length == 0 { continue; }
+        seen.push(name);
+        let mut pi: int = 0;
+        loop {
+            if pi >= result.preamble_lines.length { break; }
+            preamble_lines.push(result.preamble_lines[pi]);
+            pi += 1;
+        }
+        let mut li: int = 0;
+        loop {
+            if li >= result.locals.length { break; }
+            locals.push(result.locals[li]);
+            li += 1;
+        }
+    }
+    return ImportedBindingLoweringResult {
+        preamble_lines: preamble_lines,
+        locals: locals
     };
 }

--- a/compiler/tests/e2e/cross_module_let_const_test.sfn
+++ b/compiler/tests/e2e/cross_module_let_const_test.sfn
@@ -1,0 +1,36 @@
+// Runtime regression for issue #1368.
+//
+// Cross-module / cross-capsule import of a module-level `let` constant
+// must resolve to the producer's defined value. Pre-fix the importer
+// loaded a zero: the producer emitted the constant as an `internal global`
+// (invisible across the link) and the importing module never declared or
+// loaded the symbol, so the reference fell through expression lowering to
+// the zero-default recovery in statement lowering. Every imported constant
+// evaluated to `0` — a silent miscompile that `EXIT_OK == 0` masked until
+// a non-zero consumer (`sfn init`) surfaced it.
+//
+// Post-fix the producer exports the constant with external linkage and the
+// importer declares (`@global.<name> = external global <ty>`) and loads it,
+// so the value is the one the producing module defined. These assertions
+// fail pre-fix (the non-zero constants read back as `0`) and pass post-fix.
+import {
+    CONST_ZERO,
+    CONST_ONE,
+    CONST_USAGE,
+    CONST_INTERNAL,
+    CONST_NEG
+} from "./fixtures/cross_module_let_const_shared";
+
+test "cross-module let const: non-zero values resolve to the producer's value (#1368)" {
+    assert CONST_ONE == 1;
+    assert CONST_USAGE == 2;
+    assert CONST_INTERNAL == 70;
+}
+
+test "cross-module let const: zero baseline still resolves" {
+    assert CONST_ZERO == 0;
+}
+
+test "cross-module let const: negative value resolves" {
+    assert CONST_NEG == -5;
+}

--- a/compiler/tests/e2e/fixtures/cross_module_let_const_shared.sfn
+++ b/compiler/tests/e2e/fixtures/cross_module_let_const_shared.sfn
@@ -1,0 +1,26 @@
+// Cross-module module-level `let` constant fixture for issue #1368.
+//
+// Pairs with `compiler/tests/e2e/cross_module_let_const_test.sfn`.
+//
+// Module-level `let` constants lower to an LLVM global. Before #1368 the
+// producer emitted them with `internal` linkage and the importing module
+// never declared/loaded the symbol, so a cross-module (and cross-capsule)
+// reference fell through expression lowering to the zero-default recovery
+// in statement lowering — every imported constant evaluated to `0`,
+// silently. `EXIT_OK == 0` masked the bug until a non-zero consumer
+// (`sfn init`, importing `sfn/cli`'s `EXIT_*`) appeared. These fixtures
+// pin non-zero values (and a negative) end to end so a regression that
+// reintroduces the zero substitution fails the paired test.
+let CONST_ZERO: int = 0;
+let CONST_ONE: int = 1;
+let CONST_USAGE: int = 2;
+let CONST_INTERNAL: int = 70;
+let CONST_NEG: int = -5;
+
+export {
+    CONST_ZERO,
+    CONST_ONE,
+    CONST_USAGE,
+    CONST_INTERNAL,
+    CONST_NEG
+};


### PR DESCRIPTION
## Summary
- Cross-capsule (and cross-module) imports of a module-level `let` constant silently lowered to **`0`** — a wrong-value miscompile with no diagnostic.
- The importer now **value-inlines** each exported constant into its own self-contained `@global.<name> = internal global <ty> <value>`, so a reference loads the producer's defined value with no cross-object link dependency.

Closes #1368

## Root cause
The producer emits a module-level `let` as an `internal global` (capsule/TU-private, invisible across the link). The importer's `gather_imported_module_symbols` collected structs/enums/interfaces/functions but **never bindings**, so a reference to e.g. `EXIT_BUILD_FAIL` found no `LocalBinding`, fell through every lookup in expression lowering, and the `Return` recovery emitted `ret i64 0` via `default_return_literal`. `EXIT_OK == 0` masked the bug until a non-zero consumer (`sfn init` importing `sfn/cli`'s `EXIT_*`) appeared.

## Approach
Value-inlining (constant propagation across the import boundary) rather than external linkage:
- The importer already parses the producer's `NativeBinding` — value and all — so it re-lowers each exported constant through `_process_one_binding`, emitting a self-contained internal global + `LocalBinding`.
- This avoids the external-linkage failure mode where a **constant-only producer module is never pulled into the link** (its object carries no demanded function symbol), which leaves the importer's external reference undefined.
- Only safe-to-duplicate constants flow through: immutable bindings with a compile-time-constant initializer (`needs_init == false`). Mutable / runtime-initialized bindings are skipped (shared state / duplicated side effects — out of scope for constants).

## Files changed
- `compiler/src/llvm/lowering/lowering_phase_imports.sfn` — gather the exported module-level `let` constants from each imported `.sfn-asm`.
- `compiler/src/llvm/lowering/module_globals.sfn` — `lower_imported_bindings_to_globals` (reuses `_process_one_binding`); extracted `_binding_llvm_type`.
- `compiler/src/llvm/lowering/lowering_core.sfn` — inject the materialized constants into `module_global_locals` before function lowering.
- `compiler/tests/e2e/cross_module_let_const_test.sfn` + `fixtures/cross_module_let_const_shared.sfn` — regression test.

## Acceptance criteria
- [x] A non-zero module-level `let` constant exported from one module and imported by another evaluates to its defined value in the importer (regression test: `1`, `2`, `70`, `-5`, and a `0` baseline).
- [x] No silent `0` substitution (the importer now binds the real value end-to-end).
- [x] Self-hosts (`make compile`).

## Verification
```text
# Regression test — all 3 tests pass
sailfin test compiler/tests/e2e/cross_module_let_const_test.sfn  →  PASS (3/3)

# Real cross-capsule consumer: a program importing EXIT_USAGE from sfn/cli
fn main() -> int [io] { return EXIT_USAGE; }   →  exits 2 (was 0)

# Self-host
make compile  →  pass

# Suites (each green): unit 157/157, integration 35/35, e2e 33/33,
# capsules 36/36, e2e-sh 98/98
```

## Note on a flaky atomic-test SIGSEGV
One `make check` run flaked with a SIGSEGV (exit 139) in two unit tests — `atomic_fence_test` / `atomic_load_store_test` — during the combined `unit+integration+e2e+capsules` invocation. This is **not** caused by this change and appears unrelated:
- Both tests **pass** with this change in isolation, in the full serial unit suite, and in the combined serial run; they flaked once.
- This change is a structural no-op for those tests — they import no module-level `let` constants, so `imported_bindings.length == 0` skips the entire new injection block.
- It is a runtime crash of the compiled test binary (which links a large compiler subset). main's `#1369` "WIP(M1.A.2): flip scalar string ABI to `{i8*, i64}`" merged with **cancelled CI** and documents outstanding `i8*`↔aggregate boundary-coercion gaps — a strong candidate for non-deterministic heap corruption under sustained compilation load. This branch is rebased on top of that flip; module-global strings stay `i8*` (consistent with the new ABI's container clamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7dFWZuP4t9UWHUhhJzy2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7dFWZuP4t9UWHUhhJzy2E)_