### PR TITLE
docs(license): extend Runtime Library Exception to cover standard-library capsules

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -5,11 +5,12 @@ The Sailfin compiler is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License as published
 by the Free Software Foundation; version 2 of the License.
 
-The Sailfin runtime libraries (runtime/) are distributed under the same
-license with an additional permission described in the file
-RUNTIME_LIBRARY_EXCEPTION. This exception allows programs compiled by
-Sailfin to link against the runtime libraries without those programs
-being subject to the GPL. See RUNTIME_LIBRARY_EXCEPTION for details.
+The Sailfin runtime libraries (runtime/) and standard-library capsules
+(capsules/) are distributed under the same license with an additional
+permission described in the file RUNTIME_LIBRARY_EXCEPTION. This
+exception allows programs compiled by Sailfin to link against the
+runtime libraries and the standard library without those programs being
+subject to the GPL. See RUNTIME_LIBRARY_EXCEPTION for details.
 
 The full text of the GNU General Public License version 2 is in the file
 LICENSE.

--- a/RUNTIME_LIBRARY_EXCEPTION
+++ b/RUNTIME_LIBRARY_EXCEPTION
@@ -1,6 +1,6 @@
 SAILFIN RUNTIME LIBRARY EXCEPTION
 
-Version 1.0, 11 April 2026
+Version 1.1, 24 June 2026
 
 Copyright (C) 2026 Michael Curtis <michael@sailfin.io>
 
@@ -10,13 +10,16 @@ license document, but changing it is not allowed.
 This Sailfin Runtime Library Exception ("Exception") is an additional
 permission granted by the copyright holder of the Sailfin compiler and
 runtime libraries. It applies to the source files in the runtime/
-directory of the Sailfin source distribution (the "Runtime Library").
+directory and to the standard-library capsules under the capsules/
+directory of the Sailfin source distribution (collectively, the
+"Runtime Library").
 
 The purpose of this Exception is to allow compilation of non-GPL
 (including proprietary) programs using the Sailfin compiler, so that
-such programs may use the header files, prelude, and runtime libraries
-covered by this Exception without being subject to the copyleft
-requirements of the GNU General Public License, version 2.
+such programs may use the header files, prelude, standard library, and
+runtime support routines covered by this Exception without being subject
+to the copyleft requirements of the GNU General Public License,
+version 2.
 
 0. Definitions.
 


### PR DESCRIPTION
## Summary

The `RUNTIME_LIBRARY_EXCEPTION` scopes the GPLv2 linking exception to **`runtime/` only**. But Sailfin compiles **standard-library capsules** under `capsules/sfn/**` (e.g. `sfn/json`, `sfn/strings`, `sfn/os`, `sfn/net`, `sfn/http`) directly **into every binary that imports them**. Those capsule files carry **no per-file license headers** (verified) and therefore inherit the root **GPLv2** from `LICENSE` — *without* the exception covering them.

This is a mismatch with stated intent: the public license page (`site/src/pages/license.astro:50–51`) already tells users that linking against **"the Sailfin prelude and standard library"** carries no copyleft obligation. The operative legal text did not deliver that for `capsules/`.

**Effect of the gap:** any proprietary or permissively-licensed program (or downstream product) that imports a standard-library capsule could be argued to be a derivative of GPLv2-without-exception code. This PR closes that gap.

## Changes

- **`RUNTIME_LIBRARY_EXCEPTION`** — widen the defined **"Runtime Library"** to include *"the standard-library capsules under the `capsules/` directory"* alongside `runtime/`. Purpose clause updated to name the standard library explicitly. Version bumped **1.0 → 1.1** (24 June 2026).
- **`COPYING`** — updated to state that both `runtime/` **and** `capsules/` standard-library code are distributed under GPLv2 + the exception.

No source files touched — these are the two operative license documents only. The site license page is already consistent and needs no change.

## Why extend the exception rather than relicense capsules to Apache-2.0

I considered relicensing the capsules permissively (Apache-2.0), which is what some ecosystems do for their stdlib. **Rejected** because **Apache-2.0 is incompatible with GPLv2** (it is one-way compatible with GPLv3 only, due to the patent-termination and notice provisions). The GPLv2 compiler **self-hosts using these capsules**, so an Apache-licensed capsule tree would introduce a *new* GPLv2/Apache-2.0 incompatibility inside the build. Extending the existing GCC-style exception keeps the model internally consistent (compiler = GPLv2; runtime + standard library = GPLv2 + exception) and avoids that trap.

## Scope note

The wording covers *"the standard-library capsules under `capsules/`"* — i.e. the Sailfin standard library specifically — not arbitrary third-party capsules a user might place under that path.

## Review

⚠️ **This is a license-document change and needs copyright-holder + legal sign-off.** In particular please confirm:
1. The "standard-library capsules under `capsules/`" wording is the scope you intend (vs. naming `capsules/sfn/` explicitly).
2. The **1.0 → 1.1** version bump and date are acceptable for a substantive scope change.
3. Whether you also want per-file `SPDX`/license headers added to capsule sources in a follow-up (not done here to keep this PR minimal and reviewable).

## Test plan

- [x] No code changed; self-hosting/formatting gates not applicable.
- [x] `git diff` confirms only `COPYING` and `RUNTIME_LIBRARY_EXCEPTION` are touched.

Context: surfaced during a gap analysis for building proprietary software on Sailfin; relevant to anyone shipping non-GPL programs that import the standard library, independent of any specific product.

https://claude.ai/code/session_01LsTKj6jLV1W8B42UmXqQkp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsTKj6jLV1W8B42UmXqQkp)_