### PR TITLE
fix(install): fall back to public release URL when GitHub API is unavailable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,11 +132,17 @@ log "Using release tag: ${TAG}"
 log "Using version: ${VERSION}"
 log "Expected asset: ${ASSET}"
 
-release_json="$(api "https://api.github.com/repos/${REPO}/releases/tags/${TAG}")"
-asset_id="$(printf '%s' "$release_json" | jq -r '.assets[]? | select(.name=="'"$ASSET"'") | .id' | head -n 1)"
-
-if [ -z "$asset_id" ] || [ "$asset_id" = "null" ]; then
-  die "Could not find asset '${ASSET}' in release '${TAG}'."
+# Resolve the asset id for the GitHub API download path. This call hits
+# api.github.com, whose unauthenticated/low-quota responses can be rate
+# limited (HTTP 403) — and a scoped token may not grant REST releases
+# access at all. Treat the lookup as NON-FATAL: TAG and ASSET are already
+# known (for a pinned version they are constructed without the API), so a
+# failure here just routes us to the public release-download URL below,
+# which consumes no API quota. `|| true` keeps `set -e` from aborting.
+release_json="$(api "https://api.github.com/repos/${REPO}/releases/tags/${TAG}" 2>/dev/null || true)"
+asset_id=""
+if [ -n "$release_json" ]; then
+  asset_id="$(printf '%s' "$release_json" | jq -r '.assets[]? | select(.name=="'"$ASSET"'") | .id' 2>/dev/null | head -n 1)"
 fi
 
 TMPDIR="$(mktemp -d)"
@@ -146,17 +152,47 @@ cleanup() {
 trap cleanup EXIT
 
 ARCHIVE_PATH="${TMPDIR}/${ASSET}"
-log "Downloading asset via GitHub API (id=${asset_id})…"
 
+# Auth header shared by both download paths (optional; raises API rate
+# limits and enables private-repo asset access).
 DL_AUTH_ARGS=()
 if [ -n "${GITHUB_TOKEN:-}" ]; then
   DL_AUTH_ARGS=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
 fi
-curl --fail -sSL \
-  ${DL_AUTH_ARGS[@]+"${DL_AUTH_ARGS[@]}"} \
-  -H "Accept: application/octet-stream" \
-  "https://api.github.com/repos/${REPO}/releases/assets/${asset_id}" \
-  -o "$ARCHIVE_PATH"
+
+# Primary: GitHub API asset download (handles private repos + auth). Only
+# attempted when the asset id resolved above.
+download_via_api() {
+  [ -n "$asset_id" ] && [ "$asset_id" != "null" ] || return 1
+  log "Downloading asset via GitHub API (id=${asset_id})…"
+  curl --fail -sSL \
+    ${DL_AUTH_ARGS[@]+"${DL_AUTH_ARGS[@]}"} \
+    -H "Accept: application/octet-stream" \
+    "https://api.github.com/repos/${REPO}/releases/assets/${asset_id}" \
+    -o "$ARCHIVE_PATH"
+}
+
+# Fallback: the public browser release-download URL. Needs neither the
+# REST API nor an asset id, so it survives API rate limiting / a
+# REST-restricted token for public releases.
+DIRECT_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
+download_via_direct() {
+  log "Downloading asset via release URL (${DIRECT_URL})…"
+  curl --fail -sSL \
+    ${DL_AUTH_ARGS[@]+"${DL_AUTH_ARGS[@]}"} \
+    "$DIRECT_URL" \
+    -o "$ARCHIVE_PATH"
+}
+
+if ! download_via_api; then
+  if [ -n "$asset_id" ] && [ "$asset_id" != "null" ]; then
+    log "GitHub API asset download failed; falling back to the public release URL."
+  else
+    log "GitHub API asset lookup unavailable (rate limit or restricted token); using the public release URL."
+  fi
+  download_via_direct \
+    || die "Could not download asset '${ASSET}' for release '${TAG}' via the GitHub API or ${DIRECT_URL}."
+fi
 
 # Validate archive
 if ! tar -tzf "$ARCHIVE_PATH" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- `install.sh` (invoked by `make fetch-seed`) resolved and downloaded the seed asset **exclusively** through `api.github.com`. When that API returns **403** — unauthenticated rate limiting, or a token scoped for git/MCP but not the REST releases API — the asset lookup failed and, under `set -e`, aborted the whole script, breaking `make fetch-seed` → `make compile` even though the release asset is publicly downloadable.
- This started happening today in the web/remote execution environment (the API 403s even with `GITHUB_TOKEN` set).

## What changed
- The API asset-id lookup is now **non-fatal** (`|| true`, so `set -e` doesn't abort).
- Download logic is split into two paths:
  - **Primary — GitHub API** (`releases/assets/<id>`): tried first, preserving private-repo + auth behavior. Only attempted when the asset id resolved.
  - **Fallback — public release URL** (`releases/download/<tag>/<asset>`): needs neither the REST API nor an asset id, so it survives API rate limiting / a REST-restricted token for public releases. For a pinned version the tag and asset name are already constructed without the API, so the fallback is exact.
- Both paths still send the optional `Authorization` header.

No change to the `latest` resolution path (it fundamentally needs the API to enumerate releases); the fallback targets the pinned-version path that `make fetch-seed` uses.

## Verification
End-to-end in an environment where `api.github.com` returns 403:
```text
[...] Expected asset: sailfin_0.7.0-alpha.47_linux_x86_64.tar.gz
[...] GitHub API asset lookup unavailable (rate limit or restricted token); using the public release URL.
[...] Downloading asset via release URL (https://github.com/SailfinIO/sailfin/releases/download/v0.7.0-alpha.47/...tar.gz)…
[...] Installed: .../0.7.0-alpha.47/sailfin
sfn 0.7.0-alpha.47            # installed binary runs
EOF exit 0
```
`bash -n install.sh` passes. When the API works, behavior is unchanged (API path used first).

## Files Changed
- `install.sh` — non-fatal asset lookup + public-URL download fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8BJ8dr7r2ddH8RVG8z1re

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8BJ8dr7r2ddH8RVG8z1re)_