### PR TITLE
refactor(runtime): flip the legacy serve no-op stub to Sailfin (#1308)

### DIFF
--- a/compiler/tests/e2e/test_cross_windows_runtime_modules.sh
+++ b/compiler/tests/e2e/test_cross_windows_runtime_modules.sh
@@ -128,6 +128,26 @@ if grep -q 'define i32 @apply_default_mem_limit' "$REPO_ROOT/runtime/native/ir/w
 else
     fail "missing @apply_default_mem_limit stub in windows_stubs.ll — Windows link would break"
 fi
+# serve.sfn (concurrency/) is excluded from RUNTIME_MODS like the rest
+# of concurrency/, but #1308 moved the legacy `sailfin_runtime_serve`
+# no-op off the C runtime and into serve.sfn, so `prelude.o`'s
+# reference needs the strong Windows stub. (The real typed-serve server
+# `sfn_serve` is unaffected — it is never linked into cross-windows.)
+if echo "$sfn_vals" | norm | grep -q '^runtime/sfn/concurrency/serve\.sfn$'; then
+    ok "serve.sfn present in manifest sfn-sources (exclusion is meaningful)"
+else
+    fail "serve.sfn no longer in manifest — revisit the cross-windows serve stub"
+fi
+if echo "$actual" | grep -q '^runtime/sfn/concurrency/serve\.sfn$'; then
+    fail "serve.sfn is in RUNTIME_MODS — pulls socket/scheduler externs mingw cannot resolve"
+else
+    ok "serve.sfn excluded from cross-windows RUNTIME_MODS"
+fi
+if grep -q 'define void @sailfin_runtime_serve' "$REPO_ROOT/runtime/native/ir/windows_stubs.ll"; then
+    ok "strong @sailfin_runtime_serve stub present in windows_stubs.ll"
+else
+    fail "missing @sailfin_runtime_serve stub in windows_stubs.ll — Windows link would break (#1308)"
+fi
 ll_line="$(grep -E '^ll-sources[[:space:]]*=' "$MANIFEST" | head -n1 || true)"
 if echo "$ll_line" | grep -q 'windows_stubs'; then
     fail "windows_stubs.ll is in ll-sources — would duplicate @apply_default_mem_limit on Linux/macOS"

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2295,7 +2295,7 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 | `sailfin_runtime_spawn_*` | `sfn_spawn` | M4 |
 | `sailfin_runtime_await_*` | `sfn_await` | M4 |
 | `sailfin_runtime_channel` | `sfn_channel_create` | M4 |
-| `sailfin_runtime_serve` | `sfn_serve` | M4 |
+| `sailfin_runtime_serve` | Sailfin no-op in `serve.sfn` (distinct from `sfn_serve`) | M4 — **✓ #1308**: the typed `serve(handler, port)` syntax already lowers to the real `sfn_serve` server (#1092). This row is the *legacy untyped* `serve(handler, config?)` prelude target (`runtime_serve_fn`, declared unconditionally), which was always a no-op C stub. Flipped to a Sailfin no-op `fn sailfin_runtime_serve` so no emitted module demands a C symbol; C body + header proto deleted. Retiring the dead prelude `serve()` fallback itself is a separate API cleanup. |
 | `sailfin_runtime_is_string/number/boolean/array/callable`, `instance_of`, `resolve_type` | `sfn_is_*` / `sfn_instance_of` / `sfn_resolve_type` | M2 — ✓ #911 |
 | `sailfin_runtime_sha256_hex` | `sfn/crypto` capsule | M3 |
 | `sailfin_runtime_base64_encode` | `sfn/crypto` capsule | M3 |

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -317,7 +317,6 @@ extern "C"
     char *sailfin_runtime_channel(double capacity);
     char *sailfin_runtime_parallel(char *thunk);
     void sailfin_runtime_spawn(char *thunk, char *name);
-    void sailfin_runtime_serve(char *handler, char *config);
 
     // ---- Futures (native runtime) ----
 

--- a/runtime/native/ir/windows_stubs.ll
+++ b/runtime/native/ir/windows_stubs.ll
@@ -28,3 +28,18 @@
 define i32 @apply_default_mem_limit() {
   ret i32 0
 }
+
+; Legacy untyped `serve(handler, config?)` prelude target
+; (`runtime/sfn/concurrency/serve.sfn`, excluded from RUNTIME_MODS —
+; serve.sfn pulls BSD-socket + scheduler externs that cannot resolve
+; in a static mingw link; the process.sfn/rlimit.sfn exclusion
+; precedent). #1308 flipped this symbol from a no-op C body to a
+; Sailfin no-op in serve.sfn; since that module is not in the Windows
+; runtime set, `prelude.o`'s reference needs this stub. A no-op is the
+; byte-identical Windows behavior (the C body was also a no-op); the
+; real typed `serve(handler, port)` server (`sfn_serve`) is unaffected.
+; Sync pinned by
+; compiler/tests/e2e/test_cross_windows_runtime_modules.sh.
+define void @sailfin_runtime_serve(i8* %handler, i8* %config) {
+  ret void
+}

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -5397,12 +5397,6 @@ void *sailfin_runtime_await_ptr(struct SailfinFuturePtr *future)
     return result;
 }
 
-void sailfin_runtime_serve(char *handler, char *config)
-{
-    (void)handler;
-    (void)config;
-}
-
 char *sailfin_runtime_array_map(char *array, char *fn)
 {
     (void)fn;

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -633,3 +633,14 @@ fn sfn_serve_framed(handler: * u8, port: i32) -> void ![net, io] {
 
     close(listen_fd);
 }
+
+// `sailfin_runtime_serve(handler, config)` — #1308: the legacy untyped
+// `serve(handler, config?)` prelude builtin lowers to this 2-arg symbol
+// (registry row `runtime_serve_fn`, declared unconditionally by
+// `lowering_helpers.sfn`). It has always been a pure no-op — the real
+// HTTP server is the typed `serve(handler, port)` syntax form, which the
+// bespoke `Serve`-node lowering routes directly to `sfn_serve` above. This
+// Sailfin no-op replaces the deleted C stub so no emitted module demands a
+// C symbol; behaviour is byte-identical (no-op -> no-op). Retiring the dead
+// prelude `serve()` fallback itself is a separate API cleanup.
+fn sailfin_runtime_serve(handler: * u8, config: * u8) -> void { }


### PR DESCRIPTION
## What

Retires the C symbol `sailfin_runtime_serve` from the relink residual (epic #1308, C-runtime retirement). **Relink residual 6 → 5.**

## Why this is a clean flip

There are two distinct `serve` surfaces:

- **Typed `serve(handler, port)` syntax** → parsed to a `Serve` AST node → bespoke lowering in `expression_lowering/native/core.sfn` → emits `@sfn_serve` directly (the real HTTP/1.1 server, already flipped in #1092).
- **Untyped `serve(handler, config?)` prelude builtin** → `runtime_serve_fn` registry row (declared *unconditionally* by `lowering_helpers.sfn`) → bare symbol `sailfin_runtime_serve`, which in C was a **pure no-op stub** (`(void)handler; (void)config;`).

This PR finishes what serve.sfn's own header already advertises ("Replaces the no-op C stub `sailfin_runtime_serve`"): the legacy no-op now lives in Sailfin.

## Change (Mechanism-1 link-ownership flip)

- `runtime/sfn/concurrency/serve.sfn`: add `fn sailfin_runtime_serve(handler, config) -> void {}` (Sailfin no-op).
- `runtime/native/src/sailfin_runtime.c`: delete the C body (no internal callers).
- `runtime/native/include/sailfin_runtime.h`: drop the prototype.
- `docs/runtime_architecture.md`: correct the migration-table row (it conflated the typed-`serve`→`sfn_serve` path with this untyped no-op).

Behaviour is byte-identical (no-op → no-op). Retiring the dead prelude `serve()` fallback itself is a separate API cleanup.

## Verification

- `make rebuild` — self-host **passes** (C-runtime change → forced rebuild).
- `test_runtime_serve.sh` — 5/5 (incl. live HTTP loopback round-trip).
- `serve_loopback_test.sfn` — pass; `http_capsule_serve_gate_test.sfn` — pass (initial failure was the documented `program.ll` build-and-run cross-contamination from co-running two fixture-building tests, not a regression).
- Residual gate: C no longer defines `sailfin_runtime_serve`; the symbol is now `T`-defined in a Sailfin object with no C object demanded.

Part of #1308.

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_