### PR TITLE
docs(add-feature): drop nonexistent warn-first e2e lint claim

### DIFF
--- a/.claude/commands/add-feature.md
+++ b/.claude/commands/add-feature.md
@@ -28,7 +28,7 @@ Implement the feature **one pipeline stage at a time**, following the architect'
 4. **Effect Checker** (`compiler/src/effect_checker.sfn`) — if this involves effects
 5. **Native Emitter** (`compiler/src/emit_native.sfn`) — `.sfn-asm` emission
 6. **LLVM Lowering** (`compiler/src/llvm/`) — LLVM IR generation
-7. **Tests** — unit tests in `compiler/tests/unit/`, integration tests in `compiler/tests/integration/`. End-to-end tests go in `compiler/tests/e2e/` as `*_test.sfn` using `sfn/test` — **never** new bash scripts (a warn-first CI lint flags them; see `.claude/rules/no-bash-e2e.md` for the native e2e recipe, e.g. `guillermo_test.sfn`)
+7. **Tests** — unit tests in `compiler/tests/unit/`, integration tests in `compiler/tests/integration/`. End-to-end tests go in `compiler/tests/e2e/` as `*_test.sfn` using `sfn/test` — **never** new bash scripts (the `compiler/tests/e2e/*.sh` surface was fully migrated and deleted; see `.claude/rules/no-bash-e2e.md` for the native e2e recipe, e.g. `guillermo_test.sfn`)
 
 After each stage, run targeted tests to verify:
 ```bash


### PR DESCRIPTION
## What

`.claude/commands/add-feature.md` told agents that "a warn-first CI lint flags" new `compiler/tests/e2e/*.sh` scripts. No such lint exists — the bash e2e surface was fully migrated and **deleted** (epic #842 / #840), the Makefile `find` discovery branch was removed, and the `e2e-sh` CI shards were retired. There is no allowlist/ratchet lint (see `.claude/rules/no-bash-e2e.md`, which records exactly this).

This corrects the guidance to point at the rule and the no-bash stance rather than a phantom lint.

## Context

While auditing epic #842's open sub-issues I found the migration is 100% complete (0 `*.sh` in `compiler/tests/e2e/`, 137 `*_test.sfn`). Closed the now-done sub-issues (#1171, #1224, #1225, #1226, #1227, #1228, #1327); this PR fixes the one stale doc line surfaced during that audit. #1172 (runner carve) and #1174 (`--watch`, descoped) remain open as genuine outstanding work.

## Scope

Docs only — one line in `.claude/commands/add-feature.md`. No compiler source touched; self-host invariant not affected.

https://claude.ai/code/session_01J6uow97YsYz7F6HCd67884

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6uow97YsYz7F6HCd67884)_