### PR TITLE
fix(cli): read env vars via env.get, not POSIX shell-out (#1483)

### DIFF
--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -144,9 +144,18 @@ fn _shell_read_cmd(cmd: string) -> string ![io] {
     return _toml_trim_cmd(captured);
 }
 
-fn _get_env_cmd(name: string) -> string ![io] {
-    return _shell_read_cmd("printf '%s' \"$" + name + "\"");
-}
+// Read an environment variable via the native `env.get` builtin. The
+// prior implementation shelled out to `printf '%s' "$VAR"` — a POSIX-only
+// construct that the Windows shell (`cmd.exe`) cannot honor (`$VAR` is not
+// expanded and there is no `printf`), so every env read returned a wrong
+// value on the native Windows binary. The most visible symptom was
+// `SAILFIN_TRACE_ARGV` reading as *set* even when unset, spewing
+// `cli: argv...` trace noise on every invocation; the same breakage
+// corrupted `SAILFIN_NO_LEGACY_PROBE`, `SAILFIN_LINKER`, `HOME`, and every
+// other flag routed through this helper (#1483). `env.get` is the same
+// builtin `_resolve_sailfin_cache_dir_for_work` (cli_main.sfn) already
+// uses; it returns "" for an unset variable on every platform.
+fn _get_env_cmd(name: string) -> string ![io] { return env.get(name); }
 
 fn _get_home_cmd() -> string ![io] { return _get_env_cmd("HOME"); }
 


### PR DESCRIPTION
## Summary
- `_get_env_cmd` shelled out to `printf '%s' "$VAR"`, a POSIX-only construct the Windows shell (`cmd.exe`) cannot honor (no `$VAR` expansion, no `printf`), so every env read returned a wrong value on the native Windows binary — most visibly `SAILFIN_TRACE_ARGV` reading as *set* even when unset, spewing `cli: argv...` trace noise on every invocation.
- Switched the helper to the native `env.get` builtin (already used by `_resolve_sailfin_cache_dir_for_work` in `cli_main.sfn`), which returns `""` for an unset variable on every platform.
- `_get_home_cmd`, `_env_flag`, and `_legacy_flag_file` all route through `_get_env_cmd`, so the fix propagates to `SAILFIN_NO_LEGACY_PROBE`, `SAILFIN_LINKER`, `HOME`, etc. without further edits.

Closes #1483

## Acceptance Criteria
- [x] On native Windows, `sailfin.exe --version` / `check` produce NO `cli: argv...` / `cli: args...` output unless `SAILFIN_TRACE_ARGV` is genuinely set. (Verified on Linux: `--version` emits 0 `cli:` lines with the var unset; the same `env.get` path now runs cross-platform.)
- [x] `_get_env_cmd("SOME_UNSET_VAR")` returns `""` on both Windows and POSIX (the toggle test's "off unset" cases pin this on Linux; `env.get` is the platform-portable builtin).
- [x] `compiler/tests/e2e/compiler_debug_toggle_env_vars_test.sfn` still passes (all 16 tests pass).

## Verification
```bash
make compile                                   # self-host: PASS
build/native/sailfin --version | grep -c '^cli:'   # → 0
build/native/sailfin test \
  compiler/tests/e2e/compiler_debug_toggle_env_vars_test.sfn   # → PASS (16/16)
sfn fmt --check compiler/src/cli_commands_utils.sfn            # clean
```

## Files Changed
- `compiler/src/cli_commands_utils.sfn` — `_get_env_cmd` now calls `env.get(name)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151dks7NiuCcJUKH73VN1qD

---
_Generated by [Claude Code](https://claude.ai/code/session_0151dks7NiuCcJUKH73VN1qD)_