### PR TITLE
feat(compiler): add load_byte builtin for sound single-byte loads (#1308)

### DIFF
--- a/compiler/src/llvm/byte_load.sfn
+++ b/compiler/src/llvm/byte_load.sfn
@@ -1,0 +1,147 @@
+// compiler/src/llvm/byte_load.sfn
+//
+// The `load_byte` builtin and its LLVM lowering. `load_byte(addr: int)
+// -> int` reads a single byte from the raw address `addr` and
+// zero-extends it to `int` (i64). Like the atomic builtins (see
+// `atomics.sfn`), the reserved name bypasses normal call resolution
+// and lowers directly to LLVM instructions rather than a runtime-helper
+// call:
+//
+//   load_byte(addr: int) -> int  →
+//     %p = inttoptr i64 <addr> to i8*
+//     %b = load i8, i8* %p, align 1
+//     %r = zext i8 %b to i64
+//
+// Why this exists (#1308 — C→Sailfin runtime migration): the seed's
+// only single-byte read was `_owned_buf_load_byte` (ownedbuf.sfn),
+// which loads the *enclosing 8-aligned i64 word* via `atomic_load` and
+// shift/masks the byte out. That word-load over-reads up to 7 bytes
+// past the index, so it is only sound on the 8-aligned/padded buffers
+// `owned_buf_new` produces. `sfn_str_read_byte` / `sfn_str_grapheme_byte`
+// read arbitrary `* u8` backing buffers (getenv results, string
+// literals, foreign buffers) with no padding guarantee, which is why
+// they stayed C bridges. `load_byte` is the true single-byte load
+// (`load i8` + `zext`) that is sound at any address and any alignment,
+// retiring both bridges. Address-based (not pointer-typed) to match the
+// existing runtime byte idiom (`_owned_buf_load_byte(addr: i64)`,
+// `_num_put_byte(addr: i64, ...)`), which deliberately passes i64
+// addresses to avoid `* u8` pointer-type friction under the seed.
+//
+// `zext` (not `sext`): the byte is unsigned (0..255), matching the C
+// `(int64_t)(unsigned char)s[idx]`. A `sext` would make bytes >= 0x80
+// negative and corrupt every UTF-8 comparison on the self-host path.
+import {
+    LLVMOperand,
+    TypeContext,
+    LocalBinding,
+    StringConstant,
+    ExpressionResult,
+    ParameterBinding
+} from "./types";
+import { trim_text, number_to_string, extend_string_array } from "./utils";
+import { merge_string_constants } from "./strings";
+import { NativeFunction } from "../native_ir";
+import { format_temp_name } from "./expressions_helpers";
+// Mutually recursive with `lower_expression` (which dispatches calls
+// back through the byte-load hook): the same cycle the atomic builtins
+// rely on — see `atomics.sfn`.
+import { lower_expression } from "./expression_lowering/native/core";
+
+// Predicate over the reserved `load_byte` name. Used by the
+// pre-resolution dispatch hook in `lower_call_expression` (see
+// `core_call_resolution.sfn`) to short-circuit before consulting the
+// runtime-helper registry.
+fn is_byte_load_builtin(name: string) -> boolean {
+    let trimmed = trim_text(name);
+    if trimmed == "load_byte" { return true; }
+    return false;
+}
+
+// Lower a `load_byte(addr)` call. Caller has already validated that
+// `is_byte_load_builtin(name)` is true. Lowers the address argument
+// through `lower_expression` (as `i64`), then emits the inttoptr +
+// single-byte load + zext triple. Returns an `ExpressionResult` whose
+// `operand` is the zero-extended i64 byte value.
+fn lower_byte_load(name: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
+    let mut diagnostics: string[] = [];
+    let mut current_lines = lines;
+    let mut current_temp = temp_index;
+    let mut collected_strings: StringConstant[] = [];
+
+    if arguments.length != 1 {
+        // `[fatal]` sentinel so the emit-level entrypoints
+        // (`compile_native_text_to_llvm_file`, `write_llvm_ir`) refuse
+        // to write IR rather than silently dropping the load — mirrors
+        // the atomic-builtin arity gate (issue #306 contract).
+        let diag1 = "llvm lowering [fatal] [E0806]: load_byte expects exactly 1 argument (`int` address), got "
+            + number_to_string(arguments.length);
+        print.err(diag1);
+        diagnostics.push(diag1);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let addr_text = trim_text(arguments[0]);
+    let addr_lowered = lower_expression(addr_text, bindings, locals, current_temp, current_lines, functions, context, "i64");
+    diagnostics = extend_string_array(diagnostics, addr_lowered.diagnostics);
+    collected_strings = merge_string_constants(collected_strings, addr_lowered.string_constants);
+    current_lines = addr_lowered.lines;
+    current_temp = addr_lowered.temp_index;
+
+    if addr_lowered.operand == null {
+        diagnostics.push("llvm lowering: load_byte failed to lower address argument");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let addr_operand = addr_lowered.operand;
+    let addr_type = trim_text(addr_operand.llvm_type);
+    if addr_type != "i64" {
+        let diag2 = "llvm lowering [fatal] [E0806]: load_byte expects argument 0 of type `int` (i64), got `"
+            + addr_type
+            + "`";
+        print.err(diag2);
+        diagnostics.push(diag2);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let ptr_name = format_temp_name(current_temp);
+    current_temp += 1;
+    let byte_name = format_temp_name(current_temp);
+    current_temp += 1;
+    let result_name = format_temp_name(current_temp);
+    current_temp += 1;
+
+    current_lines.push("  " + ptr_name + " = inttoptr i64 " + addr_operand.value
+        + " to i8*");
+    current_lines.push("  " + byte_name + " = load i8, i8* " + ptr_name
+        + ", align 1");
+    current_lines.push("  " + result_name + " = zext i8 " + byte_name
+        + " to i64");
+
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: LLVMOperand { llvm_type: "i64", value: result_name },
+        diagnostics: diagnostics,
+        string_constants: collected_strings
+    };
+}
+
+export { is_byte_load_builtin, lower_byte_load };

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -35,7 +35,8 @@ import {
     resolve_call_signature,
     resolve_call_method_target,
     try_dispatch_atomic_builtin,
-    _parse_fn_pointer_annotation
+    _parse_fn_pointer_annotation,
+    try_dispatch_byte_load_builtin
 } from "./core_call_resolution";
 import { lower_enum_literal } from "./core_literals_lowering";
 import { format_temp_name, format_typed_operand } from "../../expressions_helpers";
@@ -236,6 +237,13 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     // entire call pipeline.
     let atomic_dispatch = try_dispatch_atomic_builtin(trimmed_target, arguments, bindings, locals, temp_index, lines, functions, context);
     if atomic_dispatch != null { return atomic_dispatch; }
+
+    // Pre-resolution dispatch for the `load_byte` builtin (#1308). Like
+    // the atomics, it lowers to inline LLVM (inttoptr + `load i8` +
+    // `zext`) rather than a function call, so it short-circuits the rest
+    // of the call pipeline.
+    let byte_load_dispatch = try_dispatch_byte_load_builtin(trimmed_target, arguments, bindings, locals, temp_index, lines, functions, context);
+    if byte_load_dispatch != null { return byte_load_dispatch; }
 
     // Plain C-ABI function-pointer dispatch (#1089). A call whose target is
     // a local/parameter typed `* fn (A) -> R` is an env-less indirect call

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -29,6 +29,7 @@ import { is_atomic_builtin, lower_atomic_builtin } from "../../atomics";
 import { merge_string_constants, empty_string_constant_set } from "../../strings";
 import { find_local_binding, find_parameter_binding } from "./core_scopes";
 import { collect_parameter_types } from "./core_helpers";
+import { lower_byte_load, is_byte_load_builtin } from "../../byte_load";
 import { load_local_operand } from "./core_operands";
 import { NativeFunction } from "../../../native_ir";
 import { ends_with_pointer_suffix } from "../../type_mapping";
@@ -67,6 +68,19 @@ import {
 fn try_dispatch_atomic_builtin(trimmed_target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? ![io] {
     if !is_atomic_builtin(trimmed_target) { return null; }
     return lower_atomic_builtin(trimmed_target, arguments, bindings, locals, temp_index, lines, functions, context);
+}
+
+// Pre-resolution dispatch hook for the `load_byte` builtin (#1308 —
+// C→Sailfin runtime migration). Returns a non-null `ExpressionResult`
+// when `trimmed_target` is `load_byte`; the caller short-circuits the
+// call pipeline without consulting the runtime-helper registry. Like
+// the atomic builtins, `load_byte` lowers to inline LLVM (inttoptr +
+// `load i8` + `zext`) rather than a `call @symbol(...)`. Short-circuiting
+// here also prevents a future user-defined `load_byte` from shadowing
+// the primitive the string runtime depends on.
+fn try_dispatch_byte_load_builtin(trimmed_target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? ![io] {
+    if !is_byte_load_builtin(trimmed_target) { return null; }
+    return lower_byte_load(trimmed_target, arguments, bindings, locals, temp_index, lines, functions, context);
 }
 
 // ── Closure-callee detection (issue #689) ────────────────────────────
@@ -1452,6 +1466,7 @@ export {
     resolve_parsed_method_dispatch,
     resolve_call_signature,
     try_dispatch_atomic_builtin,
+    try_dispatch_byte_load_builtin,
     _parse_fn_pointer_annotation,
     _ClosureSignatureParse
 };

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -1171,6 +1171,12 @@ fn is_builtin_call_name(name: string) -> boolean {
     if strings_equal(name, "atomic_sub") { _ret = true; }
     if strings_equal(name, "atomic_cas") { _ret = true; }
     if strings_equal(name, "atomic_fence") { _ret = true; }
+    // `load_byte(addr: int) -> int` is a call-form lowering primitive
+    // (#1308): a single-byte `load i8` + `zext`, recognized by name and
+    // emitted inline (compiler/src/llvm/byte_load.sfn). It resolves to
+    // no source-level declaration, so the #812 walker must treat it as a
+    // builtin or every `load_byte` call false-positives E0420.
+    if strings_equal(name, "load_byte") { _ret = true; }
     return _ret;
 }
 

--- a/compiler/tests/unit/byte_load_lowering_test.sfn
+++ b/compiler/tests/unit/byte_load_lowering_test.sfn
@@ -1,0 +1,71 @@
+// Unit tests for the `load_byte` builtin (#1308 — C→Sailfin runtime
+// migration). `load_byte(addr: int) -> int` is the single-byte load
+// primitive that lets `sfn_str_read_byte` / `sfn_str_grapheme_byte`
+// retire their C bridges: a true `load i8` + `zext`, sound at any
+// alignment (unlike the word-load `_owned_buf_load_byte`, which
+// over-reads the enclosing 8-aligned word).
+//
+// Two layers of coverage, mirroring `atomic_load_store_test.sfn`:
+//   1. Predicate surface — `is_byte_load_builtin` gates the dispatch
+//      hook (compiler/src/llvm/byte_load.sfn). A regression that
+//      loosens it to a prefix/suffix match is caught here.
+//   2. Golden-IR shape — the inttoptr + `load i8` + `zext` emission,
+//      pinned in-process via parse → emit_native → lower_to_llvm_ir.
+//      ONE lowering call for the file (the suite's per-process memory
+//      budget makes multiple lowerings a poor trade).
+import { parse_program } from "../../src/parser/mod";
+import { emit_native_text_with_module_name } from "../../src/emit_native";
+import { index_of } from "../../src/string_utils";
+import { is_byte_load_builtin } from "../../src/llvm/byte_load";
+import { lower_to_llvm_ir_from_text } from "../../src/llvm/lowering/entrypoints";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+// ── Predicate recognises the reserved name ──
+test "byte_load: is_byte_load_builtin recognises load_byte" {
+    assert is_byte_load_builtin("load_byte");
+}
+
+test "byte_load: is_byte_load_builtin tolerates surrounding whitespace" {
+    assert is_byte_load_builtin(" load_byte ");
+}
+
+// ── Predicate rejects non-matching / near-miss identifiers ──
+test "byte_load: is_byte_load_builtin rejects unrelated identifiers" {
+    assert ! is_byte_load_builtin("foo");
+    assert ! is_byte_load_builtin("");
+}
+
+test "byte_load: is_byte_load_builtin rejects partial / near-miss names" {
+    // Defence against a future regression that loosens the predicate to
+    // a startsWith / endsWith match — only the exact name should fire.
+    assert ! is_byte_load_builtin("load");
+    assert ! is_byte_load_builtin("byte");
+    assert ! is_byte_load_builtin("load_byt");
+    assert ! is_byte_load_builtin("load_bytex");
+    assert ! is_byte_load_builtin("store_byte");
+}
+
+// ── Golden-IR shape ──
+// `load_byte(addr: int)` lowers to `inttoptr i64 … to i8*` +
+// `load i8, i8* …, align 1` + `zext i8 … to i64`. Assert the stable
+// pieces (the three opcodes and the i8→i64 widening), not the full
+// instruction lines whose SSA register names vary. The `zext` (not
+// `sext`) is load-bearing: a signed extension would make bytes >= 0x80
+// negative and corrupt every UTF-8 comparison on the self-host path.
+test "lowering: load_byte emits inttoptr + load i8 + zext (#1308)" ![io] {
+    let source = "fn read_first(addr: int) -> int {\n"
+        + "    return load_byte(addr);\n"
+        + "}";
+    let program = parse_program(source);
+    let native = emit_native_text_with_module_name(program, "byte_load_test");
+    let ir = lower_to_llvm_ir_from_text(native, "byte_load_test");
+
+    assert _contains(ir, "inttoptr i64");
+    assert _contains(ir, "load i8, i8*");
+    assert _contains(ir, "align 1");
+    assert _contains(ir, "zext i8");
+    assert _contains(ir, "to i64");
+}

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -139,9 +139,9 @@ extern "C"
     SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot);
     void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slot);
     // #1315 (C4 of epic #1308): exported bridge primitives the Sailfin
-    // string-accessor bodies in `runtime/sfn/string.sfn` call (immediate
-    // decode, single-byte read, platform-gated grapheme production). These
-    // retire with the immediate-encoding deletion (#1283 / #822); do not
+    // string-accessor bodies in `runtime/sfn/string.sfn` call (single-byte
+    // read, platform-gated grapheme production). These retire once a seed
+    // carrying the `load_byte` builtin is pinned (#1308 two-phase); do not
     // grow this surface. See the bridge block in `sailfin_runtime.c`.
     // #1308: sfn_str_decode_owned / sfn_str_immediate_codepoint flipped to
     // trivial Sailfin bodies (string.sfn); C defs + protos deleted.

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2035,10 +2035,10 @@ char *sailfin_runtime_number_to_string(double value);
  * sites) and retires with the C file at #822. */
 
 /* Single in-bounds byte read. `s` must be deref-safe (post-decode) and
- * `0 <= idx < len`. Stays in C because the seed cannot lower a
- * single-byte `* u8` load in Sailfin, and a Sailfin word-load would
- * over-read an unpadded buffer's tail (an ASAN heap/global-buffer-
- * overflow). */
+ * `0 <= idx < len`. Stays in C until a seed carrying the `load_byte` builtin
+ * (compiler/src/llvm/byte_load.sfn) is pinned — a Sailfin word-load would
+ * over-read an unpadded buffer's tail (an ASAN heap/global-buffer-overflow).
+ * #1308: the native flip lands once that seed ships. */
 int64_t sfn_str_read_byte(const char *s, int64_t idx)
 {
     return (int64_t)(unsigned char)s[idx];

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -134,6 +134,11 @@ extern fn sailfin_runtime_string_to_number(s: * u8) -> f64;
 // -1); they are deleted, along with the C classifier + ~36 consumer guards, in
 // the #822 file-deletion cleanup. `read_byte` / `grapheme_byte` stay C externs
 // (the seed cannot lower a sub-word load / byte-store + arena-alloc).
+//
+// #1308 (two-phase): the `load_byte` builtin that replaces these bridges ships
+// in the compiler in a prior PR; the runtime flip to call it lands once a seed
+// carrying `load_byte` is pinned (the seed typechecks this module during the
+// self-host build, so it must recognize the builtin first).
 fn sfn_str_immediate_codepoint(s: * u8) -> i64 { return -1; }
 
 fn sfn_str_decode_owned(s: * u8) -> * u8 { return s; }


### PR DESCRIPTION
## What

Adds a `load_byte(addr: int) -> int` builtin: it reads one byte from a raw address and zero-extends it, lowering inline to

```llvm
%p = inttoptr i64 <addr> to i8*
%b = load i8, i8* %p, align 1
%r = zext i8 %b to i64
```

Recognized by name and short-circuited before call resolution, exactly like the atomic builtins (`atomic_load` et al.) — it bypasses the runtime-helper registry.

## Why (epic #1308 — retire the C runtime)

`load_byte` is the missing compiler capability that lets `sfn_str_read_byte` / `sfn_str_grapheme_byte` retire their C bridges. The seed's only single-byte read today is the word-load `_owned_buf_load_byte`, which reads the *enclosing 8-aligned i64 word* and is sound only on padded `owned_buf_new` storage. Those two string accessors read arbitrary `* u8` buffers (getenv results, string literals, foreign buffers) with no padding guarantee, so the word-load would over-read up to 7 bytes past the index (an ASAN heap/global-buffer-overflow) — which is exactly why they stayed in C. `load_byte` is a true single-byte load, sound at any alignment.

`zext` (not `sext`) is load-bearing: it keeps the byte unsigned (0..255), matching the C `(int64_t)(unsigned char)s[idx]`. A signed extension would make bytes ≥ 0x80 negative and corrupt every UTF-8 comparison on the self-host path.

## Capability only — why the runtime flip is a follow-up

The self-host build's **seed** typechecks `runtime/sfn/**` while staging the runtime import-context, so a new builtin the runtime *calls* must ship in a **pinned seed** before the runtime can use it (confirmed empirically: using `load_byte` in `string.sfn` fails the seed with `E0420: undefined function load_byte`). This PR therefore ships the capability only — the compiler itself does not call `load_byte`, so it self-hosts cleanly. The runtime flip (`read_byte`/`grapheme_byte` → `load_byte`, delete the C bodies, residual **4 → 2**) lands once a seed carrying this builtin is pinned.

Because PR merges and seed cuts are decoupled, this batches with the other pre-seed capability work — see the sequencing note below.

## Changes
- `compiler/src/llvm/byte_load.sfn` (new): `is_byte_load_builtin` + `lower_byte_load`
- `core_call_resolution.sfn` / `core_call_lowering.sfn`: pre-resolution dispatch hook
- `typecheck_types.sfn`: recognize `load_byte` so the call form doesn't false-positive `E0420`
- `compiler/tests/unit/byte_load_lowering_test.sfn` (new): predicate + golden-IR shape
- runtime `string.sfn` / C `.c`/`.h` comments: document the two-phase unblock

## Validation
- `make rebuild` — self-hosts ✅
- `byte_load_lowering_test.sfn` — 5/5 green ✅
- `sfn fmt --check` clean on all touched files ✅

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_