### PR TITLE
feat(concurrency): OwnedBuf channel drain + worker-ctx by-value capture (#1476)

### DIFF
--- a/compiler/src/llvm/closures.sfn
+++ b/compiler/src/llvm/closures.sfn
@@ -55,8 +55,14 @@
 // placeholder behaviour — a regression guard for issue #459's
 // acceptance criterion.
 import { Capture } from "../ast";
-import { trim_text, number_to_string, join_with_separator } from "./utils";
+import {
+    trim_text,
+    starts_with,
+    number_to_string,
+    join_with_separator
+} from "./utils";
 import { map_type_annotation, ends_with_pointer_suffix } from "./type_mapping";
+import { substring } from "../string_utils";
 import { format_temp_name } from "./expressions_helpers";
 
 // Percent-escape every character that doubles as either a marker
@@ -323,6 +329,24 @@ fn closure_field_llvm_type(capture: Capture) -> string {
     // loads it into a scalar. Keeping the env field pointer-sized preserves
     // the closure-env layout contract unchanged across the flip.
     if mapped == "{i8*, i64}" { return "i8*"; }
+    // #1476: a BY-VALUE user-struct capture is stored as the full aggregate
+    // `%T` in the env, not as a `%T*` pointer. `map_type_annotation` returns
+    // `%T*` for a user struct, but the capture-site operand for a by-value
+    // capture is the loaded `%T` aggregate, so a `%T*` field type emitted an
+    // invalid `store %T* %aggval` (operand/field type mismatch, rejected by
+    // llvm-as) — by-value struct capture was broken. Strip the pointer suffix
+    // for `by_value` captures so the env field is the aggregate `%T` and the
+    // store / load / env-load prologue all agree; a moved `OwnedBuf` then
+    // survives the thread boundary by value (the worker-ctx reclaim reads it
+    // at offset 0). A by-reference capture (`by_value == false`, e.g. an
+    // explicit `*T` pointer) keeps its `%T*` field.
+    if capture.by_value {
+        if starts_with(mapped, "%") {
+            if ends_with_pointer_suffix(mapped) {
+                return substring(mapped, 0, mapped.length - 1);
+            }
+        }
+    }
     return mapped;
 }
 
@@ -409,6 +433,9 @@ fn _field_zero_value(llvm_type: string) -> string {
     if ends_with_pointer_suffix(trimmed) { return "null"; }
     if trimmed == "double" { return "0.0"; }
     if trimmed == "float" { return "0.0"; }
+    // #1476: a by-value aggregate field (`%T`, e.g. a captured struct) zeros
+    // with `zeroinitializer`, not the scalar `0`.
+    if starts_with(trimmed, "%") { return "zeroinitializer"; }
     return "0";
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1335,12 +1335,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     }
 
     // ── channel(<capacity>) / channel:<kind>(<capacity>) ───────────────
-    // Both forms lower to `sfn_channel_create(i64 capacity, i64 elem_size)`
-    // matching `runtime/sfn/concurrency/channel.sfn` (#1266, was 1-arg i32
-    // in #1091). v0 monomorphizes every channel to pointer-sized elements,
-    // so `elem_size` is the constant 8. The kind qualifier is recorded for
-    // future typed-channel work but the runtime ABI is uniform today
-    // (opaque i8* channel handle).
+    // Both forms lower to
+    // `sfn_channel_create(i64 capacity, i64 elem_size, i64 owned)` matching
+    // `runtime/sfn/concurrency/channel.sfn` (#1266, was 1-arg i32 in #1091;
+    // the `owned` flag added in #1476). The bare form monomorphizes to
+    // pointer-sized elements (`elem_size` = 8, `owned` = 0). The typed form
+    // sizes the ring slot to the aggregate width and sets `owned` = 1 only
+    // for `channel:OwnedBuf`, so destroy can drain abandoned buffers.
     if starts_with(stripped, "channel(") {
         let chan_inner = trim_text(substring(stripped, 8, stripped.length));
         // The end index is computed in a standalone statement (not a
@@ -1377,7 +1378,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         chan_temp += 1;
         chan_lines.push("  " + chan_result + " = call i8* @sfn_channel_create("
             + cap_llvm
-            + ", i64 8)");
+            + ", i64 8, i64 0)");
         let chan_operand = LLVMOperand {
             llvm_type: "i8*",
             value: chan_result
@@ -1433,8 +1434,14 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         // stride. A divergence over-writes or under-reads the ring slot
         // (an #1205-class heap hazard under concurrent producers/consumers).
         let mut typed_elem_size_llvm: string = "i64 8";
+        // `owned` flag (#1476): 1 only when the element kind is exactly
+        // `OwnedBuf`, so `sfn_channel_destroy`'s drain seam frees each
+        // abandoned element's `ptr_addr`. A generic struct element does not
+        // own heap by this convention, so it stays 0 (no drain).
+        let mut typed_owned_llvm: string = "i64 0";
         if paren_pos > 8 {
             let kind_text = trim_text(substring(stripped, 8, paren_pos));
+            if kind_text == "OwnedBuf" { typed_owned_llvm = "i64 1"; }
             let kind_struct = resolve_struct_info_for_literal(context, kind_text);
             if kind_struct != null {
                 let esz_ptr = format_temp_name(chantyped_temp);
@@ -1461,6 +1468,8 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             + typed_cap_llvm
             + ", "
             + typed_elem_size_llvm
+            + ", "
+            + typed_owned_llvm
             + ")");
         let chantyped_operand = LLVMOperand {
             llvm_type: "i8*",

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -318,6 +318,7 @@ import {
     spawn_symbol_for_kind,
     spawn_ctx_symbol_for_kind,
     spawn_owned_ctx_symbol_for_kind,
+    spawn_owned_buf_ctx_symbol_for_kind,
     llvm_return_type_for_spawn_kind,
     future_type_for_spawn_kind,
     map_parameter_type
@@ -547,7 +548,12 @@ fn _lower_closure_env_alloc(env_var_text: string, target: NativeFunction, bindin
     // `owned_env` (spawn/parallel task lambdas, #1475) is tagged right
     // after `env_alloc` by the lift pass; route its env through the
     // malloc-backed `@sfn_env_alloc` so the spawned worker can free it.
-    let owned_env: boolean = starts_with(env_var_text, "env_alloc owned_env ");
+    // #1476: the `owned_buf` tag (env's first capture is a moved OwnedBuf)
+    // ALSO requires a malloc-backed env — the `_owned_buf_ctx` trampoline
+    // `free(env)`s the container, which corrupts the arena if the env were
+    // arena-routed (a #1205-class hazard). Treat both tags as owned-env.
+    let owned_env: boolean = starts_with(env_var_text, "env_alloc owned_env ")
+        || starts_with(env_var_text, "env_alloc owned_buf ");
     let lambda_id = _parse_marker_int_field(env_var_text, "lambda_id=");
     let captures_text = _parse_marker_string_field(env_var_text, "captures=");
     let captures = decode_captures(captures_text);
@@ -1166,7 +1172,15 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         // closure-pair operand text (set by the lift pass for spawn targets);
         // non-capturing (null env) and async ctx paths keep the plain `_ctx`.
         let mut spawn_ctx_sym = spawn_ctx_symbol_for_kind(spawn_kind);
-        if index_of(spawn_operand_text, "env_alloc owned_env ") >= 0 {
+        // #1476: a capturing task lambda whose first capture is a moved
+        // `OwnedBuf` carries the `owned_buf` tag — route through the
+        // `_owned_buf_ctx` family whose trampoline reclaims the libc-backed
+        // buffer at env offset 0. Check `owned_buf` BEFORE `owned_env`: both
+        // markers contain `env_alloc`, and `owned_buf` is the more specific
+        // (env-free + buffer reclaim) selection.
+        if index_of(spawn_operand_text, "env_alloc owned_buf ") >= 0 {
+            spawn_ctx_sym = spawn_owned_buf_ctx_symbol_for_kind(spawn_kind);
+        } else if index_of(spawn_operand_text, "env_alloc owned_env ") >= 0 {
             spawn_ctx_sym = spawn_owned_ctx_symbol_for_kind(spawn_kind);
         }
         let future_type = future_type_for_spawn_kind(spawn_kind);

--- a/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
@@ -517,6 +517,26 @@ fn spawn_owned_ctx_symbol_for_kind(kind: string) -> string {
     return "sfn_spawn_ptr_owned_ctx";
 }
 
+// #1476 (epic #1466): the owned-buffer spawn-ctx symbol. Identical to
+// `spawn_owned_ctx_symbol_for_kind` but routes to the `_owned_buf_ctx` family,
+// whose trampoline `sfn_env_free_owned`s the captured env — reclaiming the
+// libc-backed buffer behind a moved `OwnedBuf` captured at env offset 0, then
+// freeing the env container. Used only when the spawn operand is a capturing
+// lambda whose first capture is an `OwnedBuf` (tagged `owned_buf`). Disjoint
+// from the plain `_ctx` (async self-free) and `_owned_ctx` (container-only)
+// families, so no path double-frees.
+fn spawn_owned_buf_ctx_symbol_for_kind(kind: string) -> string {
+    let trimmed = trim_text(kind);
+    if trimmed.length == 0 { return "sfn_spawn_void_owned_buf_ctx"; }
+    if trimmed == "void" { return "sfn_spawn_void_owned_buf_ctx"; }
+    if trimmed == "number" { return "sfn_spawn_number_owned_buf_ctx"; }
+    if trimmed == "int" { return "sfn_spawn_int_owned_buf_ctx"; }
+    if trimmed == "bool" { return "sfn_spawn_bool_owned_buf_ctx"; }
+    if trimmed == "boolean" { return "sfn_spawn_bool_owned_buf_ctx"; }
+    if trimmed == "string" { return "sfn_spawn_string_owned_buf_ctx"; }
+    return "sfn_spawn_ptr_owned_buf_ctx";
+}
+
 // Maps a spawn kind string to the LLVM return type of the spawned function
 // (i.e. the element type of the future). Used to build the typed function
 // pointer argument `<llvm_type> ()* @fn_symbol` for spawn calls.

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -148,9 +148,19 @@ fn closure_pair_marker(lambda_id: int, env_var: string) -> string {
 // (a malloc-backed, individually-freeable block the spawned worker owns
 // and frees) instead of the arena-routed `@sfn_alloc_struct`. Synchronous
 // capturing lambdas pass false and keep the arena fast-path (status quo).
-fn closure_pair_env_alloc_marker(lambda_id: int, captures_text: string, owned_env: boolean) -> string {
+// `owned_buf` (#1476) refines `owned_env`: true when the env's first
+// capture is a moved `OwnedBuf` (at env offset 0). It emits the more
+// specific `owned_buf` tag so the spawn dispatch selects the
+// `_owned_buf_ctx` trampoline family (env-container free + libc-backed
+// buffer reclaim). It still routes env alloc through `@sfn_env_alloc`
+// (the env must be malloc-backed, else the trampoline's `free(env)`
+// corrupts the arena — a #1205-class hazard). `owned_buf` implies
+// `owned_env`; when both are true the `owned_buf` tag wins.
+fn closure_pair_env_alloc_marker(lambda_id: int, captures_text: string, owned_env: boolean, owned_buf: boolean) -> string {
     let mut owned_tag: string = "";
-    if owned_env { owned_tag = "owned_env "; }
+    if owned_buf { owned_tag = "owned_buf "; } else if owned_env {
+        owned_tag = "owned_env ";
+    }
     return "<closure_pair @sfn_lambda_" + number_to_string(lambda_id)
         + " env_alloc "
         + owned_tag
@@ -686,7 +696,20 @@ fn _rewrite_lambda(ctx: LiftContext, lambda: Expression, owned_env: boolean) -> 
         lifted: new_lifted,
         records: ctx.records
     };
-    let marker_text = closure_pair_env_alloc_marker(lambda_id, _encode_captures(record.captures), owned_env);
+    // #1476: when this is a spawn/parallel task lambda (`owned_env`) whose
+    // FIRST capture is a moved `OwnedBuf`, it sits at env offset 0, so the
+    // worker can reclaim its libc-backed buffer via the `_owned_buf_ctx`
+    // family. Gate on the first capture only — `sfn_env_free_owned` reads a
+    // single offset (0); a non-first OwnedBuf keeps the `owned_env` path
+    // (env-container free only, status quo) rather than reading the wrong
+    // 32 bytes.
+    let mut owned_buf: boolean = false;
+    if owned_env {
+        if record.captures.length > 0 {
+            if record.captures[0].type_text == "OwnedBuf" { owned_buf = true; }
+        }
+    }
+    let marker_text = closure_pair_env_alloc_marker(lambda_id, _encode_captures(record.captures), owned_env, owned_buf);
     return ExpressionRewriteResult {
         ctx: new_ctx,
         expression: Expression.Raw { text: marker_text, span: null }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -959,7 +959,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // channel-method lowering in `core.sfn` (`_try_lower_channel_method`)
     // emits the spill/load sequences around these signatures.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_create", symbol: "sfn_channel_create", return_type: "i8*", parameter_types: ["i64", "i64"], effects: [], native_signature: "sfn_channel_create", c_abi_return_type: null
+        target: "channel_create", symbol: "sfn_channel_create", return_type: "i8*", parameter_types: ["i64", "i64", "i64"], effects: [], native_signature: "sfn_channel_create", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "channel_send", symbol: "sfn_channel_send", return_type: "i64", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_channel_send", c_abi_return_type: null

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -616,6 +616,32 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "spawn_string_owned_ctx", symbol: "sfn_spawn_string_owned_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
+    // #1476 (epic #1466): owned-buffer spawn-ctx variants. Identical ABI to the
+    // `_owned_ctx` rows above; the runtime trampoline additionally reclaims the
+    // libc-backed buffer behind a moved `OwnedBuf` captured at env offset 0
+    // (via `sfn_env_free_owned`) before freeing the env container. The
+    // capturing-`spawn` emission routes here (via
+    // `spawn_owned_buf_ctx_symbol_for_kind`) only when the closure pair carries
+    // the `owned_buf` tag. Defined in future.sfn.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_number_owned_buf_ctx", symbol: "sfn_spawn_number_owned_buf_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_int_owned_buf_ctx", symbol: "sfn_spawn_int_owned_buf_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_bool_owned_buf_ctx", symbol: "sfn_spawn_bool_owned_buf_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_ptr_owned_buf_ctx", symbol: "sfn_spawn_ptr_owned_buf_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_void_owned_buf_ctx", symbol: "sfn_spawn_void_owned_buf_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_string_owned_buf_ctx", symbol: "sfn_spawn_string_owned_buf_ctx", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
     // Structured-concurrency nursery surface (#1181). The `routine { }`
     // lowering emits `call`s to these; the runtime bodies live in
     // runtime/sfn/concurrency/nursery.sfn. Registered as async-runtime

--- a/compiler/tests/e2e/concurrency_lowering_ir_test.sfn
+++ b/compiler/tests/e2e/concurrency_lowering_ir_test.sfn
@@ -70,13 +70,26 @@ test "concurrency-ir: channel(N) lowers to sfn_channel_create (#1091)" ![io] {
     assert contains(ir, "sfn_channel_create");
 }
 
-// channel_create call carries the capacity AND the elem_size operand, matching
-// runtime/sfn/concurrency/channel.sfn (§2.6.4): v0 channels are monomorphized
-// to pointer-sized elements, so elem_size is 8.
-test "concurrency-ir: channel_create carries i64 capacity + elem_size (#1266)" ![io] {
+// channel_create call carries the capacity, the elem_size operand AND the
+// `owned` flag (#1476), matching runtime/sfn/concurrency/channel.sfn (§2.6.4):
+// a bare channel(N) is monomorphized to pointer-sized, non-owned elements, so
+// elem_size is 8 and owned is 0.
+test "concurrency-ir: channel_create carries i64 capacity + elem_size + owned (#1266, #1476)" ![io] {
     let ir = _emit_llvm("fn main() ![io] {\n    let ch = channel(4);\n}\n", "channel_create_i64");
     assert ir.length > 0;
-    assert contains(ir, "sfn_channel_create(i64 4, i64 8)");
+    assert contains(ir, "sfn_channel_create(i64 4, i64 8, i64 0)");
+}
+
+// channel:OwnedBuf(N) sizes the ring slot to the 32-byte aggregate AND sets
+// the `owned` flag to 1 (#1476), so sfn_channel_destroy drains abandoned
+// buffers. A struct named OwnedBuf is defined inline so the kind resolves and
+// the elem_size GEP-sizeof idiom yields 32.
+test "concurrency-ir: channel:OwnedBuf carries elem_size 32 + owned 1 (#1476)" ![io] {
+    let src = "struct OwnedBuf {\n    ptr_addr: int;\n    len: int;\n    cap: int;\n    arena_addr: int;\n}\n\nfn main() ![io] {\n    let ch = channel:OwnedBuf(2);\n}\n";
+    let ir = _emit_llvm(src, "channel_create_owned");
+    assert ir.length > 0;
+    assert contains(ir, "@sfn_channel_create");
+    assert contains(ir, ", i64 1)");
 }
 
 // spawn:int <lambda> → sfn_spawn_int (#1090 flip)

--- a/compiler/tests/e2e/concurrency_lowering_ir_test.sfn
+++ b/compiler/tests/e2e/concurrency_lowering_ir_test.sfn
@@ -99,6 +99,22 @@ test "concurrency-ir: spawn:int lowers to sfn_spawn_int (#1090)" ![io] {
     assert contains(ir, "sfn_spawn_int");
 }
 
+// #1476: a spawn task capturing a moved OwnedBuf stores the 32-byte aggregate
+// by VALUE in the closure env (env field `%OwnedBuf`, not a `%OwnedBuf*`
+// pointer — the by-value capture fix) and routes the spawn through the
+// `_owned_buf_ctx` trampoline family, whose worker reclaims the libc-backed
+// buffer at env offset 0. A struct named OwnedBuf is defined inline so the
+// capture type resolves.
+test "concurrency-ir: spawn capturing OwnedBuf uses by-value env + owned_buf_ctx (#1476)" ![io] {
+    let src = "struct OwnedBuf {\n    ptr_addr: int;\n    len: int;\n    cap: int;\n    arena_addr: int;\n}\n\nfn main() ![io] {\n    let buf: OwnedBuf = OwnedBuf { ptr_addr: 0, len: 7, cap: 8, arena_addr: 0 };\n    let f = spawn fn() -> int { return buf.len; };\n}\n";
+    let ir = _emit_llvm(src, "spawn_owned_buf");
+    assert ir.length > 0;
+    // env field is the by-value aggregate, NOT a pointer.
+    assert contains(ir, "%sfn_closure_env_0 = type { %OwnedBuf }");
+    // spawn routes through the owned-buffer reclaim trampoline family.
+    assert contains(ir, "sfn_spawn_int_owned_buf_ctx");
+}
+
 // parallel [<lambda>, ...] → a single sfn_parallel fan-out/join call (#1474).
 // Each task's lifted-lambda closure pair `{i8*, i8*}` is unpacked (extractvalue)
 // into an (fn_ptr, ctx) i64 pair and handed to the runtime combinator, which

--- a/runtime/sfn/concurrency/channel.sfn
+++ b/runtime/sfn/concurrency/channel.sfn
@@ -9,7 +9,7 @@
 // A `Channel` is a fixed-capacity circular buffer guarded by a mutex
 // with two condition variables (`not_empty` / `not_full`), plus an
 // atomic closed flag.  Operations:
-//   sfn_channel_create(capacity, elem_size) -> * u8
+//   sfn_channel_create(capacity, elem_size, owned) -> * u8
 //   sfn_channel_send(ch, elem) -> bool   blocks if full; false if closed
 //   sfn_channel_recv(ch) -> * u8         blocks if empty; null if closed+empty
 //   sfn_channel_close(ch) -> void
@@ -67,7 +67,11 @@ struct PthreadCond {
 // blocked producers / consumers.
 //
 // Layout (max-sized handles): six i64s (48 B) + PthreadMutex (64 B)
-//   + two PthreadCond (96 B) = 208 bytes, + `closed` i64 = 216 bytes.
+//   + two PthreadCond (96 B) = 208 bytes, + `closed` i64 = 216 bytes,
+//   + `elem_owned` i64 = 224 bytes.  `elem_owned` is set at create
+//   (1 when the elements are `OwnedBuf`, #1476) so `sfn_channel_destroy`
+//   can drain abandoned buffers; it is appended after `closed` so the
+//   hand-maintained `closed` offset (208) stays put.
 struct Channel {
     buffer_addr: i64;
     capacity: i64;
@@ -79,6 +83,7 @@ struct Channel {
     not_empty: PthreadCond;
     not_full: PthreadCond;
     closed: i64;
+    elem_owned: i64;
 }
 
 // ── Externs ───────────────────────────────────────────────────────
@@ -118,16 +123,20 @@ fn _sfn_channel_struct_size() -> i64 { return 208; }
 //   [112..160) not_empty PthreadCond (48 B)
 //   [160..208) not_full PthreadCond (48 B)
 //   [208..216) closed i64
-// Total: 216 bytes.
-fn _sfn_channel_struct_size_full() -> i64 { return 216; }
+//   [216..224) elem_owned i64
+// Total: 224 bytes.
+fn _sfn_channel_struct_size_full() -> i64 { return 224; }
 
 fn _sfn_channel_closed_offset() -> i64 { return 208; }
 
 // ── sfn_channel_create ────────────────────────────────────────────
 // Allocates a channel handle and its element buffer.  `capacity` is
 // clamped to at least 1; `elem_size` must be > 0 (clamped to 1 if
-// not).  Returns null on OOM or a failed pthread init.
-fn sfn_channel_create(capacity: i64, elem_size: i64) -> * u8 {
+// not).  `owned` is 1 when the elements are `OwnedBuf` (#1476) — it is
+// stored so `sfn_channel_destroy` drains and frees any libc-backed
+// buffers abandoned in the ring at close.  Returns null on OOM or a
+// failed pthread init.
+fn sfn_channel_create(capacity: i64, elem_size: i64, owned: i64) -> * u8 {
     let mut cap: i64 = capacity;
     if cap <= 0 { cap = 1; }
     let mut esz: i64 = elem_size;
@@ -149,6 +158,7 @@ fn sfn_channel_create(capacity: i64, elem_size: i64) -> * u8 {
     ch.head = 0;
     ch.tail = 0;
     ch.count = 0;
+    ch.elem_owned = owned;
 
     // Zero the closed flag via offset arithmetic (same pattern as
     // Task.done in scheduler.sfn).
@@ -297,6 +307,39 @@ fn sfn_channel_close(ch: * u8) -> void {
 fn sfn_channel_destroy(ch: * u8) -> void {
     if ch as i64 == 0 { return; }
     let c: * Channel = ch as * Channel;
+    // Drain owned elements abandoned in the ring (#1476).  When the
+    // channel carries `OwnedBuf` elements (`elem_owned == 1`), every
+    // element still buffered at close owns its backing storage.  Free the
+    // libc-backed ones (`arena_addr == 0`); arena-backed buffers
+    // (`arena_addr != 0`) are reclaimed by their owning arena and must
+    // never be individually freed (see runtime/sfn/memory/ownedbuf.sfn).
+    // The caller has closed the channel and drained receivers, so no other
+    // thread is touching the ring here — the walk needs no lock.  An
+    // `OwnedBuf` slot is `{ i64 ptr_addr, i64 len, i64 cap, i64 arena_addr }`:
+    // `ptr_addr` at slot+0, `arena_addr` at slot+24.
+    if c.elem_owned != 0 {
+        let buf_base: i64 = c.buffer_addr;
+        let cap: i64 = c.capacity;
+        let esz: i64 = c.elem_size;
+        let live: i64 = c.count;
+        let head: i64 = c.head;
+        if buf_base != 0 && cap > 0 {
+            let mut i: i64 = 0;
+            loop {
+                if i >= live { break; }
+                let slot_index: i64 = (head + i) % cap;
+                let slot_addr: i64 = buf_base + slot_index * esz;
+                let ptr_slot: * i64 = slot_addr as * i64;
+                let ptr_addr: i64 = atomic_load(ptr_slot);
+                let arena_slot: * i64 = (slot_addr + 24) as * i64;
+                let arena_addr: i64 = atomic_load(arena_slot);
+                if arena_addr == 0 && ptr_addr != 0 {
+                    free(ptr_addr as * u8);
+                }
+                i = i + 1;
+            }
+        }
+    }
     pthread_cond_destroy(c.not_full);
     pthread_cond_destroy(c.not_empty);
     pthread_mutex_destroy(c.mutex);

--- a/runtime/sfn/concurrency/future.sfn
+++ b/runtime/sfn/concurrency/future.sfn
@@ -90,6 +90,12 @@ extern fn free(ptr: * u8) -> void;
 // arena-pointer-to-libc-free corruption hazard.
 extern fn sfn_env_free(ptr: * u8) -> void;
 
+// `sfn_env_free_owned` reclaims a captured-env block that carries a moved
+// `OwnedBuf` at offset 0 (#1476): it frees the libc-backed buffer behind the
+// `OwnedBuf.ptr_addr` (arena-backed buffers are left to their arena) and then
+// frees the env container.  Used by the `_owned_buf_ctx` trampolines below.
+extern fn sfn_env_free_owned(env: * u8, ownedbuf_off: i64) -> void;
+
 extern fn sfn_taskqueue_create(capacity: i64) -> * u8;
 
 extern fn sfn_taskqueue_enqueue(queue: * u8, task: * u8) -> void;
@@ -592,5 +598,169 @@ fn sfn_spawn_string_owned_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
     atomic_store(p0, fn_ptr as i64);
     atomic_store(p1, ctx as i64);
     let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_string_owned_ctx as * fn (* u8) -> * u8;
+    return sfn_spawn(trampoline as i64, pair as i64, 8);
+}
+
+// ── #1476 (epic #1466): owned-buffer ctx variants ──────────────────
+//
+// These are byte-identical to the `_owned_ctx` family above except they call
+// `sfn_env_free_owned(user_ctx, 0)` instead of `sfn_env_free(user_ctx)`, so a
+// **moved `OwnedBuf` captured at env offset 0** has its libc-backed backing
+// buffer reclaimed by the worker after the body runs (arena-backed buffers are
+// left to their arena).  The capturing-spawn emission routes here only when
+// the closure pair carries the `owned_buf` tag — i.e. the env's first capture
+// is an `OwnedBuf` (the lowering pins it to offset 0).  Selection is disjoint
+// from the plain `_ctx` (async self-free) and `_owned_ctx` (env-container-only
+// free) families, so no path double-frees.
+fn _sfn_trampoline_number_owned_buf_ctx(ctx: * u8) -> * u8 {
+    let base: i64 = ctx as i64;
+    let fn_slot: * i64 = base as * i64;
+    let ctx_slot: * i64 = (base + 8) as * i64;
+    let fn_addr: i64 = atomic_load(fn_slot);
+    let user_ctx: i64 = atomic_load(ctx_slot);
+    let entry: * fn (* u8) -> f64 = fn_addr as * fn (* u8) -> f64;
+    let val: f64 = entry(user_ctx as * u8);
+    let packed: i64 = val as i64;
+    sfn_env_free_owned(user_ctx as * u8, 0);
+    free(ctx);
+    return packed as * u8;
+}
+
+fn sfn_spawn_number_owned_buf_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
+    let pair: * u8 = malloc(16 as usize);
+    if pair as i64 == 0 { return null; }
+    let p0: * i64 = pair as * i64;
+    let p1: * i64 = (pair as i64 + 8) as * i64;
+    atomic_store(p0, fn_ptr as i64);
+    atomic_store(p1, ctx as i64);
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_number_owned_buf_ctx as * fn (* u8) -> * u8;
+    return sfn_spawn(trampoline as i64, pair as i64, 8);
+}
+
+fn _sfn_trampoline_int_owned_buf_ctx(ctx: * u8) -> * u8 {
+    let base: i64 = ctx as i64;
+    let fn_slot: * i64 = base as * i64;
+    let ctx_slot: * i64 = (base + 8) as * i64;
+    let fn_addr: i64 = atomic_load(fn_slot);
+    let user_ctx: i64 = atomic_load(ctx_slot);
+    let entry: * fn (* u8) -> i64 = fn_addr as * fn (* u8) -> i64;
+    let val: i64 = entry(user_ctx as * u8);
+    sfn_env_free_owned(user_ctx as * u8, 0);
+    free(ctx);
+    return val as * u8;
+}
+
+fn sfn_spawn_int_owned_buf_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
+    let pair: * u8 = malloc(16 as usize);
+    if pair as i64 == 0 { return null; }
+    let p0: * i64 = pair as * i64;
+    let p1: * i64 = (pair as i64 + 8) as * i64;
+    atomic_store(p0, fn_ptr as i64);
+    atomic_store(p1, ctx as i64);
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_int_owned_buf_ctx as * fn (* u8) -> * u8;
+    return sfn_spawn(trampoline as i64, pair as i64, 8);
+}
+
+fn _sfn_trampoline_bool_owned_buf_ctx(ctx: * u8) -> * u8 {
+    let base: i64 = ctx as i64;
+    let fn_slot: * i64 = base as * i64;
+    let ctx_slot: * i64 = (base + 8) as * i64;
+    let fn_addr: i64 = atomic_load(fn_slot);
+    let user_ctx: i64 = atomic_load(ctx_slot);
+    let entry: * fn (* u8) -> bool = fn_addr as * fn (* u8) -> bool;
+    let val: bool = entry(user_ctx as * u8);
+    sfn_env_free_owned(user_ctx as * u8, 0);
+    free(ctx);
+    if val { return 1 as * u8; }
+    return 0 as * u8;
+}
+
+fn sfn_spawn_bool_owned_buf_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
+    let pair: * u8 = malloc(16 as usize);
+    if pair as i64 == 0 { return null; }
+    let p0: * i64 = pair as * i64;
+    let p1: * i64 = (pair as i64 + 8) as * i64;
+    atomic_store(p0, fn_ptr as i64);
+    atomic_store(p1, ctx as i64);
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_bool_owned_buf_ctx as * fn (* u8) -> * u8;
+    return sfn_spawn(trampoline as i64, pair as i64, 1);
+}
+
+fn _sfn_trampoline_ptr_owned_buf_ctx(ctx: * u8) -> * u8 {
+    let base: i64 = ctx as i64;
+    let fn_slot: * i64 = base as * i64;
+    let ctx_slot: * i64 = (base + 8) as * i64;
+    let fn_addr: i64 = atomic_load(fn_slot);
+    let user_ctx: i64 = atomic_load(ctx_slot);
+    let entry: * fn (* u8) -> * u8 = fn_addr as * fn (* u8) -> * u8;
+    let result: * u8 = entry(user_ctx as * u8);
+    sfn_env_free_owned(user_ctx as * u8, 0);
+    free(ctx);
+    return result;
+}
+
+fn sfn_spawn_ptr_owned_buf_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
+    let pair: * u8 = malloc(16 as usize);
+    if pair as i64 == 0 { return null; }
+    let p0: * i64 = pair as * i64;
+    let p1: * i64 = (pair as i64 + 8) as * i64;
+    atomic_store(p0, fn_ptr as i64);
+    atomic_store(p1, ctx as i64);
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_ptr_owned_buf_ctx as * fn (* u8) -> * u8;
+    return sfn_spawn(trampoline as i64, pair as i64, 8);
+}
+
+// The owned-buffer ptr trampoline address, for `sfn_parallel`'s capturing-task
+// pair-wrap when the task moves an `OwnedBuf` at env offset 0.
+fn sfn_trampoline_ptr_owned_buf_ctx_addr() -> i64 {
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_ptr_owned_buf_ctx as * fn (* u8) -> * u8;
+    return trampoline as i64;
+}
+
+fn _sfn_trampoline_void_owned_buf_ctx(ctx: * u8) -> * u8 {
+    let base: i64 = ctx as i64;
+    let fn_slot: * i64 = base as * i64;
+    let ctx_slot: * i64 = (base + 8) as * i64;
+    let fn_addr: i64 = atomic_load(fn_slot);
+    let user_ctx: i64 = atomic_load(ctx_slot);
+    let entry: * fn (* u8) -> void = fn_addr as * fn (* u8) -> void;
+    entry(user_ctx as * u8);
+    sfn_env_free_owned(user_ctx as * u8, 0);
+    free(ctx);
+    return null;
+}
+
+fn sfn_spawn_void_owned_buf_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
+    let pair: * u8 = malloc(16 as usize);
+    if pair as i64 == 0 { return null; }
+    let p0: * i64 = pair as * i64;
+    let p1: * i64 = (pair as i64 + 8) as * i64;
+    atomic_store(p0, fn_ptr as i64);
+    atomic_store(p1, ctx as i64);
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_void_owned_buf_ctx as * fn (* u8) -> * u8;
+    return sfn_spawn(trampoline as i64, pair as i64, 0);
+}
+
+fn _sfn_trampoline_string_owned_buf_ctx(ctx: * u8) -> * u8 {
+    let base: i64 = ctx as i64;
+    let fn_slot: * i64 = base as * i64;
+    let ctx_slot: * i64 = (base + 8) as * i64;
+    let fn_addr: i64 = atomic_load(fn_slot);
+    let user_ctx: i64 = atomic_load(ctx_slot);
+    let entry: * fn (* u8) -> * u8 = fn_addr as * fn (* u8) -> * u8;
+    let result: * u8 = entry(user_ctx as * u8);
+    sfn_env_free_owned(user_ctx as * u8, 0);
+    free(ctx);
+    return result;
+}
+
+fn sfn_spawn_string_owned_buf_ctx(fn_ptr: * u8, ctx: * u8) -> * u8 {
+    let pair: * u8 = malloc(16 as usize);
+    if pair as i64 == 0 { return null; }
+    let p0: * i64 = pair as * i64;
+    let p1: * i64 = (pair as i64 + 8) as * i64;
+    atomic_store(p0, fn_ptr as i64);
+    atomic_store(p1, ctx as i64);
+    let trampoline: * fn (* u8) -> * u8 = _sfn_trampoline_string_owned_buf_ctx as * fn (* u8) -> * u8;
     return sfn_spawn(trampoline as i64, pair as i64, 8);
 }

--- a/runtime/sfn/memory/mem.sfn
+++ b/runtime/sfn/memory/mem.sfn
@@ -324,3 +324,45 @@ fn sfn_env_free(ptr: * u8) -> void {
     // non-arena block reaches libc `free`.
     unsafe { free(ptr); }
 }
+
+// `sfn_env_free_owned(env, ownedbuf_off)` frees a captured-env block that
+// carries a moved `OwnedBuf` by value (#1476).  When a spawn/parallel task
+// lambda captures (moves) an `OwnedBuf`, the 32-byte struct rides inside the
+// `@sfn_env_alloc`'d env; `sfn_env_free` alone reclaims the env container but
+// leaks the buffer the `OwnedBuf.ptr_addr` points at.  This helper reclaims a
+// **libc-backed** captured buffer (`arena_addr == 0`) before freeing the
+// container; an **arena-backed** buffer (`arena_addr != 0`) is left untouched
+// — the owning arena reclaims it, and handing an arena pointer to libc `free`
+// is the #1205-class glibc-corruption landmine.
+//
+// `ownedbuf_off` is the byte offset of the moved `OwnedBuf` within the env;
+// the lowering pins the moved buffer to offset 0 (the env's first field), so
+// callers pass 0.  A negative offset means "no owned buffer" — free the
+// container only (equivalent to `sfn_env_free`).
+//
+// `OwnedBuf` layout (runtime/sfn/memory/ownedbuf.sfn): `{ i64 ptr_addr@0,
+// i64 len@8, i64 cap@16, i64 arena_addr@24 }`.  Field addresses are computed
+// with split arithmetic (a fresh `i64` base then the field cast) — an inline
+// `(env as i64 + 24) as * i64` miscompiles under the seed.
+fn sfn_env_free_owned(env: * u8, ownedbuf_off: i64) -> void {
+    if env as i64 == 0 { return; }
+    if ownedbuf_off >= 0 {
+        let base: i64 = env as i64;
+        let ptr_field: i64 = base + ownedbuf_off;
+        let arena_field: i64 = base + ownedbuf_off + 24;
+        let ptr_slot: * i64 = ptr_field as * i64;
+        let arena_slot: * i64 = arena_field as * i64;
+        let ptr_addr: i64 = atomic_load(ptr_slot);
+        let arena_addr: i64 = atomic_load(arena_slot);
+        if arena_addr == 0 {
+            if ptr_addr != 0 {
+                // Raw disposal (#1218 / E9): the captured buffer is libc-backed
+                // and uniquely owned by this worker after the move (#1220).
+                unsafe { free(ptr_addr as * u8); }
+            }
+        }
+    }
+    // Free the env container itself (calloc-backed, non-arena — see
+    // `sfn_env_free`'s contract).
+    unsafe { free(env); }
+}


### PR DESCRIPTION
## Summary

Advances the worker-ctx / serve half of epic #1466 (issue #1476 — migrate the concurrency runtime's `ctx` / request-response buffers to **moved `OwnedBuf`**). Implementing it surfaced a genuine **pre-existing invalid-IR bug** (by-value struct capture in closures), which this PR fixes as the load-bearing prerequisite.

Four commits, each self-host-verified (`make compile` green):

1. **Channel drain seam** (`6014cb04`) — `sfn_channel_destroy` now drains by-value `OwnedBuf` elements abandoned in the ring at close, freeing each libc-backed `ptr_addr` (arena-backed buffers are left to their arena). Gated on a new `owned` flag threaded through `sfn_channel_create` (ABI 2→3 args) + a `Channel.elem_owned` field appended after `closed` (so the hand-maintained `closed` offset is unchanged). This is the settled drain-seam decision from the #1466 design gate, and closes the leak it flagged.

2. **Worker-ctx OwnedBuf reclaim runtime + lowering** (`0c46f7fe`) — `sfn_env_free_owned(env, off)` reclaims the libc-backed buffer behind a moved `OwnedBuf` captured at env offset 0 then frees the env container; six `_owned_buf_ctx` trampolines + spawns mirror the #1475 `_owned_ctx` family but route the env free through it; a `spawn_owned_buf_ctx_symbol_for_kind` selector + an `owned_buf` closure-pair tag route to them. Disjoint from the plain `_ctx` (async self-free) and `_owned_ctx` (container-only) families — **no path double-frees**.

3. **By-value struct closure capture fix** (`bef81003`) — **the prerequisite, and a real bug fix.** A by-value struct capture (e.g. a spawn task capturing an `OwnedBuf`) had its env field typed `%T*` while the capture-site operand is the loaded `%T` aggregate, so emission produced an invalid `store %T* %aggval` rejected by `llvm-as` — by-value struct capture was simply broken. `closure_field_llvm_type` now stores `by_value` captures as the aggregate `%T`; the store, the env-load prologue, and `_field_zero_value` all agree. By-reference (`*T`) captures keep `%T*`.

4. **Worker-ctx IR test** (`9fbf4ebe`).

## Status against #1476 acceptance criteria

| AC | State |
|---|---|
| Worker ctx round-trips as moved OwnedBuf (32 bytes survive) | ✅ **at IR level** — env is `%sfn_closure_env_0 = type { %OwnedBuf }`, worker does `extractvalue %OwnedBuf, 1`; `llvm-as` clean. Runtime round-trip is blocked by a **pre-existing** `spawn`/`await` defect (below), not by this work. |
| Concurrency modules pass ownership enforcement | ✅ self-hosts; #1220 move rule already marks spawn captures `Moved`. |
| Serve req/resp as moved OwnedBuf | ⬜ **not in this PR** — independent surface (architect-recommended split); no closure dependency. |
| ASAN-interleave gate | ⬜ blocked on the spawn defect below; deferred with serve. |
| `make clean-build && make check` clean | ⏳ `make compile` green at each step; full `make check` (destructive clean-build) pending. |

**Deliberately does not close #1476** — the serve half and the ASAN gate remain.

## ⚠️ Pre-existing defect surfaced (not caused here, #1474 area)
Even a **non-capturing** `spawn fn() -> int { return 42; }` + `await:int` prints `0`, not `42`. This is independent of this PR (non-capturing spawn doesn't touch the changed capture path) and indicates a `spawn`/`await` typed-result-passing gap on the runnable path — worth a maintainer look against #1474. It's why the worker-ctx round-trip is validated at the IR level rather than by execution.

## Verification
```
make compile                                  # green after each commit
build/native/sailfin test compiler/tests/integration/closure_env_emission_test.sfn   # 17/17
build/native/sailfin test compiler/tests/integration/closure_lifting_test.sfn        # 15/15
build/native/sailfin test compiler/tests/e2e/closure_capture_test.sfn                # 6/6
build/native/sailfin test compiler/tests/e2e/spawn_capture_env_free_test.sfn         # 5/5
build/native/sailfin test compiler/tests/e2e/concurrency_lowering_ir_test.sfn        # 7/7 (incl. new #1476 cases)
build/native/sailfin test compiler/tests/unit/typecheck_lambda_capture_test.sfn      # 17/17
# captured-OwnedBuf snippet: llvm-as VALID; %sfn_closure_env_0 = type { %OwnedBuf }
```
Full `make test` running at time of opening; results to follow.

## Files changed
- `runtime/sfn/concurrency/channel.sfn`, `future.sfn`; `runtime/sfn/memory/mem.sfn`
- `compiler/src/llvm/closures.sfn`, `runtime_helpers.sfn`, `expression_lowering/native/{core,core_type_mapping,lambda_lowering}.sfn`
- `compiler/tests/e2e/concurrency_lowering_ir_test.sfn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VrWzXCsvT9LdpUSELt6Aj

---
_Generated by [Claude Code](https://claude.ai/code/session_011VrWzXCsvT9LdpUSELt6Aj)_