### PR TITLE
refactor(runtime): port argv/panic/arena-telemetry off C (3 of 4 #822 residuals)

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -145,12 +145,14 @@ extern fn resolve_runtime_root(exe: * u8) -> * u8;
 // "self-path resolution works through binary symlink" pin.
 extern fn realpath(path: * u8, resolved: * u8) -> * u8;
 
-// M5.5 (#473): registers the arena-stats process-exit hook ported
-// from the retired C driver into `runtime/native/src/sailfin_runtime.c`.
-// `fn main` invokes this once before delegating to the CLI dispatch;
-// the call is a no-op unless `SAILFIN_DUMP_ARENA_STATS` is truthy.
-// Pinned by `compiler/tests/e2e/arena_default_on_test.sfn`.
-extern fn sailfin_runtime_install_arena_telemetry(label: * u8);
+// Arena-stats telemetry dump (#822 / #1308). The former C atexit hook
+// `sailfin_runtime_install_arena_telemetry` is retired — installing a
+// Sailfin callback into libc `atexit` needs an address-of-function
+// primitive the frontend lacks — so the dump is invoked inline at the
+// single exit funnel of `fn main` below (the runtime body lives in
+// `runtime/sfn/memory/arena.sfn`). A no-op unless `SAILFIN_DUMP_ARENA_STATS`
+// is truthy. Pinned by `compiler/tests/e2e/arena_default_on_test.sfn`.
+extern fn sfn_arena_telemetry_dump(label: * u8);
 
 // Self-applied compiler memory budget (`runtime/sfn/platform/rlimit.sfn`).
 // `fn main` calls this before any compilation work so every `sfn`
@@ -2938,12 +2940,12 @@ fn main(argv: string[]) -> int ![io, clock] {
     // advisory; a failed setrlimit must never block a build.
     apply_default_mem_limit();
 
-    // Arena-stats process-exit telemetry — formerly registered by
-    // the C driver's pre-main. The C-side function is a no-op
-    // unless `SAILFIN_DUMP_ARENA_STATS` is truthy; we always call
-    // it so the gate stays in one place.
+    // Arena-stats telemetry — formerly an atexit hook registered here by
+    // the C driver's pre-main; now dumped inline at main's exit funnel
+    // (see the `sfn_arena_telemetry_dump` call below). The label is
+    // captured from argv up front (same point the C hook captured it) so
+    // it reflects the invoked subcommand, not post-dispatch mutations.
     let label = _arena_telemetry_label(argv);
-    sailfin_runtime_install_arena_telemetry(label as * u8);
 
     // Issue #1159 (CLI modularization epic #351, Phase 2 / Issue 2.1,
     // Risk R1): token reference to the `sfn/cli` SOURCE capsule. The
@@ -3025,7 +3027,13 @@ fn main(argv: string[]) -> int ![io, clock] {
         tail.push(argv[i]);
         i += 1;
     }
-    return sailfin_cli_main_with_paths(tail, runtime_root as string, bin_dir as string);
+    let exit_code = sailfin_cli_main_with_paths(tail, runtime_root as string, bin_dir as string);
+    // Exit funnel: dump arena telemetry on every normal completion
+    // (replaces the retired C atexit hook). `main` has a single return,
+    // so this fires for `sfn run`/`check`/`build`/… alike — the dispatch
+    // returns its exit code up through here rather than calling `exit()`.
+    sfn_arena_telemetry_dump(label as * u8);
+    return exit_code;
 }
 
 // Issue #940: `cli_main` is the `@main` entrypoint root AND now an

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -197,19 +197,14 @@ extern "C"
     // with `cap` exposed inline. Legacy entrypoints above remain the
     // first-pass / seed-compiled IR's link target.
 
-    // M5.3 (#471): convert C `(argc, argv)` into the SfnArray ABI shape
-    // that user `fn main(argv: string[])` expects. The emitted `@main`
-    // wrapper calls this from its prologue; argv[0] is preserved so
-    // user code observes the C convention (argv[0] = program name).
-    SfnArray *sailfin_runtime_argv_to_string_array(int argc, char **argv);
-
-    // M5.3 (#471): emit an uncaught-panic message + newline to stderr.
-    // Lives behind a distinct symbol from the user-facing `sfn_print_*`
-    // family so the IO-flip pin in
-    // `compiler/tests/e2e/test_runtime_io_extended.sh` (which forbids
-    // `sailfin_runtime_print_*` references in user IR) doesn't snag
-    // the wrapper's catch-pad emission.
-    void sailfin_runtime_panic_emit(char *msg);
+    // M5.3 (#471) `@main`-wrapper helpers — `sailfin_runtime_argv_to_string_array`
+    // (C `(argc, argv)` → SfnArray) and `sailfin_runtime_panic_emit`
+    // (uncaught-panic message + newline to stderr) — are now defined in
+    // `runtime/sfn/array.sfn` / `runtime/sfn/io.sfn` (#822 / #1308
+    // link-ownership flip); the C bodies are retained `static` with no
+    // external linkage, so their prototypes are dropped here. The emitted
+    // `@main` wrapper still calls them by name; the bare Sailfin
+    // definitions are the link target.
 
     // M5.5 (#473): install the arena-allocator process-exit telemetry
     // hook ported from the retired C driver. Called once from the

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -7892,14 +7892,11 @@ static SfnArray *sailfin_runtime_concat_v2(SfnArray *a, SfnArray *b)
     return out;
 }
 
-/* M5.3 (#471): emit an uncaught-panic message and newline to stderr,
- * then flush. The emitted `@main` wrapper invokes this from its catch
- * landing pad before returning exit code 1 — equivalent in effect to
- * `sailfin_runtime_print_err` but kept under a dedicated symbol so the
- * IO-flip pin in test_runtime_io_extended.sh (which forbids
- * `sailfin_runtime_print_*` references in user IR after the SfnString
- * migration) doesn't have to whitelist the wrapper's call site. */
-void sailfin_runtime_panic_emit(char *msg)
+/* #822 / #1308 residual: the bare `sailfin_runtime_panic_emit` link target
+ * is now defined in `runtime/sfn/io.sfn`; this C body is retained `static`
+ * only (no external linkage). Emit an uncaught-panic message and newline to
+ * stderr. */
+static void sailfin_runtime_panic_emit(char *msg)
 {
     if (msg)
     {
@@ -7909,14 +7906,13 @@ void sailfin_runtime_panic_emit(char *msg)
     }
 }
 
-/* M5.3 (#471): build a Sailfin `string[]` (SfnArray of `char*`) from
- * the C `(argc, argv)` the emitted `@main` wrapper receives. Pointer-
- * copies argv[0..argc) without `strdup` — the C runtime keeps these
- * strings live for the lifetime of `main`, and `main` cannot outlive
- * them. argv[0] (the program name) is preserved so user code sees the
- * standard C convention; the compiler's own `sailfin_cli_main_with_paths`
- * (M5.4 caller) will strip it if it wants the bare argument list. */
-SfnArray *sailfin_runtime_argv_to_string_array(int argc, char **argv)
+/* #822 / #1308 residual: the bare `sailfin_runtime_argv_to_string_array`
+ * link target is now defined in `runtime/sfn/array.sfn`; this C body is
+ * retained `static` only (no external linkage). Builds a Sailfin
+ * `string[]` (SfnArray of `char*`) from the C `(argc, argv)` the emitted
+ * `@main` wrapper receives — pointer-copies argv[0..argc) (argv outlives
+ * `main`); argv[0] is preserved. */
+static SfnArray *sailfin_runtime_argv_to_string_array(int argc, char **argv)
 {
     /* Defensive: a NULL argv with argc > 0 would leave the resulting
      * SfnArray with `len = argc` and NULL element pointers, which the

--- a/runtime/sfn/array.sfn
+++ b/runtime/sfn/array.sfn
@@ -210,6 +210,43 @@ fn sailfin_runtime_concat_v2(a: * u8, b: * u8) -> * u8 {
     }
 }
 
+// `sailfin_runtime_argv_to_string_array(argc, argv)` — build a Sailfin
+// `string[]` (`SfnArray` of `char*`) from the C `(argc, argv)` the emitted
+// `@main` wrapper receives. Bare-defined here (link-ownership flip, #1308
+// residual / #822); the C body is `static`-ified. Faithful port of the C
+// body: a NULL `argv` (or negative `argc`) clamps to an empty array so a
+// caller's `argv[i]` deref always sees a consistent (empty) array rather
+// than `len = argc` over NULL element pointers. argv[0] (the program name)
+// is preserved at index 0 — `cli_main`'s dispatch strips it. The strings
+// are pointer-copied (no `strdup`): argv outlives `main`, so the array's
+// element pointers stay valid for the process lifetime. Element slots are
+// 8-byte `char*` words written with `atomic_store`, matching `concat_v2`.
+fn sailfin_runtime_argv_to_string_array(argc: i32, argv: * * u8) -> * u8 {
+    unsafe {
+        let mut n: i64 = argc as i64;
+        if n < 0 { n = 0; }
+        if (argv as i64) == 0 { n = 0; }
+        let out: * u8 = _sfn_array_alloc_v2(n, 8);
+        if (out as i64) == 0 { return null; }
+        // out.len = n (the allocator already wrote cap = n).
+        atomic_store((out as i64 + 8) as * i64, n);
+        if n > 0 {
+            let buf: i64 = atomic_load(out as * i64);
+            let src: i64 = argv as i64;
+            if buf != 0 && src != 0 {
+                let mut i: i64 = 0;
+                loop {
+                    if i >= n { break; }
+                    let p: i64 = atomic_load((src + i * 8) as * i64);
+                    atomic_store((buf + i * 8) as * i64, p);
+                    i = i + 1;
+                }
+            }
+        }
+        return out;
+    }
+}
+
 // `sailfin_runtime_append_string_v2(a, text)` — append a `char*` to a
 // string array (`{ char**, i64, i64 }`), growing the backing buffer in
 // place when `len >= cap`. Bare-defined here (#1308 residual); the C body

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -258,6 +258,23 @@ fn sfn_print_sfn(msg: * u8) -> void ![io] {
     _sfn_print_line(STDOUT_FD, empty as * u8, 0, msg, strlen(msg) as i64);
 }
 
+// `sailfin_runtime_panic_emit(msg)` — emit an uncaught-panic message and a
+// trailing newline to stderr (fd 2). Bare-defined here (link-ownership
+// flip, #1308 residual / #822); the C body is `static`-ified. The emitted
+// `@main` wrapper's catch landing pad calls this by name before returning
+// exit code 1 (`compiler/src/llvm/lowering/emission.sfn`). Kept under a
+// dedicated symbol rather than reusing `sfn_print_err` so the IO-flip pin
+// in `test_runtime_io_extended.sh` (which forbids `sailfin_runtime_print_*`
+// references in user IR) need not whitelist the wrapper's call site.
+// `write(2)` is unbuffered, so the C body's `fflush(stderr)` is a no-op
+// here and is dropped.
+fn sailfin_runtime_panic_emit(msg: * u8) -> void ![io] {
+    if (msg as i64) == 0 { return; }
+    _sfn_write_all(2, msg, strlen(msg) as i64);
+    let nl: string = "\n";
+    _sfn_write_all(2, nl as * u8, 1);
+}
+
 // `_sfn_decode_immediate_name(data)` — decode a legacy immediate-codepoint
 // tagged pseudo-pointer (pre-M1.A.2) into a real NUL-terminated buffer.
 // Mirrors the C `sfn_getenv`'s `_is_immediate_codepoint_string` +

--- a/runtime/sfn/memory/arena.sfn
+++ b/runtime/sfn/memory/arena.sfn
@@ -862,3 +862,53 @@ fn sfn_arena_sfn_print_stats(arena: * u8) -> void ![io] {
 fn sfn_arena_print_stats(arena: * u8) -> void ![io] {
     sfn_arena_sfn_print_stats(arena);
 }
+
+// `sfn_arena_telemetry_dump(label)` — emit the arena-stats telemetry line
+// to stderr if `SAILFIN_DUMP_ARENA_STATS` is truthy. Sailfin replacement
+// for the retired C atexit hook `sailfin_runtime_install_arena_telemetry`
+// (#822 / #1308): the install-an-atexit-callback mechanism needed a
+// frontend address-of-function primitive that does not exist, so the dump
+// is invoked inline at the single exit funnel of `fn main`
+// (`compiler/src/cli_main.sfn`) instead — covering every normal `sfn`
+// completion (the only loss vs. atexit is a dump on a mid-build abort,
+// which is acceptable for debug-only telemetry).
+//
+// Output is byte-compatible with the retired C `_arena_stats_atexit`:
+//   enabled : `[sailfin-arena] label=<label> ` + `sfn_arena_print_stats`
+//   disabled: `[sailfin-arena] label=<label> stats=disabled (SAILFIN_USE_ARENA="<v>" opt-out)\n`
+// Pinned by `compiler/tests/e2e/arena_default_on_test.sfn` and
+// `compiler/tests/e2e/test_check_resolver_scan_memo.sh`.
+//
+// `SAILFIN_DUMP_ARENA_STATS` gate mirrors the C
+// `_arena_stats_telemetry_enabled`: truthy means non-null, non-empty, and
+// first byte != '0'. `load_byte` reads the first byte directly (the seed's
+// `* u8` byte-load gap is closed as of the pinned seed; `string.sfn`
+// already relies on it). Each literal is bound to a `string` local before
+// the `as * u8` cast — the proven env-read pattern (`getenv("…" as * u8)`
+// miscompiles inline under the seed; see `sfn_arena_enabled` above).
+fn sfn_arena_telemetry_dump(label: * u8) -> void ![io] {
+    let dump_name: string = "SAILFIN_DUMP_ARENA_STATS";
+    let flag: * u8 = getenv(dump_name as * u8);
+    if flag as i64 == 0 { return; }
+    let b0: i64 = load_byte(flag as i64);
+    if b0 == 0 { return; }
+    if b0 == 48 { return; }
+
+    let prefix: string = "[sailfin-arena] label=";
+    let sep: string = " ";
+    _arena_write_lit(prefix as * u8);
+    _arena_write_lit(label);
+    _arena_write_lit(sep as * u8);
+
+    if sfn_arena_enabled() {
+        sfn_arena_sfn_print_stats(sfn_arena_global());
+    } else {
+        let use_name: string = "SAILFIN_USE_ARENA";
+        let optout: * u8 = getenv(use_name as * u8);
+        let head: string = "stats=disabled (SAILFIN_USE_ARENA=\"";
+        let tail: string = "\" opt-out)\n";
+        _arena_write_lit(head as * u8);
+        if optout as i64 != 0 { _arena_write_lit(optout); }
+        _arena_write_lit(tail as * u8);
+    }
+}


### PR DESCRIPTION
## What

Ports **three of the four** link-holding symbols out of `runtime/native/src/sailfin_runtime.c` into Sailfin runtime modules. This is **PR 1 of 2** toward closing epic #1308 (delete the last C runtime file); it advances #822 but does **not** close it — `shell_capture` + the file deletion + cross-windows rework land in the follow-up.

A relink-readiness experiment proved `sailfin_runtime.c` is held up by exactly **4** undefined symbols (everything else is already Sailfin-provided or dead-static). This PR retires 3 of them.

**No seed cut needed** — the bare symbol names are unchanged; only the definitions move from C to Sailfin.

## The three ports

| Symbol | New home | Mechanism |
|---|---|---|
| `sailfin_runtime_argv_to_string_array` | `runtime/sfn/array.sfn` | bare-symbol link-ownership flip (mirrors `concat_v2`/`append_string_v2`); C body `static`-ified, `.h` prototype drained |
| `sailfin_runtime_panic_emit` | `runtime/sfn/io.sfn` | same flip; `write(2)`-based body (`fflush` dropped — `write(2)` is unbuffered) |
| arena exit telemetry | `runtime/sfn/memory/arena.sfn` | **A2 retire-the-atexit-hook** (see below) |

### Why the telemetry hook was retired, not ported

The C `install_arena_telemetry` registers a libc `atexit` callback. Porting that to Sailfin would require taking the **address of a Sailfin function** to hand to `atexit` — a frontend primitive that does not exist (you can call *through* a fn-address, but there's no source-level address-of). Rather than drag a new frontend feature into #822, the dump is invoked **inline at the single exit funnel of `cli_main::main`** (which has one linear `return`, so it fires for `sfn run`/`check`/`build`/… — the dispatch returns its exit code up rather than calling `exit()`).

Output is **byte-compatible** with the retired C `_arena_stats_atexit`, both the enabled (`[sailfin-arena] label=… pages=…`) and disabled (`… stats=disabled (SAILFIN_USE_ARENA="…" opt-out)`) branches. The only semantic change is that a mid-build `abort()` no longer dumps — acceptable for debug-only telemetry.

## Cross-windows: zero risk in this PR

All three target modules (`array`/`io`/`arena`) are already in the cross-windows `RUNTIME_MODS` list, so Windows links the symbols from the Sailfin objects. `sailfin_runtime.c` **stays in place** and still provides `shell_capture` + the `_WIN32` `@sfn_process_run` body. The `process.sfn`-not-in-`RUNTIME_MODS` problem and the `@sfn_process_run` Windows-resolution question are deferred to PR 2, where they're solved together with the file deletion.

## Verification

- `make rebuild` (forces C recompile) — **self-hosts**.
- `arena_default_on_test.sfn` — **5/5** (the pinned telemetry contract, #324).
- `sailfin_main_entry_test.sfn` — **2/2** (argv marshalling).
- `sailfin_main_panic_test.sfn` — **2/2** (panic path).
- `sfn fmt --check` clean on all touched `.sfn` files.

## Follow-up (PR 2, closes #822 + epic #1308)

Port `shell_capture` (→ `process.sfn`, routed through the existing pipe-based `run_capture` with inherited `environ`), delete `sailfin_runtime.c`, drain the header, zero `c-sources`, and rework the cross-windows Makefile list + `windows_stubs.ll` for `@sfn_process_run`. The Arena 40→24 byte shrink (#1309 follow-up) is a separate issue, blocked-by #822.

https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKA7JbDdKoXt9UtorLCfrc)_