### PR TITLE
feat(diag): W0210 soft-deprecate bare assert inside test blocks

### DIFF
--- a/compiler/src/bare_assert_check.sfn
+++ b/compiler/src/bare_assert_check.sfn
@@ -1,0 +1,199 @@
+// compiler/src/bare_assert_check.sfn
+//
+// W0210 soft-deprecation: a bare `assert` statement used inside a `test`
+// block. Pure AST analysis, consumed by the `sfn check` fast path
+// (`tools/check.sfn`) — mirrors the leaf-module shape of
+// `reexport_check.sfn` so the emit-free check graph never reaches the
+// emitter.
+//
+// Why a post-parse walk and not the effect/type checker: `assert cond;`
+// is desugared at parse time (`parser/statements.sfn:parse_assert_statement`)
+// into an `IfStatement` whose `else` branch calls `runtime_assert_fail_fn`,
+// so no dedicated `assert` node ever reaches a later pass, and neither the
+// effect checker nor the type checker tracks "currently inside a test
+// block". This walker recognizes the desugared shape and recovers the
+// assert's source location from the `line` / `col` numeric-literal
+// arguments the desugarer embeds in the fail call.
+//
+// Scope: only statements lexically inside a `test { ... }` body are
+// visited, so an `assert` in ordinary function code never warns. Every
+// bare `assert` in a test body is flagged (including the stop-gap
+// `assert expect_*(...).ok;` form) — the whole `assert` statement form is
+// being soft-deprecated in tests in favor of `expect()` matchers; the
+// `--allow-bare-assert` flag is the escape hatch for code that still
+// relies on it.
+//
+// See issue #1173 (epic #842 Phase 3, sub-issue 3.3) and §11 Testing.
+import { Program, Statement, Block } from "./ast";
+
+export { BareAssertFinding, collect_bare_assert_findings };
+
+// One flagged bare `assert`, with the 1-based source location recovered
+// from the desugared fail call.
+struct BareAssertFinding {
+    line: int;
+    column: int;
+}
+
+fn _append_finding(values: BareAssertFinding[], value: BareAssertFinding) -> BareAssertFinding[] {
+    let mut out = values;
+    if out == null { out = []; }
+    out.push(value);
+    return out;
+}
+
+// Decimal parser for the `line` / `col` numeric-literal arguments the
+// assert desugarer embeds (always non-negative integers). Any non-digit
+// falls back to 0 rather than aborting — a malformed literal yields a
+// location-less finding, never a crash.
+fn _decimal_to_int(text: string) -> int {
+    if text.length == 0 { return 0; }
+    let mut value: int = 0;
+    let mut index: int = 0;
+    loop {
+        if index >= text.length { break; }
+        let ch = text[index];
+        if ch == "0" { value = value * 10; } else if ch == "1" {
+            value = value * 10 + 1;
+        } else if ch == "2" { value = value * 10 + 2; } else if ch == "3" {
+            value = value * 10 + 3;
+        } else if ch == "4" { value = value * 10 + 4; } else if ch == "5" {
+            value = value * 10 + 5;
+        } else if ch == "6" { value = value * 10 + 6; } else if ch == "7" {
+            value = value * 10 + 7;
+        } else if ch == "8" { value = value * 10 + 8; } else if ch == "9" {
+            value = value * 10 + 9;
+        } else { break; }
+        index += 1;
+    }
+    return value;
+}
+
+// Recognize the parser's desugared `assert cond;` shape:
+//   IfStatement {
+//     then_block: <empty>,
+//     else_branch: { body: { statements: [ExpressionStatement {
+//       Call { callee: Identifier "runtime_assert_fail_fn", args: [..] } }] } }
+//   }
+// The synthesized callee name is the discriminator — user code cannot
+// produce a call to `runtime_assert_fail_fn`.
+fn _is_desugared_assert(statement: Statement) -> boolean {
+    if statement.variant != "IfStatement" { return false; }
+    if statement.then_block.statements.length != 0 { return false; }
+    let else_branch = statement.else_branch;
+    if else_branch == null { return false; }
+    let else_body = else_branch.body;
+    if else_body == null { return false; }
+    if else_body.statements.length != 1 { return false; }
+    let inner = else_body.statements[0];
+    if inner.variant != "ExpressionStatement" { return false; }
+    let call = inner.expression;
+    if call.variant != "Call" { return false; }
+    if call.callee.variant != "Identifier" { return false; }
+    return call.callee.name == "runtime_assert_fail_fn";
+}
+
+// Recover the assert's 1-based location from the fail call's embedded
+// arguments: [StringLiteral file, NumberLiteral line, NumberLiteral col,
+// StringLiteral msg]. Falls back to 0:0 when the shape is unexpected.
+fn _finding_for_assert(statement: Statement) -> BareAssertFinding {
+    let mut line: int = 0;
+    let mut column: int = 0;
+    let call = statement.else_branch.body.statements[0].expression;
+    if call.arguments.length >= 3 {
+        let line_arg = call.arguments[1];
+        let col_arg = call.arguments[2];
+        if line_arg.variant == "NumberLiteral" {
+            line = _decimal_to_int(line_arg.value);
+        }
+        if col_arg.variant == "NumberLiteral" {
+            column = _decimal_to_int(col_arg.value);
+        }
+    }
+    return BareAssertFinding { line: line, column: column };
+}
+
+fn _scan_block(block: Block?, findings: BareAssertFinding[]) -> BareAssertFinding[] {
+    let mut out = findings;
+    if block == null { return out; }
+    let mut index: int = 0;
+    loop {
+        if index >= block.statements.length { break; }
+        out = _scan_statement(block.statements[index], out);
+        index += 1;
+    }
+    return out;
+}
+
+// Visit one statement: flag it if it is a desugared assert (and do NOT
+// descend into its synthesized fail branch), otherwise recurse into any
+// block-bearing children so asserts nested in if/for/loop/match/try/etc.
+// are still found.
+fn _scan_statement(statement: Statement, findings: BareAssertFinding[]) -> BareAssertFinding[] {
+    let mut out = findings;
+    if _is_desugared_assert(statement) {
+        out = _append_finding(out, _finding_for_assert(statement));
+        return out;
+    }
+
+    let variant = statement.variant;
+    if variant == "IfStatement" {
+        out = _scan_block(statement.then_block, out);
+        let else_branch = statement.else_branch;
+        if else_branch != null {
+            out = _scan_block(else_branch.body, out);
+            if else_branch.statement != null {
+                out = _scan_statement(else_branch.statement, out);
+            }
+        }
+        return out;
+    }
+    if variant == "ForStatement" {
+        return _scan_block(statement.body, out);
+    }
+    if variant == "LoopStatement" {
+        return _scan_block(statement.body, out);
+    }
+    if variant == "BlockStatement" {
+        return _scan_block(statement.body, out);
+    }
+    if variant == "WithStatement" {
+        return _scan_block(statement.body, out);
+    }
+    if variant == "RoutineStatement" {
+        return _scan_block(statement.body, out);
+    }
+    if variant == "TryStatement" {
+        out = _scan_block(statement.try_block, out);
+        out = _scan_block(statement.catch_block, out);
+        out = _scan_block(statement.finally_block, out);
+        return out;
+    }
+    if variant == "MatchStatement" {
+        let mut ci: int = 0;
+        loop {
+            if ci >= statement.cases.length { break; }
+            out = _scan_block(statement.cases[ci].body, out);
+            ci += 1;
+        }
+        return out;
+    }
+    return out;
+}
+
+// Walk every top-level `test { ... }` block and return one finding per
+// bare `assert` in its body (recursively). Statements outside test
+// blocks are never visited.
+fn collect_bare_assert_findings(program: Program) -> BareAssertFinding[] {
+    let mut findings: BareAssertFinding[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let statement = program.statements[index];
+        if statement.variant == "TestDeclaration" {
+            findings = _scan_block(statement.body, findings);
+        }
+        index += 1;
+    }
+    return findings;
+}

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -178,6 +178,7 @@ fn _find_group(groups: CheckGroup[], key: string) -> int {
 fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
     let mut quiet: boolean = false;
     let mut json: boolean = false;
+    let mut allow_bare_assert: boolean = false;
     let mut paths: string[] = [];
 
     let mut argi: int = 1;
@@ -192,11 +193,15 @@ fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
             // is accepted but `--quiet` becomes a no-op (the JSON
             // envelope IS the structured output, not noise).
             json = true;
+        } else if strings_equal(arg, "--allow-bare-assert") {
+            // #1173: opt out of the W0210 soft-deprecation warning for
+            // a bare `assert` inside a `test` block.
+            allow_bare_assert = true;
         } else if strings_equal(arg, "-h") {
-            print("usage: sfn check [--quiet] [--json] [path...]");
+            print("usage: sfn check [--quiet] [--json] [--allow-bare-assert] [path...]");
             return 0;
         } else if strings_equal(arg, "--help") {
-            print("usage: sfn check [--quiet] [--json] [path...]");
+            print("usage: sfn check [--quiet] [--json] [--allow-bare-assert] [path...]");
             return 0;
         } else { paths.push(arg); }
         argi += 1;
@@ -370,7 +375,7 @@ fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
         let path = files[fi];
         let group_idx = file_group_index[fi];
         let source = fs.readFile(path);
-        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
+        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects, groups[group_idx].capabilities_required, allow_bare_assert);
         // Emit any diagnostic — error or warning — so contributors
         // running `sfn check` under Phase B (warning default) actually
         // see the effect-violation output. The summary line keys on

--- a/compiler/src/diagnostics_json.sfn
+++ b/compiler/src/diagnostics_json.sfn
@@ -244,6 +244,7 @@ fn render_check_json_envelope(events: CheckJsonEvent[], summary: CheckJsonSummar
 //   E05xx        -> parse
 //   E06xx        -> reexport (module-structure)
 //   W00xx        -> load
+//   W02xx        -> lint (soft-deprecations, e.g. W0210 bare assert)
 // Anything else falls back to "unknown" so a future code range
 // shows up as an obvious-to-track default rather than silently
 // claiming the wrong producer.
@@ -255,6 +256,7 @@ fn render_check_json_envelope(events: CheckJsonEvent[], summary: CheckJsonSummar
 fn classify_producer(code: string) -> string {
     if _starts_with(code, "E04") { return "effect"; }
     if _starts_with(code, "W00") { return "load"; }
+    if _starts_with(code, "W02") { return "lint"; }
     if _starts_with(code, "E05") { return "parse"; }
     if _starts_with(code, "E06") { return "reexport"; }
     if _starts_with(code, "E00") { return "typecheck"; }

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -21,7 +21,7 @@
 //
 // See docs/proposals/check-architecture.md for the broader design.
 import { Statement } from "../ast";
-import { Token } from "../token";
+import { Token, TokenKind } from "../token";
 import { typecheck_diagnostics_with_import_symbols_prelude } from "../typecheck";
 import { number_to_string } from "../num_format";
 import { parse_program } from "../parser/mod";
@@ -31,7 +31,8 @@ import { validate_capsule_capabilities, validate_effects_with_imports } from "..
 import { ImportSymbolTable, empty_import_symbols } from "../effect_imports";
 import { collect_reexport_violations } from "../reexport_check";
 import { load_prelude_global_names } from "../prelude_globals";
-import { Diagnostic } from "../typecheck_types";
+import { Diagnostic, FixSuggestion } from "../typecheck_types";
+import { collect_bare_assert_findings } from "../bare_assert_check";
 import {
     render_diagnostic,
     split_source_lines,
@@ -104,7 +105,7 @@ fn _parse_diagnostic_for_unknown(stmt: Statement, file_path: string) -> Diagnost
 fn check_source(source: string, file_path: string) -> CheckResult ![io] {
     let no_interfaces: Statement[] = [];
     let no_caps: string[] = [];
-    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols(), no_caps);
+    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols(), no_caps, false);
 }
 
 // Cross-module-aware variant: `imported_interfaces` carries
@@ -133,7 +134,7 @@ fn check_source(source: string, file_path: string) -> CheckResult ![io] {
 // the manifest-allowed set. Empty list = no manifest in scope =
 // skip the cross-check (standalone .sfn files outside any capsule
 // keep working unchanged).
-fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable, capabilities_required: string[]) -> CheckResult ![io] {
+fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable, capabilities_required: string[], allow_bare_assert: boolean) -> CheckResult ![io] {
     let program = parse_program(source);
     let prelude_globals = load_prelude_global_names(runtime_helper_call_names());
     let type_diags = typecheck_diagnostics_with_import_symbols_prelude(program, imported_interfaces, function_effects, prelude_globals);
@@ -201,6 +202,48 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         rendered.push(render_diagnostic(rxdiag, source_lines, "reexport"));
         errors += 1;
         rxi += 1;
+    }
+
+    // W0210 (#1173): soft-deprecate a bare `assert` inside a `test`
+    // block in favor of `expect()` matchers, which carry a descriptive
+    // failure message instead of just the expression text. Detection
+    // runs over the parser's desugared assert shape (see
+    // bare_assert_check.sfn); only statements lexically inside a test
+    // body are visited, so an `assert` in ordinary code never warns.
+    // Always a `warning`, never an error, so the compiler's own
+    // bare-assert-heavy suite stays green; `--allow-bare-assert`
+    // suppresses it entirely. Code family W02xx = lint; see
+    // diagnostics_json.sfn classify_producer.
+    if !allow_bare_assert {
+        let bare_asserts = collect_bare_assert_findings(program);
+        let mut bai: int = 0;
+        loop {
+            if bai >= bare_asserts.length { break; }
+            let finding = bare_asserts[bai];
+            let assert_token = Token {
+                kind: TokenKind.Identifier(),
+                lexeme: "assert",
+                line: finding.line,
+                column: finding.column
+            };
+            let fix = FixSuggestion {
+                message: "replace the bare `assert` with an `expect()` matcher, e.g. `assert expect_eq_int(actual, expected).ok;`",
+                edits: []
+            };
+            let badiag = Diagnostic {
+                code: "W0210",
+                severity: "warning",
+                message: "prefer expect() over a bare assert inside a test block\nuse an sfn/test matcher (expect_eq_*, expect_contains_str, ...) for a descriptive failure; pass --allow-bare-assert to suppress",
+                file_path: file_path,
+                primary: assert_token,
+                suggestion: fix
+            };
+            combined.push(badiag);
+            producers.push("lint");
+            rendered.push(render_diagnostic(badiag, source_lines, "lint"));
+            warnings += 1;
+            bai += 1;
+        }
     }
 
     // Stamp the originating module path onto each typecheck diagnostic

--- a/compiler/tests/unit/w0210_bare_assert_test.sfn
+++ b/compiler/tests/unit/w0210_bare_assert_test.sfn
@@ -1,0 +1,60 @@
+// Regression coverage for W0210 bare-assert soft-deprecation
+// (compiler/src/bare_assert_check.sfn, issue #1173, epic #842 Phase 3).
+//
+// `collect_bare_assert_findings` walks every top-level `test { ... }`
+// block and returns one finding per bare `assert` in its body
+// (recursively through nested blocks). The parser desugars `assert cond;`
+// into an `IfStatement` calling `runtime_assert_fail_fn`, so the collector
+// recognizes that desugared shape. `assert` outside a `test` block is
+// never visited.
+import { parse_program } from "../../src/parser/mod";
+import { collect_bare_assert_findings } from "../../src/bare_assert_check";
+
+test "w0210: flags a bare assert inside a test block" ![io] {
+    let program = parse_program("test \"t\" { assert 1 == 1; }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 1;
+}
+
+test "w0210: recovers the assert source location" ![io] {
+    let program = parse_program("test \"t\" {\n    assert 1 == 1;\n}");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 1;
+    assert findings[0].line == 2;
+}
+
+test "w0210: flags multiple bare asserts in one test block" ![io] {
+    let program = parse_program("test \"t\" { assert 1 == 1; assert 2 == 2; }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 2;
+}
+
+test "w0210: assert outside a test block is never flagged" ![io] {
+    let program = parse_program("fn f() { assert 1 == 1; }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 0;
+}
+
+test "w0210: a test block with no asserts produces no findings" ![io] {
+    let program = parse_program("test \"t\" { let x = 1; }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 0;
+}
+
+test "w0210: flags a bare assert nested inside an if in a test block" ![io] {
+    let program = parse_program("test \"t\" { if true { assert 1 == 1; } }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 1;
+}
+
+test "w0210: flags a bare assert nested inside a loop in a test block" ![io] {
+    let program = parse_program("test \"t\" { loop { assert 1 == 1; break; } }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 1;
+}
+
+test "w0210: counts only test-block asserts when fn asserts coexist" ![io] {
+    let program = parse_program("fn f() { assert 9 == 9; } test \"t\" { assert 1 == 1; }");
+    let findings = collect_bare_assert_findings(program);
+    assert findings.length == 1;
+}

--- a/site/src/content/docs/docs/reference/spec/11-testing.md
+++ b/site/src/content/docs/docs/reference/spec/11-testing.md
@@ -20,6 +20,29 @@ test "name" ![effects] {
 
 ---
 
+## `expect()` is preferred over a bare `assert` (W0210)
+
+A bare `assert` inside a `test` block is **soft-deprecated**: `sfn check`
+emits the warning `W0210: prefer expect() over a bare assert inside a test
+block`, pointing at the `assert` keyword. A bare assert only reports the
+expression text on failure, whereas the `sfn/test` matchers
+(`expect_eq_int`, `expect_eq_str`, `expect_contains_str`, …) carry a
+descriptive `actual` vs `expected` message:
+
+```sfn
+test "addition" ![pure] {
+    assert 2 + 2 == 4;                 // W0210 — works, but a thin failure
+    assert expect_eq_int(2 + 2, 4).ok; // preferred — descriptive on failure
+}
+```
+
+W0210 is a **warning only** — it never fails a build or changes an exit
+code — and fires solely inside `test` blocks; an `assert` in ordinary code
+is unaffected. Pass `sfn check --allow-bare-assert` to suppress it. Removal
+of the bare `assert` form is a post-1.0 consideration, not a current plan.
+
+---
+
 ## Filtering which tests run
 
 Two flags narrow a `sfn test` run to a subset of the discovered tests.


### PR DESCRIPTION
## Summary
- Emit `W0210: prefer expect() over a bare assert inside a test block` for a bare `assert` used inside a `test` block, with a source span (caret on `assert`) and a fix-it pointing at `expect()`.
- Add `sfn check --allow-bare-assert` to suppress it. `assert` outside `test` blocks is never flagged.
- Warning is **non-fatal** (never changes the exit code) and runs only in the `sfn check` path, so the compiler's own bare-assert-heavy suite stays green.

Closes #1173

## Implementation note (deviation from groomed Files Affected)
The issue suggested emitting from `effect_checker.sfn`/`typecheck.sfn` "whichever tracks test-block context". In reality, `assert cond;` is **desugared in the parser** (`parser/statements.sfn:parse_assert_statement`) into an `IfStatement` calling `runtime_assert_fail_fn` — so no `assert` node reaches a later pass, and neither the effect checker nor the type checker tracks test-block scope. Detection therefore lives in a new emit-free leaf module `compiler/src/bare_assert_check.sfn` (mirroring `reexport_check.sfn`) that walks each `test` body for the desugared shape and recovers the source span from the embedded line/col args. It is wired into the `sfn check` pipeline only (not the build/emit path), which is what keeps it non-fatal for self-host.

Per the design gate, both decisions were confirmed: (1) new leaf module over re-grooming, and (2) flag **all** bare asserts in test blocks (the whole `assert` statement form is being soft-deprecated in tests; `--allow-bare-assert` is the escape hatch) rather than exempting `assert expect_*().ok`.

## Acceptance Criteria
- [x] A `test` block with a bare `assert` emits `W0210` with a source span and a fix-it pointing at `expect()`.
- [x] `--allow-bare-assert` suppresses it; `assert` outside `test` blocks never warns.
- [x] The compiler's own `make test` stays green — W0210 is `severity: warning`, non-fatal in self-host, and emitted only on the `sfn check` path.
- [x] `make compile` passes.
- [x] `make check` passes (self-host; stage2 == stage3 fixed point).
- [x] `sfn fmt --check` clean on touched files.

## Verification
```bash
# Targeted regression test — 8/8 pass
build/native/sailfin test compiler/tests/unit/w0210_bare_assert_test.sfn

# End-to-end (test-block assert flagged at 2:5, fn assert NOT flagged):
$ sailfin check demo.sfn
warning[W0210]: prefer expect() over a bare assert inside a test block
  --> demo.sfn:2:5
   |
 2 |     assert 1 == 1;
   |     ^^^^^^
  = use an sfn/test matcher (...) for a descriptive failure; pass --allow-bare-assert to suppress
  [kind: lint]
checked 1 files: ok

$ sailfin check --allow-bare-assert demo.sfn   # clean
$ sailfin check --json demo.sfn                # "code":"W0210" / "producer":"lint"

make check   # PASS — full suite, e2e 46/46, stage2 == stage3 fixed point
```

## Files Changed
- `compiler/src/bare_assert_check.sfn` (new) — W0210 detector (pure AST walk)
- `compiler/src/tools/check.sfn` — emit W0210, gated by `allow_bare_assert`
- `compiler/src/cli_check.sfn` — `--allow-bare-assert` flag
- `compiler/src/diagnostics_json.sfn` — classify `W02xx` → `lint`
- `compiler/tests/unit/w0210_bare_assert_test.sfn` (new) — regression coverage
- `site/src/content/docs/docs/reference/spec/11-testing.md` — deprecation note

## Seed note
This issue is a **seed-blocker** for the §11 docs (3.5): the spec must not document W0210 as shipped until this change is in the pinned seed. A seed cut + `/pin-seed` is required between this merge and 3.5 documenting it as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhAQqcpH7phF8D7sMCRDph

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhAQqcpH7phF8D7sMCRDph)_