### PR TITLE
build: auto-parallelize make check's suite runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,20 @@ TEST_BIN_CACHE_FLAGS ?=
 TEST_JOBS ?= 1
 TEST_JOBS_FLAG = --jobs $(TEST_JOBS)
 
+# Test parallelism for `make check` specifically. `make check` runs the full
+# suite TWICE (once on the first-pass binary as an early gate, once on the
+# seedcheck binary), so a serial `TEST_JOBS=1` doubles down on the slowest part
+# of the gate. Unlike a bare `make test`, `make check` already pins peak build
+# concurrency via the RAM-budgeted `BUILD_JOBS` auto-detect, so it can safely
+# reuse that same per-job budget for its suite runs. An explicit `TEST_JOBS=N`
+# (command line or environment) always wins — set it to dial the suite down on
+# a tighter RAM budget, or to 1 to restore the old serial behaviour.
+ifeq ($(filter command line environment,$(origin TEST_JOBS)),)
+CHECK_TEST_JOBS ?= $(BUILD_JOBS)
+else
+CHECK_TEST_JOBS ?= $(TEST_JOBS)
+endif
+
 help:
 	@echo "Common Sailfin tasks"
 	@echo ""
@@ -554,8 +568,8 @@ check-impl:
 		echo "[check][error] missing $$seed (run: make compile)"; \
 		exit 1; \
 	fi
-	@echo "[check] running test suite on first-pass binary (early gate)..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache
+	@echo "[check] running test suite on first-pass binary (early gate, jobs=$(CHECK_TEST_JOBS))..."
+	@$(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 	@echo "[check] first-pass tests passed — proceeding to seedcheck build..."
 	@echo "[check] verifying seed selfhost (stage2)..."
 	@# Stage2 routes through `sfn build -p compiler --work-dir <DIR>`
@@ -597,8 +611,8 @@ check-impl:
 		exit 1; \
 	fi; \
 	echo "[check] seedcheck binary runs hello-world.sfn OK"
-	@echo "[check] running test suite with seedcheck binary (no fallbacks)..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache
+	@echo "[check] running test suite with seedcheck binary (no fallbacks, jobs=$(CHECK_TEST_JOBS))..."
+	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 	@echo ""
 	@echo "[check] stage2 tests passed — building stage3 for fixed-point comparison..."
 	@# Same shape as stage2 — driver `--work-dir` with


### PR DESCRIPTION
## Problem

`make check` is the triple-pass self-host gate, and a big chunk of its wall time is the **test suite running twice** — once on the first-pass binary as an early gate (`Makefile` check-impl), and again on the seedcheck binary. Both runs inherited `TEST_JOBS ?= 1`, so they ran **fully serially** even on multi-core hosts. On a 4-core box that's two serial passes over 320 `_test.sfn` files + the e2e `.sh` set.

`make check` already pins peak **build** concurrency via the RAM-budgeted `BUILD_JOBS` auto-detect (`scripts/detect_build_jobs.sh`), but its **suite** runs ignored that and stayed at 1.

## Change

Introduce `CHECK_TEST_JOBS`, used only by `make check`'s two suite runs:

- **Default:** the RAM-budgeted `BUILD_JOBS` auto-detect (4 on a 4-core/16 GB box) — the same per-job budget `check` already uses for builds, so no new RAM-pressure model is introduced.
- **Explicit override wins:** `make check TEST_JOBS=N` (command line or environment) is respected via `$(origin TEST_JOBS)`; `TEST_JOBS=1` restores the old serial behaviour.
- A bare `make test` is **unchanged** — it still defaults to serial (`TEST_JOBS=1`).

The early-gate and seedcheck banners now print the resolved `jobs=N` so the parallelism is visible.

## Why this is safe

- Makefile-only; no `compiler/src/*.sfn` touched, so the self-host invariant and `sfn fmt` gate don't apply.
- The default reuses the existing RAM-aware budget that already governs `check`'s build parallelism; CI shards already run these suites in parallel under the same budget.
- Determinism / fixed-point logic is untouched — only how many test **children** run concurrently changes, not what is built or compared.

## Verification

Variable resolution probed across all cases:

| Invocation | `CHECK_TEST_JOBS` | bare `TEST_JOBS` |
|---|---|---|
| `make check` (default) | 4 (= `BUILD_JOBS`) | 1 (unchanged) |
| `make check TEST_JOBS=2` | 2 | 2 |
| `make check TEST_JOBS=1` | 1 (serial restored) | 1 |
| `TEST_JOBS=3 make check` (env) | 3 | 3 |

https://claude.ai/code/session_01E5gkJAekdRaFv12bLWy1GS

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5gkJAekdRaFv12bLWy1GS)_