### PR TITLE
refactor(runtime): flip mark_persistent to a Sailfin no-op (#1308)

### DIFF
--- a/compiler/tests/e2e/test_runtime_memory_mem.sh
+++ b/compiler/tests/e2e/test_runtime_memory_mem.sh
@@ -202,17 +202,14 @@ void *sfn_arena_alloc(void *arena, size_t size, size_t align) {
     return calloc(1, size);
 }
 
-/* Runtime hook the seed compiler installs in emitted IR that the harness
- * must satisfy at link time but does not exercise:
- *   - `sailfin_runtime_mark_persistent` — persistent-pointer bookkeeping
- *     the seed emits on every heap return (the get_field malloc'd
- *     buffer). No-op stub.
- * The boxed-struct allocator the seed previously emitted for the
- * bounds_check abort-diagnostic string literal
- * (`sailfin_runtime_alloc_struct`) is, as of #930, the module-defined
- * `sfn_alloc_struct` above — it is no longer an external the harness
- * provides. */
-void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+/* Runtime hooks the seed compiler installs in emitted IR that the harness
+ * must satisfy at link time: the boxed-struct allocator
+ * (`sailfin_runtime_alloc_struct`, as of #930) and the persistent-pointer
+ * marker (`sailfin_runtime_mark_persistent`, as of #1308) are now BOTH
+ * module-defined by mem.sfn (`sfn_alloc_struct` above; the bare no-op
+ * `sailfin_runtime_mark_persistent` linked from mem.o) — the harness no
+ * longer stubs either, and stubbing mark_persistent now collides with the
+ * module definition at link. */
 
 extern char *sfn_mem_get_field(char *base, char *field);
 extern void  sfn_mem_copy_bytes(char *dest, char *src, int64_t length);

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -8,6 +8,23 @@
 > **Status delta since 2026-04-15** (keep this list short; once an item is
 > fully shipped fold it into the body and remove the bullet here):
 >
+> - **Arena-cluster flips (2026-06-19, #1425 + mark_persistent, epic #1308).**
+>   (#1425 — serve): the legacy untyped `serve(handler, config?)` prelude
+>   target `sailfin_runtime_serve` (always a no-op C stub; distinct from the
+>   typed `serve` → `sfn_serve` server) is now a Sailfin no-op in
+>   `runtime/sfn/concurrency/serve.sfn`; C body + header proto deleted. Needed
+>   a `windows_stubs.ll` strong stub (serve.sfn is excluded from the
+>   cross-windows `RUNTIME_MODS`). (mark_persistent): per the design-gate
+>   decision to **retire the non-arena allocator path** (arena is the sole
+>   supported allocator — `runtime_architecture.md:1927`), the caller-side
+>   `sailfin_runtime_mark_persistent` (emitted at every `sfn_alloc_struct`) is
+>   now a Sailfin no-op in `runtime/sfn/memory/mem.sfn`; the C body is
+>   file-`static` (its one internal caller, the dead non-arena
+>   `sailfin_runtime_string_drop`, retires with the C file at #822). No
+>   registry change — emission is byte-identical. **Relink residual 6 → 4.**
+>   Residual-4: `sfn_str_read_byte` + `sfn_str_grapheme_byte` (sub-word load,
+>   #822), `sailfin_runtime_string_concat` (ABI-hard, 8 callers),
+>   `sfn_default_arena` (needs a defining-global frontend primitive).
 > - **Immediate-codepoint encoding teardown (2026-06-19, #1420/#1421/#1422,
 >   epic #1308).** Three PRs retired the `(byte << 32)` immediate-codepoint
 >   pseudo-pointer encoding end-to-end.

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -60,7 +60,9 @@ extern "C"
 
     // ---- Core helpers (minimal set) ----
 
-    void sailfin_runtime_mark_persistent(char *ptr);
+    // (#1308) sailfin_runtime_mark_persistent is now Sailfin-defined
+    // (runtime/sfn/memory/mem.sfn); the C copy is file-static, so no
+    // prototype is exported here.
 
     void sailfin_runtime_print_raw(char *msg);
     void sailfin_runtime_print_err(char *msg);

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -1641,7 +1641,13 @@ static SAILFIN_NOINLINE bool _asan_poisoned(const void *addr)
 }
 #endif
 
-void sailfin_runtime_mark_persistent(char *ptr)
+/* #1308: the bare `sailfin_runtime_mark_persistent` is now Sailfin-defined
+ * (a no-op in runtime/sfn/memory/mem.sfn — the arena makes persistent
+ * tracking unnecessary). This C copy is `static` so the only remaining
+ * internal caller (the legacy non-arena `sailfin_runtime_string_drop`) keeps
+ * a private definition; emitted code binds to the Sailfin symbol. Retires
+ * wholesale with the non-arena path at #822. */
+static void sailfin_runtime_mark_persistent(char *ptr)
 {
     if (!ptr)
     {

--- a/runtime/sfn/memory/mem.sfn
+++ b/runtime/sfn/memory/mem.sfn
@@ -193,6 +193,18 @@ fn sfn_mem_free(ptr: * u8) -> void {
     unsafe { free(ptr); }
 }
 
+// `sailfin_runtime_mark_persistent(ptr)` — #1308: the caller-side
+// persistent-pointer marker the emitter pairs with every `sfn_alloc_struct`
+// (struct/string heap allocations; pinned by runtime_call_dispatch_test).
+// Under the arena — the shipped default and now the sole supported allocator
+// (non-arena retired per the #1308 design gate) — the arena owns bulk
+// deallocation, so persistent tracking is unnecessary: a no-op, exactly what
+// the C body did when `sfn_arena_enabled()`. The legacy non-arena
+// `_sailfin_persistent_table` insert + the dead `sailfin_runtime_string_drop`
+// reader retire with the C runtime (#822). No registry change — emission still
+// targets the bare `sailfin_runtime_mark_persistent`.
+fn sailfin_runtime_mark_persistent(ptr: * u8) -> void { }
+
 // #1405 Bug 1: OOM-handler re-entrancy guard for `sfn_alloc_struct`.
 // The OOM diagnostic below materialises a `string` / `* u8` literal,
 // which lowers to its own `sfn_alloc_struct` call (verified in disasm:


### PR DESCRIPTION
## What

Flips `sailfin_runtime_mark_persistent` off the C runtime — the first cut of the **arena-cluster retirement** (epic #1308). **Relink residual 5 → 4.**

## Design decision (approved at the design gate)

A compiler-architect pass established that `mark_persistent`, `string_drop`, and the persistent/owned tables are live **only** in the `SAILFIN_USE_ARENA=0` non-arena allocator path — a no-op under the shipped arena default. The architecture docs already declare this path dead:
- `runtime_architecture.md:1927` — *"Remove the owned-string hash table and persistent-pointer set when arena mode is active."*
- `runtime_audit.md:815` — removing the *"owned/persistent tables, canaries, ASAN-safe strlen"* scaffolding is a listed end-state item.

**Decision: retire the non-arena path** (the `SAILFIN_USE_ARENA=0` rollback lever goes away). This PR is the first, lowest-risk step.

## Change

`sailfin_runtime_mark_persistent` is emitted at every `sfn_alloc_struct` site (struct/string heap returns) and early-returns a no-op whenever `sfn_arena_enabled()` — i.e. always, under the default.

- **`runtime/sfn/memory/mem.sfn`** — define it as a Sailfin no-op (bare symbol). mem.sfn is in both `sfn-sources` and the cross-windows `RUNTIME_MODS`, so **no `windows_stubs.ll` entry needed** (unlike the serve flip).
- **`runtime/native/src/sailfin_runtime.c`** — make the C body file-`static` (not deleted): its sole internal caller is the dead non-arena `sailfin_runtime_string_drop`, which retires with the C file at #822.
- **`runtime/native/include/sailfin_runtime.h`** — drop the prototype (collides with the static def).
- **No registry change** — emission stays byte-identical (pinned by `runtime_call_dispatch_test`).
- **`test_runtime_memory_mem.sh`** — drop the now-redundant harness stub (it links `mem.o`, which now owns the symbol → was a duplicate definition; mirrors the #930 `alloc_struct` precedent in that same harness).

## Deferred (separate follow-up)

Deleting `string_drop` + the persistent/owned-table machinery is **pure C dead-code cleanup that drops zero residual symbols** (string_drop isn't compiler-emitted; the tables are file-static). It also entangles a *second* structure (the owned-string table) the architect's plan under-scoped, so it's deferred to a focused cleanup / the #822 sweep rather than bundled here.

## Verification

- `make rebuild` — self-host **passes**.
- Emission byte-identical: `runtime_call_dispatch_test` 6/6.
- `mem.o` is the sole external `T` definition; C copy file-static → no duplicate symbol at link.
- e2e green: `test_runtime_memory_mem` (after stub fix), `_arena`, `_arena_mark`, `_rc`, `owned_buf_roundtrip`, `escape_promotion_boundaries`, `string_allocating`.

Part of #1308.

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_