### PR TITLE
fix(test): silence per-test phase timing and clang/ld link noise

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -156,7 +156,11 @@ fn _is_safe_capsule_version_cmd(value: string) -> boolean {
 // `docs/proposals/build-architecture.md` Stage B for the full
 // trail.
 fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_root: string, dep_ll_paths: string[], cache_dir: string, binary_dir: string) -> int ![io] {
-    let mut args: string[] = ["clang", "-O0", "-o", out_path, ll_path];
+    // `-Wno-override-module`: every emitted `.ll` carries its own `target
+    // triple`, which clang's link overrides — matching the suppression on
+    // every other clang invocation in cli_main.sfn so the test path is not
+    // the lone source of `[-Woverride-module]` noise.
+    let mut args: string[] = ["clang", "-O0", "-Wno-override-module", "-o", out_path, ll_path];
     let mut di: int = 0;
     loop {
         if di >= dep_ll_paths.length { break; }
@@ -202,14 +206,27 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
         args.push(rt.object_paths[roi]);
         roi += 1;
     }
+    // The runtime capsule's `link-libs` (runtime/capsule.toml) already
+    // carries `-lm` / `-lpthread`. Track which math/thread libs flow
+    // through so the defensive push below does not re-add a lib the
+    // capsule supplied — a duplicate `-lm` makes the macOS linker emit
+    // `ld: warning: ignoring duplicate libraries: '-lm'`.
+    let mut has_lm: boolean = false;
+    let mut has_pthread: boolean = false;
     let mut lli: int = 0;
     loop {
         if lli >= rt.link_libs.length { break; }
-        args.push(rt.link_libs[lli]);
+        let lib = rt.link_libs[lli];
+        if strings_equal(lib, "-lm") { has_lm = true; }
+        if strings_equal(lib, "-lpthread") { has_pthread = true; }
+        if strings_equal(lib, "-pthread") { has_pthread = true; }
+        args.push(lib);
         lli += 1;
     }
-    args.push("-lm");
-    args.push("-pthread");
+    // Fallback for configurations where the runtime capsule did not supply
+    // them (keeps the link complete without double-adding).
+    if !has_lm { args.push("-lm"); }
+    if !has_pthread { args.push("-pthread"); }
     return process.run(args);
 }
 

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -626,8 +626,12 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     diagnostics = extend_string_lines_checked(diagnostics, safe_parse_diagnostics, "parse");
 
     // ── Trace/timing setup ──────────────────────────────────────────
+    // Per-phase timing prints are gated on the trace flag
+    // (`SAILFIN_TRACE_TEST_RUNNER`), not merely on being in a test run, so
+    // an ordinary `sfn test` / `make test` stays quiet. Set the trace env
+    // to surface the `test llvm: phase=…` breakdown.
     let trace = test_runner_trace();
-    let timing = test_runner_active();
+    let timing = test_runner_trace();
     let start_ms = monotonic_millis();
 
     if trace {


### PR DESCRIPTION
## Summary

Three independent sources of `sfn test` output noise — the `test llvm: phase=…` lines and the macOS clang/ld warnings the user reported — all live in the test link/lower path and none were gated like their siblings. This cleans up all three.

These are **not** tracked by #893 (that's an unrelated `errno.sfn` runtime refactor); nothing currently tracks this noise.

## The three fixes

1. **`test llvm: phase=…` printed on every test compile** — `lowering_core.sfn` set `timing = test_runner_active()`, so the 7 per-phase timing lines fired on *every* `sfn test` compile, unlike the sibling `trace`-gated lines. Gated on `test_runner_trace()` now, so an ordinary `make test` is quiet; `SAILFIN_TRACE_TEST_RUNNER=1` still surfaces the breakdown.

2. **`warning: overriding the module target triple … [-Woverride-module]`** — the test linker `_clang_link_test_cmd_with_deps` (`cli_commands.sfn`) built its clang argv without `-Wno-override-module`, the lone clang invocation missing it (every call in `cli_main.sfn` has it). Each emitted `.ll`'s `target triple` triggered one warning per module. Added the suppression.

3. **`ld: warning: ignoring duplicate libraries: '-lm'`** — the same linker unconditionally re-pushed `-lm`/`-pthread`, but the runtime capsule's `link-libs` (`runtime/capsule.toml`) already supplies `-lm`/`-lpthread`. Now tracks what flowed through and only adds the fallback when the capsule didn't supply it.

## Verification

- `make compile` clean (self-host holds).
- `sfn fmt --check` clean on both touched files.
- `test llvm: phase=` lines: **absent** in normal `sfn test`, **present** under `SAILFIN_TRACE_TEST_RUNNER=1` (verified on a cold compile — the content-keyed test-bin cache otherwise masks it).
- `runner_state_marker_test.sfn` passes 3/3 (Contract 2: trace lines still fire under the flag; Contract 3: `phase=` stays off outside `sfn test`).

https://claude.ai/code/session_01GD7oLR5pGDWd8bdhBAx2Pw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GD7oLR5pGDWd8bdhBAx2Pw)_