### PR TITLE
perf(llvm): extend loop arena mark/rewind to for-range and for-array

### DIFF
--- a/benchmarks/runtime/arena_alloc_for_range.sfn
+++ b/benchmarks/runtime/arena_alloc_for_range.sfn
@@ -1,0 +1,33 @@
+// benchmarks/runtime/arena_alloc_for_range.sfn
+//
+// Runtime-execution benchmark: arena bump allocation in a for-range loop.
+//
+// The for-range counterpart to arena_alloc.sfn (#1515). Allocates a large
+// number of small structs in a `for i in 0..N { … }` loop, summing a field of
+// each so the allocation is not dead-code-eliminated. With the per-iteration
+// arena mark/rewind seam (#1514 generic `loop`, extended to for-range/for-array
+// in #1515), the non-escaping `Cell` is reclaimed each iteration, so peak RSS
+// stays flat instead of growing linearly with ITERATIONS.
+//
+// Fixed work: ITERATIONS is a compile-time constant so the measured cost is
+// comparable across releases.
+struct Cell {
+    a: number;
+    b: number;
+    c: number;
+}
+
+fn main() ![io, clock] {
+    let iterations = 30000000;
+    let start = monotonic_millis();
+    let mut acc: number = 0.0;
+    for i in 0 .. 30000000 {
+        let cell = Cell { a: i, b: i + 1, c: i + 2 };
+        acc = acc + cell.a + cell.b + cell.c;
+    }
+    let end = monotonic_millis();
+    // Guard against dead-code elimination of the allocations.
+    if acc < 0.0 { return; }
+    let dur = end - start;
+    print("RESULT arena_alloc_for_range {{dur}} {{iterations}}");
+}

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -33,12 +33,14 @@ import {
     emit_scope_drops,
     extend_mutations,
     _parse_int_from_string,
-    extend_lifetime_regions
+    extend_lifetime_regions,
+    loop_body_rewind_eligible
 } from "./instructions_helpers";
 import { find_local_binding } from "../expressions_bindings";
 import { is_number_literal, normalise_number_literal } from "../expressions_literals";
 import { allocate_block_label } from "./instructions_condition";
 import { lower_for_range, build_loop_exit_mutations } from "./instructions_for_range";
+import { get_instruction_scan_text } from "./lowering_native_helpers";
 import { array_pointer_element_type } from "../expression_lowering/arrays";
 import { lower_expression } from "../expression_lowering/native/core";
 import { parse_range_iterable } from "../expression_lowering/native/core_parse";
@@ -222,7 +224,6 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
         _ci24 += 1;
     }
     lifetime_regions = extend_lifetime_regions(lifetime_regions, body_result.lifetime_regions);
-    current_lines = extend_string_array(current_lines, body_result.lines);
     current_allocas = body_result.allocas;
     current_temp = body_result.temp_index;
     current_block_counter = body_result.block_counter;
@@ -231,6 +232,39 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
     current_next_region = body_result.next_lifetime_region_id;
     collected_mutations = extend_mutations(collected_mutations, body_result.mutations);
     collected_string_constants = merge_string_constants(collected_string_constants, body_result.string_constants);
+
+    // #1515: extend #1514's gated per-iteration arena reclamation to
+    // for-array bodies. Reuse `loop_body_rewind_eligible` over the body's
+    // locals / mutations / scan-text / lowered IR; the ancestor set is
+    // `current_locals` (the loop's enclosing scopes — the element binding is
+    // body-scope and intentionally excluded). The index increment / element
+    // load touches only the `i64` index alloca and the iteration slot, never
+    // arena memory, so a mark at body entry dominates the rewind at close.
+    let mut arena_rewind_eligible: boolean = false;
+    if !body_result.terminated {
+        let mut body_scan_texts: string[] = [];
+        let mut _bt_idx: int = structure.body_start;
+        loop {
+            if _bt_idx >= structure.body_end { break; }
+            body_scan_texts.push(get_instruction_scan_text(function.instructions, _bt_idx));
+            _bt_idx += 1;
+        }
+        arena_rewind_eligible = loop_body_rewind_eligible(body_result.locals, body_result.mutations, element_loop_scope_id, current_locals, body_scan_texts, body_result.lines, context);
+    }
+
+    // #1514/#1515: mark the arena at body entry when eligible. The matching
+    // rewind at iteration close resets the bump cursor, freeing every arena
+    // allocation made this iteration. Emitted before the body lines so it
+    // dominates the close point.
+    let mut arena_mark_temp: string = "";
+    if arena_rewind_eligible {
+        arena_mark_temp = format_temp_name(current_temp);
+        current_temp += 1;
+        current_lines.push("  " + arena_mark_temp
+            + " = call double @sfn_arena_sfn_mark()");
+    }
+
+    current_lines = extend_string_array(current_lines, body_result.lines);
 
     // M1.5.3 (issue #327): drop the for-body's owned RC locals at
     // end-of-iteration so each iteration starts with fresh refcounts.
@@ -243,6 +277,14 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
             _fcd_i += 1;
         }
         current_temp = _for_close_result.next_temp;
+        // #1515: reclaim this iteration's non-escaping arena allocations
+        // before branching to the increment block (mirror of the generic
+        // `loop` close seam in instructions_loops.sfn).
+        if arena_mark_temp.length > 0 {
+            current_lines.push("  call void @sfn_arena_sfn_rewind(double "
+                + arena_mark_temp
+                + ")");
+        }
         current_lines.push("  br label %" + loop_increment_label);
     }
 

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -25,11 +25,13 @@ import {
     emit_scope_drops,
     extend_mutations,
     _parse_int_from_string,
-    extend_lifetime_regions
+    extend_lifetime_regions,
+    loop_body_rewind_eligible
 } from "./instructions_helpers";
 import { find_local_binding } from "../expressions_bindings";
 import { is_number_literal, normalise_number_literal } from "../expressions_literals";
 import { allocate_block_label } from "./instructions_condition";
+import { get_instruction_scan_text } from "./lowering_native_helpers";
 import { lower_expression } from "../expression_lowering/native/core";
 import { parse_range_iterable } from "../expression_lowering/native/core_parse";
 import { append_local_binding } from "../expression_lowering/native/core_scopes";
@@ -477,7 +479,6 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         _ci19 += 1;
     }
     lifetime_regions = extend_lifetime_regions(lifetime_regions, body_result.lifetime_regions);
-    current_lines = extend_string_array(current_lines, body_result.lines);
     current_allocas = body_result.allocas;
     current_temp = body_result.temp_index;
     current_block_counter = body_result.block_counter;
@@ -486,6 +487,39 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_next_region = body_result.next_lifetime_region_id;
     collected_mutations = extend_mutations(collected_mutations, body_result.mutations);
     collected_string_constants = merge_string_constants(collected_string_constants, body_result.string_constants);
+
+    // #1515: extend #1514's gated per-iteration arena reclamation to
+    // for-range bodies. Reuse `loop_body_rewind_eligible` over the body's
+    // locals / mutations / scan-text / lowered IR; the ancestor set is
+    // `current_locals` (the loop's enclosing scopes — the iteration binding
+    // is body-scope and intentionally excluded). The range increment/header
+    // touches only the `double` iterator alloca, never arena memory, so a
+    // mark at body entry still dominates the rewind at iteration close.
+    let mut arena_rewind_eligible: boolean = false;
+    if !body_result.terminated {
+        let mut body_scan_texts: string[] = [];
+        let mut _bt_idx: int = structure.body_start;
+        loop {
+            if _bt_idx >= structure.body_end { break; }
+            body_scan_texts.push(get_instruction_scan_text(function.instructions, _bt_idx));
+            _bt_idx += 1;
+        }
+        arena_rewind_eligible = loop_body_rewind_eligible(body_result.locals, body_result.mutations, loop_body_scope_id, current_locals, body_scan_texts, body_result.lines, context);
+    }
+
+    // #1514/#1515: mark the arena at body entry when eligible. The matching
+    // rewind at iteration close resets the bump cursor, freeing every arena
+    // allocation made this iteration. Emitted before the body lines so it
+    // dominates the close point.
+    let mut arena_mark_temp: string = "";
+    if arena_rewind_eligible {
+        arena_mark_temp = format_temp_name(current_temp);
+        current_temp += 1;
+        current_lines.push("  " + arena_mark_temp
+            + " = call double @sfn_arena_sfn_mark()");
+    }
+
+    current_lines = extend_string_array(current_lines, body_result.lines);
 
     // M1.5.3 (issue #327): drop the for-range body's owned RC locals at
     // end-of-iteration so each iteration starts with fresh refcounts.
@@ -498,6 +532,14 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             _rcd_i += 1;
         }
         current_temp = _range_close_result.next_temp;
+        // #1515: reclaim this iteration's non-escaping arena allocations
+        // before branching to the increment block (mirror of the generic
+        // `loop` close seam in instructions_loops.sfn).
+        if arena_mark_temp.length > 0 {
+            current_lines.push("  call void @sfn_arena_sfn_rewind(double "
+                + arena_mark_temp
+                + ")");
+        }
         current_lines.push("  br label %" + loop_increment_label);
     }
 

--- a/compiler/tests/e2e/arena_loop_rewind_test.sfn
+++ b/compiler/tests/e2e/arena_loop_rewind_test.sfn
@@ -89,6 +89,23 @@ fn _scalar_push() -> string {
     return "compiler/tests/e2e/fixtures/arena_loop_rewind_scalar_push.sfn";
 }
 
+// #1515: for-range / for-array fixtures (same seam, extended to those loops).
+fn _for_range_positive() -> string {
+    return "compiler/tests/e2e/fixtures/arena_for_range_rewind_positive.sfn";
+}
+
+fn _for_range_escape() -> string {
+    return "compiler/tests/e2e/fixtures/arena_for_range_rewind_escape.sfn";
+}
+
+fn _for_array_positive() -> string {
+    return "compiler/tests/e2e/fixtures/arena_for_array_rewind_positive.sfn";
+}
+
+fn _for_array_escape() -> string {
+    return "compiler/tests/e2e/fixtures/arena_for_array_rewind_escape.sfn";
+}
+
 // ---- (1) positive: exactly one mark + one rewind ----
 test "arena-loop-rewind: non-escaping loop emits one mark and one rewind" ![io] {
     let ir = _emit_llvm(_positive(), "positive");
@@ -151,4 +168,36 @@ test "arena-loop-rewind: an eligible body with a continue emits one mark and one
     assert ir.length > 0;
     assert count(ir, "call double @sfn_arena_sfn_mark(") == 1;
     assert count(ir, "call void @sfn_arena_sfn_rewind(") == 1;
+}
+
+// ---- (6) for-range positive: one mark + one rewind (#1515) ----
+test "arena-loop-rewind: a non-escaping for-range body emits one mark and one rewind" ![io] {
+    let ir = _emit_llvm(_for_range_positive(), "forrangepos");
+    assert ir.length > 0;
+    assert count(ir, "call double @sfn_arena_sfn_mark(") == 1;
+    assert count(ir, "call void @sfn_arena_sfn_rewind(") == 1;
+}
+
+// ---- (7) for-range negative: container escape suppresses the rewind ----
+test "arena-loop-rewind: pushing the cell from a for-range body suppresses rewind" ![io] {
+    let ir = _emit_llvm(_for_range_escape(), "forrangeesc");
+    assert ir.length > 0;
+    assert count(ir, "call void @sfn_arena_sfn_rewind(") == 0;
+    assert count(ir, "call double @sfn_arena_sfn_mark(") == 0;
+}
+
+// ---- (8) for-array positive: one mark + one rewind (#1515) ----
+test "arena-loop-rewind: a non-escaping for-array body emits one mark and one rewind" ![io] {
+    let ir = _emit_llvm(_for_array_positive(), "forarraypos");
+    assert ir.length > 0;
+    assert count(ir, "call double @sfn_arena_sfn_mark(") == 1;
+    assert count(ir, "call void @sfn_arena_sfn_rewind(") == 1;
+}
+
+// ---- (9) for-array negative: container escape suppresses the rewind ----
+test "arena-loop-rewind: pushing the cell from a for-array body suppresses rewind" ![io] {
+    let ir = _emit_llvm(_for_array_escape(), "forarrayesc");
+    assert ir.length > 0;
+    assert count(ir, "call void @sfn_arena_sfn_rewind(") == 0;
+    assert count(ir, "call double @sfn_arena_sfn_mark(") == 0;
 }

--- a/compiler/tests/e2e/fixtures/arena_for_array_rewind_escape.sfn
+++ b/compiler/tests/e2e/fixtures/arena_for_array_rewind_escape.sfn
@@ -1,0 +1,23 @@
+// Fixture for compiler/tests/e2e/arena_loop_rewind_test.sfn (#1515).
+//
+// Negative case (for-array, container escape): the per-iteration `Cell` is
+// pushed into an array declared in an ancestor scope, so its pointer survives
+// the iteration. The body-text scan catches the bare `cell` argument and the
+// `results.push(…)` call; the gate must suppress the rewind — emitting one
+// here would free the pointers `results` still holds.
+struct Cell {
+    a: int;
+    b: int;
+    c: int;
+}
+
+fn main() ![io] {
+    let xs: int[] = [10, 20, 30, 40];
+    let mut results: Cell[] = [];
+    for x in xs {
+        let cell = Cell { a: x, b: x + 1, c: x + 2 };
+        results.push(cell);
+    }
+    if results.length < 0 { return; }
+    print("done");
+}

--- a/compiler/tests/e2e/fixtures/arena_for_array_rewind_positive.sfn
+++ b/compiler/tests/e2e/fixtures/arena_for_array_rewind_positive.sfn
@@ -1,0 +1,23 @@
+// Fixture for compiler/tests/e2e/arena_loop_rewind_test.sfn (#1515).
+//
+// Positive case (for-array): a `for x in arr { … }` whose only heap
+// allocation is a per-iteration `Cell` struct that never escapes — it is read
+// field-wise into a primitive accumulator and discarded. The for-array
+// lowering must wrap the body in exactly one `@sfn_arena_sfn_mark` / one
+// `@sfn_arena_sfn_rewind` pair, just like the generic `loop` seam (#1514).
+struct Cell {
+    a: int;
+    b: int;
+    c: int;
+}
+
+fn main() ![io] {
+    let xs: int[] = [10, 20, 30, 40];
+    let mut acc = 0;
+    for x in xs {
+        let cell = Cell { a: x, b: x + 1, c: x + 2 };
+        acc = acc + cell.a + cell.b + cell.c;
+    }
+    if acc < 0 { return; }
+    print("done");
+}

--- a/compiler/tests/e2e/fixtures/arena_for_range_rewind_escape.sfn
+++ b/compiler/tests/e2e/fixtures/arena_for_range_rewind_escape.sfn
@@ -1,0 +1,22 @@
+// Fixture for compiler/tests/e2e/arena_loop_rewind_test.sfn (#1515).
+//
+// Negative case (for-range, container escape): the per-iteration `Cell` is
+// pushed into an array declared in an ancestor scope, so its pointer survives
+// the iteration. The body-text scan catches the bare `cell` argument and the
+// `results.push(…)` call; the gate must suppress the rewind — emitting one
+// here would free the pointers `results` still holds.
+struct Cell {
+    a: number;
+    b: number;
+    c: number;
+}
+
+fn main() ![io] {
+    let mut results: Cell[] = [];
+    for i in 0 .. 1000 {
+        let cell = Cell { a: i, b: i + 1, c: i + 2 };
+        results.push(cell);
+    }
+    if results.length < 0 { return; }
+    print("done");
+}

--- a/compiler/tests/e2e/fixtures/arena_for_range_rewind_positive.sfn
+++ b/compiler/tests/e2e/fixtures/arena_for_range_rewind_positive.sfn
@@ -1,0 +1,22 @@
+// Fixture for compiler/tests/e2e/arena_loop_rewind_test.sfn (#1515).
+//
+// Positive case (for-range): a `for i in 0..N { … }` whose only heap
+// allocation is a per-iteration `Cell` struct that never escapes — it is read
+// field-wise into a primitive accumulator and discarded. The for-range
+// lowering must wrap the body in exactly one `@sfn_arena_sfn_mark` / one
+// `@sfn_arena_sfn_rewind` pair, just like the generic `loop` seam (#1514).
+struct Cell {
+    a: number;
+    b: number;
+    c: number;
+}
+
+fn main() ![io] {
+    let mut acc: number = 0.0;
+    for i in 0 .. 1000 {
+        let cell = Cell { a: i, b: i + 1, c: i + 2 };
+        acc = acc + cell.a + cell.b + cell.c;
+    }
+    if acc < 0.0 { return; }
+    print("done");
+}


### PR DESCRIPTION
## Summary
- Extend #1514's gated per-iteration arena `mark`/`rewind` reclamation from generic `loop` bodies to **for-range** (`instructions_for_range.sfn`) and **for-array** (`instructions_for.sfn`) loops, reusing the shared `loop_body_rewind_eligible` predicate unchanged.
- A non-escaping `for i in 0..N { let c = Cell{…}; }` / `for x in arr { … }` now emits `arena_mark` at body entry + `arena_rewind` at iteration close; escaping bodies (container push, loop-carried store, …) emit neither.
- New for-range arena workload (`benchmarks/runtime/arena_alloc_for_range.sfn`) ends at **10.2 MB peak RSS = 0.0148× the 686.6 MB raw allocation size** (30M × 24-byte `Cell`), matching #1514's generic-loop result, with identical throughput.

Closes #1515

## Implementation notes
The mark is emitted before the body lines so it dominates the close point. The range increment/header touches only the `double` iterator alloca; the array index increment / element load touches only the `i64` index + the iteration slot — neither touches arena memory, so the SSA mark temp stays valid at the rewind. The ancestor set for the loop-carried-store channel is the loop's enclosing `current_locals` (the iteration binding is body-scope and intentionally excluded).

## Acceptance Criteria
- [x] `make compile` passes (self-hosts).
- [x] `make test` passes — 161 unit / 36 integration / 36 capsules / 140 of 141 e2e. The one non-pass is `work_dir_parity_test.sfn`, which **passes standalone in 4m30s** but exceeded the per-test `timeout 300` cap under serial `--jobs 1` suite load; it builds the compiler twice and is unrelated to loop lowering.
- [x] for-range and for-array non-escaping fixtures emit gated `arena_rewind`; escaping fixtures do not (all 11 tests in `arena_loop_rewind_test.sfn` pass).
- [x] A for-range arena bench shows sub-1.0× RSS: **0.0148×** (10.2 MB / 686.6 MB).
- [x] `sfn fmt --check` clean on touched `.sfn`.

## Verification
```
$ build/native/sailfin test compiler/tests/e2e -k "arena-loop-rewind"
  PASS  (all 11 tests passed)

# emitted-IR check (mark/rewind call counts)
for_range_rewind_positive  mark=1 rewind=1   (non-escaping)
for_array_rewind_positive  mark=1 rewind=1   (non-escaping)
for_range_rewind_escape    mark=0 rewind=0   (container push)
for_array_rewind_escape    mark=0 rewind=0   (container push)

# peak RSS (getrusage), 30M Cells
arena_alloc_for_range:      10.2 MB  => 0.0148x raw (686.6 MB)
arena_alloc (generic loop): 10.2 MB  => 0.0148x raw
```

## Files Changed
- `compiler/src/llvm/lowering/instructions_for_range.sfn` — for-range mark/rewind seam
- `compiler/src/llvm/lowering/instructions_for.sfn` — for-array mark/rewind seam
- `compiler/tests/e2e/arena_loop_rewind_test.sfn` — +4 cases (for-range/for-array positive + escape)
- `compiler/tests/e2e/fixtures/arena_for_{range,array}_rewind_{positive,escape}.sfn` — new fixtures
- `benchmarks/runtime/arena_alloc_for_range.sfn` — for-range arena workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129kNw8U8NWwVjcN8v2CZPw

---
_Generated by [Claude Code](https://claude.ai/code/session_0129kNw8U8NWwVjcN8v2CZPw)_