### PR TITLE
ci: stop running branch-push CI on main (redundant + scarce-runner contention)

### DIFF
--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -1,6 +1,18 @@
 name: CI (branch push)
 
-# Runs the build + test matrix on pushes to main, rc, and beta.
+# Runs the build + test matrix on pushes to the release-prep branches
+# rc and beta.
+#
+# `main` is deliberately NOT triggered here: it is already gated
+# pre-merge by ci.yml (sharded Linux + macOS, on every PR) and validated
+# post-merge by build-quality.yml (Linux + the #615/#807 effect-gate
+# smoke). Re-running the full Linux+macOS matrix on every main push was
+# pure duplication, and its macOS leg drew a scarce macos-arm64 runner
+# from the shared account pool — contending with the feature-branch PRs
+# in ci.yml that the gate actually depends on (the leg was chronically
+# preempted/cancelled before it could finish anyway). rc/beta keep this
+# workflow because nothing else validates them and they are pushed
+# infrequently, so the runner contention is negligible.
 #
 # This workflow validates that the branch is healthy.  It does NOT create
 # releases — use the manual "Release" workflow (release.yml) for that.
@@ -16,7 +28,6 @@ name: CI (branch push)
 on:
     push:
         branches:
-            - main
             - rc
             - beta
         paths-ignore:


### PR DESCRIPTION
## Summary

Removes `main` from the `release-branches.yml` ("CI (branch push)") push
trigger, keeping only `rc`/`beta`.

On a push to `main` there were already two workflows running, and a third
gating pre-merge:
- **`ci.yml`** — `pull_request`, the real gate; sharded Linux + macOS on every PR.
- **`build-quality.yml`** — `push: [main]`; Linux post-merge quality gates + #615/#807 effect-gate smoke.
- **`release-branches.yml`** — `push: [main, rc, beta]`; full Linux **+ macOS** build+test matrix.

So `release-branches.yml` on `main` was pure duplication: Linux overlaps
`build-quality.yml`, and the macOS leg re-proves what pre-merge `ci.yml`
already proved — while drawing a scarce `macos-arm64` runner from the
**shared account-level pool**, contending with the feature-branch PRs in
`ci.yml` that the merge gate depends on. In practice the main leg was
**chronically preempted/cancelled** before finishing (every recent
main-push run shows `conclusion=cancelled`), so it was noise, not signal.

## Why this is safe (no coverage loss on main)
- **Pre-merge:** `ci.yml` validates every PR — sharded Linux + macOS (macos-26).
- **Post-merge:** `build-quality.yml` runs on `main` push (Linux + smoke gates).
- `rc`/`beta` keep `release-branches.yml`: nothing else validates them, and
  they're pushed infrequently, so runner contention is negligible.
- Nothing consumes "CI (branch push)" via `workflow_run` (checked).

## Context
Follow-up to #1408 (which flipped macOS CI/release to macos-26). The
post-merge run of #1408 had its macos-26 leg reclaimed mid-test
(`make: *** [test] Terminated: 15`, "runner received a shutdown signal")
while tests were passing — a runner preemption, not a failure, and the
trigger for auditing this redundant main-push contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)