### PR TITLE
refactor(runtime): flip sfn_str_to_cstr to Sailfin — residual 7→6 (#1308)

### DIFF
--- a/compiler/tests/e2e/test_runtime_string_basic.sh
+++ b/compiler/tests/e2e/test_runtime_string_basic.sh
@@ -115,12 +115,14 @@ test_no_bare_sfn_str_define() {
         echo "[test]   $ll missing — test_emit_define_shape must run first"
         return 1
     fi
-    # #1372: `sfn_str_{len,eq,slice}` retired from this list — they are now
-    # real bare Sailfin bodies (the C defs are `static`), so a bare `define`
-    # is expected, not a collision. Only the still-C `to_cstr` / `from_cstr`
-    # trampolines remain.
+    # #1372: `sfn_str_{len,eq,slice}` retired from this list (real bare Sailfin
+    # bodies). #1308: `sfn_str_to_cstr` flipped to a bare Sailfin identity body
+    # (so a bare `define` is now expected, asserted by the export test below) and
+    # `sfn_str_from_cstr` was deleted (dead). The still-C bridges string.sfn must
+    # NOT bare-define are `read_byte` / `grapheme_byte` (sub-word load the seed
+    # can't lower; called as externs → `declare`, not `define`). Retire at #822.
     local found=0
-    for sym in sfn_str_to_cstr sfn_str_from_cstr; do
+    for sym in sfn_str_read_byte sfn_str_grapheme_byte; do
         if grep -qE "^define .* @${sym}\(" "$ll"; then
             echo "[test]   collision risk: string.sfn emits 'define ... @${sym}(', conflicts with C trampoline"
             found=$((found + 1))
@@ -194,10 +196,12 @@ test_compiler_binary_exports_sfn_str() {
     fi
     local missing=0
     # Bare `sfn_str_{len,eq,slice}` are now Sailfin-defined (#1372); the C
-    # namesakes are `static`. `sfn_str_{to_cstr,from_cstr}` stay C-owned bare
-    # with Sailfin `sfn_str_sfn_{to_cstr,from_cstr}` infix proof-of-life. The
-    # `sfn_str_sfn_{len,eq,slice}` infix exports retired with the #1372 flip.
-    for sym in sfn_str_len sfn_str_eq sfn_str_slice sfn_str_to_cstr sfn_str_from_cstr sfn_str_sfn_to_cstr sfn_str_sfn_from_cstr; do
+    # namesakes are `static`. #1308: `sfn_str_to_cstr` is now Sailfin-defined
+    # too (bare identity body); `sfn_str_from_cstr` was deleted (dead, no caller)
+    # so it is dropped here. The Sailfin `sfn_str_sfn_{to_cstr,from_cstr}` infix
+    # proof-of-life bodies stay. The `sfn_str_sfn_{len,eq,slice}` infix exports
+    # retired with the #1372 flip.
+    for sym in sfn_str_len sfn_str_eq sfn_str_slice sfn_str_to_cstr sfn_str_sfn_to_cstr sfn_str_sfn_from_cstr; do
         # Require a defined text symbol (` T ` / ` t `). The optional
         # `_` prefix accommodates macOS Mach-O while staying tight
         # against substring collisions. A here-string avoids the

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2244,32 +2244,9 @@ static const char *_sfn_str_decode_immediate(const char *s, unsigned char scratc
     return s;
 }
 
-/* #716: Owning variant for the identity ABI bridges (`sfn_str_to_cstr` /
- * `sfn_str_from_cstr`) whose result outlives the call, so a stack
- * scratch buffer cannot back it. Materializes an immediate codepoint
- * into a tracked `_rt_malloc` buffer; genuine pointers pass through
- * untouched (preserving the identity-bridge contract for real strings).
- * On allocation failure it returns the original operand — no worse than
- * today's behaviour, and OOM is already fatal elsewhere. */
-static const char *_sfn_str_decode_immediate_owned(const char *s)
-{
-    uint32_t cp = 0;
-    if (!_is_immediate_codepoint_string(s, &cp))
-    {
-        return s;
-    }
-    unsigned char buf[5];
-    size_t n = _utf8_encode(cp, buf);
-    char *out = (char *)_rt_malloc(n + 1);
-    if (!out)
-    {
-        return s;
-    }
-    memcpy(out, buf, n);
-    out[n] = '\0';
-    _track_owned_string(out);
-    return (const char *)out;
-}
+/* #1308: `_sfn_str_decode_immediate_owned` (the owning immediate-decode helper
+ * for `sfn_str_to_cstr`/`from_cstr`) is deleted — both bridges flipped to
+ * trivial Sailfin identity bodies, leaving it without a caller. */
 
 /* #1372 (C5 of epic #1308): the canonical `sfn_str_len` emission target
  * is now a real Sailfin body in `runtime/sfn/string.sfn` (decode + bounded
@@ -2346,15 +2323,10 @@ static char *sfn_str_slice(const char *text, double start, double end)
  * materializes such inputs into a real, tracked NUL-terminated
  * buffer so the returned pointer is always dereferenceable; genuine
  * pointers are still returned unchanged. */
-const char *sfn_str_to_cstr(const char *s)
-{
-    return _sfn_str_decode_immediate_owned(s);
-}
-
-const char *sfn_str_from_cstr(const char *s)
-{
-    return _sfn_str_decode_immediate_owned(s);
-}
+/* #1308: sfn_str_to_cstr flipped to a trivial identity Sailfin body
+ * (runtime/sfn/string.sfn) — post immediate-encoding teardown every string is a
+ * real NUL-terminated buffer, so the decode is a no-op. sfn_str_from_cstr had
+ * no callers (no emission row, no runtime caller) and is deleted with it. */
 
 /* M2.5 (#403): wave-2 trampolines for the canonical sfn_str_* / sfn_*_to_str
  * names. Mirror the M2.4a wave-1 pattern: the compiler's runtime_helpers.sfn

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -450,6 +450,14 @@ fn sfn_str_slice(text: * u8, start: f64, end: f64) -> * u8 {
 // must be threaded for the copy.
 fn sfn_str_sfn_to_cstr(s: * u8) -> * u8 { return s; }
 
+// `sfn_str_to_cstr(s)` — #1308: the bare runtime-FFI entrypoint `process.sfn`
+// calls to materialize a NUL-terminated C string for `execve`/`posix_spawn`
+// (the C def is deleted). Post immediate-encoding teardown (#1420/#1421) every
+// `* u8` is already a real NUL-terminated buffer, so this is the identity (the
+// old C body's `_sfn_str_decode_immediate_owned` is now a no-op decode). No
+// registry emission row — it is runtime-to-runtime FFI, resolved at link.
+fn sfn_str_to_cstr(s: * u8) -> * u8 { return s; }
+
 // `sfn_str_sfn_from_cstr(s)` — adopt a NUL-terminated C buffer as
 // an SfnString. The architect spec scans for the NUL terminator
 // with `memchr` to recover the byte length and constructs the


### PR DESCRIPTION
## Summary

The last clean string flip in the immediate-encoding teardown. **Residual 7 → 6.**

With the encoding gone (#1420/#1421), `sfn_str_to_cstr` — the bare runtime-FFI entrypoint `process.sfn` calls to materialize a NUL-terminated C string for `execve`/`posix_spawn` — is now a pure **identity** (every `* u8` is already a real NUL-terminated buffer; the old `_sfn_str_decode_immediate_owned` decode is a no-op). So it flips to a trivial Sailfin body and drops out of the residual.

## Changes
- `runtime/sfn/string.sfn`: add bare `fn sfn_str_to_cstr(s) -> s` (identity). `process.sfn`'s existing extern resolves to it at link (runtime-to-runtime FFI; **no registry emission row**).
- `runtime/native/src/sailfin_runtime.c`: delete the C `sfn_str_to_cstr` def (no C-internal callers), the dead `sfn_str_from_cstr` def (no caller, no emission row), and the now-orphaned `_sfn_str_decode_immediate_owned` helper they shared.
- `compiler/tests/e2e/test_runtime_string_basic.sh`: update two stale assertions — repoint the must-NOT-define collision guard at the surviving C bridges (`read_byte`/`grapheme_byte`), and drop deleted `from_cstr` from the binary-export check (`to_cstr` stays, now Sailfin-defined).

`read_byte` / `grapheme_byte` remain C (sub-word load the seed can't lower) and retire with the SfnString flip at #822.

## Verification
- `make rebuild` (seed 0.7.0-alpha.39): self-host passes.
- **Residual gate**: `sfn_str_to_cstr` gone from the C source/object, now defined in `string.o`. **Residual 7 → 6.**
- `process_environ` + string utils/concat/parity/substring suites: green.
- `test_runtime_string_basic.sh` (8/8) + `test_runtime_string_utf8_numeric.sh` (9/9): green.
- `sfn fmt --check` clean.

Part of epic #1308.

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_