### PR TITLE
docs(capsules): mark runtime capability enforcement as pre-1.0

### DIFF
--- a/site/src/content/docs/docs/advanced/capsules.md
+++ b/site/src/content/docs/docs/advanced/capsules.md
@@ -15,7 +15,7 @@ Capsules are directories. The presence of a `capsule.toml` manifest file at the 
 A capsule has two responsibilities:
 
 1. **It defines a unit of compilation.** The Sailfin compiler resolves imports at capsule boundaries and uses the manifest to locate dependencies.
-2. **It defines a unit of trust.** The `[capabilities]` section of `capsule.toml` declares which effects the capsule uses. Workspaces and runtime enforcement use this declaration to audit and restrict what each capsule is allowed to do.
+2. **It defines a unit of trust.** The `[capabilities]` section of `capsule.toml` declares which effects the capsule uses. Today the compiler enforces this declaration **at compile time** — a capsule whose code uses an effect outside its declared surface fails the build (`E0403`), and workspaces audit it. *Runtime* capability enforcement (gating effects at the syscall boundary in the running binary) is a pre-1.0 goal, not yet shipped.
 
 A capsule can be one of two things:
 


### PR DESCRIPTION
## Summary

The "unit of trust" bullet in `docs/advanced/capsules.md` implied that **runtime** enforcement is a present-tense consumer of the `[capabilities]` manifest. That blurs the safety-claim discipline (`CLAUDE.md`: no parsed-but-unenforced marketing) — runtime capability enforcement at the syscall boundary is a pre-1.0 vision, not shipped.

This clarifies the now/later split:
- **Enforced today:** compile-time capability cross-check (`E0403`) + workspace audit.
- **Pre-1.0 goal (not yet shipped):** *runtime* capability enforcement (gating effects at the syscall boundary in the running binary).

This is the only public-doc line that stated it imprecisely — README, `llms.txt`, and the spec already consistently say "compile-time capability enforcement."

## Scope

One-line documentation wording change. No compiler/runtime/code changes; self-hosting unaffected.

https://claude.ai/code/session_01LE1H5RqhcK5veM1HrUexyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LE1H5RqhcK5veM1HrUexyV)_