### PR TITLE
refactor(cli): migrate the login subcommand to sfn/cli

### DIFF
--- a/compiler/src/cli/commands/login.sfn
+++ b/compiler/src/cli/commands/login.sfn
@@ -1,0 +1,130 @@
+// compiler/src/cli/commands/login.sfn
+//
+// `login` subcommand (CLI modularization epic #351, Issue 3.2 — proposal
+// §5 Phase 3 item 2, §7). Migrates `sfn login` off the legacy
+// `cli_commands` handler onto the per-command `command_def()`/`run()`
+// pattern established by Issue 2.4 (`version`) and exercised by Issues 3.1
+// (`init`) / 3.3 (`guillermo`).
+//
+// `login` takes a single optional positional `[token]`. When present it is
+// the registry token; when absent, `run` prompts and reads the token from
+// stdin exactly as the legacy handler did. The credential store
+// (`~/.sfn/credentials`), the `chmod 700/600` handling, the write-back
+// verification, and every exit code / message are reproduced byte-for-byte:
+//   - 0 — credentials written and verified.
+//   - 1 — empty token, no home directory, or a failed write.
+// The usage error (2) for extra positionals is enforced by the v2 dispatch
+// in `cli/main.sfn`: a second positional makes the parse non-ok while
+// marking `login` as descended, and the dispatch returns 2 there — the
+// parser owns argument validation, matching the legacy `args.length > 2`
+// guard.
+//
+// `get(matches, "token")` returns the Arg's `default_value` when the
+// positional is absent and "" when it is present-but-empty (`sfn login ""`);
+// the parser records both as a single "token" positional and cannot
+// otherwise tell them apart. The legacy handler split on `args.length`
+// (absent → prompt; any supplied token, even "", → use it directly), so the
+// default is a sentinel no shell-passed argv token can match: a truly absent
+// token routes to the interactive stdin prompt, while an explicit empty
+// token falls through to the "empty token" error WITHOUT reading stdin.
+// (Reading stdin on `sfn login ""` would also hang the parallel test pool,
+// whose pooled children do not see stdin EOF.)
+//
+// Exit codes are integer literals, not the `sfn/cli` `EXIT_*` constants:
+// those are module-level `let` constants with no cross-capsule import value
+// path today (see the `init.sfn` note), so they lower to 0 in the importing
+// module — `login` needs 1, so it uses literals to return it correctly.
+import {
+    get,
+    Command,
+    Matches,
+    command,
+    with_arg,
+    arg_optional
+} from "sfn/cli";
+
+import { CliContext } from "../context";
+import {
+    _get_home_cmd,
+    _toml_trim_cmd,
+    _shell_read_cmd,
+    _ensure_dir_recursive_cmd
+} from "../../cli_commands_utils";
+
+// Sentinel `default_value` for the optional `[token]` positional, returned
+// by `get(matches, "token")` only when no token was supplied on the command
+// line. The control-char wrapping makes it unmatchable by any real argv
+// token, so `run` can tell an absent token (→ prompt) from an explicit empty
+// one (`sfn login ""` → "empty token" error). A function (not a top-level
+// `let`) so the literal is read through a definite value path in both the
+// builder and `run` (see the `init.sfn` note on module-level constants).
+fn _token_absent_sentinel() -> string {
+    return "\t\t__sfn_login_token_absent__\t\t";
+}
+
+// The `sfn/cli` definition for `login`, registered on the v2 root via
+// `with_subcommand`. A single optional `[token]` positional; no flags.
+fn command_def() -> Command {
+    return with_arg(command("login", "Save a registry token to ~/.sfn/credentials"), arg_optional("token", "Registry token (read from stdin when omitted)", _token_absent_sentinel()));
+}
+
+// Save a registry token to `~/.sfn/credentials`. With a `token` positional
+// the value is used directly; without one, prompt and read a single line
+// from stdin. `ctx` is part of the per-command contract but unused here.
+// Byte-identical to the legacy `login` command-handler body.
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let token_arg = get(matches, "token");
+    let mut token: string = "";
+    if !strings_equal(token_arg, _token_absent_sentinel()) {
+        // A token was supplied on the command line (possibly empty) — use it
+        // directly, exactly as the legacy `args.length == 2` branch did.
+        token = _toml_trim_cmd(token_arg);
+    } else {
+        print("enter your registry token:");
+        let tmp = _shell_read_cmd("mktemp /tmp/.sfn_login_XXXXXX");
+        if tmp.length == 0 {
+            print("error: failed to create secure temp file");
+            return 1;
+        }
+        let read_rc = process.run(["sh", "-c", "head -1 > " + tmp]);
+        if read_rc != 0 {
+            process.run(["rm", "-f", tmp]);
+            print("error: failed to read token");
+            return 1;
+        }
+        if fs.exists(tmp) { token = _toml_trim_cmd(fs.readFile(tmp)); }
+        process.run(["rm", "-f", tmp]);
+    }
+
+    if token.length == 0 {
+        print("error: empty token");
+        return 1;
+    }
+
+    let home = _get_home_cmd();
+    if home.length == 0 {
+        print("could not determine home directory");
+        return 1;
+    }
+
+    let sfn_dir = home + "/.sfn";
+    _ensure_dir_recursive_cmd(sfn_dir);
+    process.run(["chmod", "700", sfn_dir]);
+
+    let cred_path = sfn_dir + "/credentials";
+    fs.writeFile(cred_path, token);
+    process.run(["chmod", "600", cred_path]);
+
+    if !fs.exists(cred_path) {
+        print("error: failed to write credentials to " + cred_path);
+        return 1;
+    }
+    let saved = fs.readFile(cred_path);
+    if !strings_equal(_toml_trim_cmd(saved), token) {
+        print("error: failed to write credentials to " + cred_path);
+        return 1;
+    }
+
+    print("credentials saved to " + cred_path);
+    return 0;
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -39,6 +39,7 @@ import { CliContext, parse_driver_prefix, driver_prefix_length } from "./context
 import { sailfin_cli_main_legacy } from "../cli_main";
 import { number_to_string } from "../num_format";
 import { run as init_run, command_def as init_command_def } from "./commands/init";
+import { run as login_run, command_def as login_command_def } from "./commands/login";
 import { run as version_run, command_def as version_command_def } from "./commands/version";
 import { run as guillermo_run, command_def as guillermo_command_def } from "./commands/guillermo";
 
@@ -81,7 +82,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // resolving it eagerly here would add a filesystem read to every
     // `build` / `run` invocation. `parse()` skips argv[0] (the program
     // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def());
+    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def());
 
     let mut parse_argv: string[] = ["sfn"];
     let mut j: int = 0;
@@ -117,6 +118,21 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if ctx.trace_argv { _v2_trace_argv(argv); }
         if result.ok { return init_run(result.matches, ctx); }
         print("usage: sfn init");
+        return 2;
+    }
+
+    // `sfn login [token]` — the registered subcommand matched. A clean
+    // parse dispatches to `login.run` (which uses the `token` positional
+    // when present, else prompts and reads from stdin). A non-ok parse that
+    // still descended into `login` (e.g. a second positional, or `--help`)
+    // is a usage error (exit 2), matching the legacy handler's
+    // `args.length > 2` guard — the parser owns argument validation, so the
+    // misuse never reaches `login.run`. The literal `2` mirrors the `init`
+    // dispatch above (the `sfn/cli` `EXIT_*` constants lower to 0 here).
+    if strings_equal(subcommand(result.matches), "login") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return login_run(result.matches, ctx); }
+        print("usage: sfn login [token]");
         return 2;
     }
 

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -3614,63 +3614,6 @@ fn handle_lock_command(args: string[]) -> int ![io] {
     return 0;
 }
 
-fn handle_login_command(args: string[]) -> int ![io] {
-    if args.length > 2 {
-        print("usage: sfn login [token]");
-        return 2;
-    }
-
-    let mut token: string = "";
-    if args.length == 2 { token = _toml_trim_cmd(args[1]); } else {
-        print("enter your registry token:");
-        let tmp = _shell_read_cmd("mktemp /tmp/.sfn_login_XXXXXX");
-        if tmp.length == 0 {
-            print("error: failed to create secure temp file");
-            return 1;
-        }
-        let read_rc = process.run(["sh", "-c", "head -1 > " + tmp]);
-        if read_rc != 0 {
-            process.run(["rm", "-f", tmp]);
-            print("error: failed to read token");
-            return 1;
-        }
-        if fs.exists(tmp) { token = _toml_trim_cmd(fs.readFile(tmp)); }
-        process.run(["rm", "-f", tmp]);
-    }
-
-    if token.length == 0 {
-        print("error: empty token");
-        return 1;
-    }
-
-    let home = _get_home_cmd();
-    if home.length == 0 {
-        print("could not determine home directory");
-        return 1;
-    }
-
-    let sfn_dir = home + "/.sfn";
-    _ensure_dir_recursive_cmd(sfn_dir);
-    process.run(["chmod", "700", sfn_dir]);
-
-    let cred_path = sfn_dir + "/credentials";
-    fs.writeFile(cred_path, token);
-    process.run(["chmod", "600", cred_path]);
-
-    if !fs.exists(cred_path) {
-        print("error: failed to write credentials to " + cred_path);
-        return 1;
-    }
-    let saved = fs.readFile(cred_path);
-    if !strings_equal(_toml_trim_cmd(saved), token) {
-        print("error: failed to write credentials to " + cred_path);
-        return 1;
-    }
-
-    print("credentials saved to " + cred_path);
-    return 0;
-}
-
 // ═══════════════════════════════════════════════════════════════════
 // sfn fmt — canonical formatter
 // ═══════════════════════════════════════════════════════════════════
@@ -3763,6 +3706,5 @@ export {
     handle_add_command,
     handle_config_command,
     handle_lock_command,
-    handle_login_command,
     handle_fmt_command
 };

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -58,7 +58,6 @@ import {
     handle_fmt_command,
     handle_lock_command,
     handle_test_command,
-    handle_login_command,
     handle_config_command,
     handle_package_command,
     handle_publish_command
@@ -1958,7 +1957,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     let is_package = strings_equal(cmd, "package");
     let is_add = strings_equal(cmd, "add");
     let is_lock = strings_equal(cmd, "lock");
-    let is_login = strings_equal(cmd, "login");
     let is_config = strings_equal(cmd, "config");
     let is_fmt = strings_equal(cmd, "fmt");
     let is_check = strings_equal(cmd, "check");
@@ -2790,8 +2788,8 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
 
     if is_lock { return handle_lock_command(args); }
 
-    if is_login { return handle_login_command(args); }
-
+    // `sfn login` migrated to `sfn/cli` (epic #351, Issue 3.2) — handled
+    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     if is_config { return handle_config_command(args); }
 
     if is_fmt { return handle_fmt_command(args); }


### PR DESCRIPTION
## Summary
- Migrate `sfn login` onto the per-command `command_def()`/`run()` pattern (epic #351, Issue 3.2): new `compiler/src/cli/commands/login.sfn` expresses the optional `[token]` positional via `sfn/cli` builders, registers on the v2 root, and dispatches from `sailfin_cli_main_v2`.
- Remove the legacy `handle_login_command` handler (`cli_commands.sfn`), its export, the legacy dispatch arm + `is_login` (`cli_main.sfn`), and the `handle_login_command` import.
- The credential store (`~/.sfn/credentials`), `chmod 700/600`, write-back verification, prompt text, exit codes, and the `credentials saved to …` message are reproduced byte-for-byte.

Closes #1297

## Design note — absent vs. explicit-empty token
A positional that is absent and one passed as `""` (`sfn login ""`) both read back as `""` through `get(matches, "token")` — the parser records both as a single `token` positional and cannot tell them apart. The legacy handler split on `args.length` (absent → prompt+stdin; any supplied token, even `""`, → use directly). A control-char sentinel `default_value` recovers that bit: a truly absent token routes to the interactive stdin prompt, while an explicit empty token falls through to the `error: empty token` path **without** reading stdin. This preserves legacy exit codes *and* avoids a stdin read that otherwise hangs the parallel test pool on `sfn login ""` (pooled children never see stdin EOF).

## Acceptance Criteria
- [x] `sfn login <token>` and the interactive (no-arg) path both behave identically to today, including exit codes and the `credentials saved to ...` message.
- [x] `compiler/src/cli/commands/login.sfn` exports `command_def()` + `run(matches, ctx)`; root built from `command_def()`.
- [x] Legacy path dead: `grep -rn handle_login_command compiler/src/` returns empty.
- [x] `make compile` passes (self-host).
- [ ] `make check` passes — deferred to CI (full triple-pass gate is long-running; see Verification for the local coverage already run).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```bash
make compile                          # self-host: pass
sfn fmt --check <4 touched files>     # clean
grep -rn handle_login_command compiler/src/   # empty

# functional parity (HOME pinned to a temp dir):
sfn login test-token   # exit 0, ~/.sfn/credentials = "test-token", dir 0700 / file 0600
printf 'tok\n' | sfn login   # prompts, reads stdin, exit 0
sfn login "" </dev/null      # "error: empty token", exit 1, NO prompt (no stdin read)
sfn login a b                # "usage: sfn login [token]", exit 2

# regression suite (existing e2e coverage):
sfn test compiler/tests/e2e/login_test.sfn                 # 8/8 pass
sfn test .../login_test.sfn .../guillermo_test.sfn --jobs 4 # pass under the parallel pool (no hang)
```
A prior local `make check` had already cleared unit (160/160), integration (36/36), and capsules (36/36); its only failure was the `login ""` pool hang, which this revision fixes and re-verifies under `--jobs 4`. Full `make check` left to CI.

## Files Changed
- `compiler/src/cli/commands/login.sfn` — new (`command_def()` + `run()` + absent-token sentinel).
- `compiler/src/cli/main.sfn` — register `login.command_def()` + dispatch.
- `compiler/src/cli_commands.sfn` — remove handler + export entry.
- `compiler/src/cli_main.sfn` — drop legacy arm, `is_login`, and import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2BrGbNPETYRZo5JvvQCJF

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2BrGbNPETYRZo5JvvQCJF)_