### PR TITLE
chore(runtime): retire transitional @sfn_default_arena global

### DIFF
--- a/runtime/native/ir/runtime_globals.ll
+++ b/runtime/native/ir/runtime_globals.ll
@@ -6,18 +6,10 @@
 ; i8**`; the single strong definition now comes from the Sailfin runtime
 ; object linked via `sfn-sources`.
 
-; `@sfn_default_arena` (#822 / #1308) — the IR-visible default-arena slot.
-; The compiler SOURCE no longer emits references to it (#1428 switched the
-; arena operand to a literal `null`), but the pinned macOS-arm64 seed
-; binary still emits load-from-`@sfn_default_arena` references in some
-; modules (typecheck / num_format / parser / effect_gate); the linux-x86_64
-; seed does not. The deleted `sailfin_runtime.c` was their provider
-; (`SfnArray *sfn_default_arena = NULL;`). Re-provide the global here so the
-; macOS link resolves. A `null` value is correct, not just link-satisfying:
-; the runtime threads this slot through `string.sfn::_sfn_resolve_arena`,
-; which returns `sfn_arena_global()` whenever the slot's handle is 0 — so a
-; null slot resolves to the real global arena on every path, identical to
-; #1428's direct-`null` emission. Linked on all targets; unreferenced and
-; harmless where the seed does not emit it. Retires once the seed is bumped
-; past the #1428 propagation (drop this global then).
-@sfn_default_arena = global i8* null
+; `@sfn_default_arena` (#822 / #1308 / #1437) retired. The transitional
+; `null` global only existed to satisfy a pre-#1428 macOS-arm64 seed whose
+; emitter still produced load-from-`@sfn_default_arena` references. The
+; pinned seed (v0.7.0-alpha.44) is built post-#1428 on every platform — its
+; emitter threads `ptr null` directly (resolved by
+; `string.sfn::_sfn_resolve_arena` to the real global arena), so no seed
+; references the symbol anymore and the global is gone.


### PR DESCRIPTION
## Summary
- Remove the transitional `@sfn_default_arena = global i8* null` from `runtime/native/ir/runtime_globals.ll`.
- The `null` global only existed to satisfy a **pre-#1428 macOS-arm64 seed** whose emitter still produced `load`-from-`@sfn_default_arena` references; the Linux seed never did.
- The pinned seed (`v0.7.0-alpha.44`, cut today from `main`) is built **post-#1428 on every platform** — its emitter threads `ptr null` directly (resolved by `string.sfn::_sfn_resolve_arena` to the real global arena), so **no seed references the symbol anymore**. The historical Linux/macOS split is resolved at the seed boundary.

Closes #1437

## Why this is no longer blocked
The issue was labeled `blocked` on #1319 (the C-runtime-free gated seed cut), written before the C runtime was deleted. That has since happened: `runtime/native/src/*.c` is gone, #1436 moved `@runtime` to a Sailfin object (#1447), and fresh seeds were cut today. At seed `v0.7.0-alpha.44` every `@sfn_default_arena` reference in compiler source is a **comment** (verified via `git grep` on the seed tree) — the emit paths emit `ptr null`. Since both platform seed binaries are built from that one source, the macOS-arm64 seed's emitter also emits `ptr null`.

## Acceptance Criteria
- [x] `runtime_globals.ll` no longer declares `@sfn_default_arena`.
- [x] `make clean-build && make check` self-hosts on **Linux** with no undefined `_sfn_default_arena`.
- [ ] macOS-arm64 self-host — covered by this PR's CI "Build compiler" leg.

## Verification (Linux)
```
make clean-build && make check
  → e2e-sh: 69/69 passed, 0 failed
  → stage2 == stage3: compiler is a fixed point ✓
  → ===SAILFIN-RESULT=== {"target":"check","status":"pass"} ===END===
nm -u build/sailfin/*.o | grep sfn_default_arena
  → (no undefined sfn_default_arena)
```

## Files Changed
- `runtime/native/ir/runtime_globals.ll` — drop the `@sfn_default_arena` global; leave a comments-only breadcrumb.

## Note / follow-up
The file is now comments-only. It stays in place (not deleted) because it's still wired into `runtime/native/capsule.toml` (`ll-sources`) and the `Makefile` Windows cross-compile path — deleting it is the issue's explicitly-deferred *"final `runtime/native/` removal"* step. Happy to fold that teardown into this PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAxWuyYGGCMJ6BVgJu9CmV)_