### PR TITLE
refactor(compiler): emit null arena slot, drop @sfn_default_arena reference (#1308)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -599,22 +599,21 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         }
     }
 
-    // M2.8b (#726): splice `ptr @sfn_default_arena` as the trailing
-    // arg for env.get / env.home so the SfnString aggregate trampolines
-    // can NUL-marshal the name and wrap the result. Mirrors the
-    // `sfn_str_concat` arena-threading pattern from #714. The
-    // descriptors carry `parameter_types` with the trailing `ptr` slot;
-    // the user-facing source still passes only `name` / `()`, so the
-    // operand-count gate above sees the pre-injection list and only
-    // post-gate emission sees the spliced operand.
+    // M2.8b (#726): splice the trailing arena-slot `ptr` arg for
+    // env.get / env.home (the descriptors carry `parameter_types` with
+    // the trailing `ptr` slot; the user-facing source passes only
+    // `name` / `()`, so the operand-count gate above sees the
+    // pre-injection list and only post-gate emission sees the spliced
+    // operand). #1308: the slot is now a null pointer rather than
+    // `ptr @sfn_default_arena`. The runtime `sfn_getenv` / `sfn_home_dir`
+    // bodies (io.sfn) ignore the arena param entirely, so the null is
+    // inert here — and no Sailfin object references the C global
+    // `sfn_default_arena` anymore.
     let mut _env_target_match: boolean = false;
     if trimmed_target == "env.get" { _env_target_match = true; }
     if trimmed_target == "env.home" { _env_target_match = true; }
     if _env_target_match {
-        let arena_operand = LLVMOperand {
-            llvm_type: "ptr",
-            value: "@sfn_default_arena"
-        };
+        let arena_operand = LLVMOperand { llvm_type: "ptr", value: "null" };
         operands.push(arena_operand);
     }
 

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -406,16 +406,15 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
 
             // M1.7.2d (#721): route through descriptor-driven dispatch.
             // The `string.concat` descriptor pins the three parameter
-            // types (`{i8*, i64}`, `{i8*, i64}`, `ptr`); the third
-            // operand `ptr @sfn_default_arena` is the global pointer
-            // slot primed at module load by the C constructor in
-            // `runtime/native/src/sailfin_runtime.c`. The downstream
-            // `extractvalue` (still owned by this lowering, not by
-            // the descriptor) recovers the data pointer so the rest
-            // of the pipeline keeps treating string operands as `i8*`.
+            // types (`{i8*, i64}`, `{i8*, i64}`, `ptr`); the third is
+            // the arena-slot `ptr`. #1308: now a null pointer rather
+            // than `ptr @sfn_default_arena` — `sfn_str_concat` resolves
+            // the arena via `_sfn_resolve_arena`, which falls back to
+            // `sfn_arena_global()` on a null slot, so no Sailfin object
+            // references the C global `sfn_default_arena` anymore.
             let arena_operand = LLVMOperand {
                 llvm_type: "ptr",
-                value: "@sfn_default_arena"
+                value: "null"
             };
             let concat_operands: LLVMOperand[] = [lhs_agg.operand, rhs_agg.operand, arena_operand];
             let concat_result = emit_runtime_call("string.concat", concat_operands, empty_runtime_call_overrides(), current_temp, current_lines);
@@ -639,10 +638,10 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             }
             // M1.7.2d (#721): route through descriptor-driven dispatch
             // (see the earlier call site in this file for the full
-            // migration note).
+            // migration note). #1308: arena slot is a null pointer.
             let arena_operand = LLVMOperand {
                 llvm_type: "ptr",
-                value: "@sfn_default_arena"
+                value: "null"
             };
             let concat_operands: LLVMOperand[] = [lhs_agg.operand, rhs_agg.operand, arena_operand];
             let concat_result = emit_runtime_call("string.concat", concat_operands, empty_runtime_call_overrides(), current_temp, current_lines);

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -152,18 +152,16 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, li
     // The `string.concat` descriptor (runtime_helpers.sfn) pins the
     // three parameter types (`{i8*, i64}`, `{i8*, i64}`, `ptr`) and
     // resolves the symbol via `native_signature`; the call site
-    // contributes the operands, including the third
-    // `ptr @sfn_default_arena` — the global pointer slot primed at
-    // module load by the C constructor in
-    // `runtime/native/src/sailfin_runtime.c`. The downstream
-    // `extractvalue` (still owned by this lowering, not by the
-    // descriptor) recovers the data pointer so the rest of the
-    // pipeline keeps treating string operands as `i8*` until the
-    // M1.A.2 flip lands.
-    let arena_operand = LLVMOperand {
-        llvm_type: "ptr",
-        value: "@sfn_default_arena"
-    };
+    // contributes the operands, including the third arena-slot `ptr`.
+    // #1308: the slot is now a null pointer rather than
+    // `ptr @sfn_default_arena`. The runtime `sfn_str_concat` resolves
+    // the arena via `_sfn_resolve_arena`, which falls back to the
+    // cheap cached `sfn_arena_global()` on a null slot (string.sfn),
+    // so no Sailfin object references the C global `sfn_default_arena`
+    // anymore — retiring that residual symbol. The downstream
+    // `extractvalue` recovers the data pointer so the rest of the
+    // pipeline keeps treating string operands as `i8*`.
+    let arena_operand = LLVMOperand { llvm_type: "ptr", value: "null" };
     let concat_operands: LLVMOperand[] = [left_aligned.operand, right_aligned.operand, arena_operand];
     let concat_result = emit_runtime_call("string.concat", concat_operands, empty_runtime_call_overrides(), right_aligned.temp_index, right_aligned.lines);
     let mut _concat_di: int = 0;

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -216,18 +216,15 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
     // Runtime global
     lines.push("@runtime = external global i8**");
 
-    // M2.4b (#398): the arena-aware string concat / append entrypoints
-    // (`@sfn_str_concat_arena` / `@sfn_str_append_arena`) take a third
-    // `ptr` argument that the call sites populate with
-    // `ptr @sfn_default_arena`. The slot is an `SfnArena *` defined in
-    // `runtime/native/src/sailfin_runtime.c` and primed at module load
-    // by a `__attribute__((constructor))` calling `sfn_arena_global()`.
-    // Declaring it here keeps every emitted module's IR self-consistent
-    // — even modules that never call concat carry the declare so
-    // linker behaviour is uniform.
-    lines.push("@sfn_default_arena = external global ptr");
-    lines.push("");
-
+    // #1308: the arena-aware string concat / env entrypoints take a
+    // trailing `ptr` arena-slot argument. The call sites now populate
+    // that slot with a null pointer (the runtime resolves the arena via
+    // `_sfn_resolve_arena` → cheap cached `sfn_arena_global()` on null),
+    // so no emitted module references the C global `@sfn_default_arena`
+    // anymore — the previously-unconditional `external global`
+    // declaration is dropped, retiring that residual symbol. The C
+    // definition + its module-load constructor retire with the C runtime
+    // (#822).
     // ABI version globals (issue #392 / M1.C; issue #462). Every
     // emitted module declares these so the runtime can detect ABI
     // mismatches at load time. `linkonce_odr` linkage coalesces

--- a/compiler/tests/e2e/test_runtime_string_allocating.sh
+++ b/compiler/tests/e2e/test_runtime_string_allocating.sh
@@ -7,25 +7,27 @@
 #      additions.
 #   2. The emitted IR for a `let s = a + b` source defines the
 #      arena-aware call shape (#715 renamed the symbol from
-#      `sfn_str_concat_arena` to the bare canonical name):
+#      `sfn_str_concat_arena` to the bare canonical name; #1308 then
+#      replaced the `ptr @sfn_default_arena` operand with `ptr null`):
 #        %t = call {i8*, i64} @sfn_str_concat({i8*, i64} ...,
 #                                             {i8*, i64} ...,
-#                                             ptr @sfn_default_arena)
+#                                             ptr null)
 #        %p = extractvalue {i8*, i64} %t, 0
 #      and no longer emits the legacy 2-arg `@sfn_str_concat(...)`
 #      shape, the `_arena`-suffixed transitional name, or any
 #      `@sailfin_runtime_string_concat*` form for fresh user emission.
-#   3. The global declare `@sfn_default_arena = external global ptr`
-#      lands in every emitted module (driven by
-#      `lowering_phase_render.sfn`).
+#   3. No emitted module references `@sfn_default_arena` (#1308): the
+#      previously-unconditional `external global` declaration is dropped
+#      now that the call sites pass a null slot.
 #   4. The Sailfin module defines the bare canonical `sfn_str_concat` /
 #      `sfn_str_append` emission targets (real SfnString-ABI bodies as
 #      of #1318; the OwnedBuf-returning `sfn_str_sfn_concat` / `_append`
 #      proof-of-life wrappers were retired).
 #   5. The compiler binary exports the canonical `sfn_str_concat` /
-#      `sfn_str_append` text symbols (now Sailfin-defined in string.o)
-#      and the `sfn_default_arena` global symbol so the link surface is
-#      intact.
+#      `sfn_str_append` text symbols (now Sailfin-defined in string.o).
+#      The `sfn_default_arena` data symbol is still present as the C
+#      global (sailfin_runtime.c), which retires with the C runtime
+#      (#822); fresh Sailfin emission no longer references it.
 
 set -euo pipefail
 
@@ -116,16 +118,19 @@ SAILFIN_EOF
         cat "$log"
         return 1
     fi
-    # The full call shape must appear verbatim — the `, ptr @sfn_default_arena)`
-    # tail is the discriminator that catches a regression to the 2-arg form.
-    # We anchor the symbol on the literal `\(` rather than a `\b` word
-    # boundary: BSD/macOS `grep -E` treats `\b` as a backspace (see
-    # `test_runtime_libc_skeleton.sh` lines 95-102), and the `(` that
-    # follows the symbol is unambiguous in LLVM call lines — a regression
-    # to `@sfn_str_concat_arena(` cannot collide because the `_arena`
-    # bytes appear before the `(`, not after `@sfn_str_concat`.
-    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$ll"; then
-        echo "[test]   expected 'call {i8*, i64} @sfn_str_concat(..., ptr @sfn_default_arena)' in emitted IR:"
+    # The full call shape must appear verbatim — the `, ptr null)` tail is
+    # the discriminator that catches a regression to the 2-arg form. #1308
+    # replaced the old `ptr @sfn_default_arena` operand with `ptr null`
+    # (the runtime resolves the arena via `_sfn_resolve_arena`'s
+    # `sfn_arena_global()` fallback on a null slot), dropping the last
+    # Sailfin reference to the C global. We anchor the symbol on the
+    # literal `\(` rather than a `\b` word boundary: BSD/macOS `grep -E`
+    # treats `\b` as a backspace (see `test_runtime_libc_skeleton.sh`
+    # lines 95-102), and the `(` that follows the symbol is unambiguous in
+    # LLVM call lines — a regression to `@sfn_str_concat_arena(` cannot
+    # collide because the `_arena` bytes appear before the `(`.
+    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr null\)' "$ll"; then
+        echo "[test]   expected 'call {i8*, i64} @sfn_str_concat(..., ptr null)' in emitted IR:"
         grep -nE 'call .* @sfn_str_concat' "$ll" | head -5
         return 1
     fi
@@ -162,16 +167,22 @@ SAILFIN_EOF
     return 0
 }
 
-# ---- Test: every emitted module declares @sfn_default_arena ----
-test_global_declare_present() {
+# ---- Test: no emitted module references @sfn_default_arena (#1308) ----
+# The arena-slot operand is `ptr null` now, so the previously-
+# unconditional `@sfn_default_arena = external global ptr` declaration
+# is dropped and no module references the C global. The `@sfn_str_concat`
+# declare keeps its 3-arg ptr-tail signature (only the call operand
+# changed, not the function's ABI).
+test_arena_global_not_referenced() {
     local fixture="$SCRATCH/concat_fixture.sfn"
     local ll="$SCRATCH/concat_fixture.ll"
     if [ ! -f "$ll" ]; then
         echo "[test]   $ll missing — test_concat_lowers_to_arena_form must run first"
         return 1
     fi
-    if ! grep -qE '^@sfn_default_arena = external global ptr$' "$ll"; then
-        echo "[test]   expected '@sfn_default_arena = external global ptr' declare in emitted IR"
+    if grep -qE 'sfn_default_arena' "$ll"; then
+        echo "[test]   emitted IR still references sfn_default_arena (expected none after #1308):"
+        grep -nE 'sfn_default_arena' "$ll" | head -3
         return 1
     fi
     if ! grep -qE '^declare \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$ll"; then
@@ -219,7 +230,7 @@ run_test "sfn check runtime/sfn/string.sfn passes" test_check_clean
 run_test "sfn fmt --check runtime/sfn/string.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm produces define for every new sfn_str_sfn_* export" test_emit_define_shape
 run_test "let s = a + b lowers to arena-aware @sfn_str_concat call" test_concat_lowers_to_arena_form
-run_test "emitted IR declares @sfn_default_arena and @sfn_str_concat" test_global_declare_present
+run_test "emitted IR drops @sfn_default_arena, keeps @sfn_str_concat declare" test_arena_global_not_referenced
 run_test "compiler binary exports sfn_str_concat / sfn_str_append (+ transitional _arena forwarders) / sfn_default_arena" test_compiler_binary_exports_arena_symbols
 
 echo ""

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -8,7 +8,7 @@
 #     `sailfin_runtime_string_length` call).
 #   - `+` on strings emits the arena-aware aggregate call shape
 #     (renamed in #715 to the bare canonical symbol):
-#       call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)
+#       call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr null)
 #     followed by an `extractvalue {i8*, i64} %t, 0` that recovers
 #     the legacy `i8*` operand. The C-side `sfn_str_concat_arena`
 #     forwarder still exports (so seed-built IR keeps linking) but
@@ -143,9 +143,13 @@ test_no_array_consumer_pattern() {
 # followed by an `extractvalue {i8*, i64} %t, 0` that recovers the
 # legacy `i8*` operand for the rest of the lowering pipeline. #715
 # retired the legacy 2-arg `sfn_str_concat` trampoline and promoted
-# the arena-aware function to the bare canonical name, so the
-# emitted shape is now
-#   call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)
+# the arena-aware function to the bare canonical name. #1308 then
+# replaced the third `ptr @sfn_default_arena` operand with `ptr null`
+# (the runtime resolves the arena via `_sfn_resolve_arena`'s
+# `sfn_arena_global()` fallback on a null slot), dropping the last
+# Sailfin reference to the C global `sfn_default_arena`. The emitted
+# shape is now
+#   call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr null)
 # Fresh emission must reach the bare `@sfn_str_concat` symbol — not
 # the `_arena`-suffixed transitional forwarder, not the (now-deleted)
 # 2-arg shape, and not the legacy `sailfin_runtime_string_concat_v2`
@@ -159,7 +163,7 @@ test_string_concat_uses_aggregate_abi() {
         return 1
     fi
     local called
-    called="$(grep -cE 'call \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$LL" || true)"
+    called="$(grep -cE 'call \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr null\)' "$LL" || true)"
     if [ "${called:-0}" -lt 1 ]; then
         echo "[test]   expected at least one arena-shape call to sfn_str_concat, got ${called:-0}"
         return 1

--- a/compiler/tests/unit/runtime_call_dispatch_test.sfn
+++ b/compiler/tests/unit/runtime_call_dispatch_test.sfn
@@ -26,12 +26,12 @@
 //   - `alloc_struct` (no attrs) — same descriptor without the override,
 //                              pins that the empty `return_attributes`
 //                              path stays attribute-free (no stray space).
+import { LLVMOperand } from "../../src/llvm/types";
 import {
-    RuntimeCallOverrides,
     emit_runtime_call,
+    RuntimeCallOverrides,
     empty_runtime_call_overrides
 } from "../../src/llvm/expression_lowering/native/runtime_call";
-import { LLVMOperand } from "../../src/llvm/types";
 
 // SfnString aggregate — `string.concat` parameter type per the M1.A
 // lock-in (see `runtime_helpers.sfn` lines 407-431).
@@ -54,20 +54,22 @@ fn _ptr_operand(value: string) -> LLVMOperand {
 test "emit_runtime_call: string.concat renders SfnString-aggregate call to sfn_str_concat" ![io] {
     // M2.4b (#398) + #715: the descriptor points at the arena-aware
     // `sfn_str_concat` entrypoint (bare name post-#715 rename) with a
-    // third `ptr` argument that fresh user emission populates with
-    // `ptr @sfn_default_arena`. The return type is the SfnString
-    // aggregate `{i8*, i64}`; the hardcoded call-site emitters follow
-    // the `call` with an `extractvalue` to recover the legacy `i8*`
-    // operand. This fixture pins the call shape itself; the extract
-    // step lives in the call-site emitters and is covered by the e2e
-    // test `test_runtime_string_allocating.sh`.
+    // third `ptr` argument. #1308: fresh user emission populates that
+    // slot with `ptr null` (the runtime resolves the arena via
+    // `_sfn_resolve_arena`'s `sfn_arena_global()` fallback), so the
+    // fixture uses the null operand to match real emission. The return
+    // type is the SfnString aggregate `{i8*, i64}`; the hardcoded
+    // call-site emitters follow the `call` with an `extractvalue` to
+    // recover the legacy `i8*` operand. This fixture pins the call shape
+    // itself; the extract step lives in the call-site emitters and is
+    // covered by the e2e test `test_runtime_string_allocating.sh`.
     let lhs = _sfn_string_operand("%a");
     let rhs = _sfn_string_operand("%b");
-    let arena = _ptr_operand("@sfn_default_arena");
+    let arena = _ptr_operand("null");
     let operands: LLVMOperand[] = [lhs, rhs, arena];
     let result = emit_runtime_call("string.concat", operands, empty_runtime_call_overrides(), 0, []);
     assert result.lines.length == 1;
-    assert result.lines[0] == "  %t0 = call {i8*, i64} @sfn_str_concat({i8*, i64} %a, {i8*, i64} %b, ptr @sfn_default_arena)";
+    assert result.lines[0] == "  %t0 = call {i8*, i64} @sfn_str_concat({i8*, i64} %a, {i8*, i64} %b, ptr null)";
     assert result.temp_index == 1;
     assert result.operand != null;
     assert result.diagnostics.length == 0;


### PR DESCRIPTION
## What

The string-concat and `env.get`/`env.home` descriptors carry a trailing `ptr` arena-slot argument. The lowering populated it with `ptr @sfn_default_arena` — the C global `SfnArena *sfn_default_arena` (`sailfin_runtime.c`), primed by a module-load constructor. **That reference is the only reason Sailfin-compiled objects demand the C symbol** — it's one of the four remaining relink-residual symbols for epic #1308.

This PR splices a **null pointer** instead of `@sfn_default_arena` at the four emission sites, and drops the previously-unconditional `@sfn_default_arena = external global ptr` declaration.

## Why it's sound

The runtime already tolerates a null slot:
- `sfn_str_concat` / `sfn_str_append` resolve the arena via `_sfn_resolve_arena`, which **falls back to `sfn_arena_global()` when the slot is null** (`runtime/sfn/string.sfn:510`). `sfn_arena_global()` is a cached single global read after first call (`arena.sfn:450`), so there's **no meaningful perf delta** versus the old cached-handle fast path.
- `sfn_getenv` / `sfn_home_dir` (`runtime/sfn/io.sfn:304,335`) **ignore the arena parameter entirely**, so the null is inert.

Chosen over a defining-global compiler primitive (`extern var NAME: T = init`), which would be M-sized/multi-pass and exists mainly to preserve a fast path that's worth ~nothing here.

## Bootstrap / residual timing

After this change, no emitted module references `@sfn_default_arena`. The relink residual **actually drops once this emission ships in a pinned seed** (the seed compiles the self-hosted objects). The C global + its constructor retire with the C runtime at #822. This batches with the `load_byte` capability (#1427) into a single pre-seed wave — one seed cut then unblocks the runtime-side flips.

## Sites changed
- `core_strings.sfn` — `+` concat
- `core_ops_lowering.sfn` ×2 — interpolation / op concat
- `core_call_lowering.sfn` — env.get/home slot
- `lowering_phase_render.sfn` — drop the unconditional declaration

## Validation
- `make rebuild` — self-hosts ✅
- `emit llvm` on a concat+env program: zero `@sfn_default_arena`, both call sites pass `ptr null` ✅
- Built+ran that program: `[info] hello /root` (concat + env.get correct at runtime) ✅
- String integration suite: 9/9 ✅
- `sfn fmt --check` clean ✅

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_