### PR TITLE
Atomically publish in-process import-context .sfn-asm staging (#1333)

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1357,8 +1357,27 @@ fn _cr_stage_one(src: CapsuleSource, sailfin_exe: string, work_dir: string) -> b
         // (`""`), and `trace=false` (this path has no `config`).
         ok = emit_subprocess_with_retry(sailfin_exe, src.slug, src.source_path, asm_path, "native", "", 3, false, false);
     } else {
+        // #1333: publish the in-process `.sfn-asm` atomically, mirroring
+        // the subprocess path (`emit_subprocess_with_retry`, #1011).
+        // `write_native_text_file_with_module` rewrites its `-o` target in
+        // place; under the parallel test pool two processes can cold-stage
+        // the *same* shared import to this fixed `build/native/import-
+        // context/<slug>.sfn-asm` concurrently, tearing each other's write
+        // (`link failed` downstream). Emit to a sibling temp + atomic
+        // rename so a peer reader sees a complete prior/new file — never a
+        // partial. Falls back to in-place when `mktemp` is unavailable.
         let source = fs.readFile(src.source_path);
-        ok = write_native_text_file_with_module(source, src.slug, asm_path);
+        let staged = _mktemp_sibling_cmd(asm_path);
+        let mut emit_target: string = asm_path;
+        if staged.length > 0 { emit_target = staged; }
+        ok = write_native_text_file_with_module(source, src.slug, emit_target);
+        if ok {
+            if staged.length > 0 {
+                if !_atomic_rename_into_place(staged, asm_path) { ok = false; }
+            }
+        } else {
+            if staged.length > 0 { process.run(["rm", "-f", staged]); }
+        }
     }
     if !ok {
         print.err("capsule-resolver: failed to emit native text for " + src.slug);


### PR DESCRIPTION
## Summary

- The in-process fallback in `_cr_stage_one` (`sailfin_exe == ""`, the path `sfn check` and small-dep compiles use) wrote the staged `build/native/import-context/<slug>.sfn-asm` **in place**. Under the parallel `int-e2e-caps` pool, two processes cold-staging the *same shared import* (`parser`/`ast`/…) to that fixed, slug-keyed path interleave their writes and **tear the file** → `link failed (clang exit=1)`, an intermittent flake that passes in isolation and serially.
- Fix: emit to a `_mktemp_sibling_cmd` temp + `_atomic_rename_into_place`, mirroring the already-atomic subprocess path (`emit_subprocess_with_retry`, #1011), the parallel-emit path, and the manifest/srchash/import-deps writes. A peer reader now sees a complete prior/new file — never a partial. Falls back to in-place when `mktemp` is unavailable.
- Keeps the stable slug-keyed staging path: **zero** ripple to symbol mangling, the `imports.sfn` readback (417-426), cross-file staging-cache reuse, or self-host, and **no perf cost** (avoids the rejected per-scratch isolation that timed out `unit-a`).

This was the remaining of the two collision points #1333 tracked: collision #1 (`program.ll`) was fixed in #1332; the live recurrence (issue comment, 2026-06-17 CI on PR #1383) is this torn-write race. The original "same-basename slug collision" framing reduces in practice to torn writes of identical-content shared imports — so the fix is atomic publication, not a content-keyed-slug redesign (which would break the slug-keyed readback and risk self-host).

Closes #1333

## Scope note

This closes race **class 2** (torn writes of identical-content shared imports — the live CI flake). Race **class 1** (two concurrent builds of genuinely *different* content resolving to the *same* slug from the same CWD) is a documented residual: atomic publish makes it last-writer-wins rather than torn, but it is not a real test-runner/self-host scenario, and a structural fix would require content/path-keyed staging that breaks the slug-keyed readback. Deferred by design (confirmed with maintainer).

## Verification

```text
make compile                         # self-hosts ✓
issue repro (no --work-dir)          # contaminations: 0/40 ✓
3 CI-flaky integration tests,        # 0/6 iterations failed ✓
  --jobs 8 (4-core, oversubscribed):
  closure_lifting / ownership_e6 / test_runner_json
sfn fmt --check capsule_resolver.sfn # clean ✓
make check                           # in progress (full triple-bootstrap gate)
```

## Files Changed

- `compiler/src/capsule_resolver.sfn` — `_cr_stage_one` in-process branch: atomic temp+rename publish of `.sfn-asm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3cNrt756345bMp6HZP2rE)_