### PR TITLE
feat(runtime): subprocess rusage / peak-RSS capture (#1520)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1095,6 +1095,11 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "process.run_capture");
     helpers = append_unique_effect(helpers, "process.capture_take_stdout");
     helpers = append_unique_effect(helpers, "process.capture_take_stderr");
+    // #1520: metered-capture helpers (wall-clock + peak RSS) consumed by
+    // the `sfn bench` driver and the e2e metered-capture test.
+    helpers = append_unique_effect(helpers, "process.run_capture_metered");
+    helpers = append_unique_effect(helpers, "process.capture_take_wall_ms");
+    helpers = append_unique_effect(helpers, "process.capture_take_peak_rss_kb");
     helpers = append_unique_effect(helpers, "process.spawn_with_env");
     helpers = append_unique_effect(helpers, "process.handle_write");
     helpers = append_unique_effect(helpers, "process.handle_close_stdin");

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -751,6 +751,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.capture_take_stderr", symbol: "sfn_process_capture_take_stderr", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: "sfn_process_capture_take_stderr", c_abi_return_type: null
     });
+    // #1520: metered capture — `run_capture` plus a wall-clock +
+    // peak-RSS bracket (`wait4`/`ru_maxrss`), the measurement primitive
+    // the native `sfn bench` driver (epic #1503) uses instead of GNU
+    // `/usr/bin/time -v`. `run_capture_metered` carries `clock` on top
+    // of `io` (it reads the monotonic clock); the two takes hand back
+    // `i64` measurements (wall ms / peak RSS KiB on Linux). Bodies in
+    // `runtime/sfn/process.sfn`.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.run_capture_metered", symbol: "sfn_process_run_capture_metered", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io", "clock"], native_signature: "sfn_process_run_capture_metered", c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.capture_take_wall_ms", symbol: "sfn_process_capture_take_wall_ms", return_type: "i64", parameter_types: [], effects: ["io"], native_signature: "sfn_process_capture_take_wall_ms", c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.capture_take_peak_rss_kb", symbol: "sfn_process_capture_take_peak_rss_kb", return_type: "i64", parameter_types: [], effects: ["io"], native_signature: "sfn_process_capture_take_peak_rss_kb", c_abi_return_type: null
+    });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.spawn_with_env", symbol: "sfn_process_spawn_with_env", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_spawn_with_env", c_abi_return_type: null
     });

--- a/compiler/tests/e2e/process_run_capture_metered_test.sfn
+++ b/compiler/tests/e2e/process_run_capture_metered_test.sfn
@@ -1,0 +1,74 @@
+// compiler/tests/e2e/process_run_capture_metered_test.sfn
+//
+// #1520: metered subprocess capture. `process.run_capture_metered`
+// runs a child exactly like `process.run_capture` but also brackets it
+// with a wall-clock + peak-RSS measurement (`wait4` / `ru_maxrss`) —
+// the primitive the native `sfn bench` driver (epic #1503) uses instead
+// of shelling to GNU `/usr/bin/time -v`. The metered values are taken
+// with `process.capture_take_wall_ms` / `_peak_rss_kb`, mirroring the
+// `capture_take_stdout` / `_stderr` handoff.
+//
+// These tests drive real children (`sh` / `uname`, resolved on the
+// parent PATH; the empty env array is the empty child environment, per
+// the no-bash-e2e contract) and assert the metering is sane: exit code
+// preserved, stdout still captured, wall_ms >= 0, and — on Linux, where
+// `ru_maxrss` is KiB — peak_rss_kb > 0. On Darwin `ru_maxrss` is bytes
+// (normalization deferred under #1503), so the strong RSS assertion is
+// gated to Linux, matching the issue's acceptance criteria.
+import { find } from "sfn/strings";
+
+// Host OS via `uname -s`, captured through the plain (unmetered)
+// run_capture so the metered RSS assertion can gate on the platform.
+// Plain run_capture does not touch the metered wall/RSS stash.
+fn _is_linux() -> boolean ![io] {
+    let exit = process.run_capture(["uname", "-s"], []);
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    if exit != 0 { return false; }
+    return find(out, "Linux", 0) >= 0;
+}
+
+test "run_capture_metered: exit code is preserved" ![io, clock] {
+    let exit = process.run_capture_metered(["sh", "-c", "exit 7"], []);
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    let _wall = process.capture_take_wall_ms();
+    let _rss = process.capture_take_peak_rss_kb();
+    assert exit == 7;
+}
+
+test "run_capture_metered: stdout still captured alongside metering" ![io, clock] {
+    let exit = process.run_capture_metered(["sh", "-c", "printf hello"], []);
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    let _wall = process.capture_take_wall_ms();
+    let _rss = process.capture_take_peak_rss_kb();
+    assert exit == 0;
+    assert find(out, "hello", 0) >= 0;
+}
+
+test "run_capture_metered: wall_ms is non-negative" ![io, clock] {
+    let _exit = process.run_capture_metered(["sh", "-c", "sleep 0.05"], []);
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    let wall = process.capture_take_wall_ms();
+    let _rss = process.capture_take_peak_rss_kb();
+    assert wall >= 0;
+}
+
+test "run_capture_metered: peak RSS is captured (Linux)" ![io, clock] {
+    let linux = _is_linux();
+    let _exit = process.run_capture_metered(["sh", "-c", "exit 0"], []);
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    let _wall = process.capture_take_wall_ms();
+    let rss = process.capture_take_peak_rss_kb();
+    if linux {
+        // Linux ru_maxrss is KiB; any reaped child has a non-zero peak.
+        assert rss > 0;
+    } else {
+        // Darwin reports bytes (normalization deferred under #1503) —
+        // assert only that the measurement is non-negative.
+        assert rss >= 0;
+    }
+}

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -158,6 +158,60 @@ extern fn posix_spawn_file_actions_adddup2(fa: * u8, fd: i32, newfd: i32) -> i32
 // `4` is used directly.
 let SFN_EINTR: i32 = 4;
 
+// ── metered-capture support (#1520) ────────────────────────────────
+// `wait4` is `waitpid` plus a `struct rusage` out-param the kernel
+// fills with the reaped child's resource usage. A NULL `rusage` makes
+// it behave exactly like `waitpid(pid, status, 0)`, so the shared
+// capture impl always calls `wait4` and the non-metered wrapper passes
+// NULL. Declared with a `* u8` rusage buffer read back via address
+// arithmetic + the pointer-read intrinsic — the same struct-free style
+// the handle/pollfd overlays use, sidestepping a `struct rusage`
+// binding (44 fields, platform-divergent) we never need whole.
+extern fn wait4(pid: i32, status: * i32, options: i32, rusage: * u8) -> i32;
+
+// `clock_gettime` for the metered wall-clock bracket. Declared with the
+// same `* Timespec` shape `runtime/sfn/clock.sfn` uses so the emitted
+// `declare` matches across the two runtime objects; redeclared locally
+// (rather than imported) for the #306 reason the file header documents
+// — the runtime sfn-source emit path resolves imported externs but not
+// imported *defined* fns, and inlining keeps this module self-contained.
+struct Timespec {
+    tv_sec: i64;
+    tv_nsec: i64;
+}
+
+extern fn clock_gettime(clk_id: i32, ts: * Timespec) -> i32;
+
+// `struct rusage` byte offset of `ru_maxrss` (the peak resident set
+// size): two 16-byte `timeval`s (`ru_utime`, `ru_stime`) precede it on
+// both Linux x86_64 and macOS arm64, so it sits at offset 32 as a
+// `long`. UNITS DIVERGE BY PLATFORM: KiB on Linux (the value returned
+// as-is — the load-bearing platform for the bench memory budget, see
+// `.claude/rules/compiler-safety.md`), BYTES on Darwin. Darwin
+// normalization is a deferred follow-up under epic #1503; the bench
+// memory leg is Linux/WSL-only today, and metered callers gate any
+// macOS RSS assertion accordingly.
+let SFN_RUSAGE_MAXRSS_OFFSET: i64 = 32;
+
+// Local monotonic-clock reader for the wall-clock bracket. A near-
+// verbatim copy of `clock.sfn::sfn_clock_monotonic_nanos` (kept local
+// for the #306 cross-module-defined-fn limitation above): stack-alloc a
+// `Timespec`, hand the kernel its address, then read `tv_sec` (offset 0)
+// and `tv_nsec` (the next `i64`) back through the pointer-read intrinsic
+// *after* the call. `sailfin_intrinsic_clock_monotonic_id()` folds to
+// the right `CLOCK_MONOTONIC` id per target at emit time (#908).
+fn _monotonic_nanos() -> i64 ![clock] {
+    let mut ts: Timespec = Timespec { tv_sec: 0, tv_nsec: 0 };
+    let ts_ptr: * Timespec = & ts;
+    let ret: i32 = clock_gettime(sailfin_intrinsic_clock_monotonic_id(), ts_ptr);
+    if ret != 0 { return 0; }
+    let sec_ptr: * i64 = ts_ptr as * i64;
+    let nsec_ptr: * i64 = sec_ptr + 1;
+    let sec: i64 = sailfin_intrinsic_pointer_read_i64(sec_ptr);
+    let nsec: i64 = sailfin_intrinsic_pointer_read_i64(nsec_ptr);
+    return sec * 1000000000 + nsec;
+}
+
 fn sfn_process_run(argv: string[]) -> float ![io] {
     let len: i64 = argv.length;
     if len <= 0 { return 127.0; }
@@ -266,6 +320,16 @@ fn sfn_process_run(argv: string[]) -> float ![io] {
 let mut sfn_capture_stdout_addr: i64 = 0;
 
 let mut sfn_capture_stderr_addr: i64 = 0;
+
+// Metered-capture stash (#1520): wall-clock duration (ms) and peak
+// resident set size (KiB on Linux — see `SFN_RUSAGE_MAXRSS_OFFSET`) of
+// the most recent `run_capture_metered`, retrieved by the matching
+// `capture_take_wall_ms` / `capture_take_peak_rss_kb`. `0` means "no
+// metered capture pending". Stored as `i64` for the same seed
+// module-mutable-global reason as the stdout/stderr addresses above.
+let mut sfn_capture_wall_ms: i64 = 0;
+
+let mut sfn_capture_peak_rss_kb: i64 = 0;
 
 // Growable byte buffer: `{ addr, len, cap }`, all `i64`. `addr` is
 // the malloc/realloc'd data pointer (cast to `i64`); `0` means
@@ -489,14 +553,20 @@ fn sfn_process_exit(code: float) -> void ![io] {
     exit(c as i32);
 }
 
-// ── process.run_capture ────────────────────────────────────────
+// ── process.run_capture (shared impl) ──────────────────────────
 // Port of `sailfin_runtime_process_run_capture`. Runs the child to
 // completion with stdout/stderr piped, stashes both captured streams
 // in the module globals for `capture_take_*`, and returns the exit
 // code (0..255), `128 + signal` for signal death, or `-1` on any
 // setup/spawn/wait failure. `env_flat` is a flat `string[]` of
 // `"KEY=VALUE"` entries; an empty array means the empty environment.
-fn sfn_process_run_capture(argv: string[], env_flat: string[]) -> i64 ![io] {
+//
+// `rusage_buf` (#1520): when non-NULL, the reaping `wait4` fills it with
+// the child's `struct rusage` so the metered wrapper can read `ru_maxrss`.
+// NULL makes `wait4` behave exactly like the former `waitpid` — the plain
+// `run_capture` wrapper passes NULL, so its behaviour is byte-for-byte
+// unchanged.
+fn _run_capture_impl(argv: string[], env_flat: string[], rusage_buf: * u8) -> i64 ![io] {
     if sfn_capture_stdout_addr != 0 {
         free(sfn_capture_stdout_addr as * u8);
         sfn_capture_stdout_addr = 0;
@@ -636,7 +706,7 @@ fn sfn_process_run_capture(argv: string[], env_flat: string[]) -> i64 ![io] {
 
     let mut status: i32 = 0;
     let status_ptr: * i32 = & status;
-    let wait_err: i32 = waitpid(pid, status_ptr, 0);
+    let wait_err: i32 = wait4(pid, status_ptr, 0, rusage_buf);
 
     let out_cstr: * u8 = _growbuf_take(gb_out);
     let err_cstr: * u8 = _growbuf_take(gb_err);
@@ -663,6 +733,69 @@ fn sfn_process_run_capture(argv: string[], env_flat: string[]) -> i64 ![io] {
         return signaled as i64;
     }
     return -1;
+}
+
+// Plain `process.run_capture`: the unmetered wrapper. Passes a NULL
+// `rusage` so `wait4` degrades to `waitpid` — behaviour-preserving.
+fn sfn_process_run_capture(argv: string[], env_flat: string[]) -> i64 ![io] {
+    return _run_capture_impl(argv, env_flat, 0 as * u8);
+}
+
+// ── process.run_capture_metered ────────────────────────────────
+// #1520: `run_capture` plus a wall-clock + peak-RSS bracket, the
+// measurement primitive the native `sfn bench` driver (epic #1503)
+// uses instead of shelling to GNU `/usr/bin/time -v`. Brackets the
+// child run with the monotonic clock for `wall_ms`, and threads a
+// `struct rusage` buffer through `wait4` so `ru_maxrss` records the
+// child's peak RSS. Both results are stashed in module globals for the
+// matching `capture_take_wall_ms` / `capture_take_peak_rss_kb`; the
+// stdout/stderr streams are taken exactly as for `run_capture`. Returns
+// the same exit code / `-1` contract as `run_capture`.
+//
+// Effect: `![io, clock]` — the subprocess drive is `io`, the wall-clock
+// read is `clock` (same gate `monotonic_millis` carries).
+fn sfn_process_run_capture_metered(argv: string[], env_flat: string[]) -> i64 ![io, clock] {
+    sfn_capture_wall_ms = 0;
+    sfn_capture_peak_rss_kb = 0;
+
+    // Zeroed rusage buffer (256 bytes ≫ the ~144-byte `struct rusage`
+    // on both targets). A NULL buffer (OOM) simply leaves peak RSS at 0.
+    let rusage_buf: * u8 = malloc(256 as usize);
+    if rusage_buf as i64 != 0 { memset(rusage_buf, 0, 256 as usize); }
+
+    let start: i64 = _monotonic_nanos();
+    let rc: i64 = _run_capture_impl(argv, env_flat, rusage_buf);
+    let end: i64 = _monotonic_nanos();
+
+    let mut elapsed: i64 = end - start;
+    if elapsed < 0 { elapsed = 0; }
+    sfn_capture_wall_ms = elapsed / 1000000;
+
+    if rusage_buf as i64 != 0 {
+        let maxrss_ptr: * i64 = ((rusage_buf as i64) + SFN_RUSAGE_MAXRSS_OFFSET) as * i64;
+        let maxrss: i64 = sailfin_intrinsic_pointer_read_i64(maxrss_ptr);
+        if maxrss > 0 { sfn_capture_peak_rss_kb = maxrss; }
+        free(rusage_buf);
+    }
+
+    return rc;
+}
+
+// ── process.capture_take_wall_ms / _peak_rss_kb ────────────────
+// Hand off the metered measurements stashed by the preceding
+// `run_capture_metered`, clearing each global so a second take yields
+// 0. `wall_ms` is whole milliseconds; `peak_rss_kb` is KiB on Linux
+// (see `SFN_RUSAGE_MAXRSS_OFFSET` for the Darwin unit caveat).
+fn sfn_process_capture_take_wall_ms() -> i64 ![io] {
+    let v: i64 = sfn_capture_wall_ms;
+    sfn_capture_wall_ms = 0;
+    return v;
+}
+
+fn sfn_process_capture_take_peak_rss_kb() -> i64 ![io] {
+    let v: i64 = sfn_capture_peak_rss_kb;
+    sfn_capture_peak_rss_kb = 0;
+    return v;
 }
 
 // ── process.capture_take_stdout / _stderr ──────────────────────


### PR DESCRIPTION
## Summary
- Adds `process.run_capture_metered` + `process.capture_take_wall_ms` / `process.capture_take_peak_rss_kb`: runs a child like `run_capture` but also brackets it with a monotonic wall-clock measurement and threads a `struct rusage` through `wait4` to record peak RSS.
- This is the measurement primitive the native `sfn bench` driver (epic #1503) uses **instead of shelling to GNU `/usr/bin/time -v`** (absent on stock macOS, flaky in CI).
- Implemented **purely in Sailfin via libc externs** (`wait4`, `clock_gettime`) — no C adapter, contrary to the issue's estimate. `run_capture` is refactored into a shared `_run_capture_impl(…, rusage_buf)`; the plain wrapper passes a NULL rusage so `wait4` degrades to `waitpid` (behaviour-preserving).

Foundation sub-issue **A** of epic #1503. Closes #1520.

## Design notes for review
- **`ru_maxrss` unit:** returned raw — KiB on Linux (the load-bearing platform for the bench memory budget per `.claude/rules/compiler-safety.md`), **bytes on Darwin**. Darwin normalization is deferred under #1503 (no target-OS intrinsic exists today; adding one is frontend work needing a seed cut). The issue's own wording sanctions this ("normalize, **or skip** when unavailable"); the e2e test gates its `peak_rss_kb > 0` assertion to Linux.
- **`run_capture_metered` effects** = `["io", "clock"]` (it reads the monotonic clock); the plain `run_capture` stays `["io"]`.
- **Files-Affected addition:** `llvm/lowering/lowering_helpers.sfn` (declare-tracking) was not in the issue's list but is the mechanical sibling of the `runtime_helpers.sfn` descriptor row — same change-class, folded in rather than treated as scope creep.

## Acceptance Criteria
- [x] A `*_test.sfn` spawns a child and asserts `wall_ms >= 0` and (Linux) `peak_rss_kb > 0`; macOS memory leg skips cleanly.
- [x] `make compile` passes (compiler self-hosts)
- [x] `make test` — targeted regressions green; full e2e running (0 failures at push); CI is the final gate.

## Verification
```text
make compile                                  # self-hosts ✓
sailfin test .../process_run_capture_metered_test.sfn   # 4/4 ✓ (Linux peak_rss_kb > 0)
runtime_process 5/5 ✓   run_capture (os) 8/8 ✓   spawn_with_env 6/6 ✓
no_duplicate_declares 2/2 ✓   runtime_helper_declare_integrity 4/4 ✓
fmt --check clean on all touched files ✓
```

## Files Changed
- `runtime/sfn/process.sfn` — externs, local monotonic-nanos reader, shared `_run_capture_impl`, metered capture + two take helpers, stash globals
- `compiler/src/llvm/runtime_helpers.sfn` — 3 helper descriptors
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — declare-tracking for the 3 helpers
- `compiler/tests/e2e/process_run_capture_metered_test.sfn` — new e2e test

https://claude.ai/code/session_01FKoYrCtnxBX969HvoovFWf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKoYrCtnxBX969HvoovFWf)_