### PR TITLE
ci: fix nested-make-compile mtime skew (the real macOS e2e "exit 134", not #892)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,19 @@ jobs:
           set -euo pipefail
           tar -xzf "build-tree-linux-x86_64.tar.gz"
           rm -f "build-tree-linux-x86_64.tar.gz"
+          # mtime fix (the real cause of the macOS e2e "exit 134"
+          # misattributed to #892): the artifact binary was built from
+          # THIS commit's sources, but tar transport leaves it older than
+          # the freshly-checked-out sources. A nested `make compile` (run
+          # by make_result_contract_test / make_report_contract_test) then
+          # sees the binary as stale -> triggers `make rebuild` -> and,
+          # since build/seed is not bundled, fetches the seed over the
+          # network (unauthenticated, no GITHUB_TOKEN in the test child
+          # env) and fails -> status != "pass" -> the test aborts (134).
+          # The binary IS up-to-date for this commit, so mark it current
+          # and `make compile` becomes the intended no-op.
+          touch build/native/sailfin
+          [ -f build/native/.build-stamp ] && touch build/native/.build-stamp || true
           ls -lh build/native/sailfin
 
       - name: Test + package (via Makefile)
@@ -688,19 +701,6 @@ jobs:
     # blind 8 that previously OOMed the int-e2e-caps shard.
     runs-on: macos-26
     timeout-minutes: 120
-    # TEMPORARY (#892): the macOS `e2e-*` legs are non-gating. They still
-    # run and report, but a failure does NOT red the PR. Reason: #892
-    # (residual non-deterministic heap corruption in runtime-helper
-    # declare emission) is live on macOS-arm64 and crashes some e2e
-    # fixture *builds* (SIGABRT/SIGKILL before any test output), so it
-    # cannot be skipped in-source. The #1529 fan-out governor (this PR)
-    # already removed the whole-shard exit-137 cascade — these are now
-    # bounded single-test build crashes. The SAME e2e tests still gate on
-    # Linux (where #892 does not reproduce), so e2e *logic* regressions
-    # are still caught; only macOS-specific e2e breakage can slip while
-    # this holds. macOS unit + int-caps + the compiler build stay
-    # gating. REVERT this `continue-on-error` when #892 is fixed.
-    continue-on-error: ${{ startsWith(matrix.shard, 'e2e-') }}
     strategy:
       fail-fast: false
       matrix:
@@ -752,6 +752,19 @@ jobs:
           set -euo pipefail
           tar -xzf "build-tree-macos-arm64.tar.gz"
           rm -f "build-tree-macos-arm64.tar.gz"
+          # mtime fix (the real cause of the macOS e2e "exit 134"
+          # misattributed to #892): the artifact binary was built from
+          # THIS commit's sources, but tar transport leaves it older than
+          # the freshly-checked-out sources. A nested `make compile` (run
+          # by make_result_contract_test / make_report_contract_test) then
+          # sees the binary as stale -> triggers `make rebuild` -> and,
+          # since build/seed is not bundled, fetches the seed over the
+          # network (unauthenticated, no GITHUB_TOKEN in the test child
+          # env) and fails -> status != "pass" -> the test aborts (134).
+          # The binary IS up-to-date for this commit, so mark it current
+          # and `make compile` becomes the intended no-op.
+          touch build/native/sailfin
+          [ -f build/native/.build-stamp ] && touch build/native/.build-stamp || true
           ls -lh build/native/sailfin
 
       - name: Test + package (via Makefile)


### PR DESCRIPTION
## Summary

Fixes the macOS `int-e2e-caps`/`e2e-*` red-on-every-PR that was **misattributed to #892** (heap corruption). It is neither corruption nor flaky — it's a deterministic mtime/network artifact.

## Root cause

`make_result_contract_test` (and `make_report_contract_test`) run a **nested `make compile`** and assert its JSON verdict is `status == "pass"` (`make_result_contract_test.sfn:171`). On a CI shard leg:

1. The compiler binary arrives via a **tar artifact**, so its mtime is *older* than the freshly `git checkout`'d sources.
2. `make compile`'s freshness check (`find compiler/src runtime -newer $NATIVE_BIN`) therefore sees the binary as **stale** → triggers `make rebuild`.
3. `build/seed` is **not bundled** in the shard artifact, so rebuild **fetches the seed over the network** — unauthenticated (the test's child env has no `GITHUB_TOKEN`) — and fails.
4. → `status != "pass"` → the test's `assert` aborts the process with **exit 134**, which looked like a SIGABRT from #892.

Deterministic, which is exactly why it red-flagged *every* PR. The "different victims across runs" noted in #1529 were just whichever nested-`make` test ran — same cause.

## Fix

After extracting the shard artifact, **`touch build/native/sailfin`** (and `.build-stamp`) so `make compile`'s up-to-date check passes. The binary genuinely *was* built from this commit, so marking it current is correct — and the nested `make compile` becomes the intended no-op (`status: "pass"`). Applied to **both** the Linux and macOS extract steps.

Also reverts the temporary `continue-on-error` on the macOS `e2e-*` legs (added in #1536 while this was misattributed to #892): with the real cause fixed, those legs **gate normally again**.

## Verification

Confirmed locally (the actual mechanism, not a guess):
- Forcing the shard condition (`touch` a source newer than the binary + a missing seed) reproduces it: `make compile` → `[rebuild] missing seed compiler` → `[rebuild] fetching seed with: make fetch-seed` → fails.
- With the binary touched current: `make compile` → `[compile] ... up-to-date` → `status: "pass"`; `make_result_contract_test` → **PASS**.

#892 is being corrected/closed separately — the macOS-arm64 evidence cited when it was reopened is explained by this mtime/seed issue, not heap corruption.