### PR TITLE
fix(compiler): flow-sensitive variant narrowing for enum member access

### DIFF
--- a/compiler/src/llvm/expression_lowering/bindings.sfn
+++ b/compiler/src/llvm/expression_lowering/bindings.sfn
@@ -31,7 +31,8 @@ fn bindings_mark_parameter_consumed(bindings: ParameterBinding[], name: string) 
                 llvm_type: binding.llvm_type,
                 type_annotation: binding.type_annotation,
                 consumed: true,
-                span: binding.span
+                span: binding.span,
+                narrowed_variant: binding.narrowed_variant
             };
             result.push(updated);
         } else { result.push(binding); }
@@ -57,7 +58,8 @@ fn bindings_mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBi
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -83,7 +85,8 @@ fn bindings_reset_local_consumption(locals: LocalBinding[], name: string) -> Loc
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -109,7 +112,8 @@ fn bindings_update_local_ownership(locals: LocalBinding[], name: string, ownersh
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -41,7 +41,7 @@ import {
 import { index_of, substring } from "../../../string_utils";
 import { lower_inline_gep_field_access } from "./core_member_helpers";
 import { format_temp_name, default_return_literal } from "../../expressions_helpers";
-import { find_local_binding } from "../../expressions_bindings";
+import { find_local_binding, find_parameter_binding } from "../../expressions_bindings";
 import {
     find_struct_field_info,
     find_variant_field_info,
@@ -179,7 +179,7 @@ fn lower_runtime_global_reference(temp_index: int, lines: string[]) -> Expressio
     };
 }
 
-fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, base_operand: LLVMOperand, pointer_available: boolean, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[], expected_type: string) -> ExpressionResult {
+fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, base_operand: LLVMOperand, pointer_available: boolean, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[], expected_type: string, narrowed_variant: string) -> ExpressionResult {
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
     let mut enum_string_constants: StringConstant[] = string_constants;
@@ -331,6 +331,31 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             matched_fields.push(resolved_field);
         }
         variant_check_index += 1;
+    }
+
+    // Flow-sensitive variant narrowing: when the base is guarded by an
+    // enclosing `if <base>.variant == "<V>"`, resolve the field against
+    // variant V alone. Without this, a field name shared by several
+    // variants with *different* types makes the type selection below bail
+    // to a null operand (the caller then defaults the local to `double`,
+    // miscompiling the access). Restricting to the narrowed variant yields
+    // a single, unambiguous field type.
+    if narrowed_variant.length > 0 {
+        let mut nv_variants: EnumVariantInfo[] = [];
+        let mut nv_fields: StructFieldInfo[] = [];
+        let mut nv_index: int = 0;
+        loop {
+            if nv_index >= matched_variants.length { break; }
+            if matched_variants[nv_index].name == narrowed_variant {
+                nv_variants.push(matched_variants[nv_index]);
+                nv_fields.push(matched_fields[nv_index]);
+            }
+            nv_index += 1;
+        }
+        if nv_variants.length > 0 {
+            matched_variants = nv_variants;
+            matched_fields = nv_fields;
+        }
     }
 
     if matched_variants.length == 0 {
@@ -658,6 +683,24 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     let mut current_temp: int = base_result.temp_index;
     let base_operand = base_result.operand;
 
+    // Flow-sensitive variant narrowing (see `lower_enum_member_access`):
+    // if the base is a simple local guarded by `if <base>.variant == "<V>"`,
+    // pick up "<V>" so an enum field access resolves against that variant.
+    let mut base_narrowed_variant: string = "";
+    let _narrow_binding = find_local_binding(locals, parse.base);
+    if _narrow_binding != null {
+        base_narrowed_variant = _narrow_binding.narrowed_variant;
+    }
+    if base_narrowed_variant.length == 0 {
+        // The guarded base is frequently a parameter (e.g. AST-pass
+        // dispatch `fn f(statement: Statement)`), so consult the parameter
+        // bindings too.
+        let _narrow_param = find_parameter_binding(bindings, parse.base);
+        if _narrow_param != null {
+            base_narrowed_variant = _narrow_param.narrowed_variant;
+        }
+    }
+
     if parse.field == "length" {
         if ends_with_pointer_suffix(base_operand.llvm_type) {
             let inner_type = strip_pointer_suffix(base_operand.llvm_type);
@@ -774,7 +817,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
         if struct_info == null {
             let enum_info_candidate = find_enum_info_by_llvm_type(context, candidate);
             if enum_info_candidate != null {
-                return lower_enum_member_access(parse, enum_info_candidate, base_operand, true, current_temp, current_lines, diagnostics, collected_string_constants, expected_type);
+                return lower_enum_member_access(parse, enum_info_candidate, base_operand, true, current_temp, current_lines, diagnostics, collected_string_constants, expected_type, base_narrowed_variant);
             }
             if base_type_trimmed == "i8*" {
                 let _igep_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, locals, current_temp, current_lines, diagnostics, collected_string_constants, context);
@@ -803,7 +846,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
         if struct_info == null {
             let enum_info_candidate = find_enum_info_by_llvm_type(context, base_type_trimmed);
             if enum_info_candidate != null {
-                return lower_enum_member_access(parse, enum_info_candidate, base_operand, false, current_temp, current_lines, diagnostics, collected_string_constants, expected_type);
+                return lower_enum_member_access(parse, enum_info_candidate, base_operand, false, current_temp, current_lines, diagnostics, collected_string_constants, expected_type, base_narrowed_variant);
             }
             if base_type_trimmed == "i8*" {
                 let _igep2_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, locals, current_temp, current_lines, diagnostics, collected_string_constants, context);

--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -228,7 +228,8 @@ fn promote_local_to_rc(locals: LocalBinding[], name: string) -> LocalBinding[] {
                         scope_id: entry.scope_id,
                         scope_depth: entry.scope_depth,
                         allocation_kind: "rc",
-                        init_sentinel: entry.init_sentinel
+                        init_sentinel: entry.init_sentinel,
+                        narrowed_variant: entry.narrowed_variant
                     };
                 }
             }
@@ -311,7 +312,8 @@ fn mark_last_local_consumed(locals: LocalBinding[], name: string) -> LocalBindin
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
         }
         result.push(updated);

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -103,7 +103,8 @@ fn _ipc_make_parameter_binding(name: string, llvm_name: string, llvm_type: strin
         llvm_type: llvm_type,
         type_annotation: type_annotation,
         consumed: false,
-        span: null
+        span: null,
+        narrowed_variant: ""
     };
 }
 
@@ -118,7 +119,8 @@ fn _ipc_make_local_binding(name: string, pointer: string, llvm_type: string, typ
         scope_id: scope_id,
         scope_depth: scope_depth,
         allocation_kind: default_allocation_kind(),
-        init_sentinel: ""
+        init_sentinel: "",
+        narrowed_variant: ""
     };
 }
 

--- a/compiler/src/llvm/expressions_bindings.sfn
+++ b/compiler/src/llvm/expressions_bindings.sfn
@@ -41,7 +41,8 @@ fn mark_parameter_consumed(bindings: ParameterBinding[], name: string) -> Parame
                 llvm_type: binding.llvm_type,
                 type_annotation: binding.type_annotation,
                 consumed: true,
-                span: binding.span
+                span: binding.span,
+                narrowed_variant: binding.narrowed_variant
             };
             result.push(updated);
         } else { result.push(binding); }
@@ -67,7 +68,8 @@ fn mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -93,7 +95,8 @@ fn reset_local_consumption(locals: LocalBinding[], name: string) -> LocalBinding
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/lifetime.sfn
+++ b/compiler/src/llvm/lifetime.sfn
@@ -576,7 +576,8 @@ fn update_local_ownership(locals: LocalBinding[], name: string, ownership: Owner
                 scope_id: entry.scope_id,
                 scope_depth: entry.scope_depth,
                 allocation_kind: entry.allocation_kind,
-                init_sentinel: entry.init_sentinel
+                init_sentinel: entry.init_sentinel,
+                narrowed_variant: entry.narrowed_variant
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -183,7 +183,8 @@ fn _emit_make_parameter_binding(name: string, llvm_name: string, llvm_type: stri
         llvm_type: llvm_type,
         type_annotation: type_annotation,
         consumed: false,
-        span: null
+        span: null,
+        narrowed_variant: ""
     };
 }
 

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -716,7 +716,7 @@ fn _lower_closure_env_load_prologue_marker(marker: string, bindings: ParameterBi
         if bi >= prologue.bindings.length { break; }
         let loaded = prologue.bindings[bi];
         new_bindings.push(ParameterBinding {
-            name: loaded.name, llvm_name: loaded.llvm_name, llvm_type: loaded.llvm_type, type_annotation: captures[bi].type_text, consumed: false, span: null
+            name: loaded.name, llvm_name: loaded.llvm_name, llvm_type: loaded.llvm_type, type_annotation: captures[bi].type_text, consumed: false, span: null, narrowed_variant: ""
         });
         bi += 1;
     }

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -209,7 +209,8 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
         scope_id: element_loop_scope_id,
         scope_depth: scope_depth + 1,
         allocation_kind: "arena",
-        init_sentinel: ""
+        init_sentinel: "",
+        narrowed_variant: ""
     };
     let body_locals = append_local_binding(current_locals, iteration_binding);
     let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, element_loop_scope_id, scope_depth

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -311,7 +311,8 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         scope_id: loop_body_scope_id,
         scope_depth: scope_depth + 1,
         allocation_kind: "arena",
-        init_sentinel: ""
+        init_sentinel: "",
+        narrowed_variant: ""
     };
     let header_load = load_local_operand(iteration_binding, current_temp, current_lines);
     let mut _ci16: int = 0;

--- a/compiler/src/llvm/lowering/instructions_if.sfn
+++ b/compiler/src/llvm/lowering/instructions_if.sfn
@@ -138,6 +138,114 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: int, end
     };
 }
 
+// Flow-sensitive variant narrowing (enum member-access type resolution).
+// A guard of the exact shape `<base>.variant == "<V>"` narrows `<base>`
+// to variant `<V>` inside the then-branch so an enum field access resolves
+// against that variant — see `lower_enum_member_access`.
+struct _VariantGuard {
+    matched: boolean;
+    base: string;
+    variant: string;
+}
+
+// Parse a guard of the exact shape `<base>.variant == "<V>"`. `<base>` must
+// be a simple identifier (rejects compound conditions, calls, member
+// chains); the remainder must be exactly the quoted variant name so a
+// trailing `&& ...` / `|| ...` does not narrow (conservative, sound).
+fn _parse_variant_guard(condition: string) -> _VariantGuard {
+    let none = _VariantGuard { matched: false, base: "", variant: "" };
+    let trimmed = trim_text(condition);
+    let marker = ".variant";
+    let vi = index_of(trimmed, marker);
+    if vi <= 0 { return none; }
+    let base = trim_text(substring(trimmed, 0, vi));
+    if !is_simple_identifier(base) { return none; }
+    let mut rest = trim_text(substring(trimmed, vi + marker.length, trimmed.length));
+    if !starts_with(rest, "==") { return none; }
+    rest = trim_text(substring(rest, 2, rest.length));
+    // The remainder must be exactly a quoted variant name — a trailing
+    // `&& ...` / `|| ...` leaves a non-quote final char, so a compound
+    // condition does not narrow (conservative, sound).
+    if rest.length < 2 { return none; }
+    if rest[0] != "\"" { return none; }
+    if rest[rest.length - 1] != "\"" { return none; }
+    let variant = substring(rest, 1, rest.length - 1);
+    if variant.length == 0 { return none; }
+    if index_of(variant, "\"") >= 0 { return none; }
+    return _VariantGuard { matched: true, base: base, variant: variant };
+}
+
+// Return a copy of `locals` with the binding named `base_name` carrying
+// `narrowed_variant = variant` (all other fields preserved).
+fn _narrow_locals_for_variant(locals: LocalBinding[], base_name: string, variant: string) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= locals.length { break; }
+        let b = locals[i];
+        if b.name == base_name {
+            out.push(LocalBinding {
+                name: b.name, pointer: b.pointer, llvm_type: b.llvm_type, type_annotation: b.type_annotation, ownership: b.ownership, consumed: b.consumed, scope_id: b.scope_id, scope_depth: b.scope_depth, allocation_kind: b.allocation_kind, init_sentinel: b.init_sentinel, narrowed_variant: variant
+            });
+        } else { out.push(b); }
+        i += 1;
+    }
+    return out;
+}
+
+// Restore the `narrowed_variant` of the binding named `base_name` in
+// `locals` to `original` — clearing the then-branch narrowing so it does
+// not leak past the `if` block.
+fn _restore_narrowing(locals: LocalBinding[], base_name: string, original: string) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= locals.length { break; }
+        let b = locals[i];
+        if b.name == base_name {
+            out.push(LocalBinding {
+                name: b.name, pointer: b.pointer, llvm_type: b.llvm_type, type_annotation: b.type_annotation, ownership: b.ownership, consumed: b.consumed, scope_id: b.scope_id, scope_depth: b.scope_depth, allocation_kind: b.allocation_kind, init_sentinel: b.init_sentinel, narrowed_variant: original
+            });
+        } else { out.push(b); }
+        i += 1;
+    }
+    return out;
+}
+
+// Parameter-binding mirror of `_narrow_locals_for_variant` — the guarded
+// base is often a function parameter, not a local.
+fn _narrow_bindings_for_variant(bindings: ParameterBinding[], base_name: string, variant: string) -> ParameterBinding[] {
+    let mut out: ParameterBinding[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= bindings.length { break; }
+        let b = bindings[i];
+        if b.name == base_name {
+            out.push(ParameterBinding {
+                name: b.name, llvm_name: b.llvm_name, llvm_type: b.llvm_type, type_annotation: b.type_annotation, consumed: b.consumed, span: b.span, narrowed_variant: variant
+            });
+        } else { out.push(b); }
+        i += 1;
+    }
+    return out;
+}
+
+fn _restore_bindings_narrowing(bindings: ParameterBinding[], base_name: string, original: string) -> ParameterBinding[] {
+    let mut out: ParameterBinding[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= bindings.length { break; }
+        let b = bindings[i];
+        if b.name == base_name {
+            out.push(ParameterBinding {
+                name: b.name, llvm_name: b.llvm_name, llvm_type: b.llvm_type, type_annotation: b.type_annotation, consumed: b.consumed, span: b.span, narrowed_variant: original
+            });
+        } else { out.push(b); }
+        i += 1;
+    }
+    return out;
+}
+
 fn lower_if_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult ![io] {
     let mut current_lines: string[] = lines;
     let base_lines_snapshot = copy_string_array(lines);
@@ -262,9 +370,33 @@ fn lower_if_instruction(function: NativeFunction, start_index: int, llvm_return:
     let base_local_id = current_next_local;
     let base_block_counter = current_block_counter;
 
+    // Flow-sensitive variant narrowing: an `if <base>.variant == "<V>"`
+    // guard narrows `<base>` to variant V inside the then-branch only.
+    let _guard = _parse_variant_guard(sanitized_condition_source);
+    let mut then_locals: LocalBinding[] = base_locals;
+    let mut then_param_bindings: ParameterBinding[] = bindings;
+    let mut _guard_local_active: boolean = false;
+    let mut _guard_local_original: string = "";
+    let mut _guard_param_active: boolean = false;
+    let mut _guard_param_original: string = "";
+    if _guard.matched {
+        let _gb = find_local_binding(base_locals, _guard.base);
+        if _gb != null {
+            _guard_local_active = true;
+            _guard_local_original = _gb.narrowed_variant;
+            then_locals = _narrow_locals_for_variant(base_locals, _guard.base, _guard.variant);
+        }
+        let _gp = find_parameter_binding(bindings, _guard.base);
+        if _gp != null {
+            _guard_param_active = true;
+            _guard_param_original = _gp.narrowed_variant;
+            then_param_bindings = _narrow_bindings_for_variant(bindings, _guard.base, _guard.variant);
+        }
+    }
+
     current_lines.push(then_label + ":");
     let then_scope_id = make_child_scope_id(scope_id, then_label);
-    let then_result = lower_instruction_range(function, structure.then_start, structure.then_end, llvm_return, bindings, base_locals, base_allocas, [], base_temp, base_block_counter, base_local_id, current_next_region, functions, loop_stack, context, then_scope_id, scope_depth
+    let then_result = lower_instruction_range(function, structure.then_start, structure.then_end, llvm_return, then_param_bindings, then_locals, base_allocas, [], base_temp, base_block_counter, base_local_id, current_next_region, functions, loop_stack, context, then_scope_id, scope_depth
         + 1, then_label);
     let mut _ci14: int = 0;
     loop {
@@ -275,10 +407,17 @@ fn lower_if_instruction(function: NativeFunction, start_index: int, llvm_return:
     lifetime_regions = extend_lifetime_regions(lifetime_regions, then_result.lifetime_regions);
     current_allocas = then_result.allocas;
     current_locals = then_result.locals;
+    // Clear the then-branch narrowing so it does not leak past the `if`.
+    if _guard_local_active {
+        current_locals = _restore_narrowing(current_locals, _guard.base, _guard_local_original);
+    }
     current_temp = then_result.temp_index;
     current_block_counter = then_result.block_counter;
     current_next_local = then_result.next_local_id;
     then_bindings = then_result.bindings;
+    if _guard_param_active {
+        then_bindings = _restore_bindings_narrowing(then_bindings, _guard.base, _guard_param_original);
+    }
     current_next_region = then_result.next_lifetime_region_id;
     current_lines = extend_string_array(current_lines, then_result.lines);
     let then_exit_label = find_last_label(current_lines, then_label);

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -592,7 +592,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         if _is_channel_init { local_type_annotation = "channel"; }
     }
     current_locals = append_local_binding(current_locals, LocalBinding {
-        name: instruction.name, pointer: pointer, llvm_type: llvm_type, type_annotation: local_type_annotation, ownership: ownership, consumed: false, scope_id: scope_id, scope_depth: scope_depth, allocation_kind: "arena", init_sentinel: init_sentinel
+        name: instruction.name, pointer: pointer, llvm_type: llvm_type, type_annotation: local_type_annotation, ownership: ownership, consumed: false, scope_id: scope_id, scope_depth: scope_depth, allocation_kind: "arena", init_sentinel: init_sentinel, narrowed_variant: ""
     });
 
     let mutation = LocalMutation {

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -85,7 +85,8 @@ fn _match_make_local_binding(name: string, pointer: string, llvm_type: string, s
         scope_id: scope_id,
         scope_depth: scope_depth,
         allocation_kind: "arena",
-        init_sentinel: ""
+        init_sentinel: "",
+        narrowed_variant: ""
     };
 }
 
@@ -763,7 +764,7 @@ fn lower_match_instruction(function: NativeFunction, start_index: int, llvm_retu
 
                         base_locals.push(LocalBinding {
                             name: subject_name, pointer: local_alloca_temp, llvm_type: payload_type, type_annotation: "", ownership: null, consumed: false, scope_id: make_child_scope_id(scope_id, body_labels[index]), scope_depth: scope_depth
-                                + 1, allocation_kind: "arena", init_sentinel: ""
+                                + 1, allocation_kind: "arena", init_sentinel: "", narrowed_variant: ""
                         });
                         base_local_id += 1;
                     }

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -480,7 +480,7 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
                     + err_slot);
                 catch_locals = append_local_binding(catch_locals, LocalBinding {
                     name: trimmed_name, pointer: err_slot, llvm_type: "i8*", type_annotation: "string", ownership: null, consumed: false, scope_id: catch_scope_id, scope_depth: scope_depth
-                        + 1, allocation_kind: "arena", init_sentinel: ""
+                        + 1, allocation_kind: "arena", init_sentinel: "", narrowed_variant: ""
                 });
             }
         }

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -181,7 +181,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
             scope_id: scope_id,
             scope_depth: 0,
             allocation_kind: "arena",
-            init_sentinel: ""
+            init_sentinel: "",
+            narrowed_variant: ""
         };
         return BindingLoweringResult {
             preamble_lines: extern_preamble,
@@ -282,7 +283,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
         scope_id: scope_id,
         scope_depth: 0,
         allocation_kind: "arena",
-        init_sentinel: ""
+        init_sentinel: "",
+        narrowed_variant: ""
     };
     let mut locals: LocalBinding[] = [];
     locals.push(local);

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -171,6 +171,11 @@ struct ParameterBinding {
     type_annotation: string;
     consumed: boolean;
     span: NativeSourceSpan?;
+    // Flow-sensitive variant narrowing for an enum parameter guarded by
+    // `if <name>.variant == "<V>"` (mirror of LocalBinding.narrowed_variant
+    // — the guarded base is often a parameter, e.g. the AST-pass dispatch
+    // `fn f(statement: Statement)`). Empty = no narrowing.
+    narrowed_variant: string;
 }
 
 struct ParameterPreparation {
@@ -200,6 +205,14 @@ struct LocalBinding {
     // Empty string = no sentinel (binding is outside any try body, or this
     // is a non-let binding such as a catch variable / for-loop iterator).
     init_sentinel: string;
+    // Flow-sensitive variant narrowing (issue: enum member-access type
+    // resolution). When this binding is an enum value guarded by an
+    // enclosing `if <name>.variant == "<V>"`, this holds "<V>" for the
+    // guarded region so member access (`<name>.field`) resolves the field
+    // against variant V specifically — rather than mis-inferring `double`
+    // when several variants share the field name with different types.
+    // Empty string = no narrowing in effect.
+    narrowed_variant: string;
 }
 
 struct ModuleGlobalLoweringResult {

--- a/compiler/src/llvm/utils.sfn
+++ b/compiler/src/llvm/utils.sfn
@@ -529,7 +529,8 @@ fn _merge_copy_parameter_binding(primary: ParameterBinding, consumed_flag: boole
         llvm_type: primary.llvm_type,
         type_annotation: primary.type_annotation,
         consumed: consumed_flag,
-        span: primary.span
+        span: primary.span,
+        narrowed_variant: primary.narrowed_variant
     };
 }
 

--- a/compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt
+++ b/compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt
@@ -19,5 +19,5 @@
 #      (see `rendering.sfn` / `core_call_emission.sfn`).
 #   3. Delete the bypass comment AND the allowlist line in the same PR.
 
-compiler/src/llvm/lowering/emission.sfn:622:            wrapper_lines.push("  %argv_arr_i8 = call i8* @sailfin_runtime_argv_to_string_array(i32 %argc, i8** %argv)");
-compiler/src/llvm/lowering/emission.sfn:693:        wrapper_lines.push("  call void @sailfin_runtime_panic_emit(i8* %msg)");
+compiler/src/llvm/lowering/emission.sfn:623:            wrapper_lines.push("  %argv_arr_i8 = call i8* @sailfin_runtime_argv_to_string_array(i32 %argc, i8** %argv)");
+compiler/src/llvm/lowering/emission.sfn:694:        wrapper_lines.push("  call void @sailfin_runtime_panic_emit(i8* %msg)");


### PR DESCRIPTION
## Summary
Fixes a foundational self-hosting miscompilation: **enum member access mis-resolves a field's type when several variants share that field name with *different* types**, silently defaulting the binding to `double` (pointer bits reinterpreted as a float) and corrupting any pass that reads it.

This is the root cause uncovered while landing #1440 (the extern-var defining-global primitive). Reusing the field name `initializer` on a second `Statement` variant — `VariableDeclaration.initializer: Expression?` vs the new `ExternVarDeclaration.initializer: string?` — made `ownership_checker.sfn::_scope_after_statement` read `statement.initializer` as `double`, corrupting `check_ownership` for programs containing **no** extern var and crashing multiple CI shards. #1440 shipped with a defensive rename (`init_value`); this PR fixes the compiler so the collision class can't miscompile at all.

## Root cause
`lower_enum_member_access` collects every variant declaring the field. With no expected type and inconsistent field types across variants, it bailed to a `null` operand; the caller then defaulted the local's LLVM type to `double`. The IR diff was conclusive — a local that should be `%Expression*` became `alloca double`.

## Fix: flow-sensitive variant narrowing
Inside an `if <base>.variant == "<V>"` guard, narrow `<base>` to variant `V` so the field resolves against that variant's type alone.

- `LocalBinding` / `ParameterBinding` carry a `narrowed_variant` field (the guarded base is often a **parameter**, e.g. AST-pass dispatch `fn f(statement: Statement)`).
- `lower_if_instruction` parses the exact guard shape `<base>.variant == "<V>"` — conservative: simple-identifier base only, no compound conditions — narrows the base for the **then-branch only**, and restores it afterward so narrowing never leaks past the `if`.
- `lower_enum_member_access` filters matched variants to the narrowed one, yielding a single unambiguous field type instead of the `double` default.

## Verification
```
make clean-build && make compile        # self-hosts on current main
# minimal two-variant collision repro: returns 42 (was 4.78e+18 garbage)
sailfin test compiler/tests/integration/ownership_e6_test.sfn   # PASS
bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh build/native/sailfin  # PASS
```
- Clean self-host exercises this path on every `if x.variant == ...` guard across the whole compiler.
- Updated `runtime_emission_allowlist.txt` for the two pinned `emission.sfn` line numbers shifted by the `ParameterBinding` field addition (623/694).

## Files
`llvm/types.sfn` (the two binding fields), `llvm/lowering/instructions_if.sfn` (guard parse + narrow/restore), `llvm/expression_lowering/native/core_member_lowering.sfn` (variant filter), the `LocalBinding`/`ParameterBinding` construction sites that thread the new field, and the audit allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ubtcczo4WgbcHHwGtxxvy

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ubtcczo4WgbcHHwGtxxvy)_