### PR TITLE
chore: scope linguist language stats to exclude docs/tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,23 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+
+# --- GitHub linguist language-bar accuracy ---
+# Sailfin (.sfn) has no upstream linguist grammar yet, so the compiler,
+# runtime, and capsules (the actual codebase, all .sfn) contribute zero
+# bytes to GitHub's language stats. Without the rules below the bar is
+# computed entirely from the marketing site and dev tooling, which
+# misrepresents the repo as a Shell/Astro/TypeScript project. These
+# attributes exclude the non-representative surfaces so the bar reflects
+# what's left honestly (rather than aliasing .sfn to an unrelated
+# language, which would pollute GitHub language search). A real "Sailfin"
+# entry requires an upstream github-linguist submission backed by broad
+# repo adoption.
+
+# Marketing / documentation site (Astro, CSS, config) — not the language.
+site/** linguist-documentation
+
+# Developer & build tooling — not the language.
+tools/** linguist-vendored
+scripts/** linguist-vendored
+.claude/** linguist-vendored
+.codex/** linguist-vendored
+install.sh linguist-vendored


### PR DESCRIPTION
## Problem

GitHub's linguist computes the repo language bar over **git-tracked files, byte-weighted**, and drops anything it can't classify or that it treats as prose/data:

- **`.sfn`** has no upstream linguist grammar → all **710 Sailfin files (the compiler, runtime, capsules) contribute zero bytes**.
- Markdown (prose) and TOML/JSON (data) are excluded too.

So the entire bar was computed from the small recognized remainder — the Astro marketing site, dev shell scripts, and the MCP server tooling — misrepresenting a pure-Sailfin compiler repo as **Shell / Astro / TypeScript / Makefile**.

## Change

Add `.gitattributes` rules so the non-representative surfaces drop out of the language stats:

- `site/**` → `linguist-documentation` (marketing/docs site)
- `tools/**`, `scripts/**`, `.claude/**`, `.codex/**`, `install.sh` → `linguist-vendored` (dev/build tooling)

This is **honest-by-omission**: it does *not* alias `.sfn` to an unrelated language (which would inflate the bar but mislabel Sailfin as e.g. Rust and pollute GitHub's language search). Linguist cannot display "Sailfin" until an upstream `github-linguist` grammar lands, which requires broad cross-repo adoption.

## Notes

- No `.sfn` files touched — self-host invariant and `sfn fmt` gate are not engaged.
- Pure repo-metadata change; no code or build impact.

https://claude.ai/code/session_0139BxvsN6wJZYZ9T4VKwmXX

---
_Generated by [Claude Code](https://claude.ai/code/session_0139BxvsN6wJZYZ9T4VKwmXX)_