### PR TITLE
refactor(runtime): flip substring_unchecked to Sailfin — residual 10→9 (#1308)

### DIFF
--- a/compiler/tests/unit/substring_unchecked_test.sfn
+++ b/compiler/tests/unit/substring_unchecked_test.sfn
@@ -1,3 +1,12 @@
+// #1308 (M1.A.2): regression coverage for the Sailfin-native substring body
+// (`_sfn_substring_unchecked` in `runtime/sfn/string.sfn`) that replaced the C
+// `sailfin_runtime_substring_unchecked` entrypoint (now `static`). The
+// `substring_unchecked(...)` builtin lowers via the registry to `sfn_str_slice`,
+// which now calls the Sailfin body. The crash-sensitive arm is the
+// immediate-codepoint pseudo-pointer (`src[i]`, a tagged bufferless grapheme on
+// Linux): the body must classify it via `sfn_str_immediate_codepoint` and slice
+// the codepoint's UTF-8 encoding WITHOUT dereferencing the pseudo-pointer — a
+// wrong deref segfaults the suite (#714/#716 class).
 test "string: substring_unchecked returns expected slice" {
     let text = "hello";
     let result = substring_unchecked(text, 1, 4);
@@ -7,4 +16,50 @@ test "string: substring_unchecked returns expected slice" {
 test "string: substring_unchecked handles empty spans" {
     let text = "hello";
     assert substring_unchecked(text, 2, 2) == "";
+}
+
+test "string: substring_unchecked full-range and head/tail slices" {
+    let text = "hello";
+    assert substring_unchecked(text, 0, 5) == "hello";
+    assert substring_unchecked(text, 0, 1) == "h";
+    assert substring_unchecked(text, 4, 5) == "o";
+}
+
+test "string: substring_unchecked clamps a negative start to 0" {
+    let text = "hello";
+    assert substring_unchecked(text, -3, 2) == "he";
+}
+
+test "string: substring_unchecked on an empty string is empty" {
+    let text = "";
+    assert substring_unchecked(text, 0, 0) == "";
+}
+
+// Immediate-codepoint path: `src[i]` is a tagged pseudo-pointer on Linux. The
+// body slices the 1-byte UTF-8 encoding of the grapheme without dereferencing.
+test "string: substring_unchecked of an immediate grapheme (full)" {
+    let src = "hello";
+    let g = src[0];
+    assert substring_unchecked(g, 0, 1) == "h";
+}
+
+test "string: substring_unchecked of an immediate grapheme (empty span)" {
+    let src = "hello";
+    let g = src[1];
+    assert substring_unchecked(g, 0, 0) == "";
+}
+
+// End beyond the grapheme width clamps to the encoded length (the C `end > n`
+// arm); slicing a 1-byte immediate with [0, 5) yields the whole grapheme.
+test "string: substring_unchecked of an immediate grapheme clamps end" {
+    let src = "hello";
+    let g = src[2];
+    assert substring_unchecked(g, 0, 5) == "l";
+}
+
+// Start at/after the grapheme width yields empty (the C `start > n` arm).
+test "string: substring_unchecked of an immediate grapheme past end" {
+    let src = "hello";
+    let g = src[3];
+    assert substring_unchecked(g, 1, 1) == "";
 }

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -377,12 +377,6 @@ extern "C"
     bool sailfin_runtime_is_whitespace_char(double ch);
     bool sailfin_runtime_is_alpha_char(double ch);
 
-    // ---- Fast string helpers (unchecked) ----
-
-    // These helpers assume the caller has already validated bounds.
-    // They exist to avoid repeatedly scanning large strings with strlen.
-    char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end);
-
     // ---- Safety ----
 
     void sailfin_runtime_bounds_check(int64_t index, int64_t length);

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2208,7 +2208,10 @@ void sailfin_runtime_debug_dump_ptr(void *ptr)
  * the project's CWD without a guaranteed prelude.o probe). */
 int64_t sailfin_runtime_string_length(char *text);
 
-char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end);
+/* #1308 (M1.A.2): bare def flipped to Sailfin (`_sfn_substring_unchecked` in
+ * runtime/sfn/string.sfn). This C copy is now `static`, serving only the two
+ * internal C callers (`sailfin_runtime_substring`, the `sfn_str_slice` C wrapper). */
+static char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end);
 
 /* #716: Immediate-codepoint pseudo-pointer guard for the `sfn_str_*`
  * trampoline family.
@@ -3311,7 +3314,7 @@ char *sailfin_runtime_substring(char *text, int64_t start, int64_t end)
     return out;
 }
 
-char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end)
+static char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end)
 {
     _runtime_enter();
     _maybe_init_alloc_stats();

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -87,13 +87,6 @@ extern fn strnlen(s: * u8, n: usize) -> usize;
 // through and discards the endptr by passing `null`.
 extern fn strtod(nptr: * u8, endptr: * * u8) -> f64;
 
-// #1372: i64-indexed substring entrypoint for `sfn_str_slice`. NOT the
-// `substring_unchecked` C wrapper — that is a registry target whose
-// `native_signature` is `sfn_str_slice`, so a Sailfin call to it re-lowers
-// to `@sfn_str_slice` (infinite self-recursion). `sailfin_runtime_*` carries
-// no registry row, so it lowers to a plain direct call.
-extern fn sailfin_runtime_substring_unchecked(text: * u8, start: i64, end: i64) -> * u8;
-
 // M2.4b (#398) + #715: the C-side allocating ops. The Sailfin
 // trampolines below preserve the `sfn_str_sfn_*` infix pattern
 // (proof-of-life presence under the Sailfin namespace) while the
@@ -349,26 +342,92 @@ fn sfn_str_eq(a: * u8, b: * u8) -> bool {
     return memcmp(ra, b, la2 as usize) == 0;
 }
 
+// `_sfn_substring_unchecked(text, start, end)` — #1308 (M1.A.2): the i64-indexed
+// substring entrypoint, now a real Sailfin body (the C
+// `sailfin_runtime_substring_unchecked` def is `static`, retaining only its two
+// internal C callers). Byte-faithful to that C body's three arms:
+//   1. NULL text → the empty string.
+//   2. Immediate-codepoint pseudo-pointer (classified by the non-allocating
+//      `sfn_str_immediate_codepoint` bridge, #714/#716): slice the codepoint's
+//      UTF-8 encoding WITHOUT dereferencing `text`. Both bounds clamp to the
+//      encoded width `n` (the C `start > n` / `end > n` arms); bytes are written
+//      via `_sfn_utf8_byte` directly, so no real buffer is materialised.
+//   3. Real pointer: truly unchecked — trust the caller's bounds (already
+//      validated via `.length`), clamping only `start >= 0` and `end >= start`,
+//      then `memcpy [start, end)`.
+// Arena-backed (the process-global arena, like `sfn_str_concat` /
+// `sfn_str_from_codepoint`) rather than the C body's `_rt_malloc` + owned-string
+// tracking: the arena reclaims on rewind, the discipline the rest of the ported
+// string surface already follows. The `roundup8(length + 1)` 8-aligned alloc +
+// `_num_put_byte` trailing NUL keeps the word read-modify-write in-bounds (the
+// seed cannot lower a single-byte `* u8` store). A non-owning `Slice` view stays
+// blocked on #1283 (an immediate pseudo-pointer has no real `text + start`).
+fn _sfn_substring_unchecked(text: * u8, start: i64, end: i64) -> * u8 {
+    if (text as i64) == 0 {
+        let empty: string = "";
+        return empty as * u8;
+    }
+
+    let cp: i64 = sfn_str_immediate_codepoint(text);
+    if cp >= 0 {
+        let n: i64 = _sfn_utf8_byte_len(cp);
+        let mut s: i64 = start;
+        if s < 0 { s = 0; }
+        let mut e: i64 = end;
+        if e < s { e = s; }
+        if s > n { s = n; }
+        if e > n { e = n; }
+        let length: i64 = e - s;
+        let cap: i64 = ((length + 1 + 7) / 8) * 8;
+        let arena: * u8 = sfn_arena_global();
+        let out: * u8 = sfn_arena_alloc(arena, cap as usize, 8 as usize);
+        if (out as i64) == 0 {
+            let empty: string = "";
+            return empty as * u8;
+        }
+        let mut i: i64 = 0;
+        loop {
+            if i >= length { break; }
+            _num_put_byte(out as i64 + i, _sfn_utf8_byte(cp, n, s + i));
+            i = i + 1;
+        }
+        _num_put_byte(out as i64 + length, 0);
+        return out;
+    }
+
+    let mut rs: i64 = start;
+    if rs < 0 { rs = 0; }
+    let mut re: i64 = end;
+    if re < rs { re = rs; }
+    let length2: i64 = re - rs;
+    let cap2: i64 = ((length2 + 1 + 7) / 8) * 8;
+    let arena2: * u8 = sfn_arena_global();
+    let out2: * u8 = sfn_arena_alloc(arena2, cap2 as usize, 8 as usize);
+    if (out2 as i64) == 0 {
+        let empty: string = "";
+        return empty as * u8;
+    }
+    if length2 > 0 {
+        memcpy(out2, (text as i64 + rs) as * u8, length2 as usize);
+    }
+    _num_put_byte(out2 as i64 + length2, 0);
+    return out2;
+}
+
 // `sfn_str_slice(text, start, end)` — #1372: the real Sailfin body for the
 // `substring` / `string.slice` emission target (the C `sfn_str_slice` def is
 // now `static`). Keeps the ALLOCATING shape: clamps the `f64` indices to i64
-// and calls the i64 substring entrypoint `sailfin_runtime_substring_unchecked`,
-// which materialises a real, decode-safe buffer. It does NOT call the
-// `substring_unchecked` C wrapper (a registry target whose `native_signature`
-// is `sfn_str_slice` → infinite self-recursion). The `f64 -> i64` clamp is
-// inlined: NaN maps to 0 (`v != v`), in-range doubles truncate toward zero;
-// substring indices are small, so the C `_clamp_to_i64` INT64 saturation arms
-// are unnecessary. This requires the f64-parameter codegen fix
-// (`core_type_mapping.sfn`, this PR) to be present in the building seed —
-// hence the seed bump to 0.7.0-alpha.37. A non-owning `Slice` view stays
-// blocked on #1283 (an immediate-codepoint pseudo-pointer has no real
-// `text + start` address).
+// and calls the Sailfin i64 substring entrypoint `_sfn_substring_unchecked`
+// (#1308 M1.A.2), which materialises a real, decode-safe buffer. The `f64 -> i64`
+// clamp is inlined: NaN maps to 0 (`v != v`), in-range doubles truncate toward
+// zero; substring indices are small, so the C `_clamp_to_i64` INT64 saturation
+// arms are unnecessary.
 fn sfn_str_slice(text: * u8, start: f64, end: f64) -> * u8 {
     let mut si: i64 = 0;
     if start == start { si = start as i64; }
     let mut ei: i64 = 0;
     if end == end { ei = end as i64; }
-    return sailfin_runtime_substring_unchecked(text, si, ei);
+    return _sfn_substring_unchecked(text, si, ei);
 }
 
 // `sfn_str_sfn_to_cstr(s)` — NUL-terminated C string view of `s`.


### PR DESCRIPTION
## Summary

The first wedge of the **string keystone (M1.A.2)** leg of epic #1308 (retire the C runtime). Ports `sailfin_runtime_substring_unchecked` to a native Sailfin body, retiring the bare C symbol from the link surface. **Residual 10 → 9.**

An architect scoping pass established the key finding: the `(cp<<32)` immediate-codepoint encoding is produced **only by the C runtime** (`grapheme_at`/`grapheme_byte`), never by the compiler's emitted IR — it's a producer→consumer contract internal to the runtime. That makes `substring_unchecked` independently flippable now (it must still *decode* immediates, but never produces them), while the encoding-elimination teardown (#1283) and `string_concat` (7 internal callers) stay sequenced behind it.

## Changes

**Sailfin** (`runtime/sfn/string.sfn`)
- New `_sfn_substring_unchecked(text, start, end)` — byte-faithful to the C body's three arms:
  - NULL text → the empty string
  - immediate-codepoint pseudo-pointer (classified via the non-allocating `sfn_str_immediate_codepoint` bridge) → slice the codepoint's UTF-8 encoding **without dereferencing** the tagged pointer (#714/#716 class)
  - real pointer → truly unchecked `memcpy [start, end)`
- Arena-backed (process-global arena, like `sfn_str_concat`/`sfn_str_from_codepoint`) rather than the C body's `_rt_malloc` + owned-string tracking; `roundup8(len+1)` 8-aligned alloc keeps the `_num_put_byte` trailing NUL in-bounds under the seed.
- `sfn_str_slice` now calls the Sailfin body; removed the `sailfin_runtime_substring_unchecked` extern.

**C side**
- `static`-ified the def + forward decl (`sailfin_runtime.c`); dropped the header prototype (`sailfin_runtime.h`). The two internal C callers (`sailfin_runtime_substring`, the C `sfn_str_slice` wrapper) bind to the static copy, which `-O2` inlines away — the global is fully eliminated.

**No seed cut** — `sfn_str_slice`'s emission target is unchanged; only what it calls underneath flips.

## Verification
- `make rebuild`: self-host passes (exit 0).
- **Residual gate**: no Sailfin object demands the bare symbol; the C global is gone from the fresh `sailfin_runtime.c-O2.o` link surface. **Residual 10 → 9.**
- `substring_unchecked_test.sfn`: expanded 2 → 9 cases incl. the crash-sensitive immediate-codepoint path (a wrong deref would segfault the suite on Linux); all green.
- Adjacent string suites (concat / concat-immediate / append / stress / utils / building): green.
- `sfn fmt --check` clean on both touched `.sfn` files.

Part of epic #1308.

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_