### PR TITLE
build(macos): shim bare clang to Apple's /usr/bin/clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,21 @@ ifeq ($(UNAME_S),Darwin)
 # macOS ships no GNU `timeout`; pick up `gtimeout` from homebrew coreutils if present.
 # Empty is an acceptable fallback — callers must guard on non-empty before invoking.
 TIMEOUT_CMD ?= $(shell command -v gtimeout 2>/dev/null)
+
+# Clang shim (macOS). Homebrew's llvm clang (e.g. `llvm@17`) commonly shadows
+# Apple's clang on PATH, but it cannot drive Apple's `ld` to the macOS SDK
+# system libs — linking the self-hosted compiler then fails with
+# `ld: library 'm' not found`. Only Apple's `/usr/bin/clang` links system libs
+# here. The seed and the built compiler invoke a bare `clang` via PATH
+# (`process.run(["clang", ...])`), so a make variable cannot steer them;
+# instead expose a one-symlink dir that redirects ONLY `clang` to the chosen
+# compiler and put it first on PATH for every recipe. Minimal blast radius: no
+# other tool is shadowed. Override the target with `SAILFIN_CC=/path/to/clang`;
+# no-ops (empty dir, harmless PATH prefix) if the target does not exist.
+SAILFIN_CC ?= /usr/bin/clang
+CLANG_SHIM_DIR := $(CURDIR)/build/.toolchain-shim
+$(shell mkdir -p $(CLANG_SHIM_DIR) >/dev/null 2>&1; [ -x "$(SAILFIN_CC)" ] && ln -sf "$(SAILFIN_CC)" "$(CLANG_SHIM_DIR)/clang" 2>/dev/null)
+export PATH := $(CLANG_SHIM_DIR):$(PATH)
 else ifeq ($(IS_WINDOWS),1)
 TIMEOUT_CMD ?=
 else


### PR DESCRIPTION
## Goal

Fix a macOS-local self-host build failure: the cold link of the compiler dies with `ld: library 'm' not found`.

## Root cause

Homebrew's llvm clang (e.g. `llvm@17`) commonly sits ahead of Apple's clang on PATH, but it cannot drive Apple's `ld` to the macOS SDK system libs — so linking the self-hosted compiler fails with `ld: library 'm' not found`. Only Apple's `/usr/bin/clang` links system libs here.

The seed and the built compiler invoke a bare `clang` via PATH (`process.run(["clang", ...])`, `compiler/src/cli_main.sfn:947`), so a make variable cannot steer them — the only lever (without a seed bump) is PATH.

## Change

Prepend a one-symlink shim dir (`build/.toolchain-shim/clang -> $SAILFIN_CC`, default `/usr/bin/clang`) to PATH for all make recipes, gated on Darwin. Only `clang` is redirected — no other tool is shadowed. Override with `SAILFIN_CC=/path/to/clang`; no-ops (empty dir, harmless PATH prefix) if the target is absent. `build/` is gitignored, so the shim is not committed.

## Verification

- Clean `make rebuild` links with **zero** `-lm` errors and self-hosts (`build/native/sailfin --version` → `0.7.0-alpha.45+dev.…`), using only this fix (no manual PATH).
- Non-Darwin recipes unchanged (block is inside the existing `ifeq ($(UNAME_S),Darwin)`).

## Follow-up (not in this PR)

This fixes the make-driven build. A direct `sfn build`/`sfn run` invoked outside make still resolves `clang` from the shell PATH. The durable cross-the-board fix is teaching the compiler to prefer `/usr/bin/clang` on Darwin (or honor `SAILFIN_CC`) in `cli_main.sfn` — effective after a seed bump. Can file separately.