### PR TITLE
ci(test): instrument macOS-arm64 legs for wall + cache hit-rate (#1235)

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -161,6 +161,19 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
+        # #1235 measurement (macOS only — the issue scopes Linux OUT).
+        # Time the build phase and flip on the existing SAILFIN_AGENT_REPORT
+        # gate (Makefile rebuild-impl, #1120) so the seed emits its module-IR
+        # BuildReport to build/native/.build-report.json — that is where
+        # `cache.hit_rate` lives. Purely additive + macOS-scoped: the two
+        # `date` calls are no-ops and every write is behind `_measure`, so
+        # Linux / release builds stay byte-identical.
+        _measure=0
+        if [ "${{ inputs.target }}" = "macos-arm64" ]; then
+          _measure=1
+          export SAILFIN_AGENT_REPORT=1
+        fi
+        _t0=$(date +%s)
         # Forward build_jobs only when explicitly set; an empty value means
         # "let the Makefile auto-detect" (scripts/detect_build_jobs.sh).
         # The if/else split avoids bash 3.2's "${arr[@]}" empty-array
@@ -175,6 +188,22 @@ runs:
           make rebuild \
             CLANG="${{ inputs.clang }}" \
             SEED_NATIVE="build/seed/bin/sailfin"
+        fi
+        _t1=$(date +%s)
+        if [ "$_measure" = "1" ]; then
+          _build_s=$(( _t1 - _t0 ))
+          _hit_rate="n/a"
+          if command -v jq >/dev/null 2>&1 && [ -f build/native/.build-report.json ]; then
+            _hit_rate="$(jq -r '.cache.hit_rate // "n/a"' build/native/.build-report.json 2>/dev/null || echo n/a)"
+          fi
+          mkdir -p build
+          {
+            echo "ci_metrics_phase=build"
+            echo "ci_metrics_target=${{ inputs.target }}"
+            echo "build_seconds=${_build_s}"
+            echo "build_cache_hit_rate=${_hit_rate}"
+          } >> build/ci-metrics.env
+          echo "[ci-metrics] build phase: ${_build_s}s, module-IR cache.hit_rate=${_hit_rate}"
         fi
 
     # skip-build mode: the compiler tree was downloaded from the shared
@@ -206,6 +235,18 @@ runs:
       shell: bash {0}
       run: |
         set -euo pipefail
+        # #1235 measurement (macOS only). Time the test phase and flip on
+        # the SAILFIN_AGENT_REPORT gate so `make test-shard` →
+        # scripts/test_shards.sh forwards `--json` + tees
+        # build/agent-test.shard-<shard>.jsonl, whose `summary` event carries
+        # cache.test_bin_hit_rate (#1230). Additive + macOS-scoped; Linux
+        # shard legs keep the byte-identical human run.
+        _measure=0
+        if [ "${{ inputs.target }}" = "macos-arm64" ]; then
+          _measure=1
+          export SAILFIN_AGENT_REPORT=1
+        fi
+        _t0=$(date +%s)
         # No step-level ulimit: since seed 0.7.0-alpha.33 every sailfin
         # invocation self-applies an 8 GiB RLIMIT_AS on Linux at its own
         # startup (#1291, .claude/rules/compiler-safety.md) — each
@@ -241,6 +282,24 @@ runs:
           echo "::warning title=test flake (likely #892)::tests failed on attempt 1; retrying once. If this recurs, it is the non-deterministic codegen corruption tracked in #892."
           echo "[ci] retrying tests once (attempt 2/2) — see #892"
           run_tests
+        fi
+        if [ "$_measure" = "1" ]; then
+          _t1=$(date +%s)
+          _test_s=$(( _t1 - _t0 ))
+          _tbhr="n/a"
+          sidecar="build/agent-test.shard-${{ inputs.shard }}.jsonl"
+          if command -v jq >/dev/null 2>&1 && [ -s "$sidecar" ]; then
+            _tbhr="$(jq -rs 'map(select(.event == "summary")) | last | .cache.test_bin_hit_rate // "n/a"' "$sidecar" 2>/dev/null || echo n/a)"
+          fi
+          mkdir -p build
+          {
+            echo "ci_metrics_phase=test"
+            echo "ci_metrics_target=${{ inputs.target }}"
+            echo "ci_metrics_shard=${{ inputs.shard }}"
+            echo "test_seconds=${_test_s}"
+            echo "test_bin_hit_rate=${_tbhr}"
+          } >> build/ci-metrics.env
+          echo "[ci-metrics] test phase (shard ${{ inputs.shard }}): ${_test_s}s, cache.test_bin_hit_rate=${_tbhr}"
         fi
 
     - name: Package artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,33 @@ jobs:
           seed_version: ${{ steps.seed.outputs.seed_version }}
           package: 'false'
 
+      # #1235 measurement (read-only): surface the build-phase wall time and
+      # the module-IR cache.hit_rate that the sailfin-build action captured
+      # (build/ci-metrics.env) into the job log + step summary. The findings
+      # comment scrapes the `[ci-metrics]` line; queue/start/end come from
+      # the Actions API at analysis time. macOS-only — Linux is out of scope.
+      - name: Emit macOS build-leg metrics (#1235)
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          f=build/ci-metrics.env
+          if [ ! -f "$f" ]; then
+            echo "[ci-metrics] no metrics file ($f) — build likely failed before measurement"
+            exit 0
+          fi
+          # shellcheck disable=SC1090
+          . "$f"
+          echo "[ci-metrics] target=${ci_metrics_target:-macos-arm64} phase=build build_s=${build_seconds:-?} build_cache_hit_rate=${build_cache_hit_rate:-?}"
+          {
+            echo "### macOS build leg metrics (#1235)"
+            echo ""
+            echo "| metric | value |"
+            echo "| --- | --- |"
+            echo "| build wall (s) | ${build_seconds:-?} |"
+            echo "| module-IR cache.hit_rate | ${build_cache_hit_rate:-?} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Bounded shard payload — see the Linux twin above for the
       # include/exclude rationale.
       - name: Bundle compiler tree for shard legs
@@ -780,6 +807,35 @@ jobs:
           # Each leg runs only its shard; package only on the primary leg.
           shard: ${{ matrix.shard }}
           package: ${{ matrix.primary && 'true' || 'false' }}
+
+      # #1235 measurement (read-only): surface this shard leg's test-phase
+      # wall time and cache.test_bin_hit_rate (captured by the sailfin-build
+      # action into build/ci-metrics.env) into the job log + step summary.
+      # The findings comment scrapes the per-shard `[ci-metrics]` line; the
+      # per-leg queue/start/end come from the Actions API at analysis time.
+      - name: Emit macOS test-leg metrics (#1235)
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          f=build/ci-metrics.env
+          if [ ! -f "$f" ]; then
+            echo "[ci-metrics] no metrics file ($f) — tests likely failed before measurement (shard ${{ matrix.shard }})"
+            exit 0
+          fi
+          # shellcheck disable=SC1090
+          . "$f"
+          shard="${ci_metrics_shard:-${{ matrix.shard }}}"
+          echo "[ci-metrics] target=${ci_metrics_target:-macos-arm64} phase=test shard=${shard} test_s=${test_seconds:-?} test_bin_hit_rate=${test_bin_hit_rate:-?}"
+          {
+            echo "### macOS test leg metrics — shard ${shard} (#1235)"
+            echo ""
+            echo "| metric | value |"
+            echo "| --- | --- |"
+            echo "| shard | ${shard} |"
+            echo "| test wall (s) | ${test_seconds:-?} |"
+            echo "| cache.test_bin_hit_rate | ${test_bin_hit_rate:-?} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report compiler metadata
         if: ${{ matrix.primary }}

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,11 @@ test-shard:
 	fi
 	@# Every shard is a disjoint slice of the unified `*_test.sfn` runner
 	@# (the legacy e2e `.sh` shards were retired with the bash suite — #840).
+	@# JSON=1 gate (#1235): `JSON=1 make test-shard` (or SAILFIN_AGENT_REPORT=1
+	@# in the env, as the macOS measurement legs set) makes test_shards.sh
+	@# forward `--json` and tee build/agent-test.shard-<shard>.jsonl, whose
+	@# `summary` event carries cache.test_bin_hit_rate (#1230). Default
+	@# (gate off) keeps the byte-identical human run — see scripts/test_shards.sh.
 	@bash scripts/test_shards.sh run "$(SHARD)" "$(NATIVE_BIN)"
 
 # Coverage guard: fail if the shard map drops or double-counts any test

--- a/scripts/test_shards.sh
+++ b/scripts/test_shards.sh
@@ -104,8 +104,25 @@ run() {
 		exit 1
 	fi
 	echo "[test_shards] shard '$shard': $(printf '%s\n' "$files" | wc -l | tr -d ' ') file(s)"
+	# JSON-report gate (#1235, additive / default-off). When
+	# SAILFIN_AGENT_REPORT=1 (the repo-wide JSON=1 gate, exported by the
+	# Makefile and set directly by the macOS measurement legs in
+	# .github/actions/sailfin-build), forward `--json` and tee the runner's
+	# JSONL stream — whose `summary` event carries `cache.test_bin_hit_rate`
+	# (#1230) — to a per-shard sidecar so CI can dump the per-test-binary
+	# cache hit-rate without a second test pass. `set -o pipefail` preserves
+	# the runner's real exit status across the tee (the `exec` form below
+	# would lose it to `tee`). The default path stays the byte-identical
+	# `exec "$native" test $files` so normal local/Linux runs are unchanged.
 	# Word-splitting is intentional: pass the file list as positionals.
 	# shellcheck disable=SC2086
+	if [ "${SAILFIN_AGENT_REPORT:-}" = "1" ]; then
+		mkdir -p build
+		local sidecar="build/agent-test.shard-${shard}.jsonl"
+		set -o pipefail
+		"$native" test $files --json | tee "$sidecar"
+		exit "${PIPESTATUS[0]}"
+	fi
 	exec "$native" test $files
 }
 


### PR DESCRIPTION
## Summary
- Instruments the macOS-arm64 CI legs to measure, per leg: **build vs test phase wall split**, the module-IR **`cache.hit_rate`** (build), and the per-test-binary **`cache.test_bin_hit_rate`** (test) — the data needed to diagnose why macOS is the ~47‑min long pole before throwing more shards at it (#4).
- All new behavior is gated on `target == macos-arm64`, so **Linux and release legs are byte-identical**. No `.sfn` touched.
- Measurement reuses the existing `SAILFIN_AGENT_REPORT` / `JSON=1` report gate (#1120/#1230) — **no second build or test pass**.

Closes #1235

## How it works
| Field | Source | Where |
|---|---|---|
| build wall, test wall (phase split) | `date +%s` around the build/test steps | `sailfin-build/action.yml` |
| `cache.hit_rate` (module-IR) | `build/native/.build-report.json` (gated build report) | build leg |
| `cache.test_bin_hit_rate` | per-shard `--json` summary sidecar `build/agent-test.shard-<shard>.jsonl` | each test leg |
| per-leg queue / start / end | GitHub Actions API (`created_at`/`started_at`/`completed_at`) | read at findings-writing time |

The action writes `build/ci-metrics.env`; the macOS `ci.yml` jobs read it into a grep-friendly `[ci-metrics] …` log line + a step-summary table for easy scraping into the findings comment.

## Scope note
The issue's `## Files Affected` listed only `ci.yml` + `action.yml`, but dumping the **module-level** `cache.hit_rate` / `cache.test_bin_hit_rate` requires forwarding `--json` on the `make rebuild` / `make test-shard` paths. The build path already honors the gate; the shard path did not. Per a scope confirmation, this PR adds a **default-off, additive** `--json` sidecar to `scripts/test_shards.sh` (the single source of truth) and documents the gate on `make test-shard`. Normal local/Linux runs are unchanged (`exec "$native" test $files`, no `--json`).

On "No behavior change": nothing the macOS legs **build or test** changes (pass/fail, artifacts, the shipped compiler are identical). The only change is macOS-leg **log/stdout format** (JSON instead of human) and additive sidecar/metrics files — the measurement surface the issue authorizes ("timing/hit-rate logging (measurement only)").

## Acceptance Criteria
- [x] Per-leg **build/test split + both hit-rates** are emitted on macOS-arm64 (instrumentation landed).
- [ ] **Findings comment** with per-leg wall + queue + build/test split + both hit-rates → follows from this PR's own macOS run (queue/wall from the Actions API).
- [ ] **Concrete next-step recommendation** (finer shards vs. cache-restore fix vs. concurrency) → in the findings comment.
- [x] No behavior change to what's built/tested; no `.sfn` touched; Linux out of scope.

## Verification
```bash
# Local smoke (mock compiler): gated sidecar + hit-rate extraction + exit-code propagation
SAILFIN_AGENT_REPORT=1 bash scripts/test_shards.sh run unit-a <mock>   # → writes sidecar, exit propagates
bash scripts/test_shards.sh run unit-a <mock>                          # gate off → no sidecar (byte-identical)
# jq -rs 'map(select(.event=="summary"))|last|.cache.test_bin_hit_rate' sidecar  → 0.6667
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"        # YAML OK
bash -n scripts/test_shards.sh                                                    # shell OK
```
CI: the macOS build + shard legs emit `[ci-metrics] …` lines and step-summary tables. The findings comment + recommendation will be posted from this PR's macOS run.

## Files Changed
- `.github/actions/sailfin-build/action.yml` — phase timing + hit-rate capture (macOS-gated)
- `.github/workflows/ci.yml` — macOS build/test leg metrics-emit steps
- `scripts/test_shards.sh` — additive default-off `--json` sidecar
- `Makefile` — document the `test-shard` JSON gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzwQoFz5tXSF2j6o7F5upq)_