### PR TITLE
feat(compiler): per-target _SC_NPROCESSORS_ONLN emit-time intrinsic (PR1 of #1480)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -44,6 +44,7 @@ import {
     stat_buf_size_value,
     errno_locator_symbol,
     clock_monotonic_id_value,
+    sc_nprocessors_onln_value,
     stat_st_mode_offset_value
 } from "../../lowering_debug_state";
 import { find_interface_info_by_name } from "../../type_context_queries";
@@ -706,6 +707,30 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                 lines: result_lines,
                 temp_index: result_temp,
                 operand: _cm_operand,
+                diagnostics: result_diagnostics,
+                string_constants: collected_string_constants
+            };
+        }
+    }
+
+    // `_SC_NPROCESSORS_ONLN` request-number sentinel (#1480, epic #763):
+    // lower to a bare `i32` immediate — `84` on Linux/glibc, `58` on
+    // Darwin/macOS — chosen at emit time via `sc_nprocessors_onln_value`.
+    // Like the clk_id sentinel above (and unlike the errno `call` and the
+    // pointer-read `load`), this is a pure inline constant: no line is
+    // pushed and `temp_index` is unchanged, so the value flows straight
+    // into the consuming `sysconf` call. No symbol is emitted, so the
+    // declare loop in `rendering.sfn` has nothing to declare.
+    if helper_descriptor != null {
+        if helper_descriptor.symbol == "sailfin_intrinsic_sc_nprocessors_onln" {
+            let _np_operand = LLVMOperand {
+                llvm_type: "i32",
+                value: number_to_string(sc_nprocessors_onln_value())
+            };
+            return ExpressionResult {
+                lines: result_lines,
+                temp_index: result_temp,
+                operand: _np_operand,
                 diagnostics: result_diagnostics,
                 string_constants: collected_string_constants
             };

--- a/compiler/src/llvm/lowering_debug_state.sfn
+++ b/compiler/src/llvm/lowering_debug_state.sfn
@@ -66,7 +66,8 @@ export {
     trace_call_lowering,
     skip_module_globals,
     errno_locator_symbol,
-    clock_monotonic_id_value
+    clock_monotonic_id_value,
+    sc_nprocessors_onln_value
 };
 
 // Per-flag cache cells. `_X_initialized` flips from false to true on
@@ -97,6 +98,14 @@ let mut _errno_locator_value: string = "";
 // `clock_monotonic_id_value` below.
 let mut _clock_monotonic_id_initialized: boolean = false;
 let mut _clock_monotonic_id_value: int = 0;
+// Cache for the resolved `_SC_NPROCESSORS_ONLN` `sysconf` request number
+// (#1480, epic #763). `_sc_nprocessors_onln_initialized` flips to true
+// after the one-time resolution (the `SAILFIN_TARGET_OS` override or the
+// `uname -s` host probe); `_sc_nprocessors_onln_value` holds the resolved
+// immediate (`84` on Linux/glibc, `58` on Darwin/macOS). See
+// `sc_nprocessors_onln_value` below.
+let mut _sc_nprocessors_onln_initialized: boolean = false;
+let mut _sc_nprocessors_onln_value: int = 0;
 // Cache for the resolved executable-path leg tag (#967, epic #390).
 // `_exe_path_locator_initialized` flips to true after the one-time
 // resolution (the `SAILFIN_TARGET_OS` override or the `uname -s`
@@ -228,6 +237,40 @@ fn clock_monotonic_id_value() -> int ![io] {
         _clock_monotonic_id_initialized = true;
     }
     return _clock_monotonic_id_value;
+}
+
+// The `_SC_NPROCESSORS_ONLN` `sysconf` request number for the host target
+// (#1480, epic #763). POSIX leaves the numeric request implementation-
+// defined and it diverges by platform — Linux/glibc `84`, Darwin/macOS
+// `58` — so the `sailfin_intrinsic_sc_nprocessors_onln` sentinel's lowering
+// branch (`core_call_emission.sfn`) reads this to emit a bare `i32`
+// immediate (no `call`, no `declare`), letting the same compiler source
+// bake the correct request number on either platform when built natively.
+// The scheduler currently hardcodes the Linux `84`, so `sysconf(84)` fails
+// closed to `-1` on macOS and the pool falls back to the two-worker
+// deadlock floor regardless of real core count; a seed-gated follow-up PR
+// swaps that hardcode for this intrinsic once it lands in a pinned seed.
+//
+// Resolution order matches `clock_monotonic_id_value` above:
+//   1. `SAILFIN_TARGET_OS` env override — the *target* OS, for the
+//      cross-compile path where a bare `uname -s` reports the host.
+//   2. `uname -s` host probe — the native-build path. `Darwin` → 58,
+//      anything else → 84, so the dominant Linux leg is the default and
+//      Windows (no POSIX `sysconf`) harmlessly falls through to the Linux
+//      value.
+//
+// Probed once and cached; mirrors the lazy-init contract of the trace
+// toggles and `clock_monotonic_id_value`.
+fn sc_nprocessors_onln_value() -> int ![io] {
+    if !_sc_nprocessors_onln_initialized {
+        let mut os: string = _get_env_cmd("SAILFIN_TARGET_OS");
+        if os.length == 0 { os = _shell_read_cmd("uname -s"); }
+        if os == "Darwin" { _sc_nprocessors_onln_value = 58; } else {
+            _sc_nprocessors_onln_value = 84;
+        }
+        _sc_nprocessors_onln_initialized = true;
+    }
+    return _sc_nprocessors_onln_value;
 }
 
 // Resolve which executable-path leg the call-emission dispatcher

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -212,6 +212,17 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.target == "sailfin_intrinsic_clock_monotonic_id" {
                 _preamble_inlined = true;
             }
+            // #1480: the `_SC_NPROCESSORS_ONLN` request-number sentinel
+            // never appears as a real
+            // `call @sailfin_intrinsic_sc_nprocessors_onln(` — the lowering
+            // branch (`core_call_emission.sfn`) inlines a bare `i32 84`/
+            // `i32 58` immediate instead, so there is no symbol to declare.
+            // The source-text walker still picks the sentinel target up from
+            // the call expression, so skip it here to avoid a bogus
+            // `declare` to a symbol that does not exist.
+            if descriptor.target == "sailfin_intrinsic_sc_nprocessors_onln" {
+                _preamble_inlined = true;
+            }
             // #967: the executable-path sentinel never appears as a real
             // `call @sailfin_intrinsic_exe_path(` — the lowering branch
             // (`core_call_emission.sfn`) emits the host's concrete primitive

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -301,6 +301,33 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "sailfin_intrinsic_clock_monotonic_id", symbol: "sailfin_intrinsic_clock_monotonic_id", return_type: "i32", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
 
+    // `_SC_NPROCESSORS_ONLN` `sysconf` request-number sentinel (#1480,
+    // epic #763). POSIX leaves the numeric request implementation-defined:
+    // glibc/Linux uses `84`, Darwin/macOS uses `58`. Like the clk_id
+    // sentinel above (and unlike errno, which emits a `call`, or
+    // pointer-read, which emits a `load`), this lowers to a bare `i32`
+    // immediate — no symbol, no runtime call. The call-emission dispatcher
+    // (`coerce_and_emit_call` in `core_call_emission.sfn`) special-cases
+    // this symbol and returns an inline `i32 84`/`i32 58` operand chosen by
+    // `sc_nprocessors_onln_value` at emit time (the `SAILFIN_TARGET_OS`
+    // target override, else the `uname -s` host probe). This is the
+    // seed-gated replacement for the Linux-only `84` that
+    // `runtime/sfn/concurrency/scheduler.sfn` hardcodes today — which makes
+    // `sysconf(84)` fail closed to `-1` on macOS and the worker pool
+    // collapse to the two-worker deadlock floor regardless of real core
+    // count (#1474 exposure). A later PR swaps the scheduler's hardcoded
+    // `84` for this intrinsic once it lands in a cut+pinned seed (the same
+    // intrinsic-then-seed-then-swap sequence the clk_id sentinel above
+    // followed for `clock.sfn`); scheduler.sfn is an `sfn-source` the seed
+    // compiles during self-host, so the swap cannot precede the seed.
+    // Empty effects: selecting a constant is not a capability — the request
+    // feeds the `sysconf` call whose effects live on that call. The declare
+    // loop in `rendering.sfn` skips the sentinel target; since the lowering
+    // emits no call, there is no concrete symbol to declare.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sailfin_intrinsic_sc_nprocessors_onln", symbol: "sailfin_intrinsic_sc_nprocessors_onln", return_type: "i32", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
     // executable-path sentinel (#967, epic #390). Resolves the running
     // binary's own absolute path. Unlike errno (a pure symbol swap across
     // three same-shape locators), the per-target primitives differ in arity

--- a/compiler/tests/e2e/sc_nprocessors_onln_sentinel_test.sfn
+++ b/compiler/tests/e2e/sc_nprocessors_onln_sentinel_test.sfn
@@ -1,0 +1,185 @@
+// E2E test for the host-aware `_SC_NPROCESSORS_ONLN` request-number
+// sentinel (#1480, epic #763).
+//
+// `sailfin_intrinsic_sc_nprocessors_onln` is a registry sentinel whose
+// lowering branch (`core_call_emission.sfn`) emits a bare `i32` immediate
+// — `84` on Linux/glibc, `58` on Darwin/macOS — chosen at emit time from
+// `SAILFIN_TARGET_OS` (cross-compile target override) or the `uname -s`
+// host probe. Unlike the errno sentinel (a `call`) and the pointer-read
+// sentinel (a `load`), it lowers to NO symbol and NO runtime call: the
+// constant flows straight into the consuming `sysconf` call as its request
+// argument. This is the per-target fix for the scheduler's core detection,
+// which previously hardcoded the Linux `84` and so failed closed to `-1`
+// on macOS, collapsing the worker pool to the two-worker deadlock floor.
+//
+// Host-independent. The Linux/Darwin base paths are forced via the
+// `SAILFIN_TARGET_OS` override (consulted before the `uname -s` host
+// probe), so they assert the same thing on Linux or macOS CI. The
+// precedence test additionally installs a `uname` shim on PATH forcing the
+// *opposite* host OS, proving `SAILFIN_TARGET_OS` wins over the host probe
+// (the cross-compile path, mirroring the #908 clk_id sentinel precedence
+// behavior). For each path it pins:
+//
+//   1. typecheck       — `sfn check <fixture>` exits 0.
+//   2. request immediate — `@sysconf(i32 84` on Linux, `@sysconf(i32 58`
+//                        on Darwin.
+//   3. override wins   — uname-shim=Linux + SAILFIN_TARGET_OS=Darwin → 58.
+//   4. no sentinel leak — no `call`/`declare` targets the sentinel name.
+//
+// NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]` and so
+// cannot be called from an `![io]` test like this. Assert on the captured
+// `.ll` text with `sfn/strings` predicates instead. (#842.)
+import { contains, split } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Base child env: PATH/HOME/TMPDIR + SAILFIN_TEST_SCRATCH. The caller
+// appends SAILFIN_TARGET_OS and/or a PATH override per case.
+fn _base_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+fn _env_with_target(target_os: string) -> string[] ![io] {
+    let mut e = _base_env();
+    e.push("SAILFIN_TARGET_OS=" + target_os);
+    return e;
+}
+
+fn _any_line_with(text: string, a: string, b: string) -> bool {
+    let lines = split(text, "\n");
+    let mut i = 0;
+    loop {
+        if i >= lines.length { break; }
+        if contains(lines[i], a) && contains(lines[i], b) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// Fixture mirrors the consumer shape (scheduler.sfn): feed the request-
+// number sentinel straight into `sysconf` as its argument, exactly where
+// the scheduler's core-count query sits.
+fn _fixture_source() -> string {
+    return "extern fn sysconf(name: i32) -> i64;\n\nfn read_ncpu() -> i64 {\n    return sysconf(sailfin_intrinsic_sc_nprocessors_onln());\n}\n\nfn main() -> void {\n    let n: i64 = read_ncpu();\n}\n";
+}
+
+fn _fixture_path() -> string ![io] {
+    let dir = _scratch_dir();
+    let src = dir + "/sfn-ncpu.sfn";
+    fs.writeFile(src, _fixture_source());
+    return src;
+}
+
+// Install a `uname` shim under `dir` that reports `os` for `uname -s` and
+// delegates everything else to the real binary, so the compiler's
+// `uname -s` probe resolves to the forced platform. Returns `dir`.
+fn _make_uname_shim(dir: string, os: string) -> string ![io] {
+    fs.createDirectory(dir, true);
+    let shim = dir + "/uname";
+    fs.writeFile(shim, "#!/bin/sh\nif [ \"$1\" = \"-s\" ]; then echo \"" + os
+        + "\"; exit 0; fi\nexec /usr/bin/uname \"$@\"\n");
+    let _ = process.run_capture(["chmod", "+x", shim], _base_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    return dir;
+}
+
+fn _emit(src: string, child_env: string[], tag: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let ll = dir + "/sfn-ncpu-" + tag + ".ll";
+    if fs.exists(ll) { fs.deleteFile(ll); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", ll, "llvm", src], child_env);
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    if !fs.exists(ll) { return ""; }
+    let ir = fs.readFile(ll);
+    fs.deleteFile(ll);
+    return ir;
+}
+
+test "ncpu: sfn check passes on the fixture" ![io] {
+    let src = _fixture_path();
+    let exit = process.run_capture([_sfn_bin(), "check", src], _base_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    fs.deleteFile(src);
+    assert exit == 0;
+}
+
+test "ncpu: Linux target feeds immediate 84, never 58" ![io] {
+    let src = _fixture_path();
+    let ir = _emit(src, _env_with_target("Linux"), "linux");
+    fs.deleteFile(src);
+    assert ir.length > 0;
+    assert contains(ir, "@sysconf(i32 84");
+    assert ! contains(ir, "@sysconf(i32 58");
+}
+
+test "ncpu: Darwin target feeds immediate 58, never 84" ![io] {
+    let src = _fixture_path();
+    let ir = _emit(src, _env_with_target("Darwin"), "darwin");
+    fs.deleteFile(src);
+    assert ir.length > 0;
+    assert contains(ir, "@sysconf(i32 58");
+    assert ! contains(ir, "@sysconf(i32 84");
+}
+
+test "ncpu: SAILFIN_TARGET_OS=Darwin overrides uname=Linux (req 58)" ![io] {
+    let src = _fixture_path();
+    let shimdir = _make_uname_shim(_scratch_dir() + "/shim-ncpu-override", "Linux");
+    // Build the env by hand so the shim dir is the *only* PATH entry (a
+    // second `PATH=` in the array would be ambiguous). The shim's `uname`
+    // therefore wins over the host's; SAILFIN_TARGET_OS=Darwin must still
+    // override it.
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    e.push("PATH=" + shimdir + ":" + path);
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    e.push("SAILFIN_TARGET_OS=Darwin");
+    let ir = _emit(src, e, "override");
+    fs.deleteFile(src);
+    assert ir.length > 0;
+    assert contains(ir, "@sysconf(i32 58");
+    assert ! contains(ir, "@sysconf(i32 84");
+}
+
+test "ncpu: sentinel symbol never emitted as call/declare" ![io] {
+    let src = _fixture_path();
+    let mut i = 0;
+    let targets = ["Linux", "Darwin"];
+    loop {
+        if i >= targets.length { break; }
+        let ir = _emit(src, _env_with_target(targets[i]), "leak-" + targets[i]);
+        assert ir.length > 0;
+        assert ! _any_line_with(ir, "call ", "@sailfin_intrinsic_sc_nprocessors_onln");
+        assert ! _any_line_with(ir, "declare ", "@sailfin_intrinsic_sc_nprocessors_onln");
+        i += 1;
+    }
+    fs.deleteFile(src);
+}


### PR DESCRIPTION
## Summary
- Adds `sailfin_intrinsic_sc_nprocessors_onln`, an emit-time sentinel that folds to a bare `i32` immediate per target — Linux/glibc `84`, Darwin/macOS `58` — for the POSIX `_SC_NPROCESSORS_ONLN` `sysconf` request number (implementation-defined, diverges by platform).
- Exact mirror of the `clock_monotonic_id` intrinsic (#908): registry descriptor row, lazy target-resolver (`SAILFIN_TARGET_OS` override → `uname -s` host probe), call-emission fold branch, declare-skip in rendering.
- New regression test mirroring `clock_monotonic_id_sentinel_test.sfn`.

**PR1 of a seed-gated split.** Refs #1480 (does **not** close it).

### Why split
The runtime consumer — `runtime/sfn/concurrency/scheduler.sfn`, which hardcodes the Linux `84` so `sysconf(84)` fails closed to `-1` on macOS and the worker pool collapses to the two-worker deadlock floor (#1474 exposure) — is an **sfn-source the seed compiles during self-host**. The current seed (`v0.7.0-alpha.46`) rejects the new intrinsic (`error[E0420]: undefined function sailfin_intrinsic_sc_nprocessors_onln`), so swapping the scheduler before the intrinsic is in a cut+pinned seed would break `make compile`. This is the same intrinsic → seed-cut → swap sequence `clk_id` followed for `clock.sfn`.

**After this merges:** cut + pin a new alpha seed, then PR2 swaps the scheduler hardcode and closes #1480.

## Verification
\`\`\`bash
make compile   # self-host PASS (compiler with new intrinsic compiles itself)
make test      # unit 160/160, integration 36/36, e2e 138/138, capsules 36/36 — status: pass
# new regression test (5/5):
build/native/sailfin test compiler/tests/e2e/sc_nprocessors_onln_sentinel_test.sfn
#   Linux target  → @sysconf(i32 84  (never 58)
#   Darwin target → @sysconf(i32 58  (never 84)
#   SAILFIN_TARGET_OS=Darwin overrides uname=Linux shim → 58
#   sentinel never emitted as call/declare
\`\`\`
sfn fmt --check clean on all touched files.

## Files Changed
- `compiler/src/llvm/lowering_debug_state.sfn` — `sc_nprocessors_onln_value()` resolver + cache + export
- `compiler/src/llvm/runtime_helpers.sfn` — descriptor row
- `compiler/src/llvm/rendering.sfn` — skip bogus `declare` for the sentinel
- `compiler/src/llvm/expression_lowering/native/core_call_emission.sfn` — fold branch + import
- `compiler/tests/e2e/sc_nprocessors_onln_sentinel_test.sfn` — new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)