### PR TITLE
feat(llvm): real array.map(closure) for int[] via by-value closure dispatch

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -512,6 +512,12 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                         if _pre_field == "concat" {
                             _pre_is_array_method = true;
                         }
+                        // #1507: `arr.map(closure)` is an array method too —
+                        // route it through the early fallback so it reaches
+                        // the `runtime_array_map_fn` helper below instead of
+                        // falling into the struct-method fusion (which would
+                        // form the bogus `<type>map` target).
+                        if _pre_field == "map" { _pre_is_array_method = true; }
                         if _pre_is_array_method {
                             if is_simple_identifier(_pre_base) {
                                 let _pre_am_local = find_local_binding(locals, _pre_base);
@@ -585,6 +591,34 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                                 helper_descriptor = make_concat_descriptor(_pre_am_type, [_pre_am_type, _pre_am_type]);
                                             }
                                         }
+                                        // #1507: route `arr.map(closure)` to the
+                                        // `runtime_array_map_fn` helper. The array
+                                        // is already injected as arg0 (method_operand
+                                        // / injected_argument_count above); the
+                                        // user's closure becomes arg1, passed by
+                                        // value as `{i8*, i8*}` (descriptor
+                                        // parameter_types[1]) to the real
+                                        // `sfn_array_sfn_map` body. The helper
+                                        // returns the mapped array as `i8*`, coerced
+                                        // to the binding's element-array type at use.
+                                        // Pointer-width `i64` element arrays only
+                                        // (the mapper ABI is `i64(i8* env, i64)`).
+                                        // `string[]` (a `{i8*, i64}` element),
+                                        // `float[]`, and struct-element arrays would
+                                        // miscompile through this i64-only body, so
+                                        // they are NOT routed — they fall through to
+                                        // an honest "callee signature is not known"
+                                        // diagnostic. Generic / non-i64 element maps
+                                        // are gated on generics (#766).
+                                        if _pre_field == "map" {
+                                            if _pre_am_elem == "i64" {
+                                                let _pre_map_desc = find_runtime_helper("runtime_array_map_fn");
+                                                if _pre_map_desc != null {
+                                                    result_target = "runtime_array_map_fn";
+                                                    helper_descriptor = _pre_map_desc;
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -598,6 +632,12 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                         _pre_struct = _pre_local.type_annotation;
                                     }
                                 }
+                                // #1507: `map` was already routed to the
+                                // `runtime_array_map_fn` helper above; clear the
+                                // struct type so the fusion below skips it (it
+                                // would otherwise overwrite the helper target
+                                // with the bogus `<type>map`).
+                                if _pre_field == "map" { _pre_struct = ""; }
                                 if _pre_struct.length > 0 {
                                     // #1041: fail closed when the base local's
                                     // declared type is a bare struct name that is

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -999,7 +999,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
 
     // Collection helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_map_fn", symbol: "sfn_array_sfn_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_map", c_abi_return_type: null
+        target: "runtime_array_map_fn", symbol: "sfn_array_sfn_map", return_type: "i8*", parameter_types: ["i8*", "{i8*, i8*}"], effects: [], native_signature: "sfn_array_sfn_map", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_array_filter_fn", symbol: "sfn_array_sfn_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_filter", c_abi_return_type: null

--- a/compiler/tests/e2e/array_map_closure_test.sfn
+++ b/compiler/tests/e2e/array_map_closure_test.sfn
@@ -1,0 +1,49 @@
+// End-to-end test for `arr.map(closure)` over a capturing lambda (#1507).
+//
+// `.map` dispatch routes to the `runtime_array_map_fn` helper, which
+// passes the `{i8*, i8*}` closure pair BY VALUE to `sfn_array_sfn_map`
+// (descriptor `parameter_types[1] = "{i8*, i8*}"`, in lockstep with the
+// runtime body's `mapper: fn(int) -> int` signature). The real runtime
+// body in `runtime/sfn/array.sfn` closure-dispatches the mapper per
+// element — the same by-value path `fn apply(cb: fn(int) -> int, x)`
+// exercises (closure_higher_order / closure_two_int_capture).
+//
+// Drives the compiler-under-test as a subprocess with the runtime
+// `process.*` builtins and asserts on captured stdout — the canonical
+// e2e pattern (see `.claude/rules/no-bash-e2e.md`, `closure_capture_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from. Mirrors
+// `sfn/test`'s `_resolve_sfn_bin` so CI can point the test at any compiler.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, plus SAILFIN_TEST_SCRATCH
+// for per-invocation build-cache isolation under the parallel pool, #1333).
+// Inherit the full parent environment — mirrors closure_capture_test.sfn.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+// Compile+run a fixture and return its exit code plus the trailing-
+// newline-normalized stdout.
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "array map: capturing lambda transforms elements (sum 36, not 6)" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/array_map_closure/main.sfn");
+    assert r.exit == 0;
+    assert r.out == "36";
+}

--- a/compiler/tests/e2e/fixtures/array_map_closure/capsule.toml
+++ b/compiler/tests/e2e/fixtures/array_map_closure/capsule.toml
@@ -1,0 +1,4 @@
+[capsule]
+name = "fixture/array-map-closure"
+version = "0.0.0"
+description = "Isolated capsule manifest for the issue #1507 array.map(closure) e2e fixture so that `discover_project_root` doesn't walk up into compiler/capsule.toml — that would inherit `sfn/runtime-native`, drag `native_driver.c` (with its own `int main`) into the link, and clobber the fixture's own `fn main()`. Mirrors `fixtures/closure_two_int_capture/capsule.toml`."

--- a/compiler/tests/e2e/fixtures/array_map_closure/main.sfn
+++ b/compiler/tests/e2e/fixtures/array_map_closure/main.sfn
@@ -1,0 +1,23 @@
+// compiler/tests/e2e/fixtures/array_map_closure/main.sfn
+//
+// Issue #1507 acceptance — `arr.map(closure)` over a capturing lambda
+// returns transformed values, not the input unchanged. `.map` dispatch
+// routes to the `runtime_array_map_fn` helper, which passes the
+// `{i8*, i8*}` closure pair by value to `sfn_array_sfn_map`; the real
+// runtime body closure-dispatches the mapper per element.
+//
+// base = 10, [1,2,3].map(x => x + base) = [11,12,13], sum = 36.
+// (A stub `map` returning the input unchanged would sum to 6.)
+fn main() ![io] {
+    let base: int = 10;
+    let xs: int[] = [1, 2, 3];
+    let ys: int[] = xs.map(fn (x: int) -> int { return x + base; });
+    let mut total: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= ys.length { break; }
+        total = total + ys[i];
+        i = i + 1;
+    }
+    print(total);
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-06-22. Seed pinned to `0.7.0-alpha.39` (`.seed-version`);
+Updated: 2026-06-23. Seed pinned to `0.7.0-alpha.39` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -111,6 +111,7 @@ doc, or `docs/runtime_architecture.md`, not here.
 | Bitwise operators (`&`, `\|`, `^`, `<<`, `>>`) | **Shipped** | Slice B; rejected on `double` operands |
 | `Result<T, E>` + `?` operator | **Shipped** | Prelude `Result`/`Error` (#832), typed `?` (`E0810`–`E0812`, #833), pure control-flow desugar (#834); spec §12. `From<E>` coercion and the `E: Error` bound gate on generic constraints |
 | Closures with capture | **Shipped** | Capture inference (#458) → env synthesis (#459) → lifting + hidden-env dispatch (#689); multi-capture fix #1106 |
+| `array.map(closure)` | **Shipped** (pointer-width int elements) | `arr.map(fn (x: int) -> int { ... })` dispatches via `runtime_array_map_fn` → `sfn_array_sfn_map` (`runtime/sfn/array.sfn`); by-value `{i8*, i8*}` closure pair; capturing closures work. Scope: pointer-width (`i64`) element arrays only — generic element types gated on #766. `filter` / `reduce` remain stubs (return input/initial unchanged, #766). E2e: `compiler/tests/e2e/array_map_closure_test.sfn` |
 | Generic type inference | Partial | Type params captured; coverage limited |
 | Generic type constraints | Planned | `fn sort<T: Comparable>`, real `Array<T>` / `HashMap<K, V>` / `Channel<T>` |
 | Raw pointer types (`*T`) enforced | Planned | Pointer-typed struct fields lower correctly (#713, seed-blocker); full typecheck enforcement pending |

--- a/runtime/sfn/array.sfn
+++ b/runtime/sfn/array.sfn
@@ -43,8 +43,11 @@
 //
 // Still under the `sfn_array_sfn_*` infix (proof-of-life, not yet
 // flipped): `create` / `push` / `slice` (spec-ABI stubs) and
-// `map` / `filter` / `reduce` (gated on generics + closures, #766).
-// Those rename to bare form when their real bodies land.
+// `filter` / `reduce` (gated on generics + closures, #766). `map` now
+// carries a real pointer-width body (#1507): the `runtime_array_map_fn`
+// descriptor passes the `{i8*, i8*}` closure by value and the body
+// closure-dispatches it per element. Those rename to bare form when
+// their real bodies land.
 //
 // Naming: the `_sfn_` infix distinguishes this module's exports from
 // the C trampolines' canonical names. The C runtime's
@@ -509,7 +512,48 @@ fn sfn_array_push_slot(data_ptr: * * u8, len_ptr: * i64, cap_ptr: * i64, elem_si
 // the descriptor arity (`["i8*","i8*"]` / `["i8*","i8*","i8*"]`)
 // matches the defined symbol's signature one-to-one — no reliance
 // on the SysV/AAPCS "extra args are ignored" rule.
-fn sfn_array_sfn_map(arr: * u8, mapper: * u8) -> * u8 { return arr; }
+// `sfn_array_sfn_map(arr, mapper) -> arr'` — real one-element-at-a-time
+// map (#1507). `mapper` is typed `fn(int) -> int` so the call
+// `mapper(elem)` below is an ordinary closure dispatch: the descriptor
+// `runtime_array_map_fn` passes the `{i8*, i8*}` closure pair by value
+// (parameter_types[1] = `{i8*, i8*}`, in lockstep with this signature),
+// and the emitter extracts the fn-ptr + env and prepends the env to the
+// call — the same path `fn apply(cb: fn(int) -> int, x)` exercises
+// (closure_two_int_capture). Pointer-width elements only (the lambda ABI
+// is `i64(i8* env, i64 arg)`); generic / typed element widths are
+// post-1.0 (gated on generics — #766). Allocates a fresh `SfnArray`
+// (`{ data @0, len @8, cap @16 }`) of `len` 8-byte slots, applies the
+// mapper to each element, and stores the result — the concat_v2 span
+// idiom. The container is freshly, uniquely owned (#1218 / E9).
+fn sfn_array_sfn_map(arr: * u8, mapper: fn (int) -> int) -> * u8 {
+    unsafe {
+        let mut len: i64 = 0;
+        let mut data: i64 = 0;
+        if (arr as i64) != 0 {
+            let l: i64 = atomic_load((arr as i64 + 8) as * i64);
+            if l > 0 { len = l; }
+            data = atomic_load(arr as * i64);
+        }
+        let out: * u8 = _sfn_array_alloc_v2(len, 8);
+        if (out as i64) == 0 { return null; }
+        // out.len = len (the allocator already wrote cap = len).
+        atomic_store((out as i64 + 8) as * i64, len);
+        let buf: i64 = atomic_load(out as * i64);
+        if buf != 0 {
+            if data != 0 {
+                let mut i: i64 = 0;
+                loop {
+                    if i >= len { break; }
+                    let elem: i64 = atomic_load((data + i * 8) as * i64);
+                    let mapped: int = mapper(elem as int);
+                    atomic_store((buf + i * 8) as * i64, mapped as i64);
+                    i = i + 1;
+                }
+            }
+        }
+        return out;
+    }
+}
 
 fn sfn_array_sfn_filter(arr: * u8, predicate: * u8) -> * u8 { return arr; }
 

--- a/site/src/content/docs/docs/reference/standard-library.md
+++ b/site/src/content/docs/docs/reference/standard-library.md
@@ -400,13 +400,20 @@ fn main() ![io] {
 
 #### `array_map(items: any[], mapper: (any) -> any) -> any[]`
 
-Apply `mapper` to each element and return a new array of results.
+Apply `mapper` to each element and return a new array of results. The
+working spelling today is the method form `arr.map(closure)` for `int[]`
+arrays (see [Arrays (available today)](#arrays-available-today) above) —
+use that:
 
 ```sfn
 let numbers = [1, 2, 3, 4];
-let doubled = array_map(numbers, fn(n: int) -> int { return n * 2; });
+let doubled: int[] = numbers.map(fn (n: int) -> int { return n * 2; });
 // [2, 4, 6, 8]
 ```
+
+This `array_map` prelude free function is a thin wrapper and remains an
+internal utility; its generic `(any) -> any` closure path is gated on
+generics (#766). Prefer the `.map` method form.
 
 #### `array_filter(items: any[], predicate: (any) -> boolean) -> any[]`
 
@@ -1081,7 +1088,7 @@ fn parse_token(raw: string) -> string ![io] {
 
 > **Coming in 1.0:** Generic containers (`Map<K, V>`, `Set<T>`, and an explicit growable `Vec<T>`) depend on generic type constraints landing first. See the [roadmap](/roadmap) for sequencing.
 >
-> Today, array literals (`[1, 2, 3]`) with `T[]` types, `.length`, `.push(item)`, and the prelude array utilities (`array_map`, `array_filter`, `array_reduce`) are the shipped collection surface.
+> Today, array literals (`[1, 2, 3]`) with `T[]` types, `.length`, `.push(item)`, `.map(closure)` (pointer-width `int` elements), and the prelude array utilities (`array_map`, `array_filter`, `array_reduce`) are the shipped collection surface. `.filter` and `.reduce` method forms are stubs pending generic type constraints (#766).
 
 ### Arrays (available today)
 
@@ -1089,8 +1096,15 @@ fn parse_token(raw: string) -> string ![io] {
 let numbers: int[] = [1, 2, 3];
 numbers.push(4);
 let n = numbers.length;        // 4
-let first = numbers[0];         // 1
+let first = numbers[0];        // 1
+
+// .map(closure) — shipped for pointer-width int arrays
+let base: int = 10;
+let shifted: int[] = numbers.map(fn (x: int) -> int { return x + base; });
+// shifted == [11, 12, 13, 14]
 ```
+
+**`.map` scope:** the element ABI is `i64(i8* env, i64 arg)`, so `.map` works on `int[]` arrays today (the binding must be annotated `int[]`). Generic element types (e.g. `float[]`, `string[]`, struct arrays) are gated on type-constraint generics (#766) and are rejected with a diagnostic rather than mis-mapped. `.filter` and `.reduce` have **no** method dispatch yet — only the prelude free functions exist and their runtime bodies are stubs (return the input array / initial value unchanged) until #766 ships.
 
 ### Planned `Vec<T>`
 


### PR DESCRIPTION
## Summary
- Wires `arr.map(closure)` end-to-end for **pointer-width `int[]` arrays**: `.map` method dispatch routes to the `runtime_array_map_fn` helper, whose descriptor now passes the `{i8*, i8*}` closure pair **by value** to a real one-element-at-a-time `sfn_array_sfn_map` body that closure-dispatches the mapper per element.
- `[1,2,3].map(fn (x: int) -> int { return x + base; })` with a captured `base` now returns transformed values (the stub returned the input unchanged).

Closes #1507

## Design note — by-value, not heap-boxed (intentional deviation)
The issue proposed a **heap-boxed** path: the closure arrives as an `i8*` box and the runtime body does `load {i8*,i8*}` before `extractvalue`. I confirmed against a real emit that passing a closure to an `i8*` param *does* heap-box it — **but** the cleaner, lower-risk path is the issue's own "flip `parameter_types` to the closure type" scope item: pass `{i8*, i8*}` **by value**, reusing the **existing** closure-HOF dispatch (`fn apply(cb: fn(int) -> int, x) { return cb(x); }`, proven by `closure_two_int_capture`). No new box-load seam, no `is_closure_dispatch` extension.

Consequence: acceptance criterion 2's literal `load {i8*,i8*}` does **not** appear — the runtime body does `extractvalue {i8*,i8*} %mapper, 0/1` → bitcast → indirect call with env prepended directly. This satisfies the criterion's *intent* (closure unpacked to fn-ptr + env, indirect call) more simply.

## Scope expansion (approved)
The issue assumed the call site already routed the closure to `runtime_array_map_fn`. It did not — `.map`/`.filter`/`.reduce` had **no** array-method dispatch (only `.push`/`.concat`), so the end-to-end acceptance criterion required wiring `.map` dispatch, which was outside the issue's original Files Affected. The maintainer approved bundling that wiring into this PR.

Scope limits (honest):
- Pointer-width `i64` element arrays only (lambda ABI is `i64(i8* env, i64 arg)`). `string[]` / `float[]` / struct-element arrays are **rejected with a diagnostic** (not mis-mapped) via an `_pre_am_elem == "i64"` guard.
- `.map` result binding must be annotated `int[]` (the helper returns `i8*`, coerced at the binding).
- `filter`/`reduce` remain stubs and have no method dispatch (#766).

## Acceptance Criteria
- [x] A `map` over a capturing lambda returns transformed values, not the input unchanged (`[1,2,3].map(x+base)` → `11,12,13`; e2e asserts sum `36`, stub would be `6`).
- [x] Emitted IR shows the closure unpacked (`extractvalue {i8*,i8*}` → bitcast → indirect call, env prepended) — via **by-value** rather than `load {i8*,i8*}` (see Design note).
- [x] Boxed-pair representation confirmed against a real emit (closes the probe; informed the by-value choice).
- [x] Descriptor `parameter_types` flip + runtime fn signature move in lockstep (`{i8*, i8*}` on both; `declare` rendered from the descriptor matches the `define`).
- [x] `make compile` self-hosts.
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Verification
```
make compile                              # self-hosts (green)
build/native/sailfin run map_int.sfn      # -> 11, 12, 13  (transformed)
build/native/sailfin run map_string.sfn   # -> diagnostic (rejected, no miscompile)
sailfin test compiler/tests/e2e -k "array map"   # PASS (out=36)
make check                                # unit 161/161, integration 36/36,
                                          # capsules 36/36, e2e 141/142
```
The single e2e miss is `work_dir_parity_test.sfn` — the heaviest test in the suite (it self-builds `-p compiler` up to 4× and compares build determinism). It is unrelated to this change (no array/map surface), and these changes are deterministic by construction. Re-running it in isolation to confirm it's parallel-pool contention rather than a determinism regression; will update the thread with the result.

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — `runtime_array_map_fn` descriptor param flip to `{i8*, i8*}`
- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — `.map` dispatch + `i64`-element guard
- `runtime/sfn/array.sfn` — real `sfn_array_sfn_map` body
- `compiler/tests/e2e/array_map_closure_test.sfn` + `fixtures/array_map_closure/` — capturing-lambda e2e
- `docs/status.md`, `site/.../reference/standard-library.md` — status sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4srYzutqdG6vv6Bnm68jU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4srYzutqdG6vv6Bnm68jU)_