### PR TITLE
feat(compiler): defining-global extern var primitive (extern var NAME: T = init)

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -277,9 +277,16 @@ enum Statement {
     ExternVarDeclaration {
         name: string;
         type_annotation: TypeAnnotation;
-        initializer: string?;
         name_span: SourceSpan?;
         decorators: Decorator[];
+        // Defining-global initializer for `extern var NAME: T = init;`
+        // (#1436); null for a bare reference declaration (#1313). Named
+        // `init_value`, NOT `initializer`, deliberately: `VariableDeclaration`
+        // already has a field `initializer: Expression?`, and a same-named
+        // field with a *different* type on another `Statement` variant makes
+        // enum member-access type resolution mis-infer `statement.initializer`
+        // (it resolved to the default `double`, miscompiling unrelated passes).
+        init_value: string?;
     },
     StructDeclaration {
         name: string;

--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -277,6 +277,7 @@ enum Statement {
     ExternVarDeclaration {
         name: string;
         type_annotation: TypeAnnotation;
+        initializer: string?;
         name_span: SourceSpan?;
         decorators: Decorator[];
     },

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -250,7 +250,7 @@ fn emit_statement_declarations(state: NativeState, statement: Statement) -> Stat
     }
     if statement.variant == "ExternVarDeclaration" {
         return StatementDispatchResult {
-            state: emit_extern_var(state, statement.name, statement.type_annotation, statement.initializer, statement.decorators),
+            state: emit_extern_var(state, statement.name, statement.type_annotation, statement.init_value, statement.decorators),
             handled: true
         };
     }

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -250,7 +250,7 @@ fn emit_statement_declarations(state: NativeState, statement: Statement) -> Stat
     }
     if statement.variant == "ExternVarDeclaration" {
         return StatementDispatchResult {
-            state: emit_extern_var(state, statement.name, statement.type_annotation, statement.decorators),
+            state: emit_extern_var(state, statement.name, statement.type_annotation, statement.initializer, statement.decorators),
             handled: true
         };
     }
@@ -389,10 +389,19 @@ fn emit_extern_function(state: NativeState, signature: FunctionSignature, unsafe
 // directive. The native-IR parser collects it as an extern module binding
 // (`NativeBinding { is_extern: true }`), which lowers to an
 // `@NAME = external global <ty>` declaration whose references auto-load.
-fn emit_extern_var(state: NativeState, name: string, type_annotation: TypeAnnotation, decorators: Decorator[]) -> NativeState {
+//
+// With an initializer (`extern var NAME: TYPE = INIT;`) the directive
+// carries the value (`.extern-var NAME : TYPE = INIT`), so exactly one
+// module *defines* the C-ABI symbol (`@NAME = global <ty> <init>`) while
+// every other `extern var NAME: TYPE;` stays an `external global`
+// reference (#1436 defining-global primitive).
+fn emit_extern_var(state: NativeState, name: string, type_annotation: TypeAnnotation, initializer: string?, decorators: Decorator[]) -> NativeState {
     let mut current = emit_decorators(state, decorators);
     let mut line: string = ".extern-var " + name;
     line = append_optional_type_annotation(line, type_annotation);
+    if initializer != null {
+        if initializer.length > 0 { line = line + " = " + initializer; }
+    }
     return state_emit_line(current, line);
 }
 

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -80,6 +80,44 @@ fn _strip_string_quotes(s: string) -> string {
     return s;
 }
 
+// Render the constant LLVM initializer for a defining `extern var`
+// (`extern var NAME: TYPE = INIT;`). A defining global must carry a
+// compile-time constant, so only literal forms are honored; anything else
+// falls back to the type's zero/null default rather than emitting an
+// invalid runtime expression as a global initializer. Pointer types take
+// `null` (the only constant pointer), matching the runtime-global slots
+// this primitive replaces (e.g. `@runtime = global i8* null`, #1436).
+fn _extern_definition_initializer(llvm_type: string, value: string?) -> string {
+    if value == null { return default_return_literal(llvm_type); }
+    let init_expr = trim_text(value);
+    let mut is_pointer: boolean = false;
+    if llvm_type.length > 0 {
+        if llvm_type[llvm_type.length - 1] == "*" { is_pointer = true; }
+    }
+    if is_pointer {
+        if init_expr == "null" { return "null"; }
+        return default_return_literal(llvm_type);
+    }
+    if llvm_type == "double" {
+        if is_number_literal(init_expr) {
+            return normalise_number_literal(init_expr);
+        }
+    }
+    if llvm_type == "i64" {
+        if is_integer_literal(init_expr) { return init_expr; }
+    }
+    if llvm_type == "i32" {
+        if is_integer_literal(init_expr) { return init_expr; }
+    }
+    if llvm_type == "i1" {
+        if is_boolean_literal(init_expr) {
+            if matches_case_insensitive(init_expr, "true") { return "1"; }
+            return "0";
+        }
+    }
+    return default_return_literal(llvm_type);
+}
+
 // Process a single module binding and return its lowered preamble lines,
 // a zero-or-one-element locals array, and whether it needs runtime init.
 fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: string) -> BindingLoweringResult {
@@ -118,7 +156,21 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
     if binding.is_extern {
         let extern_symbol = "@" + sanitize_symbol(name);
         let mut extern_preamble: string[] = [];
-        extern_preamble.push(extern_symbol + " = external global " + llvm_type);
+        // With an initializer the `extern var` *defines* the C-ABI symbol
+        // (`@NAME = global <ty> <init>`, strong external linkage, verbatim
+        // name) so a Sailfin object can own a runtime global that one of the
+        // hand-written `runtime/native/ir/*.ll` files used to define (#1436);
+        // exactly one module may carry the initializer or the link fails with
+        // a duplicate symbol (the C-tentative-definition contract). Without
+        // one it stays an `external global` reference (#1313).
+        if binding.value != null {
+            let init_literal = _extern_definition_initializer(llvm_type, binding.value);
+            extern_preamble.push(extern_symbol + " = global " + llvm_type + " "
+                + init_literal);
+        } else {
+            extern_preamble.push(extern_symbol + " = external global "
+                + llvm_type);
+        }
         let extern_local = LocalBinding {
             name: name,
             pointer: extern_symbol,

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -180,7 +180,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             if include_top_level_bindings {
                 let parsed = parse_binding_components(trim_text(strip_prefix(line, ".extern-var ")));
                 bindings.push(NativeBinding {
-                    name: parsed.name, mutable: false, is_thread_local: false, is_extern: true, type_annotation: parsed.type_annotation, value: null
+                    name: parsed.name, mutable: false, is_thread_local: false, is_extern: true, type_annotation: parsed.type_annotation, value: parsed.value
                 });
             }
             index += 1;

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -1039,9 +1039,9 @@ fn parse_extern_var(initial_parser: Parser, starts_with_unsafe: boolean, decorat
     let statement = Statement.ExternVarDeclaration {
         name: name,
         type_annotation: TypeAnnotation { text: type_text },
-        initializer: initializer,
         name_span: name_span,
-        decorators: decorators
+        decorators: decorators,
+        init_value: initializer
     };
     return StatementParseResult { parser: parser, statement: statement };
 }

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -1013,9 +1013,25 @@ fn parse_extern_var(initial_parser: Parser, starts_with_unsafe: boolean, decorat
         if arrow_result.found { parser = arrow_result.parser; }
     }
 
-    let capture = collect_until(skip_trivia(parser), [";"]);
+    // Capture the type up to either `=` (defining-global initializer) or
+    // `;` (a bare reference declaration). An initializer turns the
+    // `extern var` into a single strong *definition* of the C-ABI symbol
+    // (`@NAME = global <ty> <init>`) so a Sailfin object can own a runtime
+    // global instead of a hand-written `.ll` (#1436); without one it stays
+    // an `external global` reference (#1313).
+    let capture = collect_until(skip_trivia(parser), ["=", ";"]);
     parser = capture.parser;
     let type_text = trim_text(tokens_to_text(capture.tokens));
+
+    parser = skip_trivia(parser);
+    let mut initializer: string? = null;
+    if symbol_matches(parser_peek_raw(parser), "=") {
+        parser = consume_symbol(parser, "=");
+        let init_capture = collect_until(skip_trivia(parser), [";"]);
+        parser = init_capture.parser;
+        let init_text = trim_text(tokens_to_text(init_capture.tokens));
+        if init_text.length > 0 { initializer = init_text; }
+    }
 
     parser = skip_trivia(parser);
     parser = consume_symbol(parser, ";");
@@ -1023,6 +1039,7 @@ fn parse_extern_var(initial_parser: Parser, starts_with_unsafe: boolean, decorat
     let statement = Statement.ExternVarDeclaration {
         name: name,
         type_annotation: TypeAnnotation { text: type_text },
+        initializer: initializer,
         name_span: name_span,
         decorators: decorators
     };

--- a/compiler/tests/e2e/extern_var_emit_test.sfn
+++ b/compiler/tests/e2e/extern_var_emit_test.sfn
@@ -94,3 +94,31 @@ test "extern-var: a reference emits a real load from the global" ![io] {
     // The reference is not elided — it loads from `@environ`.
     assert _has_line_with_both(ir, "load", "@environ");
 }
+
+// Defining-global primitive (#1436): an initializer turns the reference
+// declaration into a single strong *definition* of the C-ABI symbol, so a
+// Sailfin object can own a runtime global that a hand-written `.ll` used to
+// define. The verbatim symbol, no `@global.` mangling, no `internal`.
+fn _def_probe() -> string {
+    return "extern var owned_slot: * u8 = null;\n"
+        + "fn read_slot() -> * u8 {\n"
+        + "    return owned_slot;\n"
+        + "}\n";
+}
+
+test "extern-var: an initializer emits a strong `@NAME = global` definition" ![io] {
+    let ir = _emit_llvm(_def_probe(), "def");
+    assert ir.length > 0;
+    // Strong external definition of the verbatim symbol with the null init.
+    assert _has_line_with_both(ir, "@owned_slot = global", "null");
+    // Not the `external global` reference form, never `internal`, never mangled.
+    assert ! contains(ir, "@owned_slot = external global");
+    assert ! contains(ir, "@owned_slot = internal");
+    assert ! contains(ir, "@global.owned_slot");
+}
+
+test "extern-var: a defining global is still loadable" ![io] {
+    let ir = _emit_llvm(_def_probe(), "defload");
+    assert ir.length > 0;
+    assert _has_line_with_both(ir, "load", "@owned_slot");
+}

--- a/compiler/tests/unit/parser_extern_var_test.sfn
+++ b/compiler/tests/unit/parser_extern_var_test.sfn
@@ -51,7 +51,7 @@ test "parser: a bare extern var has no initializer" ![io] {
     let program = parse_program("extern var errno: i32;");
     let stmt = program.statements[0];
     assert stmt.variant == "ExternVarDeclaration";
-    assert stmt.initializer == null;
+    assert stmt.init_value == null;
 }
 
 test "parser: `extern var NAME: TYPE = null;` captures the initializer" ![io] {
@@ -60,8 +60,8 @@ test "parser: `extern var NAME: TYPE = null;` captures the initializer" ![io] {
     let stmt = program.statements[0];
     assert stmt.variant == "ExternVarDeclaration";
     assert stmt.name == "runtime";
-    assert stmt.initializer != null;
-    assert stmt.initializer == "null";
+    assert stmt.init_value != null;
+    assert stmt.init_value == "null";
     assert _contains(stmt.type_annotation.text, "u8");
 }
 
@@ -70,5 +70,5 @@ test "parser: a defining extern var with an integer initializer" ![io] {
     let stmt = program.statements[0];
     assert stmt.variant == "ExternVarDeclaration";
     assert stmt.name == "counter";
-    assert stmt.initializer == "0";
+    assert stmt.init_value == "0";
 }

--- a/compiler/tests/unit/parser_extern_var_test.sfn
+++ b/compiler/tests/unit/parser_extern_var_test.sfn
@@ -44,3 +44,31 @@ test "parser: `extern fn` still dispatches to a function declaration" ![io] {
     assert program.statements.length == 1;
     assert program.statements[0].variant == "ExternFunctionDeclaration";
 }
+
+// Defining-global primitive (#1436): an initializer turns the reference
+// declaration into a strong definition of the C-ABI symbol.
+test "parser: a bare extern var has no initializer" ![io] {
+    let program = parse_program("extern var errno: i32;");
+    let stmt = program.statements[0];
+    assert stmt.variant == "ExternVarDeclaration";
+    assert stmt.initializer == null;
+}
+
+test "parser: `extern var NAME: TYPE = null;` captures the initializer" ![io] {
+    let program = parse_program("extern var runtime: * u8 = null;");
+    assert program.statements.length == 1;
+    let stmt = program.statements[0];
+    assert stmt.variant == "ExternVarDeclaration";
+    assert stmt.name == "runtime";
+    assert stmt.initializer != null;
+    assert stmt.initializer == "null";
+    assert _contains(stmt.type_annotation.text, "u8");
+}
+
+test "parser: a defining extern var with an integer initializer" ![io] {
+    let program = parse_program("extern var counter: i64 = 0;");
+    let stmt = program.statements[0];
+    assert stmt.variant == "ExternVarDeclaration";
+    assert stmt.name == "counter";
+    assert stmt.initializer == "0";
+}


### PR DESCRIPTION
## Summary
- Extends `extern var` (#1313) with an optional **constant initializer**, turning a reference declaration into a strong *definition* of a C-ABI global: `extern var NAME: TYPE = INIT;` → `@NAME = global <ty> <init>` (verbatim symbol, no `@global.` mangling, no `internal` linkage).
- The bare `extern var NAME: TYPE;` form is **unchanged** — still emits `@NAME = external global <ty>`.
- This is the source-level **defining-global primitive** #1436 needs to move `@runtime`'s definition out of `runtime/native/ir/runtime_globals.ll` into a Sailfin-owned module — the substrate for runtime-capability enforcement (epic #1308).

Advances #1436. (Not `Closes` — see *Scope / what's deferred*.)

## Scope / what's deferred
The issue's full acceptance (flip `@runtime`, drop the `.ll` line, `make check` on both platforms) is **not** in this PR. Using the new syntax inside `runtime/sfn/**` would require the **seed** to parse it, which the current pinned seed (`0.7.0-alpha.42`) cannot. So this PR lands only the frontend primitive (no consumer in seed-compiled source), keeping self-hosting green. The consumer flip is a follow-up gated on a seed cut — per maintainer direction that the seed cut being interspersed is acceptable.

Also corrected along the way: the issue's example `@runtime = global i8** null` is the wrong type — the consumer does `load i8*, i8** @runtime`, so the definition must be `global i8* null`. With a single `extern var` annotation the definition and the sibling `external` declarations share one llvm type, which is *more* consistent than today's i8*/i8** mismatch.

## Pipeline changes
| Stage | File | Change |
|---|---|---|
| parser | `parser/declarations.sfn` | capture optional `= init` up to `;` |
| ast | `ast.sfn` | new `ExternVarDeclaration.initializer: string?` |
| emit | `emit_native.sfn` | thread initializer into the `.extern-var` directive |
| native-ir | `native_ir_parser.sfn` | carry `parsed.value` into `NativeBinding.value` (parser already split `NAME : TYPE = VALUE`) |
| lowering | `llvm/lowering/module_globals.sfn` | emit strong definition + constant-initializer rendering (`null` for pointers; int/double/bool literals; zero/null default for non-constants) |

## Acceptance Criteria (this PR's slice)
- [x] `extern var NAME: TYPE = INIT;` emits exactly one strong `@NAME = global <ty> <init>` definition (verbatim symbol, no mangling/`internal`).
- [x] bare `extern var NAME: TYPE;` still emits `@NAME = external global <ty>` (no behavior change).
- [x] Self-hosts (`make compile`).
- [x] `sfn fmt --check` clean on touched `.sfn`.
- [ ] _(deferred, follow-up + seed cut)_ flip `@runtime`, drop it from `runtime_globals.ll`, `make check` Linux+macOS.

## Verification
```
sailfin check <5 touched compiler files>     # checked 5 files: ok
make compile                                  # status: pass (self-host)
sailfin test compiler/tests/unit/parser_extern_var_test.sfn      # 7/7 PASS
sailfin test compiler/tests/e2e/extern_var_emit_test.sfn         # 4/4 PASS
sailfin test compiler/tests/unit/typecheck_extern_var_test.sfn   # 7/7 PASS (no regression)
sfn fmt --check <touched>                     # clean
```

## Files Changed
`ast.sfn`, `parser/declarations.sfn`, `emit_native.sfn`, `native_ir_parser.sfn`, `llvm/lowering/module_globals.sfn`, plus `parser_extern_var_test.sfn` / `extern_var_emit_test.sfn` regression coverage.

https://claude.ai/code/session_014Ubtcczo4WgbcHHwGtxxvy

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ubtcczo4WgbcHHwGtxxvy)_