### PR TITLE
refactor(runtime): retarget resolve_runtime_root off legacy C concat (#1308)

### DIFF
--- a/runtime/sfn/platform/exec.sfn
+++ b/runtime/sfn/platform/exec.sfn
@@ -143,16 +143,6 @@ extern fn realpath(path: * u8, resolved: * u8) -> * u8;
 // the filesystem adapter.
 extern fn sfn_fs_exists(path: * u8) -> bool;
 
-// `sailfin_runtime_string_concat` is the C runtime's
-// NUL-terminated concat. Used to build the
-// `<exe_dir>/runtime` / `<exe_dir>/../runtime` / ...
-// candidate strings without rolling a manual concat loop here.
-// M2.4b's pure-Sailfin concat is keyed on the M1.A.2
-// aggregate-by-value parameter flip; until that lands, this C
-// trampoline is the only way to produce a fresh NUL-terminated
-// buffer from two `* u8` inputs.
-extern fn sailfin_runtime_string_concat(a: * u8, b: * u8) -> * u8;
-
 // `memcmp` is needed for the empty-string check in
 // `resolve_runtime_root`'s `$SAILFIN_RUNTIME_ROOT` override
 // branch — the C original treats an empty env value as "not
@@ -341,12 +331,18 @@ fn resolve_runtime_root(exe_path: * u8) -> * u8 ![io] {
         }
     }
     let exe_dir_str: string = binary_dir(exe_path);
-    let exe_dir: * u8 = exe_dir_str as * u8;
     let mut idx: i32 = 0;
     loop {
         if idx >= 3 { break; }
-        let suffix: * u8 = _candidate_suffix(idx);
-        let candidate: * u8 = sailfin_runtime_string_concat(exe_dir, suffix);
+        // #1308: build `<exe_dir><suffix>` via the native `string` `+`
+        // operator (lowers to `sfn_str_concat`, a real Sailfin arena-backed
+        // body) instead of the legacy C `sailfin_runtime_string_concat` extern
+        // — the last Sailfin-side demand on that C symbol. `candidate_str` is a
+        // computed (alloca-backed) string, so the `as * u8` cast takes the safe
+        // slot-load path, not the literal-cast quirk.
+        let suffix: string = _candidate_suffix(idx);
+        let candidate_str: string = exe_dir_str + suffix;
+        let candidate: * u8 = candidate_str as * u8;
         if sfn_fs_exists(candidate) {
             let canon: * u8 = realpath(candidate, null);
             if canon as i64 != 0 { return canon as string; }
@@ -366,18 +362,12 @@ fn resolve_runtime_root(exe_path: * u8) -> * u8 ![io] {
 // prefixed strings at module scope (verified during M2.7a
 // bring-up), and a switch-on-index dispatch is the cheapest
 // workaround until that bug closes.
-fn _candidate_suffix(idx: i32) -> * u8 {
-    // Route through `string`-typed locals to dodge the seed's
-    // `<literal> as * u8` cast bug — see the cast-quirk note in
-    // the module header. The slot-load makes the cast safe.
-    if idx == 0 {
-        let s0: string = "/runtime";
-        return s0 as * u8;
-    }
-    if idx == 1 {
-        let s1: string = "/../runtime";
-        return s1 as * u8;
-    }
-    let s2: string = "/../../runtime";
-    return s2 as * u8;
+fn _candidate_suffix(idx: i32) -> string {
+    // #1308: returns `string` (was `* u8`) so the caller can build the
+    // candidate path with the native `string` `+` operator. The literals are
+    // returned directly — the cast-quirk only bit the `<literal> as * u8` form,
+    // which is now gone from this path.
+    if idx == 0 { return "/runtime"; }
+    if idx == 1 { return "/../runtime"; }
+    return "/../../runtime";
 }

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -87,22 +87,12 @@ extern fn strnlen(s: * u8, n: usize) -> usize;
 // through and discards the endptr by passing `null`.
 extern fn strtod(nptr: * u8, endptr: * * u8) -> f64;
 
-// M2.4b (#398) + #715: the C-side allocating ops. The Sailfin
-// trampolines below preserve the `sfn_str_sfn_*` infix pattern
-// (proof-of-life presence under the Sailfin namespace) while the
-// canonical `sfn_str_concat` / `sfn_str_append` symbols live on
-// the C side (#715 promoted these from their interim `_arena`
-// suffix to the bare canonical names). The two `* u8` parameters
-// mirror the wave-1a pattern — today's Sailfin frontend can't
-// pass / return the SfnString aggregate by value, so the bodies
-// bridge through the legacy NUL-terminated concat. The user IR
-// emission lands directly on `@sfn_str_concat` (the C entrypoint
-// with the new arena-aware ABI); these wrappers are not on the
-// hot path.
-extern fn sailfin_runtime_string_concat(a: * u8, b: * u8) -> * u8;
-
-extern fn sailfin_runtime_string_append(buf: * u8, suffix: * u8) -> * u8;
-
+// #1308: the legacy C `sailfin_runtime_string_concat` / `_append` externs were
+// deleted here — they had zero callers (the canonical `sfn_str_concat` /
+// `sfn_str_append` have been real Sailfin bodies since #1318, and the last
+// Sailfin demand on the legacy concat — `resolve_runtime_root` in exec.sfn —
+// was retargeted to the native `+` path). The C definitions are now purely
+// C-internal and retire with the C runtime at #822.
 // `sailfin_runtime_string_to_number` is the still-C `strtod` boundary
 // `to_number` delegates to (allocating-op family — retires in #1318/#822).
 // Returns `double` (System V x86_64 `%xmm0`), matched exactly here.


### PR DESCRIPTION
## What

`sailfin_runtime_string_concat` was the **last** relink-residual symbol on the tracked `sailfin_runtime.c` migration list. The compiler no longer emits it (string `+` lowers to native `@sfn_str_concat`); the only remaining Sailfin-side demand was a single call site:

- `runtime/sfn/platform/exec.sfn::resolve_runtime_root` built `<exe_dir><suffix>` candidate paths via `sailfin_runtime_string_concat(exe_dir, suffix)`.

This PR retargets it to the native `string` `+` operator (lowers to `sfn_str_concat`, a real arena-backed Sailfin body since #1318): `_candidate_suffix` now returns `string`, and the loop builds `exe_dir_str + suffix`. It also deletes the now-dead `sailfin_runtime_string_concat` / `_append` externs in `exec.sfn` and `string.sfn` (zero callers).

## Why it's safe

- **No #1205 aliasing hazard**: the native concat always fresh-allocs arena storage and `memcpy`s both operands — it never grows-at-tip into an aliased buffer (unlike `sfn_str_append`, which this doesn't touch).
- **No C edit**: the C `sailfin_runtime_string_concat` body has C-internal callers; it retires with the whole file at #822. No registry change, no seed cut.

## Residual

This clears the last tracked `sailfin_runtime.c` residual symbol. Combined with the merged seed pin (#1429) + `read_byte`/`grapheme_byte` flip (#1430) + the null-arena-slot emission, the **tracked C→Sailfin runtime residual is now 0**.

What remains to actually delete the C files (#822): the **arena port (#1309)** — `sailfin_arena.c`'s `realloc`/`reset`/`mark`/`rewind`/`destroy` (the #1205-class shared-struct hazard) — and then the definitive relink-readiness experiment.

## Validation
- `make rebuild` self-hosts ✅
- After a clean rebuild, **no `build/sailfin` object demands `sailfin_runtime_string_concat`** ✅
- hello-world runs (`resolve_runtime_root` intact — exercised on every compiler startup) ✅
- exec-path e2e 5/5 ✅; `sfn check` + `fmt --check` clean ✅

`resolve_runtime_root` runs on every invocation, so the self-host build + suite are themselves the coverage for this call-site retarget — no new test needed.

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_