### PR TITLE
fix(cli): isolate `sfn run` build cache under SAILFIN_TEST_SCRATCH (#1411)

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -2685,11 +2685,21 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
             return 1;
         }
 
-        _ensure_dir("build");
-        _ensure_dir("build/sailfin");
+        // #1411: route the top-level `run.ll`/`run` executable under the
+        // per-invocation scratch when one is set (`SAILFIN_TEST_SCRATCH`),
+        // exactly as `sfn build` does (line ~2322). Bare-file dispatch
+        // delegates here (`["run", cmd]`), so it inherits this too. Without
+        // it, two concurrent `sfn run`/bare-dispatch children in the
+        // parallel `sfn test --jobs N` pool both write the fixed
+        // `build/sailfin/run` and clobber each other's executable — a test
+        // asserting on the run's stdout then sees another fixture's output
+        // (non-deterministic, #1411). Empty scratch resolves to
+        // `build/sailfin`, keeping the default invocation byte-for-byte.
+        let run_cache_dir = _resolve_sailfin_cache_dir_for_work("");
+        _ensure_dir(run_cache_dir);
 
-        let ll_path = "build/sailfin/run.ll";
-        let exe_path = "build/sailfin/run";
+        let ll_path = run_cache_dir + "/run.ll";
+        let exe_path = run_cache_dir + "/run";
 
         // Resolve and compile capsule deps before lowering the main file.
         // The unified resolver covers relative imports, manifest-declared

--- a/compiler/tests/e2e/run_scratch_isolation_test.sfn
+++ b/compiler/tests/e2e/run_scratch_isolation_test.sfn
@@ -1,0 +1,64 @@
+// Regression for #1411: `sfn run` (and bare-file dispatch, which delegates
+// to it) must route its top-level `run.ll`/`run` executable under
+// `SAILFIN_TEST_SCRATCH` when set, exactly as `sfn build` does. Before the
+// fix it always wrote the fixed `build/sailfin/run`, so two concurrent
+// `sfn run`/bare-dispatch children in the parallel `sfn test --jobs N` pool
+// clobbered each other's executable and a test asserting on the run's stdout
+// saw another fixture's output (non-deterministic).
+//
+// The collision itself is a *concurrent* pool property and can't be
+// reproduced from a single serial test. What is deterministic — and what
+// locks the fix — is the routing invariant: with a per-invocation scratch,
+// the executable lands under that scratch, NOT under `build/sailfin`. If a
+// regression reverts the fix, `<scratch>/run` is never written and the
+// fixed `build/sailfin/run` collision path returns.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Child env = the full parent environment (PATH/HOME/TMPDIR + macOS
+// toolchain vars the nested clang/linker need), but with
+// `SAILFIN_TEST_SCRATCH` forced to `scratch` so the routing target is
+// known regardless of whether this test runs under the pool. Any inherited
+// `SAILFIN_TEST_SCRATCH` entry is dropped first so the forced value wins.
+fn _child_env(scratch: string) -> string[] ![io] {
+    let base = process.environ();
+    let mut e: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= base.length { break; }
+        let entry = base[i];
+        if find(entry, "SAILFIN_TEST_SCRATCH=", 0) != 0 { e.push(entry); }
+        i += 1;
+    }
+    e.push("SAILFIN_TEST_SCRATCH=" + scratch);
+    return e;
+}
+
+test "run: executable is routed under SAILFIN_TEST_SCRATCH, not build/sailfin" ![io] {
+    // A unique scratch dir for this invocation so the assertion is not
+    // polluted by a prior `build/sailfin/run` or another test's scratch.
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    let scratch = base + "/sfn-run-iso-1411";
+    fs.createDirectory(scratch, true);
+    let exe = scratch + "/run";
+    if fs.exists(exe) { fs.deleteFile(exe); }
+
+    let exit = process.run_capture([_sfn_bin(), "run", "examples/advanced/lambda-closure.sfn"], _child_env(scratch));
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+
+    // The fixture compiled, linked, and ran correctly...
+    assert exit == 0;
+    assert find(out, "7", 0) >= 0;
+    // ...and its executable landed under the per-invocation scratch, proving
+    // `sfn run` no longer hard-codes `build/sailfin/run` (#1411).
+    assert fs.exists(exe);
+
+    if fs.exists(exe) { fs.deleteFile(exe); }
+}


### PR DESCRIPTION
## Summary
- `sfn run` / bare-file dispatch hard-coded `build/sailfin/run.ll` + `build/sailfin/run`, ignoring `SAILFIN_TEST_SCRATCH` (only `sfn build` honored it). Under `sfn test --jobs N` (N>1), concurrent `run`/bare-dispatch children clobber each other's executable → a test asserting on run stdout sees another fixture's output (the `closure_capture_test.sfn:74` flake from macOS CI greening).
- Route `run.ll`/`run` through `_resolve_sailfin_cache_dir_for_work("")`, mirroring `sfn build`. Empty scratch → `build/sailfin` (default byte-for-byte unchanged); the runner's per-child `sub-<i>` scratch now isolates each nested run.
- Adds `run_scratch_isolation_test.sfn` locking the routing invariant.

**Root cause: collision, not contention.** A tight 2-process concurrent `sfn run` of distinct fixtures collided **30/30** before the fix, **0/30** after (with per-run scratch).

Closes #1411

## Acceptance Criteria
- [x] A documented deterministic repro under `sailfin test --jobs N` (direct 2-process `sfn run` collision: 30/30, included in PR description).
- [x] Root cause identified — build-cache collision (`sfn run` not scratch-isolated), not resource contention.
- [x] Build-and-run e2e tests pass under `--jobs 4` (macOS arm64, 3× green; Linux self-host via `make compile`).
- [x] No regression to the serial path — full e2e suite 53/53; default `build/sailfin/run` path unchanged when scratch unset.

## Verification
\`\`\`text
# Root-cause repro (old binary, no scratch — fixed path collides):     30/30 collisions
# Pool-accurate (new binary, distinct per-run scratch):                 0/30 collisions
# Default path unchanged (scratch unset): build/sailfin/run still written
# Acceptance set @ --jobs 4 (3×):        all 7 tests PASS
# Full e2e suite:                         53/53 passed, 0 failed
# Self-host:                              make compile → pass
\`\`\`

## Files Changed
- `compiler/src/cli_main.sfn` — route `sfn run` cache dir through `_resolve_sailfin_cache_dir_for_work`
- `compiler/tests/e2e/run_scratch_isolation_test.sfn` — new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)