### PR TITLE
feat(concurrency): spawn/await lambdas actually execute on the pool (#1474)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -316,6 +316,7 @@ import {
     future_pointer_type_for_return_type,
     await_symbol_for_future_pointer_type,
     spawn_symbol_for_kind,
+    spawn_ctx_symbol_for_kind,
     llvm_return_type_for_spawn_kind,
     future_type_for_spawn_kind,
     map_parameter_type
@@ -1154,6 +1155,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             }
         }
         let spawn_sym = spawn_symbol_for_kind(spawn_kind);
+        let spawn_ctx_sym = spawn_ctx_symbol_for_kind(spawn_kind);
         let future_type = future_type_for_spawn_kind(spawn_kind);
         let fn_ret_llvm = llvm_return_type_for_spawn_kind(spawn_kind);
         let fn_ptr_type = fn_ret_llvm + " ()*";
@@ -1161,7 +1163,9 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         let mut spawn_temp: int = temp_index;
         let mut spawn_diag: string[] = diagnostics;
         let empty_spawn_constants: StringConstant[] = [];
-        let mut fn_ptr_value: string = "";
+        let mut have_operand: boolean = false;
+        let mut op_llvm_type: string = "";
+        let mut op_value: string = "";
         if spawn_operand_text.length > 0 {
             let lowered_op = lower_expression(spawn_operand_text, bindings, locals, spawn_temp, spawn_lines, functions, context, "");
             spawn_diag = extend_string_array(spawn_diag, lowered_op.diagnostics);
@@ -1169,21 +1173,12 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             spawn_temp = lowered_op.temp_index;
             if lowered_op.operand != null {
                 let raw_op = lowered_op.operand;
-                if raw_op.llvm_type == fn_ptr_type {
-                    fn_ptr_value = raw_op.value;
-                } else {
-                    let cast_t = format_temp_name(spawn_temp);
-                    spawn_temp += 1;
-                    spawn_lines.push("  " + cast_t + " = bitcast " + raw_op.llvm_type
-                        + " "
-                        + raw_op.value
-                        + " to "
-                        + fn_ptr_type);
-                    fn_ptr_value = cast_t;
-                }
+                op_llvm_type = raw_op.llvm_type;
+                op_value = raw_op.value;
+                have_operand = true;
             }
         }
-        if fn_ptr_value.length == 0 {
+        if !have_operand {
             spawn_diag.push("llvm lowering: spawn:<kind>: could not lower operand for `"
                 + stripped
                 + "`");
@@ -1195,20 +1190,61 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 string_constants: empty_spawn_constants
             };
         }
-        // Bitcast typed fn_ptr to i8* — sfn_spawn_* accepts i8* (#1090).
-        let fn_ptr_cast_t = format_temp_name(spawn_temp);
-        spawn_temp += 1;
-        spawn_lines.push("  " + fn_ptr_cast_t + " = bitcast " + fn_ptr_type
-            + " "
-            + fn_ptr_value
-            + " to i8*");
-        // Call sfn_spawn_*(i8*) → i8* raw handle.
-        let spawn_raw_t = format_temp_name(spawn_temp);
-        spawn_temp += 1;
-        spawn_lines.push("  " + spawn_raw_t + " = call i8* @" + spawn_sym
-            + "(i8* "
-            + fn_ptr_cast_t
-            + ")");
+        // The spawned task lowers to one of two operand shapes:
+        //   1. A lifted-lambda closure pair `{i8*, i8*}` = {fn_ptr, env}
+        //      (issue #686). The lifted worker is `fn(i8* env) -> <ret>` —
+        //      exactly the shape the runtime's `_ctx` trampoline calls — so
+        //      extract the fn_ptr + env and route through
+        //      `sfn_spawn_<kind>_ctx(fn_ptr, env)`. Non-capturing lambdas
+        //      carry a null env; capturing lambdas (follow-up) carry a heap
+        //      env. This is the path the surface `spawn fn() -> T { ... }`
+        //      takes, and it makes the task actually run on the pool (the
+        //      former `bitcast {i8*,i8*} to <ret> ()*` was invalid IR — an
+        //      aggregate cannot be bitcast to a function pointer — so the
+        //      task was never spawned).
+        //   2. A bare function reference (`i8*` or a typed `<ret> ()*`),
+        //      i.e. a zero-argument worker. Coerce to i8* and use the no-ctx
+        //      `sfn_spawn_<kind>(fn_ptr)` variant.
+        let mut spawn_raw_t: string = "";
+        if op_llvm_type == "{i8*, i8*}" {
+            let cp_fn_t = format_temp_name(spawn_temp);
+            spawn_temp += 1;
+            spawn_lines.push("  " + cp_fn_t + " = extractvalue {i8*, i8*} "
+                + op_value
+                + ", 0");
+            let cp_env_t = format_temp_name(spawn_temp);
+            spawn_temp += 1;
+            spawn_lines.push("  " + cp_env_t + " = extractvalue {i8*, i8*} "
+                + op_value
+                + ", 1");
+            spawn_raw_t = format_temp_name(spawn_temp);
+            spawn_temp += 1;
+            spawn_lines.push("  " + spawn_raw_t + " = call i8* @"
+                + spawn_ctx_sym
+                + "(i8* "
+                + cp_fn_t
+                + ", i8* "
+                + cp_env_t
+                + ")");
+        } else {
+            let mut fn_ptr_i8: string = op_value;
+            if op_llvm_type != "i8*" {
+                let fn_ptr_cast_t = format_temp_name(spawn_temp);
+                spawn_temp += 1;
+                spawn_lines.push("  " + fn_ptr_cast_t + " = bitcast "
+                    + op_llvm_type
+                    + " "
+                    + op_value
+                    + " to i8*");
+                fn_ptr_i8 = fn_ptr_cast_t;
+            }
+            spawn_raw_t = format_temp_name(spawn_temp);
+            spawn_temp += 1;
+            spawn_lines.push("  " + spawn_raw_t + " = call i8* @" + spawn_sym
+                + "(i8* "
+                + fn_ptr_i8
+                + ")");
+        }
         // Bitcast raw i8* result back to typed future pointer for
         // downstream IR type tracking (e.g. the await dispatch).
         let spawn_result_t = format_temp_name(spawn_temp);

--- a/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
@@ -480,6 +480,24 @@ fn spawn_symbol_for_kind(kind: string) -> string {
     return "sfn_spawn_ptr";
 }
 
+// The `_ctx` spawn variant for a kind tag. Mirrors `spawn_symbol_for_kind`
+// but selects the `sfn_spawn_<kind>_ctx(fn_ptr, ctx)` family — used when the
+// spawned task is a lifted lambda whose closure pair `{fn_ptr, env}` carries
+// an env to thread to the worker (the lifted worker is `fn(i8* env) -> T`,
+// the exact shape the runtime's `_ctx` trampoline calls). Non-capturing
+// lambdas pass a null env; capturing lambdas (follow-up) pass the heap env.
+fn spawn_ctx_symbol_for_kind(kind: string) -> string {
+    let trimmed = trim_text(kind);
+    if trimmed.length == 0 { return "sfn_spawn_void_ctx"; }
+    if trimmed == "void" { return "sfn_spawn_void_ctx"; }
+    if trimmed == "number" { return "sfn_spawn_number_ctx"; }
+    if trimmed == "int" { return "sfn_spawn_int_ctx"; }
+    if trimmed == "bool" { return "sfn_spawn_bool_ctx"; }
+    if trimmed == "boolean" { return "sfn_spawn_bool_ctx"; }
+    if trimmed == "string" { return "sfn_spawn_string_ctx"; }
+    return "sfn_spawn_ptr_ctx";
+}
+
 // Maps a spawn kind string to the LLVM return type of the spawned function
 // (i.e. the element type of the future). Used to build the typed function
 // pointer argument `<llvm_type> ()* @fn_symbol` for spawn calls.

--- a/compiler/tests/e2e/spawn_await_concurrent_execution_test.sfn
+++ b/compiler/tests/e2e/spawn_await_concurrent_execution_test.sfn
@@ -1,0 +1,89 @@
+// E2E: `spawn` / `await` of a non-capturing lambda actually EXECUTES the
+// task on the runtime thread pool and returns the correct typed value
+// (issue #1474, epic #965/#1209).
+//
+// Before #1474, `spawn fn() -> T { ... }` mis-lowered: the lifted-lambda
+// closure pair `{i8*, i8*}` was `bitcast` straight to a function pointer
+// (`bitcast {i8*,i8*} to <ret> ()*`) — invalid IR for any spawned task
+// that reached the pool, and the bare-`spawn`/`parallel` forms routed to
+// the `sfn_spawn_task` stub that never enqueues. Net effect: spawned task
+// bodies never ran. The fix extracts the `{fn_ptr, env}` slots from the
+// closure pair and routes through the runtime's `sfn_spawn_<kind>_ctx`
+// family, whose `_ctx` trampoline calls `fn(i8* env) -> T` — exactly the
+// lifted worker's shape — so the task runs on a worker thread and its
+// typed result round-trips through `await`.
+//
+// This test fans out THREE tasks (all spawned before any await), then
+// joins them. A correct value coming back through `await` can ONLY have
+// been produced by a worker thread pulling the task off the shared queue
+// and running it (the await result field is written by the worker), so
+// asserting the values proves real execution on the pool — not inline
+// evaluation.
+//
+// Fixtures use string concatenation + `number_to_string` (NOT `{{ }}`
+// interpolation) so the host compiler does not interpolate the fixture
+// before it is written.
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Empty `run_capture` env is the EMPTY environment, not "inherit"; a
+// nested `sailfin run` spawns clang + linker (needs PATH) and routes its
+// program.ll build-cache under SAILFIN_TEST_SCRATCH so the parallel pool
+// does not collide on the fixed build/sailfin (#1333).
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    fs.createDirectory(base, true);
+    return fs.mkdtemp(base + "/sfn-spawn-exec-");
+}
+
+fn _run_and_capture(label: string, source: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let src = dir + "/" + label + ".sfn";
+    fs.writeFile(src, source);
+    let exit = process.run_capture([_sfn_bin(), "run", src], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    if exit != 0 { return "RUN_FAILED:" + out + err; }
+    return out + err;
+}
+
+// ── three spawned int tasks run on the pool and round-trip via await ──
+test "spawn/await: non-capturing int tasks execute on the pool (#1474)" ![io] {
+    let out = _run_and_capture("int_fanout", "fn main() ![io] {\n"
+        + "    let a = spawn fn() -> int { return 6 * 7; };\n"
+        + "    let b = spawn fn() -> int { return 100 + 23; };\n"
+        + "    let c = spawn fn() -> int { return 9 * 9; };\n"
+        + "    let va: int = await a;\n"
+        + "    let vb: int = await b;\n"
+        + "    let vc: int = await c;\n"
+        + "    let sum: int = va + vb + vc;\n"
+        + "    print.info(\"sum: \" + number_to_string(sum));\n"
+        + "    if va == 42 { print.info(\"A-OK\"); }\n"
+        + "    if vb == 123 { print.info(\"B-OK\"); }\n"
+        + "    if vc == 81 { print.info(\"C-OK\"); }\n"
+        + "}");
+    // 42 + 123 + 81 = 246 — every task ran and its typed result survived.
+    assert contains(out, "sum: 246");
+    assert contains(out, "A-OK");
+    assert contains(out, "B-OK");
+    assert contains(out, "C-OK");
+}


### PR DESCRIPTION
## Summary

Slice 1 of #1474 (epic #965/#1209): make `spawn`/`await` of a non-capturing lambda **actually execute on the runtime thread pool** and round-trip its typed result.

`spawn fn() -> T { ... }` mis-lowered. The lifted-lambda closure pair `{i8*, i8*}` was bitcast straight to a function pointer:

```llvm
%t3 = bitcast {i8*, i8*} %t2 to i64 ()*   ; INVALID — aggregate→fnptr
%t5 = call i8* @sfn_spawn_int(i8* %t4)     ; passes garbage
```

An aggregate cannot be bitcast to a function pointer, so any spawned task that reached the runtime never ran. Net effect: **spawned task bodies were silently dropped** — M4 structured concurrency (#965) was marked shipped, but `spawn`/`parallel` never executed concurrently (existing tests only typecheck / inspect IR, so the gap hid).

## Root cause & fix

The runtime futures layer (`future.sfn` / `scheduler.sfn`) is fully functional — it lazily boots a global pthread pool and ships typed `sfn_spawn_<kind>`/`sfn_await_<kind>` families. The gap was purely frontend lowering.

The lifted worker is `fn(i8* env) -> T` — **exactly** the shape the runtime's `_ctx` trampoline (`_sfn_trampoline_<kind>_ctx`) calls. So the fix extracts the `{fn_ptr, env}` slots from the closure pair and routes through `sfn_spawn_<kind>_ctx(fn, env)`:

```llvm
%t3 = extractvalue {i8*, i8*} %t2, 0       ; fn_ptr
%t4 = extractvalue {i8*, i8*} %t2, 1       ; env (null for non-capturing)
%t5 = call i8* @sfn_spawn_int_ctx(i8* %t3, i8* %t4)
```

Non-capturing lambdas pass a null env; capturing lambdas (follow-up) pass a heap env, so this extends naturally to arg-capture. Bare function references keep the zero-arg `sfn_spawn_<kind>` path. This is **zero blast radius on the shared closure-as-value ABI** — the lifter and closure consumption are untouched; only the spawn call site changes.

## Changes

- `core_type_mapping.sfn`: add `spawn_ctx_symbol_for_kind` (kind tag → `sfn_spawn_<kind>_ctx`).
- `core.sfn`: branch the `spawn:<kind>` lowering on closure-pair vs bare-fn operand; emit `extractvalue` + the `_ctx` spawn call for closure pairs.
- `compiler/tests/e2e/spawn_await_concurrent_execution_test.sfn` (new): fans out three int tasks (all spawned before any `await`), joins them, asserts each typed result survived — a correct value can only return via a worker thread pulling the task off the shared queue.

## Verification

- **Self-host green** (`make compile`).
- New e2e passes; emitted IR has zero invalid aggregate→fnptr bitcasts.
- No regressions: concurrency unit suite (lowering 1/1, emit 8/8, typecheck 15/15, effect 8/8) + `routine_nursery` 5/5 + `sync_rejects_unimplemented_concurrency` 8/8 all pass.

## Scope (stops here for review, per plan)

In: non-capturing-lambda `spawn`+`await` executing on the pool with correct typed results.

Out (tracked follow-ups): `parallel` fan-out/join routing through the same path (#1474 remainder), argument-capture / heap-env closures (#1475/#1476), the effectful-lambda return-kind classification bug (`fn() -> int [io]` currently classifies as `ptr` — pre-existing, surfaced during this work), and the concurrent ASAN interleave gate (#1466 AC2).

Refs #1474

https://claude.ai/code/session_01EWb9ysUktuxnKrV93qxztS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWb9ysUktuxnKrV93qxztS)_