### PR TITLE
feat(concurrency): serve req/resp moved-OwnedBuf handler ABI (#1476)

### DIFF
--- a/capsules/sfn/http/src/server.sfn
+++ b/capsules/sfn/http/src/server.sfn
@@ -2,11 +2,12 @@
 //
 // Wave 2 of epic #1321. Wires the capsule's typed `fn(Request) -> Response`
 // handler onto the runtime's framed accept loop (`sfn_serve_framed`,
-// runtime/sfn/concurrency/serve.sfn). The runtime speaks a raw
-// `fn(* u8 request) -> * u8 response` ABI and sends the handler's return
-// verbatim; this module supplies a trampoline that parses the raw request
-// into a `Request`, invokes the user handler, and serializes the
-// `Response` back to bytes — so status codes and headers reach the wire.
+// runtime/sfn/concurrency/serve.sfn). The runtime speaks a moved-`OwnedBuf`
+// `fn(OwnedBuf request) -> OwnedBuf response` ABI (#1476) and sends the
+// handler's returned buffer verbatim; this module supplies a trampoline
+// that parses the moved request buffer into a `Request`, invokes the user
+// handler, and serializes the `Response` back into a moved `OwnedBuf` — so
+// status codes and headers reach the wire.
 //
 // Handler ABI. The user handler must be a TOP-LEVEL function passed
 // address-taken: `serve(my_handler as * fn (Request) -> Response, 8080)`.
@@ -23,10 +24,62 @@
 // so the extern resolves at link time (like the libc externs in the
 // client adapter). The extern carries no effect annotation (externs may
 // not); enforcement rides on `serve`'s own `![net, io]`.
-import { Request, Response } from "./types";
 import { parse_request, serialize_response } from "./wire";
+import { Request, Response } from "./types";
 
 extern fn sfn_serve_framed(handler: * u8, port: i32) -> void;
+
+// libc surface for marshalling the serialized response into a moved
+// `OwnedBuf` (the #1476 handler ABI). Inlined per the every-module
+// convention (mirrors `runtime/sfn/concurrency/serve.sfn`).
+extern fn malloc(size: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+// `OwnedBuf` — the runtime owned-buffer aggregate, inlined byte-identically
+// (four `i64` fields, 32 bytes, `arena_addr == 0` = libc-backed). The
+// trampoline marshals the request in and the serialized response out as
+// moved `OwnedBuf` values (#1476). Layout MUST match
+// `runtime/sfn/memory/ownedbuf.sfn` and `serve.sfn`'s inlined copy.
+struct OwnedBuf {
+    ptr_addr: i64;
+    len: i64;
+    cap: i64;
+    arena_addr: i64;
+}
+
+// `_http_owned_from_str(s)` — copy a serialized response string into a
+// fresh libc-backed `OwnedBuf` moved back to the runtime worker (which is
+// its last owner and frees it after the send). A copy — not the string's
+// own backing — so the worker's free never collides with the capsule's
+// string storage. NUL-terminated (the framed send path measures with
+// `strlen`); HTTP/1.1 text responses carry no internal NUL. Empty
+// `OwnedBuf` on OOM (the worker emits a `500`).
+fn _http_owned_from_str(s: string) -> OwnedBuf {
+    let src: * u8 = s as * u8;
+    let n: i64 = strlen(src) as i64;
+    let copy: * u8 = malloc((n + 1) as usize);
+    if copy as i64 == 0 {
+        return OwnedBuf {
+            ptr_addr: 0,
+            len: 0,
+            cap: 0,
+            arena_addr: 0
+        };
+    }
+    memcpy(copy, src, n as usize);
+    memset(((copy as i64) + n) as * u8, 0, 1 as usize);
+    return OwnedBuf {
+        ptr_addr: copy as i64,
+        len: n,
+        cap: n + 1,
+        arena_addr: 0
+    };
+}
 
 // Handler code pointer, set by `serve` before the accept loop starts and
 // read by `_sfn_http_trampoline` on pool-worker threads. Written once
@@ -34,31 +87,35 @@ extern fn sfn_serve_framed(handler: * u8, port: i32) -> void;
 // per process). 0 = no handler registered.
 let mut _sfn_http_handler_addr: i64 = 0;
 
-// `_sfn_http_trampoline(raw)` — the raw `fn(* u8) -> * u8` boundary the
-// runtime dispatches to. Parses the request, calls the registered typed
-// handler, and serializes the response to full HTTP/1.1 bytes. Must be a
-// top-level function so its address is a bare code pointer.
-// M1.A.2: the runtime dispatches to this trampoline through a bare
-// `fn(* u8) -> * u8` code pointer (registered via `sfn_serve_framed`), so
-// its parameter and return MUST keep the `* u8` ABI. Declaring them as
-// `string` worked only while `string` lowered to a bare `i8*`; after the
-// scalar flip a `string` parameter is the two-word `{i8*, i64}` aggregate,
-// which mismatches the runtime's single-pointer call — the second
-// (length) word arrives as a garbage register, so `raw.length` is wrong
-// and the request body is truncated. Take/return `* u8` and bridge to
-// `string` internally: `raw as string` recovers the full request length
-// via `sfn_str_len` (the request buffer is NUL-terminated), and the
-// serialized response is handed back as its data pointer.
-fn _sfn_http_trampoline(raw: * u8) -> * u8 {
+// `_sfn_http_trampoline(req)` — the `fn(OwnedBuf) -> OwnedBuf` boundary the
+// runtime dispatches to (#1476). Parses the request, calls the registered
+// typed handler, and serializes the response to full HTTP/1.1 bytes moved
+// back as an owned buffer. Must be a top-level function so its address is
+// a bare code pointer.
+//
+// ABI (#1476): the handler boundary is now moved `OwnedBuf` in / moved
+// `OwnedBuf` out. A user struct crosses the call as a boxed `%OwnedBuf*` —
+// a SINGLE pointer, the same register footprint as the old `* u8` — so it
+// is shape-stable. This is precisely why the OwnedBuf push is immune to
+// the M1.A.2 trap that bit the earlier `string` ABI: declaring the param
+// `string` made it the two-word `{i8*, i64}` aggregate, whose second
+// (length) word arrived as a garbage register on the runtime's
+// single-pointer dispatch and truncated the body. `OwnedBuf`-by-pointer
+// never changes word count, so the dispatch register layout always agrees.
+// Bridge to `string` internally: `req.ptr_addr as * u8 as string` recovers
+// the full request length via `sfn_str_len` (the request buffer is
+// NUL-terminated by the runtime recv), and the serialized response is
+// copied into a fresh libc `OwnedBuf` the runtime worker reclaims.
+fn _sfn_http_trampoline(req: OwnedBuf) -> OwnedBuf {
     if _sfn_http_handler_addr == 0 {
-        return serialize_response(Response {
+        return _http_owned_from_str(serialize_response(Response {
             status: 500, headers: [], body: ""
-        }) as * u8;
+        }));
     }
     let entry: * fn (Request) -> Response = _sfn_http_handler_addr as * fn (Request) -> Response;
-    let req: Request = parse_request(raw as string);
-    let resp: Response = entry(req);
-    return serialize_response(resp) as * u8;
+    let parsed: Request = parse_request(req.ptr_addr as * u8 as string);
+    let resp: Response = entry(parsed);
+    return _http_owned_from_str(serialize_response(resp));
 }
 
 // `serve(handler, port)` — start a blocking HTTP/1.1 server that

--- a/compiler/tests/e2e/runtime_serve_test.sfn
+++ b/compiler/tests/e2e/runtime_serve_test.sfn
@@ -177,6 +177,24 @@ test "serve emit: define for sfn_serve + sfn_serve_handler_dispatch" ![io] {
     assert _has_define(ir, "sfn_serve_handler_dispatch");
 }
 
+// #1476 — the serve handler boundary carries moved `OwnedBuf` (request
+// in, response out). At the call ABI a user struct crosses as a boxed
+// `%OwnedBuf*` (a single pointer — shape-stable, immune to the #1387
+// word-count class). Pins the 32-byte four-i64 layout and the dispatch
+// signature so a layout drift or an accidental ABI revert is caught at
+// emit time (the IR-level round-trip evidence; the live round-trip is
+// `serve_loopback_test.sfn`).
+test "serve emit: handler dispatch carries the OwnedBuf ABI (#1476)" ![io] {
+    let ir = _emit_module("serve", "runtime/sfn/concurrency/serve.sfn");
+    assert ir != "EMIT_FAILED";
+    // The owned-buffer aggregate is the 32-byte four-i64 layout.
+    assert contains(ir, "%OwnedBuf = type { i64, i64, i64, i64 }");
+    // The dispatch boundary returns an OwnedBuf and takes the moved
+    // request OwnedBuf (boxed `%OwnedBuf*` at the ABI).
+    assert contains(ir, "define %OwnedBuf* @sfn_serve_handler_dispatch(");
+    assert contains(ir, "@sfn_serve_handler_dispatch(i8* %handler, %OwnedBuf*");
+}
+
 test "serve emit: declares the BSD-sockets server surface" ![io] {
     let ir = _emit_module("serve", "runtime/sfn/concurrency/serve.sfn");
     assert ir != "EMIT_FAILED";

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -21,19 +21,23 @@
 // external linkage — two `sfn-sources` modules defining `_append`
 // would be a duplicate-symbol link error.
 //
-// Handler ABI (v0). The emitter (`compiler/src/llvm/expression_lowering/
-// native/core.sfn`) lowers `serve(<handler>, <port>)` by bitcasting the
-// handler function value to a bare `i8*` code pointer and passing it
-// with the port to `sfn_serve`. The handler's compiled C-ABI is
-// `fn (* u8 request) -> * u8 response_body`: it receives the raw
-// request bytes (NUL-terminated) and returns the response BODY as a
-// NUL-terminated string. `sfn_serve` wraps that body in a minimal
-// HTTP/1.1 `200 OK` response. This raw `i8*`-in / `i8*`-out shape
-// mirrors the `sfn_http_*` client exactly and needs NO Request /
-// Response struct marshalling — keeping the boxing self-contained
-// (the issue's architect flag). The richer `fn (Request) -> Response`
-// struct handler (the `sfn/http` capsule types) is a follow-up wave
-// that adds the request/response marshalling on top of this ABI.
+// Handler ABI (#1476 — moved OwnedBuf). The emitter (`compiler/src/llvm/
+// expression_lowering/native/core.sfn`) lowers `serve(<handler>, <port>)`
+// by bitcasting the handler function value to a bare `i8*` code pointer
+// and passing it with the port to `sfn_serve` (unchanged — the bitcast
+// is ABI-agnostic). The handler's compiled ABI is now
+// `fn (OwnedBuf request) -> OwnedBuf response`: the request bytes are
+// MOVED in as an owned buffer and the response BODY is moved out the
+// same way, so ownership transfers end-to-end across the handler
+// boundary. A user struct crosses the call as a boxed `%OwnedBuf*` (a
+// single pointer — the SAME register footprint as the old `* u8`), so
+// this is shape-stable and immune to the #1387/M1.A.2 word-count
+// mismatch that bit the `string` flip. `sfn_serve` wraps the response
+// body in a minimal HTTP/1.1 `200 OK` response; the worker is the
+// response buffer's last owner and reclaims it after the send. The
+// richer `fn (Request) -> Response` struct handler (the `sfn/http`
+// capsule types) marshals OwnedBuf <-> Request/Response in its
+// trampoline on top of this ABI.
 //
 // ABI flip. `compiler/src/llvm/runtime_helpers.sfn` flips the two
 // serve registry rows to the symbols defined here:
@@ -394,16 +398,95 @@ fn _serve_send_raw(fd: i32, resp: * u8) -> bool {
     return _serve_send_all(fd, resp, strlen(resp) as i64);
 }
 
+// `OwnedBuf` — the runtime owned-buffer aggregate (`runtime/sfn/memory/
+// ownedbuf.sfn`), inlined here byte-identically per the every-module
+// convention (the seed cannot return a struct defined in another module
+// — see `ownedbuf.sfn` for the rationale). MUST stay layout-identical:
+// four `i64` fields, 32 bytes, `arena_addr == 0` meaning libc-backed.
+struct OwnedBuf {
+    ptr_addr: i64;
+    len: i64;
+    cap: i64;
+    arena_addr: i64;
+}
+
+// `_serve_wrap_owned(ptr, len)` — wrap a libc-backed byte buffer into a
+// moved `OwnedBuf` (`arena_addr == 0`, `cap == len + 1` for the trailing
+// NUL the recv/serialize paths guarantee). The returned value carries
+// ownership of `ptr` across the handler boundary.
+fn _serve_wrap_owned(ptr: * u8, len: i64) -> OwnedBuf {
+    return OwnedBuf {
+        ptr_addr: ptr as i64,
+        len: len,
+        cap: len + 1,
+        arena_addr: 0
+    };
+}
+
+// `_serve_empty_owned()` — the null/error sentinel `OwnedBuf` (no backing
+// buffer). The framed/unframed send helpers treat a zero `ptr_addr` as
+// the `500` path.
+fn _serve_empty_owned() -> OwnedBuf {
+    return OwnedBuf {
+        ptr_addr: 0,
+        len: 0,
+        cap: 0,
+        arena_addr: 0
+    };
+}
+
+// `_serve_free_owned(buf)` — reclaim a moved `OwnedBuf`'s backing buffer.
+// Frees `ptr_addr` only when libc-backed (`arena_addr == 0`) and non-null;
+// arena-backed buffers are left to their arena (the #1205-class guard,
+// mirroring `mem.sfn::sfn_env_free_owned`'s arena check). There is no
+// container to free here — the `OwnedBuf` is a by-value aggregate, not a
+// heap env block — so this frees the buffer ONLY (do NOT route through
+// `sfn_env_free_owned`, which would also `free` a non-container address).
+fn _serve_free_owned(buf: OwnedBuf) -> void {
+    if buf.arena_addr == 0 {
+        if buf.ptr_addr != 0 { free(buf.ptr_addr as * u8); }
+    }
+}
+
 // `sfn_serve_handler_dispatch(handler, request)` — invoke the user
-// handler through its raw `i8*` code pointer. The handler's compiled
-// C-ABI is `fn (* u8 request) -> * u8 response_body`; this is the
-// single boxing boundary between the runtime and user code (mirrors
-// the `sfn_task_run` fn-pointer call in `scheduler.sfn`). Null-safe
-// on the handler (returns null so the worker emits a `500`).
-fn sfn_serve_handler_dispatch(handler: * u8, request: * u8) -> * u8 {
-    if handler as i64 == 0 { return null; }
-    let entry: * fn (* u8) -> * u8 = (handler as i64) as * fn (* u8) -> * u8;
-    return entry(request);
+// handler through its erased `i8*` code pointer. The handler's compiled
+// ABI is `fn (OwnedBuf request) -> OwnedBuf response` (#1476): the
+// request buffer is MOVED in as an `OwnedBuf` (a boxed `%OwnedBuf*` at
+// the call ABI — a single pointer, the SAME register footprint as the
+// old `* u8`, so this is immune to the #1387/M1.A.2 word-count class of
+// mismatch) and the response buffer is moved out the same way. This is
+// the single boxing boundary between the runtime and user code (mirrors
+// the `sfn_task_run` fn-pointer call in `scheduler.sfn`).
+//
+// Ownership: the request is moved end-to-end (worker -> dispatch ->
+// handler). Dispatch is the request's drop point: after the handler
+// returns, dispatch reclaims the request's libc backing — the handler
+// borrowed the bytes only for the duration of the call and must NOT
+// free or retain them (the same discipline as the `future.sfn`
+// `_owned_ctx` trampolines, which free the moved ctx after the body
+// runs). The handler returns a FRESH response `OwnedBuf`; if a handler
+// instead returns the request buffer itself (an echo), the alias guard
+// skips the request free so the worker frees it exactly once as the
+// response. Null-safe on the handler (frees the orphaned request and
+// returns an empty `OwnedBuf` so the worker emits a `500`).
+fn sfn_serve_handler_dispatch(handler: * u8, request: OwnedBuf) -> OwnedBuf {
+    if handler as i64 == 0 {
+        _serve_free_owned(request);
+        return _serve_empty_owned();
+    }
+    let entry: * fn (OwnedBuf) -> OwnedBuf = (handler as i64) as * fn (OwnedBuf) -> OwnedBuf;
+    let req_ptr: i64 = request.ptr_addr;
+    let req_arena: i64 = request.arena_addr;
+    let response: OwnedBuf = entry(request);
+    // Reclaim the request now the handler has returned — unless the
+    // handler echoed it back as the response (then the worker frees it
+    // once as the response, avoiding an alias double-free).
+    if req_arena == 0 {
+        if req_ptr != 0 {
+            if response.ptr_addr != req_ptr { free(req_ptr as * u8); }
+        }
+    }
+    return response;
 }
 
 // `_serve_conn_worker(ctx)` — the per-connection pool task body. It
@@ -416,8 +499,8 @@ fn sfn_serve_handler_dispatch(handler: * u8, request: * u8) -> * u8 {
 // effect annotation (matching `future.sfn`'s trampolines).
 //
 // A null request (recv error, OOM, or the header cap exceeded) is
-// NOT handed to user code — the handler receives a `* u8 request` it
-// is free to read, so a null would risk a crash inside the handler.
+// NOT handed to user code — the handler reads the request `OwnedBuf`'s
+// bytes, so a null backing would risk a crash inside the handler.
 // Instead the worker skips dispatch and sends a `500` directly
 // (`_serve_send_response(fd, null)`).
 fn _serve_conn_worker(ctx: * u8) -> * u8 {
@@ -437,10 +520,17 @@ fn _serve_conn_worker(ctx: * u8) -> * u8 {
         close(client_fd as i32);
         return null;
     }
-    let response: * u8 = sfn_serve_handler_dispatch(handler as * u8, request);
-    _serve_send_response(client_fd as i32, response);
+    // Move the request bytes into the handler as an OwnedBuf; dispatch
+    // reclaims the request after the handler returns, and the handler
+    // returns a FRESH response OwnedBuf moved back out. The worker is the
+    // response's last owner and frees it after the send (closing the v0
+    // leak). The raw `request` buffer is owned by the move now — do NOT
+    // free it here (dispatch does).
+    let req_box: OwnedBuf = _serve_wrap_owned(request, strlen(request) as i64);
+    let response: OwnedBuf = sfn_serve_handler_dispatch(handler as * u8, req_box);
+    _serve_send_response(client_fd as i32, response.ptr_addr as * u8);
     close(client_fd as i32);
-    free(request);
+    _serve_free_owned(response);
     return null;
 }
 
@@ -452,13 +542,13 @@ fn _serve_conn_worker(ctx: * u8) -> * u8 {
 // Sailfin and registers a trampoline as the handler, so framing is the
 // handler's job here. Same 16-byte [client_fd][handler] ctx.
 //
-// Ownership: the worker does NOT free the handler's returned `response`
-// buffer (it has no way to know the handler's allocation discipline). A
-// handler that allocates a fresh response per request therefore leaks one
-// buffer per connection until a request-scoped arena lands (same class as
-// the documented fire-and-forget `Task` leak; same caveat applies to the
-// unframed `_serve_conn_worker`). v0 servers are expected to be short-lived
-// or tolerate this; the bounded fix is tracked with the arena work.
+// Ownership (#1476): the handler returns a moved response `OwnedBuf`; the
+// worker is its last owner and reclaims the backing buffer after the send
+// (`_serve_free_owned`), closing the per-connection response-buffer leak
+// the v0 `* u8`-out ABI could not — the runtime now has a typed last
+// owner that knows the libc/arena discipline. The fire-and-forget `Task`
+// handle leak (a separate concern) is still tracked with the pool-reaping
+// work.
 fn _serve_conn_worker_framed(ctx: * u8) -> * u8 {
     if ctx as i64 == 0 { return null; }
     let base: i64 = ctx as i64;
@@ -474,10 +564,11 @@ fn _serve_conn_worker_framed(ctx: * u8) -> * u8 {
         close(client_fd as i32);
         return null;
     }
-    let response: * u8 = sfn_serve_handler_dispatch(handler as * u8, request);
-    _serve_send_raw(client_fd as i32, response);
+    let req_box: OwnedBuf = _serve_wrap_owned(request, strlen(request) as i64);
+    let response: OwnedBuf = sfn_serve_handler_dispatch(handler as * u8, req_box);
+    _serve_send_raw(client_fd as i32, response.ptr_addr as * u8);
     close(client_fd as i32);
-    free(request);
+    _serve_free_owned(response);
     return null;
 }
 


### PR DESCRIPTION
## Summary

Completes the **serve half of #1476** (epic #1466) — the remaining deliverable after PR #1545 landed the worker-ctx/channel OwnedBuf flip. Migrates the `serve` per-connection request/response buffers from the v0 raw `i8*`-in/`i8*`-out ABI to **moved `OwnedBuf` values**, so a buffer crossing the connection → handler → response boundary transfers ownership end-to-end.

- The handler ABI becomes `fn(OwnedBuf) -> OwnedBuf`. A user struct crosses the call as a boxed `%OwnedBuf*` — **a single pointer, the same register footprint as the old `* u8`** — so it is shape-stable and **immune to the #1387/M1.A.2 word-count mismatch** that bit the earlier `string` flip (declaring a param `string` made it a two-word `{i8*, i64}` aggregate whose length word arrived garbage on the single-pointer dispatch). Confirmed in emitted IR and `llvm-as`-clean.
- Ownership is a **genuine move** (worker → dispatch → handler), mirroring the `future.sfn` `_owned_ctx` trampolines: dispatch reclaims the moved request after the handler returns (with an **alias guard** so an echo-the-request handler can't double-free), and the worker is the response's last owner and frees it after the send.
- **Closes the documented per-connection response-buffer leak** (`serve.sfn` v0 `* u8`-out ABI had no typed last owner that knew the libc/arena discipline).
- **No compiler-source change** (the bespoke `serve` lowering bitcasts the handler to `i8*` ABI-agnostically), so **no seed cut** — the runtime + capsule are compiled by the same self-host pass.

Refs #1476 #1466

> Note: #1476 was already closed (auto-closed by PR #1545's title despite that PR's body stating it deliberately did not close it). This PR delivers the remaining serve deliverable; it references rather than re-closes the issue.

## Acceptance criteria

- [x] Serve request/response buffers round-trip as moved `OwnedBuf` (full 32-byte aggregate survives the boundary) — IR-pinned: `define %OwnedBuf* @sfn_serve_handler_dispatch(i8* %handler, %OwnedBuf* %request)`, `%OwnedBuf = type { i64, i64, i64, i64 }`, `llvm-as` clean; validated end-to-end by the live loopback round-trip.
- [x] Concurrency modules pass ownership enforcement with the new OwnedBuf ABI (`sfn check` clean; move/borrow ordering sound, no use-after-move).
- [ ] **ASAN-interleave gate over concurrent serve handlers — deferred behind #1546.** The pre-existing `spawn`/`await` typed-result defect blocks reliable concurrent runtime round-trip on the concurrency surface; the live ASAN gate lands once #1546 is fixed, exactly as PR #1545 split its ACs. The single-threaded loopback round-trip + the leak-closure-by-construction carry the now-coverage.
- [ ] `make clean-build && make check` — **in progress at time of opening; results to follow** (no compiler-source change → low self-host risk).

## Verification

```text
runtime_serve_test.sfn          7/7  (incl. new #1476 %OwnedBuf ABI emit-shape pin)
http_capsule_serve_gate_test    1/1  (#1323 capsule-vs-builtin gate intact)
serve_loopback_test             1/1  (live HTTP round-trip: POST body echo,
                                      custom 403 status+headers via framed path,
                                      oversize Content-Length -> 500, typed fetch client)
sfn check / fmt --check         clean on all touched files
emit llvm + llvm-as             clean; boxed %OwnedBuf* dispatch ABI confirmed
```

## Files changed

- `runtime/sfn/concurrency/serve.sfn` — inlined `OwnedBuf` + `_serve_wrap_owned`/`_serve_empty_owned`/`_serve_free_owned`; `sfn_serve_handler_dispatch` flipped to the moved-OwnedBuf ABI with request reclaim + alias guard; both workers wrap → dispatch → send → reclaim response.
- `capsules/sfn/http/src/server.sfn` — `_sfn_http_trampoline` flipped to `fn(OwnedBuf) -> OwnedBuf`; `_http_owned_from_str` copies the serialized response into a fresh libc-backed `OwnedBuf` the worker reclaims (no cross-free with the capsule string storage).
- `compiler/tests/e2e/runtime_serve_test.sfn` — pin the 32-byte `%OwnedBuf` layout + the dispatch define ABI.

## Follow-ups / notes

- **#1546** (filed this session) — pre-existing non-capturing `spawn fn() -> int { 42 }` + `await:int` returns `0`; blocks the ASAN gate above.
- The `serve_handler_dispatch` registry row (`runtime_helpers.sfn`) is now cosmetically stale (still `i8*`/`[i8*,i8*]`) but **dead for emission** — the symbol is defined and called only within `serve.sfn`. Left untouched to avoid emitting a mismatched `declare`; worth a tiny follow-up for registry honesty.
- Binary response bodies with embedded NULs would truncate (the framed send path measures with `strlen`) — consistent with the v0 "text responses only" scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191jijHzqm7x8V3QSKqKvJo

---
_Generated by [Claude Code](https://claude.ai/code/session_0191jijHzqm7x8V3QSKqKvJo)_