### PR TITLE
refactor(runtime): port fs list_directory + read_file_bytes to Sailfin

### DIFF
--- a/capsules/sfn/fs/tests/fs_test.sfn
+++ b/capsules/sfn/fs/tests/fs_test.sfn
@@ -18,6 +18,7 @@ import {
     exists,
     write,
     read,
+    read_dir,
     remove
 } from "../src/mod";
 
@@ -166,6 +167,41 @@ test "fs: symlink returns false when link path already exists" ![io] {
     write(link, "occupant");
 
     assert symlink("/tmp", link) == false;
+
+    process.run(["rm", "-rf", scratch]);
+}
+
+// ── read_dir (list_directory) ──────────────────────────────────────
+// Exercises the pure-Sailfin `sfn_fs_list_dir` body (#1317): it must
+// build a real `string[]` of the directory's entries, omit the `.`
+// and `..` pseudo-entries, and return them sorted ascending. Files
+// are written out of order to prove the sort runs.
+test "fs: read_dir lists entries sorted, omitting . and .." ![io] {
+    let scratch = mkdtemp("sfn-fs-test-listdir-");
+    assert scratch.length > 0;
+    write(scratch + "/charlie.txt", "c");
+    write(scratch + "/alpha.txt", "a");
+    write(scratch + "/bravo.txt", "b");
+
+    let entries = read_dir(scratch);
+    // Exactly the three files — `.`/`..` are filtered out.
+    assert entries.length == 3;
+    // Sorted ascending by byte order (libc `strcmp`).
+    assert strings_equal(entries[0], "alpha.txt");
+    assert strings_equal(entries[1], "bravo.txt");
+    assert strings_equal(entries[2], "charlie.txt");
+
+    process.run(["rm", "-rf", scratch]);
+}
+
+// An empty directory lists as a zero-length array (never null), so
+// callers can iterate it unconditionally.
+test "fs: read_dir on an empty directory is empty" ![io] {
+    let scratch = mkdtemp("sfn-fs-test-emptydir-");
+    assert scratch.length > 0;
+
+    let entries = read_dir(scratch);
+    assert entries.length == 0;
 
     process.run(["rm", "-rf", scratch]);
 }

--- a/runtime/sfn/adapters/filesystem.sfn
+++ b/runtime/sfn/adapters/filesystem.sfn
@@ -35,26 +35,23 @@
 //     in Sailfin) by treating "directory exists afterward" as the
 //     success signal — equivalent outcome, no platform errno
 //     coupling.
-//   - **`sfn_fs_list_dir`**: trampolines to the legacy C
-//     `sailfin_adapter_fs_list_directory_v2`. Reading `dirent`'s
-//     `d_name` field needs a platform-specific byte offset (19 on
-//     Linux glibc, 21 on macOS arm64 — see the layout caveat in
-//     `libc.sfn`'s directory/stat block) and the result is an
-//     `SfnArray` (`{ i8**, i64, i64 }*`) the C adapter already
-//     builds with sorting + `.`/`..` filtering. Replicating both
-//     in Sailfin is a follow-up inline wave; the symbol flip lands
-//     against the canonical `sfn_fs_list_dir` name now (#1311 `Out:`,
-//     tracked as epic #1308 C8).
-//   - **`sfn_fs_read_bytes`**: trampolines to the C
-//     `sailfin_runtime_read_file_bytes` (the read_bytes row's
-//     existing `symbol`). That body reports the true binary length
-//     through the `int64_t *out_length` out-param via `fseek`/
-//     `ftell` (neither extern is declared in `libc.sfn`; the
-//     `sfn_fs_read_file` chunked-read body cannot recover an
-//     embedded-NUL length). No `fs.read_bytes` call site exists in
-//     the tree yet, so the flip is pure forward surface — a
-//     follow-up wave inlines a binary-safe chunked body once a
-//     caller and e2e exist.
+//   - **`sfn_fs_list_dir`**: pure Sailfin (#1317, epic #1308 C8) —
+//     walks `opendir`/`readdir`/`closedir`, reads each `dirent`'s
+//     `d_name` at the platform byte offset (19 on Linux glibc, 21 on
+//     macOS arm64 — canonical home `platform/sizes_linux.sfn`, inlined
+//     here per the #306 workaround), filters `.`/`..`, `strdup`s each
+//     name, and builds a sorted `SfnArray` (`{ i8**, i64, i64 }*`)
+//     through the runtime array core (`concat_v2(null,null)` for the
+//     empty container + `append_string_v2` per entry, `strcmp`-sorted
+//     in place). The slot store rides `append_string_v2` and `memcpy`
+//     because Sailfin exposes no pointer-write intrinsic.
+//   - **`sfn_fs_read_bytes`**: pure Sailfin (#1317) — the same chunked
+//     `fread`-until-short-read slurp as `sfn_fs_read_file`, whose
+//     running byte count *is* the true binary length (embedded NULs
+//     counted), written into the `int64_t *out_length` out-param
+//     little-endian via `memset`. This recovers the length the C
+//     `sailfin_runtime_read_file_bytes` reported via `fseek`/`ftell`
+//     (neither extern is in `libc.sfn`) without the seek/tell pair.
 //
 // Out (deferred to M3.9):
 //   - Deleting `runtime/native/src/sailfin_runtime.c`'s
@@ -120,8 +117,9 @@
 //
 //   Porting `get_perms` / `mkdtemp` / `symlink` to pure Sailfin is the
 //   documented #1311 follow-up (gated on the #468 `cfg`/stub story).
-//   `list_dir` / `read_bytes` likewise remain C trampolines (#1311
-//   `Out:` — dirent-offset / `fseek`+`ftell` story, epic #1308 C8).
+//   `list_dir` / `read_bytes` are now pure Sailfin (#1317, epic #1308
+//   C8 — Linux-first; macOS `dirent` offset 21 is the documented
+//   follow-up in `platform/sizes_linux.sfn`).
 //
 // Why inline the externs rather than `import { fopen, ... }
 // from "../platform/libc"`? Same rationale as every other
@@ -212,18 +210,53 @@ extern fn rmdir(path: * u8) -> i32;
 // below route through it.
 extern fn sailfin_intrinsic_fs_exists(path: * u8) -> bool;
 
-// Legacy C adapters the M3.1b list/read_bytes flips trampoline
-// through (see the file header). `sailfin_adapter_fs_list_directory_v2`
-// returns an `SfnArray` (`{ i8**, i64, i64 }*`) — spelled `* u8`
-// here per the `runtime/sfn/array.sfn` convention (both lower to
-// the same pointer at the IR level). `sailfin_runtime_read_file_bytes`
-// is the read_bytes row's existing C `symbol`; its second arg is an
-// `int64_t *out_length` out-param, spelled `* u8` to stay on the
-// extern accept-list (it lowers to the same pointer). Both stay
-// exported until M3.9 retires `sailfin_runtime.c`.
-extern fn sailfin_adapter_fs_list_directory_v2(path: * u8) -> * u8;
+// Directory-enumeration primitives for the pure-Sailfin
+// `sfn_fs_list_dir` body (#1317, epic #1308 C8). `opendir` / `readdir`
+// / `closedir` are declared canonically in `runtime/sfn/platform/
+// libc.sfn` (~lines 276-280) and inlined here per the #306
+// cross-module-extern workaround documented in the file header.
+// `opendir`'s `DIR *` and `readdir`'s `struct dirent *` are spelled
+// `* u8` (opaque-pointee, identical IR lowering) to keep this module
+// self-contained — the same redeclaration pattern the `unlink` /
+// `mkdir` / `rmdir` externs above use.
+extern fn opendir(path: * u8) -> * u8;
 
-extern fn sailfin_runtime_read_file_bytes(path: * u8, out_length: * u8) -> * u8;
+extern fn readdir(dirp: * u8) -> * u8;
+
+extern fn closedir(dirp: * u8) -> i32;
+
+// `strcmp` (ISO C — links and behaves identically on Linux / macOS /
+// Windows) backs the `.`/`..` entry filter and the name sort in
+// `sfn_fs_list_dir`. Same redeclaration pattern `type_meta.sfn` and
+// `adapters/http.sfn` already use for `strcmp`.
+extern fn strcmp(a: * u8, b: * u8) -> i32;
+
+// Runtime array core used to build `sfn_fs_list_dir`'s sorted result.
+// `sailfin_runtime_concat_v2(null, null)` materializes an empty
+// `SfnArray` container; `sailfin_runtime_append_string_v2(arr, name)`
+// stores a `char*` into the next slot and grows the backing buffer —
+// it performs the slot store for us (Sailfin exposes no pointer-write
+// intrinsic, only the special-cased `pointer_read_i64` load). Both are
+// declared canonically in `runtime/sfn/array.sfn` and inlined here per
+// the same #306 workaround; both lower over `{ i8**, i64, i64 }*`
+// (spelled `* u8`).
+extern fn sailfin_runtime_concat_v2(a: * u8, b: * u8) -> * u8;
+
+extern fn sailfin_runtime_append_string_v2(a: * u8, text: * u8) -> * u8;
+
+// Byte offset of `struct dirent::d_name` on Linux glibc. Canonical
+// home: `runtime/sfn/platform/sizes_linux.sfn::DIRENT_DNAME_OFFSET`
+// (which also documents macOS arm64 = 21 as the follow-up). Inlined
+// here as the literal `19` per the #306 cross-module workaround in the
+// file header — the same reason the libc externs above are inlined and
+// `_fs_is_immediate` is a copy rather than an import (importing a
+// *defined* symbol into an `sfn-source` fails lowering; see
+// `errno.sfn`'s Linkage note). `readdir` returns the address of the
+// `struct dirent`; the entry name is the NUL-terminated C string that
+// begins at that address + this offset — `d_name` is an inline char
+// array, not a pointer, so its bytes are read directly with no
+// `pointer_read` step.
+let DIRENT_DNAME_OFFSET: i64 = 19;
 
 // Immediate-codepoint fallback (the same shape `runtime/sfn/io.sfn`'s
 // print family uses). Pre-M1.A.2 a single grapheme can arrive as a
@@ -509,30 +542,190 @@ fn sfn_fs_mkdir(path: * u8, recursive: bool) -> bool ![io] {
     return sfn_fs_exists(path);
 }
 
-// `sfn_fs_list_dir(path)` — enumerate the entries of `path`,
-// returning a sorted `SfnArray` (`{ i8**, i64, i64 }*`, spelled
-// `* u8`) that omits `.` and `..`. Trampolines to the legacy C
-// `sailfin_adapter_fs_list_directory_v2`: reading `dirent.d_name`
-// needs a platform-specific byte offset and the sorted SfnArray
-// construction is non-trivial, so both are deferred to a follow-up
-// inline wave (see the file header). The symbol flip lands against
-// the canonical `sfn_fs_list_dir` name now.
-fn sfn_fs_list_dir(path: * u8) -> * u8 ![io] {
-    return sailfin_adapter_fs_list_directory_v2(path);
+// `_fs_dup_cstr(src)` — copy the NUL-terminated C string `src`
+// (including its terminator) into a fresh `malloc`'d buffer the caller
+// owns; null on a null input or OOM. `readdir` reuses its `dirent`
+// buffer across calls, so each entry name must be duplicated before it
+// is appended into the result array. Mirrors `adapters/http.sfn`'s
+// `_strdup_n` shape (`strlen` + `malloc` + `memcpy`); avoids libc
+// `strdup` (MinGW spells it `_strdup`).
+fn _fs_dup_cstr(src: * u8) -> * u8 {
+    if src as i64 == 0 { return null; }
+    let n: i64 = strlen(src) as i64;
+    let buf: * u8 = malloc((n + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    memcpy(buf, src, (n + 1) as usize);
+    return buf;
 }
 
-// `sfn_fs_read_bytes(path, out_length)` — slurp `path` into a
-// freshly allocated NUL-terminated buffer and write the true byte
-// count (binary-safe, embedded NULs counted) through the
-// `int64_t *out_length` out-param. Trampolines to the C
-// `sailfin_runtime_read_file_bytes`, whose `fseek`/`ftell` size
-// probe recovers a length the `sfn_fs_read_file` chunked body
-// cannot (its `strlen`-free NUL terminator hides embedded NULs).
-// No `fs.read_bytes` call site exists yet, so the flip is forward
-// surface; a follow-up wave inlines a binary-safe chunked body
-// once a caller and e2e land.
+// `_fs_name_is_dot(name)` — true iff `name` is the `.` or `..`
+// pseudo-entry every directory carries, which `sfn_fs_list_dir` omits
+// (matching the C `sailfin_adapter_fs_list_directory_v2` filter).
+fn _fs_name_is_dot(name: * u8) -> bool {
+    let dot: string = ".";
+    if strcmp(name, dot as * u8) == 0 { return true; }
+    let dotdot: string = "..";
+    if strcmp(name, dotdot as * u8) == 0 { return true; }
+    return false;
+}
+
+// `_fs_sort_str_array(arr)` — sort the `char*` element slots of the
+// `SfnArray` `arr` ascending by byte order (libc `strcmp`), in place.
+// Selection sort (directory entry counts are small) swapping
+// pointer-sized slots via `memcpy` through an 8-byte scratch —
+// `memcpy` is the only pointer-store primitive Sailfin exposes (there
+// is no `pointer_write` intrinsic, only the special-cased
+// `pointer_read_i64` load). Each slot's `char*` is read as an `i64`
+// address via `sailfin_intrinsic_pointer_read_i64` (the same overlay
+// trick `sfn_fs_write_lines` uses). A `malloc` failure for the scratch
+// leaves the array unsorted rather than corrupting it.
+fn _fs_sort_str_array(arr: * u8) -> void {
+    if arr as i64 == 0 { return; }
+    let view: * SfnArrayView = arr as * SfnArrayView;
+    let n: i64 = view.len;
+    if n <= 1 { return; }
+    let base: i64 = view.data;
+    if base == 0 { return; }
+    let slots: * i64 = base as * i64;
+
+    let tmp: * u8 = malloc(8 as usize);
+    if tmp as i64 == 0 { return; }
+
+    let mut i: i64 = 0;
+    loop {
+        if i >= n - 1 { break; }
+        let mut min_idx: i64 = i;
+        let mut j: i64 = i + 1;
+        loop {
+            if j >= n { break; }
+            let pj: i64 = sailfin_intrinsic_pointer_read_i64(slots + j);
+            let pm: i64 = sailfin_intrinsic_pointer_read_i64(slots + min_idx);
+            if strcmp(pj as * u8, pm as * u8) < 0 { min_idx = j; }
+            j = j + 1;
+        }
+        if min_idx != i {
+            let slot_i: * u8 = (base + i * 8) as * u8;
+            let slot_m: * u8 = (base + min_idx * 8) as * u8;
+            memcpy(tmp, slot_i, 8 as usize);
+            memcpy(slot_i, slot_m, 8 as usize);
+            memcpy(slot_m, tmp, 8 as usize);
+        }
+        i = i + 1;
+    }
+
+    free(tmp);
+}
+
+// `sfn_fs_list_dir(path)` — enumerate the entries of `path`, returning
+// a sorted `SfnArray` (`{ i8**, i64, i64 }*`, spelled `* u8`) that
+// omits `.` and `..`. Pure Sailfin (#1317, epic #1308 C8): walk
+// `opendir`/`readdir`/`closedir`, read each entry's name at
+// `dirent + DIRENT_DNAME_OFFSET`, `strdup` it (the `dirent` buffer is
+// reused across `readdir` calls), append it through the runtime array
+// core, then `strcmp`-sort in place. Mirrors the C
+// `sailfin_adapter_fs_list_directory_v2` contract exactly: a null or
+// empty `path` lists the current directory, and an `opendir` failure
+// returns an empty array (never null) so callers can iterate
+// unconditionally.
+fn sfn_fs_list_dir(path: * u8) -> * u8 ![io] {
+    // Null/empty path ⇒ current directory (C body's `path_str = "."`).
+    let mut target: * u8 = path;
+    if target as i64 == 0 {
+        let dot: string = ".";
+        target = dot as * u8;
+    }
+    if (strlen(target) as i64) == 0 {
+        let dot: string = ".";
+        target = dot as * u8;
+    }
+
+    let dir: * u8 = opendir(target);
+    if dir as i64 == 0 { return sailfin_runtime_concat_v2(null, null); }
+
+    let mut arr: * u8 = sailfin_runtime_concat_v2(null, null);
+    loop {
+        let entry: * u8 = readdir(dir);
+        if entry as i64 == 0 { break; }
+        let name: * u8 = ((entry as i64) + DIRENT_DNAME_OFFSET) as * u8;
+        if _fs_name_is_dot(name) { continue; }
+        let copy: * u8 = _fs_dup_cstr(name);
+        if copy as i64 == 0 { continue; }
+        arr = sailfin_runtime_append_string_v2(arr, copy);
+    }
+    closedir(dir);
+
+    _fs_sort_str_array(arr);
+    return arr;
+}
+
+// `sfn_fs_read_bytes(path, out_length)` — slurp `path` into a freshly
+// `malloc`'d NUL-terminated buffer the caller owns and write the true
+// byte count (binary-safe, embedded NULs counted) through the
+// `int64_t *out_length` out-param. Pure Sailfin (#1317, epic #1308
+// C8): the same chunked `fread`-until-short-read slurp as
+// `sfn_fs_read_file` — `fread` returns the real byte count regardless
+// of embedded NULs, so the running `len` *is* the binary length the C
+// `sailfin_runtime_read_file_bytes` recovered via `fseek`/`ftell`
+// (neither extern is declared in `libc.sfn`, and `strlen` of the
+// buffer would stop at the first embedded NUL). The length is stored
+// into the out-param byte-by-byte (little-endian) with `memset`, since
+// Sailfin has no pointer-write intrinsic; x86_64 / aarch64 / arm64 are
+// all little-endian. Returns null on a null `path` / `out_length`, on
+// `fopen` failure, or on OOM.
 fn sfn_fs_read_bytes(path: * u8, out_length: * u8) -> * u8 ![io] {
-    return sailfin_runtime_read_file_bytes(path, out_length);
+    if path as i64 == 0 { return null; }
+    if out_length as i64 == 0 { return null; }
+
+    let mode_str: string = "rb";
+    let f: * File = fopen(path, mode_str as * u8);
+    if f as i64 == 0 { return null; }
+
+    let mut capacity: i64 = 4096;
+    let mut len: i64 = 0;
+    let mut buf: * u8 = malloc((capacity + 1) as usize);
+    if buf as i64 == 0 {
+        fclose(f);
+        return null;
+    }
+
+    let chunk_size: i64 = 4096;
+    loop {
+        if len + chunk_size > capacity {
+            let new_cap: i64 = capacity * 2;
+            let new_buf: * u8 = realloc(buf, (new_cap + 1) as usize);
+            if new_buf as i64 == 0 {
+                free(buf);
+                fclose(f);
+                return null;
+            }
+            buf = new_buf;
+            capacity = new_cap;
+        }
+        let dst: * u8 = ((buf as i64) + len) as * u8;
+        let read_n: usize = fread(dst, 1 as usize, chunk_size as usize, f);
+        let read_i: i64 = read_n as i64;
+        len = len + read_i;
+        if read_i < chunk_size { break; }
+    }
+
+    fclose(f);
+
+    // NUL-terminate at offset `len` (the +1 capacity slack reserves it).
+    let term_ptr: * u8 = ((buf as i64) + len) as * u8;
+    memset(term_ptr, 0, 1 as usize);
+
+    // Store the binary length into the `int64_t *out_length` out-param,
+    // one little-endian byte at a time (no pointer-write intrinsic).
+    let mut k: i64 = 0;
+    loop {
+        if k >= 8 { break; }
+        let b: i64 = (len >> (k * 8)) & 255;
+        let slot: * u8 = ((out_length as i64) + k) as * u8;
+        memset(slot, b as i32, 1 as usize);
+        k = k + 1;
+    }
+
+    return buf;
 }
 
 // `sfn_fs_set_perms(path, mode)` — `chmod(2)` equivalent. Masks

--- a/runtime/sfn/platform/sizes_linux.sfn
+++ b/runtime/sfn/platform/sizes_linux.sfn
@@ -1,0 +1,53 @@
+// runtime/sfn/platform/sizes_linux.sfn
+//
+// Minimal per-platform struct-layout constants for the Sailfin-native
+// runtime adapters. Companion to `runtime/sfn/platform/libc.sfn`; see
+// that file's "Layout caveats" block for the long-form rationale on
+// why `struct dirent` / `struct stat` field offsets cannot be reached
+// through the opaque-pointee discipline and must be supplied as
+// per-platform byte offsets instead.
+//
+// First constant: `DIRENT_DNAME_OFFSET`, the byte offset of the
+// `d_name` character array within `struct dirent`. The directory
+// adapter (`runtime/sfn/adapters/filesystem.sfn::sfn_fs_list_dir`)
+// walks `opendir`/`readdir`/`closedir` and reads each entry's name as
+// the NUL-terminated C string that begins at `readdir`'s returned
+// `struct dirent *` plus this offset.
+//
+//   - **Linux glibc x86_64 / aarch64**: `d_name` sits at offset 19
+//     (`ino_t d_ino` 8 + `off_t d_off` 8 + `unsigned short d_reclen`
+//     2 + `unsigned char d_type` 1 = 19).
+//   - **macOS arm64**: `d_name` sits at offset 21 (`__uint64_t d_ino`
+//     8 + `__uint64_t d_seekoff` 8 + `__uint16_t d_reclen` 2 +
+//     `__uint16_t d_namlen` 2 + `__uint8_t d_type` 1 = 21). Shipping
+//     the Darwin offset (and selecting between the two at emit time
+//     from `uname -s` / `SAILFIN_TARGET_OS`, the same mechanism the
+//     errno locator uses in `errno.sfn`) is a documented follow-up —
+//     the directory adapter is Linux-first scoped for the self-host
+//     target (#1317, epic #1308 C8).
+//
+// Linkage (mirrors the #893 decision for `runtime/sfn/platform/
+// errno.sfn`): this file stays OUT of `runtime/native/capsule.toml`
+// `sfn-sources`. `sfn-sources` registration forces a standalone link
+// on every target for a module with no entry point of its own, and
+// nothing imports it yet: the runtime `sfn-source` emit path
+// (`_compile_runtime_sfn_sources` in `cli_main.sfn`) resolves imported
+// *extern* signatures but not imported *defined* functions, so
+// importing `dirent_dname_offset()` into an `sfn-source` would fail
+// lowering with "callee signature is not known to the compiler" (see
+// `errno.sfn`'s Linkage note). Until that cross-module resolution
+// lands, `filesystem.sfn` inlines the literal `19` (with a comment
+// pointing back here as the canonical home) exactly as `clock.sfn`
+// inlines the errno sentinel chain rather than importing `errno()`.
+// This file is therefore the canonical, type-checked home for the
+// constant — the consumer folds it in until the import path exists.
+// Byte offset of `struct dirent::d_name` on Linux glibc (x86_64 and
+// aarch64 agree at 19). macOS arm64 = 21 is the documented follow-up.
+let DIRENT_DNAME_OFFSET: i64 = 19;
+
+// `dirent_dname_offset()` — the canonical accessor adapters will import
+// from here once cross-module resolution of imported defined functions
+// lands in the runtime sfn-source emit path (#306 / epic #763). Until
+// then consumers inline the literal; this proves the constant resolves
+// and type-checks as a real runtime module.
+fn dirent_dname_offset() -> i64 { return DIRENT_DNAME_OFFSET; }


### PR DESCRIPTION
## Summary
- Flip the last two R6 filesystem symbols off their C trampolines (epic #1308 C8). `sfn_fs_list_dir` and `sfn_fs_read_bytes` now resolve to pure-Sailfin bodies in `runtime/sfn/adapters/filesystem.sfn` — **no C call remains** (`sailfin_adapter_fs_list_directory_v2` / `sailfin_runtime_read_file_bytes` externs removed).
- `sfn_fs_list_dir` walks `opendir`/`readdir`/`closedir`, reads each `dirent.d_name` at the platform byte offset, filters `.`/`..`, `strdup`s each name, and builds a sorted `SfnArray` via the runtime array core (`concat_v2(null,null)` empty container + `append_string_v2` per entry, `strcmp`-sorted in place with `memcpy` slot swaps — Sailfin has no pointer-write intrinsic).
- `sfn_fs_read_bytes` uses the chunked `fread`-until-short-read slurp; the running byte count is the true binary length (embedded NULs counted), written into the `int64_t *out_length` out-param little-endian via `memset`.
- New `runtime/sfn/platform/sizes_linux.sfn` is the canonical home for `DIRENT_DNAME_OFFSET` (19 glibc; macOS 21 documented follow-up). Kept **out of `sfn-sources`** and inlined in `filesystem.sfn`, mirroring the `errno.sfn` precedent — importing a defined symbol into an sfn-source still fails lowering (#306 / epic #763).

Linux-first scoping (the self-host target); the macOS dirent offset is the documented follow-up.

Closes #1317

## Acceptance Criteria
- [x] `list_directory` / `read_file_bytes` resolve to Sailfin bodies; no C call.
- [x] `fs` directory tests pass on Linux x86_64.
- [x] `make compile` && `make test` pass.

## Verification
```bash
make compile                                              # self-hosts ✅
build/native/sailfin test capsules/sfn/fs/tests/fs_test.sfn    # 14/14 ✅ (incl. new read_dir sort/list tests)
build/native/sailfin test capsules/sfn/fs/tests/remove_test.sfn # 8/8 ✅ (recursive listDirectory)
# full suite (faithful make-test command):
build/native/sailfin test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules --jobs 1 --json
#  → {"event":"summary","passed":2484,"failed":0,"skipped":0}  ✅
```

Note: an initial `make test` run hit a single transient teardown SIGSEGV (exit 139) in the runner *after* all 2484 tests + 85/85 e2e-sh passed. This is the documented transient-under-memory-pressure class the runner already carries 137/139 retry logic for (`cli_commands.sfn:723`); it did **not** reproduce on the faithful repro (deterministic green). `make compile` exercises the new `list_dir` heavily via `capsule_resolver`'s source-tree walk and self-hosts cleanly.

## Files Changed
- `runtime/sfn/adapters/filesystem.sfn` — pure-Sailfin `list_dir` + `read_bytes`, new dir/strcmp/array externs, dead trampoline externs removed
- `runtime/sfn/platform/sizes_linux.sfn` (new) — canonical `DIRENT_DNAME_OFFSET`
- `capsules/sfn/fs/tests/fs_test.sfn` — `read_dir` regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kq4agYBPSz6RtvAHiwvkep

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kq4agYBPSz6RtvAHiwvkep)_