### PR TITLE
fix(windows): emulated TLS fixes native Windows startup segfault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,3 +981,61 @@ jobs:
           name: ci-installer-macos-arm64
           path: dist/installer-macos-arm64.tar.gz
           if-no-files-found: error
+
+  # Native Windows smoke test. The Windows .exe is cross-compiled on
+  # ubuntu (build-compiler-linux) and was, until now, shipped without
+  # ever being executed (#DOA: it segfaulted at startup on a native-TLS
+  # access — fixed by -femulated-tls in `make ci-cross-windows`). This
+  # job runs the cross-built binary on a real windows-latest runner so
+  # that regression can never ship again.
+  smoke-windows:
+    name: Smoke test [windows-x86_64]
+    needs: build-compiler-linux
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Download Windows installer archive
+        uses: actions/download-artifact@v8
+        with:
+          name: ci-installer-windows-x86_64
+          path: dist
+
+      - name: Extract installer bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p win-bundle
+          tar -xzf dist/installer-windows-x86_64.tar.gz -C win-bundle
+          EXE="$(find "$PWD/win-bundle" -name sailfin.exe | head -1)"
+          if [ -z "$EXE" ]; then
+            echo "sailfin.exe not found in installer bundle" >&2
+            exit 1
+          fi
+          echo "SAILFIN_EXE=$EXE" >> "$GITHUB_ENV"
+          echo "found: $EXE"
+
+      # Regression guard for the native-TLS startup segfault. Before the
+      # -femulated-tls fix this exited with 0xC0000005 before printing
+      # anything; --version exiting 0 with a version string proves the
+      # binary boots and TLS is initialized.
+      - name: Smoke - version (boots without segfault)
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$("$SAILFIN_EXE" --version)"
+          echo "version: $out"
+          case "$out" in
+            "sfn "*) echo "ok: binary boots and prints version" ;;
+            *) echo "FAIL: unexpected --version output: $out" >&2; exit 1 ;;
+          esac
+
+      # Frontend smoke (lex + parse + typecheck + effect-check). Run from
+      # the repo root so the runtime bundle (runtime/) resolves via CWD.
+      - name: Smoke - frontend check
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$SAILFIN_EXE" check examples/basics/hello-world.sfn

--- a/Makefile
+++ b/Makefile
@@ -1037,7 +1037,7 @@ ci-cross-windows:
 		$$LLVM_LINK --opaque-pointers -o "$$WIN_OBJ/sailfin.linked.bc" $$LL_FILES; \
 	\
 	echo "[cross-windows] compiling linked bitcode -> .o"; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks -femulated-tls \
 		-c "$$WIN_OBJ/sailfin.linked.bc" -o "$$WIN_OBJ/native.linked.o"; \
 	\
 	echo "[cross-windows] emitting + compiling runtime modules..."; \
@@ -1091,7 +1091,7 @@ ci-cross-windows:
 			$(NATIVE_OUT) emit --attempts 3 --validate -o "$$ll" llvm "$$src" >/dev/null || { \
 				echo "[cross-windows][error] failed to emit valid $$mod IR" >&2; exit 1; }; \
 		fi; \
-		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks -femulated-tls \
 			-c "$$ll" -o "$$obj"; \
 		RUNTIME_OBJS="$$RUNTIME_OBJS $$obj"; \
 	done; \


### PR DESCRIPTION
## Summary
The cross-compiled Windows x86_64 binary was **dead on arrival** — `sailfin.exe --version` (and every invocation, even with no args) exited `0xC0000005` (SIGSEGV) before printing anything. The Windows target had never been executed in CI, so it shipped unverified.

## Root cause
`thread_local` globals (e.g. `exception.sfn`'s `sfn_exception_frame_head_addr`) lower to LLVM `thread_local global`. `clang -target x86_64-w64-mingw32` emits the **native PE TLS** sequence:

```asm
movl  _tls_index(%rip), %eax
movq  %gs:0x58, %rdx          ; TEB.ThreadLocalStoragePointer
movq  (%rdx,%rax,8), %rax     ; TLS block base — NULL on the IR-cross-built image
movq  0x8(%rax), %rdx         ; FAULT (0xC0000005)
```

The IR-cross-built mingw image never initializes that TLS slot, so the first TLS access — `sfn_exception_push_frame`, reached early via the try/catch in `@main` — dereferences a NULL block. mingw's runtime (libgcc, linked via `-static`) expects **emulated TLS** via `__emutls_get_address`.

## Fix
Compile both Windows cross objects with `-femulated-tls` (`Makefile` `ci-cross-windows`, both `clang` invocations, so no object mixes native/emutls for the same symbol — ABI-incompatible).

## Regression guard
Adds a `windows-latest` CI smoke job that runs the cross-built exe (`--version` boot check + frontend `check`) so this can never ship unverified again.

## Verification (native Windows)
| command | before | after |
| --- | --- | --- |
| `sailfin.exe --version` | exit 139 (SIGSEGV) | exit 0 → `sfn 0.7.0-alpha.46` |
| `sailfin.exe check hello-world.sfn` | never reached | exit 0 → `checked 1 files: ok` |

Linux self-host (`make rebuild`) unaffected — the change is isolated to the `ci-cross-windows` recipe.

## Follow-ups (out of scope)
- `sfn run`/build on Windows: self-path resolution (`cannot resolve self path ... binary_dir="."`) + a native Windows clang toolchain.
- Debug-print noise on stdout/stderr (`cli: argv...`, `emit-llvm: mangle...`).
