### PR TITLE
fix(runtime): guard immediate-codepoint heuristic on Linux (#1407)

### DIFF
--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -34,6 +34,9 @@
 #include <mach/mach_vm.h>
 #include <mach/mach_time.h>
 #endif
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
 #include <errno.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -361,6 +364,78 @@ char *sailfin_runtime_get_field(char *base, char *field)
     return _get_field_safe_buf;
 }
 
+// Probe whether `text` points inside a mapped, readable memory region.
+//
+// Disambiguates the upper-32-bit immediate-codepoint encoding (a codepoint
+// shifted into bits [32:64) with the low 32 bits zero) from a genuine
+// heap/arena pointer whose low 32 bits happen to be zero. The latter is a rare
+// but real ASLR outcome on both macOS and Linux; without this probe the real
+// pointer is misclassified as an immediate codepoint and the string is silently
+// corrupted (issue #1407: an arena buffer at 0x00007f22_00000000 decoded as
+// U+7F22, replacing an emitted `insertvalue` opcode with garbage `E7 BC A2`).
+//
+// A synthetic immediate (codepoint << 32) is never mapped, so it stays an
+// immediate; a genuine buffer at a low-32-zero address is mapped, so it is
+// treated as a real string.
+//
+// Only defined where the upper-32-bit guard below actually calls it, to avoid
+// an unused-static-function warning on targets without the guard.
+#if (defined(__APPLE__) && !defined(SAILFIN_WITH_ASAN)) || defined(__linux__)
+static bool _sfn_addr_mapped_readable(const char *text)
+{
+#if defined(__APPLE__)
+    mach_vm_address_t query = (mach_vm_address_t)(uintptr_t)text;
+    mach_vm_address_t region = query;
+    mach_vm_size_t region_size = 0;
+    vm_region_basic_info_data_64_t info;
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t object_name = MACH_PORT_NULL;
+
+    kern_return_t kr = mach_vm_region(
+        mach_task_self(),
+        &region,
+        &region_size,
+        VM_REGION_BASIC_INFO_64,
+        (vm_region_info_t)&info,
+        &count,
+        &object_name);
+
+    if (object_name != MACH_PORT_NULL)
+    {
+        mach_port_deallocate(mach_task_self(), object_name);
+    }
+
+    if (kr != KERN_SUCCESS)
+    {
+        return false;
+    }
+    bool readable = (info.protection & VM_PROT_READ) != 0;
+    bool contains = (query >= region) && (query < (region + region_size));
+    return readable && contains;
+#elif defined(__linux__)
+    // `msync()` on the containing page returns 0 when the range is mapped and
+    // -1/ENOMEM when it is not — the standard, side-effect-free "is this pointer
+    // mapped" probe. MS_ASYNC only schedules writeback of dirty pages, so it
+    // never mutates clean/read-only string storage.
+    static long page_size = 0;
+    if (page_size <= 0)
+    {
+        page_size = sysconf(_SC_PAGESIZE);
+        if (page_size <= 0)
+        {
+            page_size = 4096;
+        }
+    }
+    uintptr_t mask = (uintptr_t)page_size - 1u;
+    uintptr_t page = (uintptr_t)text & ~mask;
+    return msync((void *)page, (size_t)page_size, MS_ASYNC) == 0;
+#else
+    (void)text;
+    return false;
+#endif
+}
+#endif
+
 static bool _is_immediate_codepoint_string(const char *text, uint32_t *out_codepoint)
 {
     if (!text)
@@ -400,11 +475,12 @@ static bool _is_immediate_codepoint_string(const char *text, uint32_t *out_codep
         return false;
     }
 
-#if defined(__APPLE__) && !defined(SAILFIN_WITH_ASAN)
-    // On macOS it is possible (though rare) to have a real, mapped pointer
-    // whose low 32 bits are zero. The upper-32-bit heuristic would wrongly
-    // classify that as an "immediate" codepoint string, causing subtle memory
-    // corruption when the value is later treated as a C string.
+#if (defined(__APPLE__) && !defined(SAILFIN_WITH_ASAN)) || defined(__linux__)
+    // On both macOS and Linux it is possible (though rare) to have a real,
+    // mapped pointer whose low 32 bits are zero. The upper-32-bit heuristic
+    // would wrongly classify that as an "immediate" codepoint string, causing
+    // subtle memory corruption when the value is later treated as a C string
+    // (issue #1407).
     //
     // Guard: only treat this encoding as immediate when the address is not
     // mapped as a readable region.
@@ -450,39 +526,10 @@ static bool _is_immediate_codepoint_string(const char *text, uint32_t *out_codep
         if (cached_val == 2)
         {
             // Known-unmapped immediate; skip the expensive kernel query.
-            goto apple_upper32_immediate_done;
+            goto upper32_immediate_done;
         }
 
-        bool mapped_readable = false;
-        {
-            mach_vm_address_t query = (mach_vm_address_t)(uintptr_t)text;
-            mach_vm_address_t region = query;
-            mach_vm_size_t region_size = 0;
-            vm_region_basic_info_data_64_t info;
-            mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
-            mach_port_t object_name = MACH_PORT_NULL;
-
-            kern_return_t kr = mach_vm_region(
-                mach_task_self(),
-                &region,
-                &region_size,
-                VM_REGION_BASIC_INFO_64,
-                (vm_region_info_t)&info,
-                &count,
-                &object_name);
-
-            if (object_name != MACH_PORT_NULL)
-            {
-                mach_port_deallocate(mach_task_self(), object_name);
-            }
-
-            if (kr == KERN_SUCCESS)
-            {
-                bool readable = (info.protection & VM_PROT_READ) != 0;
-                bool contains = (query >= region) && (query < (region + region_size));
-                mapped_readable = readable && contains;
-            }
-        }
+        bool mapped_readable = _sfn_addr_mapped_readable(text);
 
         // Store the result.
         for (uint32_t probe = 0; probe < MAP_CACHE_PROBES; probe++)
@@ -502,7 +549,7 @@ static bool _is_immediate_codepoint_string(const char *text, uint32_t *out_codep
         }
     }
 
-apple_upper32_immediate_done:
+upper32_immediate_done:
 #endif
 
     if (out_codepoint)


### PR DESCRIPTION
## Summary
- The C runtime classifier `_is_immediate_codepoint_string` treats a `char*` whose **low 32 bits are zero** (and whose high 32 bits form a valid codepoint) as an *immediate-codepoint pseudo-string* rather than a real pointer. macOS guarded this ambiguity by probing whether the address is actually mapped; the guard was `#if defined(__APPLE__)` only.
- On Linux x86_64, ASLR + arena bump-allocation can hand out a genuine string buffer at a low-32-zero address (e.g. `0x00007f22_00000000`). Without the guard that real pointer is misclassified as codepoint **U+7F22** and decoded to the 3 bytes `E7 BC A2`, silently corrupting an emitted string — observed in CI as a garbage byte replacing the `insertvalue` opcode in a subprocess-emitted `.ll`, failing the link **non-deterministically**.
- Fix: extend the existing mapped-readable guard (and its cache) to Linux via `msync(MS_ASYNC)` — the standard, side-effect-free "is this page mapped" probe. A synthetic immediate (`codepoint << 32`) is never mapped → stays an immediate; a real buffer at a low-32-zero address is mapped → treated as a string. The mach probe is factored into `_sfn_addr_mapped_readable` so both platforms share the cache logic; **macOS behavior is unchanged** (the mach body moved verbatim into the helper).

Closes #1407

## Root cause
`compiler/src/...` is not at fault — the operands in the corrupt line were intact; only the **fixed opcode mnemonic** was clobbered. It traces to `runtime/native/src/sailfin_runtime.c:_is_immediate_codepoint_string`, whose "upper-32-bit" heuristic (low-32-zero ⇒ immediate) collides with real arena pointers on Linux. The existing macOS comment block documents this exact hazard for Darwin; Linux simply lacked the guard.

## Migration note (per maintainer guidance — "stopgap + harden the port")
This is a **stopgap for the still-load-bearing C runtime**. The immediate-codepoint pseudo-pointer encoding is slated for **deletion** with `sailfin_runtime.c` under **#822 / epic #1308** (the encoding is *created* at `sailfin_runtime.c:6157`, `packed = ((uintptr_t)byte) << 32;`, and its removal is tracked there — see #1283 Gap 2). When that lands, `_is_immediate_codepoint_string` and this guard are deleted along with it and the bug class disappears structurally. The native Sailfin runtime does **not** reimplement the classifier today — `runtime/sfn/string.sfn` delegates to the C bridges `sfn_str_immediate_codepoint` / `sfn_str_decode_owned` — so the corruption is C-only. A hardening note will be posted on #822 so the native port does not reintroduce the low-32-zero discriminator.

## Acceptance Criteria
- [x] Source of the opcode-string corruption found in the emit/runtime path
- [x] Emitted `.ll` is byte-stable across runs (stress loop, 30× cold builds, 0 corruption)
- [x] Legitimate immediate-codepoint behavior preserved (`string_concat_immediate_test.sfn` 6/6)
- [x] Self-hosts (`make rebuild`)
- [x] No regressions (`make test`)

## Verification
```text
make rebuild                                  → status: pass (self-hosts with the fix)
sailfin test string_concat_immediate_test.sfn → PASS (6/6 immediate-codepoint tests)
stress loop (30× cold work-dir builds)        → 0/30 corrupted, byte-stable
make test                                      → status: pass; e2e-sh 81/81; 0 failed
  (affected shard: struct_field_pointer / runtime_int_helpers /
   runtime_libc_skeleton / runtime_posix_skeleton / routine_nursery /
   unresolvable_literal — all pass)
```

**Note on the ASAN leg:** the issue suggested ASAN as the *diagnostic* path to *locate* the bug. Now that the root cause is a **logic misclassification** (a valid-but-wrong pointer read), not a use-after-free / heap-overflow, an ASAN run would not have flagged it and is not required to validate the fix. The guard is a pure read-only classification change. Happy to add an ASAN leg if you'd like belt-and-suspenders coverage (needs `SAILFIN_MEM_LIMIT=unlimited` + uncapped shell per `.claude/rules/compiler-safety.md`).

## Files Changed
- `runtime/native/src/sailfin_runtime.c` — extract `_sfn_addr_mapped_readable`, extend the mapped-readable guard to Linux via `msync`, add `<sys/mman.h>`, rename the shared label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd2oUNg77SHsAZRg4kXSqq)_