### PR TITLE
chore(runtime): scrub stale C-runtime/M1.A.2 comments + drop dead extern

### DIFF
--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -45,8 +45,7 @@
 //
 // Retiring the `runtime.X` magic namespace wholesale (and with it the
 // now-permanently-`null` `@runtime` global in
-// `runtime/sfn/runtime_globals.sfn` — the keystone for deleting
-// `runtime/native/` entirely) is seed-gated: the pinned seed still
+// `runtime/sfn/runtime_globals.sfn`) is seed-gated: the pinned seed still
 // emits `@runtime = external global` in every module it compiles, so
 // the definition must survive until a post-flip seed is cut. See
 // `docs/runtime_audit.md` for the full per-symbol table.

--- a/runtime/sfn/adapters/filesystem.sfn
+++ b/runtime/sfn/adapters/filesystem.sfn
@@ -54,7 +54,7 @@
 //     (neither extern is in `libc.sfn`) without the seek/tell pair.
 //
 // Out (deferred to M3.9):
-//   - Deleting `runtime/native/src/sailfin_runtime.c`'s
+//   - Deleting the retired C runtime's
 //     `sailfin_adapter_fs_*` bodies. They stay exported during the
 //     M3 window so seed-built compiler IR (which still calls them
 //     by their legacy names) continues to link. M3.9 retires

--- a/runtime/sfn/adapters/http.sfn
+++ b/runtime/sfn/adapters/http.sfn
@@ -3,7 +3,7 @@
 // First-wave Sailfin-native HTTP/1.1 client adapter (M3, #818 —
 // epic #390 / tracker #321). Replaces the curl-subprocess HTTP
 // path (`sailfin_runtime_http_get` / `_post_json` / `_download`
-// in `runtime/native/src/sailfin_runtime.c`, which shell out to
+// in the retired C runtime, which shell out to
 // `curl -sfS`) with a pure-Sailfin socket client built on the
 // BSD-sockets surface declared in `runtime/sfn/platform/net.sfn`.
 // Mirrors the migration shape of `runtime/sfn/adapters/filesystem.sfn`

--- a/runtime/sfn/array.sfn
+++ b/runtime/sfn/array.sfn
@@ -6,23 +6,23 @@
 // element type, replacing both the legacy `SailfinPtrArray` (with the
 // hidden 2-word header that backed `_recent_array_*` ring-buffer
 // tracking and the canary slots in
-// `runtime/native/src/sailfin_runtime.c`) and the byte-addressed array
+// the retired C runtime) and the byte-addressed array
 // header.
 //
 // Status (#1316, C6 of epic #1308): the array *core* —
 // `sfn_array_concat` / `sfn_array_push_string` / `sfn_array_push_slot`
 // — is **bare-defined here** (link-ownership flipped off the C
 // runtime, mirroring the #1309 arena flip). Their C definitions in
-// `runtime/native/src/sailfin_runtime.c` are retired; emission's
+// the retired C runtime are retired; emission's
 // `@sfn_array_*` calls resolve to these Sailfin bodies at link because
-// this module is listed in `runtime/native/capsule.toml::sfn-sources`
-// and linked into every binary alongside the C runtime.
+// this module is listed in `runtime/capsule.toml::sfn-sources`
+// and linked into every binary.
 //
 // Status (#1308 residual): the `sailfin_runtime_*_v2` trio the core
 // wrappers delegate to — `concat_v2` / `append_string_v2` /
 // `array_push_slot_v2` — is **now also bare-defined here** in Sailfin
 // (link-ownership flip, mechanism 1). The C bodies in
-// `runtime/native/src/sailfin_runtime.c` are `static`-ified and the
+// the retired C runtime are `static`-ified and the
 // header prototypes dropped; emission's `@sfn_array_*` wrappers and the
 // `runtime/sfn/adapters/filesystem.sfn` C-ABI externs resolve to these
 // Sailfin definitions at link. The `SfnArray` container layout
@@ -71,7 +71,7 @@
 // `runtime/sfn/memory/arena.sfn`) when the process arena is enabled, and
 // fall through to libc `calloc` / `realloc` otherwise — exactly the
 // dual-mode `_rt_calloc` / `_rt_realloc` contract the retired C bodies
-// used (`runtime/native/src/sailfin_runtime.c`). `memcpy` / `memset`
+// used (the retired C runtime). `memcpy` / `memset`
 // move and zero the element storage.
 extern fn calloc(count: usize, size: usize) -> * u8;
 
@@ -363,7 +363,7 @@ fn sailfin_runtime_array_push_slot_v2(data_ptr: * * u8, len_ptr: * i64, cap_ptr:
 // of element storage from the arena.
 //
 // Status: stub returning `null`. Matches the C stub
-// (`sfn_array_create` in `runtime/native/src/sailfin_runtime.c`) so
+// (`sfn_array_create` in the retired C runtime) so
 // accidental callers fail fast at the next push/concat with a
 // consistent surface across both the Sailfin and C definitions. The
 // first compiler-emitted callers land in M2.7 when array-literal
@@ -395,10 +395,10 @@ fn sfn_array_sfn_push(arr: * u8, elem_ptr: * u8, elem_size: i64, arena: * u8) ->
 // that `compiler/src/llvm/runtime_helpers.sfn` (`concat` descriptor)
 // and the direct emission sites in
 // `compiler/src/llvm/expression_lowering/arrays.sfn` emit `@sfn_array_concat`
-// against — the C definition in `runtime/native/src/sailfin_runtime.c`
+// against — the C definition in the retired C runtime
 // is retired and emission now binds here at link (`runtime/sfn/array.sfn`
-// is in `runtime/native/capsule.toml::sfn-sources`, linked into every
-// binary alongside the C runtime).
+// is in `runtime/capsule.toml::sfn-sources`, linked into every
+// binary).
 //
 // ABI: **2-arg** `(a, b)` to match the descriptor's emitted shape
 // (`parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"]`).
@@ -421,7 +421,7 @@ fn sfn_array_concat(a: * u8, b: * u8) -> * u8 {
     // input's buffer); the element slots are **shallow**-copied, so for
     // `char*` elements the result's element pointers still alias the same
     // string bytes as the inputs (`sailfin_runtime_concat_v2`,
-    // `runtime/native/src/sailfin_runtime.c:8736-8751`) — `unsafe` here is
+    // `sailfin_runtime.c:8736-8751` in the retired C runtime) — `unsafe` here is
     // bounded by container ownership, not element-content uniqueness.
     // Deep element-content ownership lands with the arena-backed body
     // (M3 per §2.1.1).
@@ -439,7 +439,7 @@ fn sfn_array_sfn_slice(arr: * u8, start: i64, end: i64) -> * u8 { return arr; }
 
 // Compiler-emission helpers under the `_sfn_` infix. The C
 // trampolines (`sfn_array_push_string`, `sfn_array_push_slot` in
-// `runtime/native/src/sailfin_runtime.c`) carry the bare names that
+// the retired C runtime) carry the bare names that
 // `compiler/src/llvm/expression_lowering/arrays.sfn` emits against;
 // these proof-of-life Sailfin exports preserve the same ABIs so the
 // migration to arena-backed bodies stays a single PR — rename

--- a/runtime/sfn/assert.sfn
+++ b/runtime/sfn/assert.sfn
@@ -1,8 +1,8 @@
 // runtime/sfn/assert.sfn
 //
 // Assertion-failure handler (#822 / #1308). Ports `sailfin_assert_fail`
-// and the `runtime_assert_fail_fn` trampoline out of the deleted
-// `runtime/native/src/sailfin_runtime.c`.
+// and the `runtime_assert_fail_fn` trampoline out of the retired
+// C runtime (formerly `sailfin_runtime.c`).
 //
 // The compiler emits `call @runtime_assert_fail_fn(file, line, col, msg)`
 // for every `assert` it cannot prove true at compile time
@@ -26,7 +26,7 @@
 // Excluded from the cross-windows RUNTIME_MODS (its `fopen`/`fwrite`
 // sink + the SFAF protocol are Linux/macOS test-harness plumbing);
 // Windows resolves `@runtime_assert_fail_fn` / `@sailfin_assert_fail`
-// from the abort stubs in `runtime/native/ir/windows_stubs.ll`. Sync
+// from the abort stubs in `runtime/ir/windows_stubs.ll`. Sync
 // pinned by `compiler/tests/e2e/test_cross_windows_runtime_modules.sh`.
 extern fn malloc(size: usize) -> * u8;
 

--- a/runtime/sfn/clock.sfn
+++ b/runtime/sfn/clock.sfn
@@ -2,7 +2,7 @@
 //
 // Sailfin-native definition of `@sfn_sleep`. PR 2 of the sleep
 // migration (issue #397, part of M2 epic #389) replaces the
-// pre-existing C trampoline in `runtime/native/src/sailfin_runtime.c`
+// pre-existing C trampoline in the retired C runtime
 // with a direct `nanosleep` call from
 // `runtime/sfn/platform/posix.sfn`. The C entrypoint
 // `sailfin_runtime_sleep` and its `platform/libc.sfn` declaration
@@ -15,7 +15,7 @@
 // `docs/runtime_architecture.md` §2.7.4. Issue #307 is the unit
 // audit that locked this in across all four layers.
 //
-// Linkage: this file is listed in `runtime/native/capsule.toml`'s
+// Linkage: this file is listed in `runtime/capsule.toml`'s
 // `sfn-sources` array; `_compile_runtime_sfn_sources` in
 // `compiler/src/cli_main.sfn` compiles it to a `.o` and threads it
 // into the final link. The `@sfn_sleep` symbol becomes the sole

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -6,8 +6,8 @@
 // migration: primitives only. The compiler-emission migration
 // in `compiler/src/llvm/lowering/instructions_try.sfn` lands at
 // M2.7b; the legacy TLS-polling path (`sailfin_runtime_set/
-// has/clear/take_exception` in `runtime/native/src/
-// sailfin_runtime.c`) stays operational during the transition,
+// has/clear/take_exception` in the retired C runtime,
+// formerly `sailfin_runtime.c`) stays operational during the transition,
 // and M2.7c deletes it once every emission site has cut over.
 //
 // Status: pure-Sailfin frame management with direct
@@ -61,7 +61,7 @@
 // because the C runtime exposes no `sfn_try_*` / `sfn_throw`
 // / `sfn_take_exception` symbols today (it uses the
 // `sailfin_runtime_*` family — see
-// `runtime/native/src/sailfin_runtime.c:223-296`). The
+// `sailfin_runtime.c:223-296` in the retired C runtime). The
 // `sfn_exception_*` helpers carry the longer prefix so a future
 // `sfn_alloc_frame` user-facing helper does not collide with the
 // runtime namespace. The coexistence-regression assertion in
@@ -386,7 +386,7 @@ fn sfn_take_exception(frame: * SfnExceptionFrame) -> * u8 {
 // The trio (`sfn_set_exception` / `sfn_clear_exception` /
 // `sfn_has_exception`) plus `sfn_raise_value_error` port the C runtime's
 // live TLS-polling exception path (`sailfin_runtime_*` set/clear/has and
-// the value-error raiser in `runtime/native/src/sailfin_runtime.c`) into
+// the value-error raiser in the retired C runtime) into
 // Sailfin. This is a SEPARATE surface from the setjmp/frame API above:
 // the frame API (`sfn_throw` / `sfn_try_enter` / `sfn_take_exception`)
 // backs `try`/`throw` lowering, while this message-slot API backs the
@@ -402,7 +402,7 @@ fn sfn_take_exception(frame: * SfnExceptionFrame) -> * u8 {
 // this module do (see the file-header "Frame layout" and "TLS" notes).
 // The flip to `thread_local let mut` lands with the same post-seed
 // follow-up that upgrades the chain head. The legacy C symbols stay
-// exported in `runtime/native/` for seed-built IR until the M3 seed cut
+// exported in the retired C runtime for seed-built IR until the M3 seed cut
 // retires them.
 let mut sfn_exception_message_addr: i64 = 0;
 

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -10,7 +10,7 @@
 //      runtime-retirement epic (#1308, issue #1310) these are **real
 //      native bodies** that write directly to fd 1 / fd 2 via the
 //      `write(2)` syscall — no longer C trampolines. The prior C
-//      definitions in `runtime/native/src/sailfin_runtime.c`
+//      definitions in the retired C runtime
 //      (`sfn_print*`, the SfnString-by-value trampolines) are removed
 //      in the same change; this module's TU is now the sole definition
 //      site for these symbols.
@@ -63,7 +63,7 @@
 //      removed; the C `sailfin_runtime_{getenv,home_dir}` trampolines retire
 //      with #822.
 //
-// Linkage: this file is listed in `runtime/native/capsule.toml`'s
+// Linkage: this file is listed in `runtime/capsule.toml`'s
 // `sfn-sources` array; `_compile_runtime_sfn_sources` in
 // `compiler/src/cli_main.sfn` compiles it to a `.o` (via
 // `_emit_runtime_sfn_to_obj`, `mangle_symbols=false`) and threads it
@@ -108,7 +108,7 @@ extern fn sfn_str_from_codepoint(cp: i64) -> * u8;
 // capture). `popen`/`pclose`/`fread` are provided by glibc on
 // Linux/macOS and by mingw's msvcrt on Windows, so this body links on
 // every target io.sfn is compiled for (it is in both
-// `runtime/native/capsule.toml` and the cross-windows RUNTIME_MODS).
+// `runtime/capsule.toml` and the cross-windows RUNTIME_MODS).
 extern fn malloc(size: usize) -> * u8;
 
 extern fn free(ptr: * u8) -> void;
@@ -140,7 +140,7 @@ fn sfn_write_fd(fd: i32, buf: * u8, count: usize) -> i64 ![io] {
 // `0` which the C printers no-op) or the codepoint shifted into the
 // upper 32 bits (`cp << 32`, so the low 32 bits are zero and the value
 // is non-zero). Mirrors the C `_is_immediate_codepoint_string`
-// classification (`runtime/native/src/sailfin_runtime.c`). A real
+// classification (the retired C runtime). A real
 // string pointer is `> 0x7f` with a non-zero low word, so it never
 // matches. Pointer math only — no syscall, no `errno` (which keeps this
 // module free of the glibc-only `__errno_location` that does not link

--- a/runtime/sfn/memory/arena.sfn
+++ b/runtime/sfn/memory/arena.sfn
@@ -2,8 +2,9 @@
 //
 // Sailfin-native bump allocator backed by a linked list of pages.
 // First fully-implemented runtime module in the M2 rewrite — ships
-// alongside the C arena (`runtime/native/src/sailfin_arena.c`) so
-// downstream callers stay on the production allocator until M3
+// alongside the C arena (the retired C runtime, formerly
+// `sailfin_arena.c`) so downstream callers stay on the production
+// allocator until M3
 // flips the C namesakes to `static` and retires the C source. M2.2
 // per `docs/runtime_architecture.md` §2.1.1 and issue #477 (epic
 // #389 M2 — Core Runtime in Sailfin).
@@ -176,7 +177,7 @@ struct Arena {
 // and bitwise NOT (both unverified in the seed compiler at the time
 // this module was written). For `align == 8` and `value == 0` this
 // returns `0`; for `value == 9` it returns `16`. Behavior matches the
-// C arena's `_align_up` (`runtime/native/src/sailfin_arena.c:19`)
+// C arena's `_align_up` (the retired C runtime, formerly `sailfin_arena.c:19`)
 // bit-for-bit on every power-of-two `align`.
 fn _sfn_arena_align_up(value: i64, align: i64) -> i64 {
     let stepped: i64 = (value + align - 1) / align;
@@ -207,8 +208,8 @@ fn _sfn_arena_page_create(capacity: i64) -> * u8 {
 
 // `_sfn_arena_page_destroy(page_addr)` releases a single page (its
 // backing buffer and its header). Null-safe: a `0` address is a
-// no-op. The C arena's matching helper sits at
-// `runtime/native/src/sailfin_arena.c:44`.
+// no-op. The C arena's matching helper sat at
+// `sailfin_arena.c:44` in the retired C runtime.
 fn _sfn_arena_page_destroy(page_addr: i64) -> void {
     if page_addr == 0 { return; }
     let page: * ArenaPage = page_addr as * ArenaPage;
@@ -563,7 +564,7 @@ fn sfn_arena_realloc(arena: * u8, ptr: * u8, old_size: usize, new_size: usize, a
 // #390). Port of the double-encoding wrappers
 // `sailfin_intrinsic_runtime_arena_mark` /
 // `sailfin_intrinsic_runtime_arena_rewind`
-// (`runtime/native/src/sailfin_runtime.c:7811,7834`), NOT the
+// (the retired C runtime, formerly `sailfin_runtime.c:7811,7834`), NOT the
 // low-level struct-returning `sfn_arena_mark` /  `sfn_arena_rewind`
 // (`sailfin_arena.c:94,104`). The runtime-helper descriptors flip
 // `sailfin_intrinsic_runtime_arena_mark` →

--- a/runtime/sfn/memory/mem.sfn
+++ b/runtime/sfn/memory/mem.sfn
@@ -5,7 +5,7 @@
 // `bounds_check`, and `free`. Sub-issue of #390 (tracker #821),
 // grouped with the arena mark/rewind pair in
 // `runtime/sfn/memory/arena.sfn`. Each body reproduces the C
-// original in `runtime/native/src/sailfin_runtime.c` exactly; the
+// original in the retired C runtime exactly; the
 // runtime-helper descriptors in
 // `compiler/src/llvm/runtime_helpers.sfn` flip their `symbol` /
 // `native_signature` to the `sfn_mem_*` names so call-site emission
@@ -44,12 +44,12 @@ extern fn write(fd: i32, buf: * u8, count: usize) -> i64;
 extern fn abort() -> void;
 
 // arena-mode probe (C `sfn_arena_enabled`, exported from
-// `runtime/native/src/sailfin_arena.c`). Backs the `sfn_mem_free`
+// the retired C runtime). Backs the `sfn_mem_free`
 // arena-mode no-op guard below and the `sfn_alloc_struct` routing.
 extern fn sfn_arena_enabled() -> bool;
 
 // process-global arena handle + bump allocator, both exported from
-// `runtime/native/src/sailfin_arena.c`. Back the arena path of
+// the retired C runtime. Back the arena path of
 // `sfn_alloc_struct`. `sfn_arena_alloc(arena, size, align)` returns an
 // **uninitialised** slice of the current page (see `sailfin_arena.c:144`),
 // so the port zero-fills via `memset` to match `_rt_calloc`'s contract.

--- a/runtime/sfn/memory/rc.sfn
+++ b/runtime/sfn/memory/rc.sfn
@@ -41,7 +41,7 @@
 // Naming: every export uses the `sfn_rc_sfn_*` infix so the
 // Sailfin module coexists with the C runtime's existing
 // `sfn_rc_release` no-op stub in
-// `runtime/native/src/sailfin_runtime.c:1885` (M1.5.2 placeholder
+// the retired C runtime (formerly `sailfin_runtime.c:1885`, M1.5.2 placeholder
 // from #326) without a link-time collision. Mirrors the
 // `sfn_arena_sfn_*` infix in `runtime/sfn/memory/arena.sfn` and
 // the same rationale documented there. When M3 retires the C

--- a/runtime/sfn/platform/errno.sfn
+++ b/runtime/sfn/platform/errno.sfn
@@ -34,7 +34,7 @@
 // runtime function is supported in the link path — see Linkage below.
 //
 // Linkage (#893 decision): this file stays OUT of
-// `runtime/native/capsule.toml` `sfn-sources`. `sfn-sources`
+// `runtime/capsule.toml` `sfn-sources`. `sfn-sources`
 // registration forces a standalone link on every target for a module
 // with no entry point of its own; nothing requires that yet. The
 // natural DRY consumer, `clock.sfn::sfn_sleep`, therefore keeps

--- a/runtime/sfn/platform/libc.sfn
+++ b/runtime/sfn/platform/libc.sfn
@@ -6,8 +6,8 @@
 // Extern Declarations").
 //
 // Status: typecheck smoke test. Not imported anywhere yet; the
-// runtime continues to reach libc through `runtime/native/src/
-// sailfin_runtime.c` until the Sailfin-native runtime lands at M2
+// runtime continues to reach libc through the retired C runtime
+// (formerly `sailfin_runtime.c`) until the Sailfin-native runtime lands at M2
 // (per the milestone plan in `docs/runtime_architecture.md` §4).
 // Once `int`/`float` numeric types and `Result<T, E>` ship, this
 // file becomes the seed for `runtime/sfn/memory.sfn`,

--- a/runtime/sfn/platform/process_windows.sfn
+++ b/runtime/sfn/platform/process_windows.sfn
@@ -1,7 +1,7 @@
 // runtime/sfn/platform/process_windows.sfn
 //
 // Windows (mingw-w64) process family — the module split that lets the
-// last C runtime file (`runtime/native/src/sailfin_runtime.c`) be
+// last C runtime file (the retired C runtime, formerly `sailfin_runtime.c`) be
 // deleted (#822 / epic #1308).
 //
 // WHY A SEPARATE MODULE. Sailfin has no source-level platform
@@ -11,7 +11,7 @@
 // Win32 `CreateProcessA` body — the unused extern family would leave
 // undefined references on each target. Instead:
 //   - `runtime/sfn/process.sfn` keeps the POSIX bodies (posix_spawnp /
-//     waitpid). It is in `runtime/native/capsule.toml` (native builds)
+//     waitpid). It is in `runtime/capsule.toml` (native builds)
 //     and is DELIBERATELY EXCLUDED from the cross-windows RUNTIME_MODS.
 //   - this module provides the same `@sfn_process_*` symbols for Windows.
 //     It is in the cross-windows RUNTIME_MODS ONLY and is NOT in

--- a/runtime/sfn/platform/rlimit.sfn
+++ b/runtime/sfn/platform/rlimit.sfn
@@ -49,7 +49,7 @@
 // getrlimit/setrlimit, so the externs cannot resolve in a static
 // link — the process.sfn exclusion precedent). The Windows binary
 // resolves `apply_default_mem_limit` from the strong no-op stub in
-// `runtime/native/ir/windows_stubs.ll`, which only the
+// `runtime/ir/windows_stubs.ll`, which only the
 // cross-windows link consumes — Linux/macOS link this module's
 // definition and never see the stub. Sync pinned by
 // `compiler/tests/e2e/test_cross_windows_runtime_modules.sh`.

--- a/runtime/sfn/platform/sizes_linux.sfn
+++ b/runtime/sfn/platform/sizes_linux.sfn
@@ -29,7 +29,7 @@
 // mirrors that selection so the canonical home stays accurate.
 //
 // Linkage (mirrors the #893 decision for `runtime/sfn/platform/
-// errno.sfn`): this file stays OUT of `runtime/native/capsule.toml`
+// errno.sfn`): this file stays OUT of `runtime/capsule.toml`
 // `sfn-sources`. `sfn-sources` registration forces a standalone link
 // on every target for a module with no entry point of its own, and
 // nothing imports it yet: the runtime `sfn-source` emit path

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -23,7 +23,7 @@
 // sentinel. The body allocates a `(len + 1) * 8`-byte buffer
 // via libc `malloc`, copies each `sfn_str_to_cstr(argv[i])`
 // pointer (no-op on today's NUL-terminated strings — see
-// `runtime/native/src/sailfin_runtime.c:2075` for the identity-
+// `sailfin_runtime.c:2075` in the retired C runtime for the identity-
 // bridge rationale that this Sailfin module preserves at the
 // API boundary), and writes a NULL terminator past the last
 // element. `atomic_store` is the seed-supported pointer-slot
@@ -60,7 +60,7 @@
 // `environ` is referenced directly via `extern var` (#1313) and
 // loaded by the Sailfin `get_environ` accessor below — the former
 // C bridge `sailfin_runtime_get_environ` in
-// `runtime/native/src/sailfin_runtime.c` is no longer called.
+// the retired C runtime is no longer called.
 // Passing literal NULL instead gave the child
 // an empty environment on Linux glibc and broke env-inheritance
 // callers (caught by
@@ -123,7 +123,7 @@ extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
 
 extern fn strlen(s: * u8) -> usize;
 
-// String-array append (`runtime/native/src/sailfin_runtime.c:
+// String-array append (the retired C runtime's `sailfin_runtime.c:
 // sfn_array_push_string` → `sailfin_runtime_append_string_v2`).
 // Stores the `char*` by pointer (no copy) and returns the SfnArray,
 // or the null pointer on OOM. Consumed by `sfn_process_environ`,
@@ -240,7 +240,7 @@ fn sfn_process_run(argv: string[]) -> float ![io] {
 // Ports `sailfin_runtime_process_{exit,run_capture,
 // capture_take_stdout,capture_take_stderr,handle_write,
 // handle_close_stdin,handle_read_stdout,handle_read_stderr,
-// handle_wait}` from `runtime/native/src/sailfin_runtime.c` to
+// handle_wait}` from the retired C runtime to
 // Sailfin-native bodies. `process_spawn_with_env` stays C (M4) and
 // remains the sole producer of the handle the `handle_*` family
 // consumes — see the `SailfinProcessHandle` note below.
@@ -1066,7 +1066,7 @@ fn sfn_process_handle_wait(handle_id: i64) -> i64 ![io] {
 //
 // On Windows the cross-windows Makefile path skips this module and
 // the `#if defined(_WIN32)` shim in
-// `runtime/native/src/sailfin_runtime.c` resolves the symbol with an
+// the retired C runtime's `_WIN32` shim resolves the symbol with an
 // empty array instead (same shim strategy as `sfn_process_run` /
 // `sfn_process_spawn_with_env` — see the lesson from PR #1240).
 //

--- a/runtime/sfn/runtime_globals.sfn
+++ b/runtime/sfn/runtime_globals.sfn
@@ -1,11 +1,11 @@
 // runtime/sfn/runtime_globals.sfn
 //
 // Sailfin-owned definitions of the process-wide runtime globals that the
-// hand-written `runtime/native/ir/*.ll` link-glue used to provide. This is
+// hand-written `runtime/ir/*.ll` link-glue used to provide. This is
 // the Sailfin replacement for the `@runtime` slot in
-// `runtime/native/ir/runtime_globals.ll` — part of epic #1308 / the
-// unfinished tail of #822 (whose acceptance, `find runtime/native -name
-// '*.ll'` empty, is the keystone for deleting `runtime/native/` entirely).
+// `runtime/ir/runtime_globals.ll` — part of epic #1308 / the
+// unfinished tail of #822 (whose acceptance, the former `runtime/native/ir/`
+// `.ll` glue retired, was the keystone for deleting `runtime/native/`).
 //
 // `@runtime` (#1436) — the process runtime-context slot. Every emitted
 // module declares it `@runtime = external global i8**` and member-access
@@ -24,7 +24,7 @@
 // (#1445, `lowering_phase_render.sfn` / `lowering_core.sfn`), so this module
 // emits the definition alone and every other module keeps the reference.
 //
-// Universality: this module is listed in `runtime/native/capsule.toml`'s
+// Universality: this module is listed in `runtime/capsule.toml`'s
 // `sfn-sources`, so its object is linked into every Sailfin program
 // alongside the rest of the native runtime — the same unconditional reach
 // the `.ll` had. No Sailfin code references the `runtime` binding (the

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -3,33 +3,30 @@
 // First wave of Sailfin-native `SfnString` operations (M2.4a, #396).
 // The module pins the future shape of the five non-allocating
 // `sfn_str_*` helpers — `len`, `eq`, `slice`, `to_cstr`,
-// `from_cstr` — and ships into the compiler binary alongside the
-// C runtime so the migration footprint is visible at link time.
+// `from_cstr` — and ships into the compiler binary as the live
+// Sailfin bodies (the retired C runtime is deleted).
 //
-// Status: trampoline bodies. The architect plan in
+// Status: real Sailfin bodies. The architect plan in
 // `docs/runtime_architecture.md` §2.2 specifies these helpers
 // against the SfnString aggregate (`{i8*, i64}` by value) so
 // `sfn_str_len` is a single field load and `sfn_str_eq` is a length
-// compare + `memcmp`. Today's Sailfin frontend lowers `string` to
-// `i8*` for parameters/locals (M1.A only locked the literal/aggregate
-// shape, not the type-mapping flip slated for M1.A.2), so these
-// bodies still bridge through the legacy NUL-terminated C
-// entrypoints. The function *names* are the migration unit — once
-// M1.A.2 lands the bodies can be rewritten in-place over the
-// aggregate shape without touching any caller.
+// compare + `memcmp`. The M1.A.2 type-mapping flip has landed —
+// the Sailfin frontend now lowers `string` to the `{i8*, i64}`
+// aggregate (`compiler/src/llvm/type_mapping.sfn`) — but these
+// bodies still take their payloads as NUL-terminated `* u8` by the
+// registry ABI and bridge through libc, so the body rewrite over
+// the aggregate field-read shape is still future work. The function
+// *names* are the migration unit — that rewrite can land in-place
+// over the aggregate shape without touching any caller.
 //
-// Naming: every export uses the `sfn_str_sfn_*` infix so the
-// Sailfin module coexists with the C runtime's matching
-// `sfn_str_*` exports without a link-time collision (mirrors the
-// arena module's `sfn_arena_sfn_*` infix; see
-// `runtime/sfn/memory/arena.sfn` for the same rationale). The
-// canonical user-facing names — the ones the new compiler emits
-// `call`s against — are `sfn_str_*` (no infix), provided by the C
-// trampolines in `runtime/native/src/sailfin_runtime.c`. This
-// module's exports are presence-only proof of life today and the
-// migration unit for M2.4b: when the aggregate-typed parameter
-// flip lands, the C trampolines retire and these `_sfn_` names
-// rename to the bare canonical form in a single rollback-safe PR.
+// Naming: the `sfn_str_sfn_*` infix originally let the Sailfin
+// module coexist with the retired C runtime's matching `sfn_str_*`
+// exports without a link-time collision (mirrors the arena module's
+// `sfn_arena_sfn_*` infix; see `runtime/sfn/memory/arena.sfn` for
+// the same rationale). With the C trampolines deleted, the
+// canonical user-facing names — the ones the compiler emits
+// `call`s against — are the bare `sfn_str_*` Sailfin bodies here;
+// the `_sfn_` infix migration is complete.
 //
 // Effects: none. String primitives live below the I/O layer (same
 // discipline as `runtime/sfn/memory/arena.sfn`). The `![io]`
@@ -47,7 +44,7 @@
 // modules' `.sfn-asm` into the import-context the lowering consults, so the
 // call now resolves; with a seed containing #1288 pinned, this consumer
 // collapses the duplication. `ownedbuf.sfn` and `arena.sfn` are linked
-// alongside this module via `runtime/native/capsule.toml`'s `sfn-sources`.
+// alongside this module via `runtime/capsule.toml`'s `sfn-sources`.
 //
 // #1318 retired the OwnedBuf-returning `sfn_str_sfn_concat` / `_append`
 // proof-of-life wrappers; the real `sfn_str_concat` / `sfn_str_append` bodies
@@ -93,11 +90,6 @@ extern fn strtod(nptr: * u8, endptr: * * u8) -> f64;
 // Sailfin demand on the legacy concat — `resolve_runtime_root` in exec.sfn —
 // was retargeted to the native `+` path). The C definitions are now purely
 // C-internal and retire with the C runtime at #822.
-// `sailfin_runtime_string_to_number` is the still-C `strtod` boundary
-// `to_number` delegates to (allocating-op family — retires in #1318/#822).
-// Returns `double` (System V x86_64 `%xmm0`), matched exactly here.
-extern fn sailfin_runtime_string_to_number(s: * u8) -> f64;
-
 // #1315 (C4 of epic #1308): the accessor family — `byte_at`/`find_byte`/
 // `codepoint`/`grapheme_at`/`grapheme_count` — are now real Sailfin
 // bodies below (bare-named emission targets; the C defs are `static`).


### PR DESCRIPTION
## Summary

Post-C-runtime documentation hygiene across the `runtime/sfn` tree — the tail of epic #1308. The C runtime and `runtime/native/` are deleted and the M1.A.2 `string` `i8*`→`{i8*, i64}` type-mapping flip has landed, but many runtime comments still described the old world (deleted file paths, a "pending" flip that already shipped).

## Changes

- **Remove the dead `extern fn sailfin_runtime_string_to_number`** from `string.sfn` — zero callers (`sfn_str_to_number` calls `strtod` directly), and the C symbol it referenced is gone. This is the **only** non-comment change.
- **Rewrite `string.sfn`'s module header** to landed tense: the flip landed (the frontend lowers `string` to the `{i8*, i64}` aggregate) — while accurately noting the bodies *still* take `* u8` by the registry ABI, so the body collapse remains future work (tracked in #1457). No overclaiming.
- **Replace stale path references** (`runtime/native/src/sailfin_runtime.c`, `runtime/native/capsule.toml`, `runtime/native/ir/windows_stubs.ll`) with their current homes (`runtime/capsule.toml`, `runtime/ir/windows_stubs.ll`) or "the retired C runtime".
- **Correct `prelude.sfn`'s** stale "deleting `runtime/native/` is a seed-gated future" framing — the directory is already deleted (#1452).

Accurate historical mentions (the `capsule.toml` manifest-move narration; the `runtime_globals.sfn` deletion-gate history) are deliberately **preserved**.

## Verification

- `make compile` — **self-hosts** (pass) ✅
- `sfn fmt --check` — clean on all 19 touched files ✅
- Comment-only (plus the single dead-extern removal); the diff confirms no other executable line changed.

## Context

Part of the epic #1308 close-out. Sibling follow-ups filed for the genuinely deferred, non-cosmetic work: **#1457** (seed-gated `sfn_str_*` aggregate-body collapse), **#1458** (dead immediate-codepoint arm removal), **#1454** (sound non-owning `string.slice`).

Closes #1453

https://claude.ai/code/session_01NwP4sKLPHzJcoHMRyxDwTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwP4sKLPHzJcoHMRyxDwTP)_