### PR TITLE
fix(effects): make contains_code identifier-boundary aware

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -40,7 +40,7 @@ import {
     MethodDeclaration
 } from "./ast";
 import { Token, TokenKind } from "./token";
-import { substring } from "./string_utils";
+import { substring, char_code_at_text } from "./string_utils";
 import {
     ImportSymbolTable,
     empty_import_symbols,
@@ -905,9 +905,32 @@ fn collect_effects_from_text(text: string) -> EffectRequirement[] {
     return required;
 }
 
+fn _is_effect_ident_char(ch: string) -> boolean {
+    if ch.length == 0 { return false; }
+    let c = char_code_at_text(ch, 0);
+    let mut _ret: boolean = false;
+    if c >= 65 {
+        if c <= 90 { _ret = true; }
+    }
+    if c >= 97 {
+        if c <= 122 { _ret = true; }
+    }
+    if c >= 48 {
+        if c <= 57 { _ret = true; }
+    }
+    if c == 95 { _ret = true; }
+    return _ret;
+}
+
 fn contains_code(text: string, needle: string) -> boolean {
     if needle.length == 0 { return true; }
     if text.length < needle.length { return false; }
+
+    // When the needle begins with an identifier char (e.g. "spawn("),
+    // require a left identifier boundary so it does not match inside a
+    // longer identifier (e.g. "spawn(" inside "sfn_spawn("). All current
+    // heuristic needles start with a letter; see #1530.
+    let needle_starts_ident = _is_effect_ident_char(substring(needle, 0, 1));
 
     let mut index: int = 0;
     let mut in_line_comment: boolean = false;
@@ -984,7 +1007,16 @@ fn contains_code(text: string, needle: string) -> boolean {
 
         let _end_pos = index + needle.length;
         if _end_pos <= text.length {
-            if substring(text, index, _end_pos) == needle { return true; }
+            if substring(text, index, _end_pos) == needle {
+                let mut _boundary_ok: boolean = true;
+                if needle_starts_ident {
+                    if index > 0 {
+                        let _prev = substring(text, index - 1, index);
+                        if _is_effect_ident_char(_prev) { _boundary_ok = false; }
+                    }
+                }
+                if _boundary_ok { return true; }
+            }
         }
         index += 1;
     }

--- a/compiler/tests/unit/effect_checker_test.sfn
+++ b/compiler/tests/unit/effect_checker_test.sfn
@@ -11,20 +11,20 @@
 // check_tool_test.sfn preamble for the same dodge).
 import {
     Block,
+    Program,
     Decorator,
+    Statement,
     Expression,
+    SourceSpan,
+    TypeParameter,
+    TypeAnnotation,
     FieldDeclaration,
     FunctionSignature,
-    MethodDeclaration,
-    Program,
-    SourceSpan,
-    Statement,
-    TypeAnnotation,
-    TypeParameter
+    MethodDeclaration
 } from "../../src/ast";
+import { Token } from "../../src/token";
 import { EffectViolation, validate_effects } from "../../src/effect_checker";
 import { canonical_effects, is_canonical_effect } from "../../src/effect_taxonomy";
-import { Token } from "../../src/token";
 
 // -------------------------------------------------------------------
 // Builder helpers
@@ -116,6 +116,86 @@ fn _make_spawn_routine(name: string, declared_effects: string[], span_line: int)
         decorators: empty_decorators,
         is_unsafe: false
     };
+}
+
+// Build a FunctionDeclaration whose body is an arbitrary `Raw` text
+// blob, so the effect checker's `collect_effects_from_text` fallback
+// path is the only thing that runs. Used by the #1530 identifier-
+// boundary regression tests below.
+fn _make_raw_routine(name: string, declared_effects: string[], body_text: string, span_line: int) -> Statement {
+    let span = _span(span_line, 4);
+    let body_stmt = Statement.ExpressionStatement {
+        expression: Expression.Raw { text: body_text },
+        span: null
+    };
+    let body_block = Block {
+        tokens: [],
+        text: body_text,
+        statements: [body_stmt]
+    };
+    let mut empty_decorators: Decorator[] = [];
+    return Statement.FunctionDeclaration {
+        signature: _signature(name, declared_effects, span),
+        body: body_block,
+        decorators: empty_decorators,
+        is_unsafe: false
+    };
+}
+
+fn _effects_contains(effects: string[], target: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= effects.length { break; }
+        if effects[index] == target { return true; }
+        index += 1;
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------
+// #1530 — text-fallback heuristics are identifier-boundary aware
+// -------------------------------------------------------------------
+test "effect violation: sfn_spawn( in text body does not require io (#1530)" {
+    // `spawn(` inside the longer identifier `sfn_spawn(` must NOT match
+    // the `spawn(` needle — otherwise a runtime call spuriously demands
+    // ![io]. This is the false-positive that bit #1475 / PR #1519.
+    let body = "let handle = sfn_spawn(worker, payload);";
+    let stmt = _make_raw_routine("rt_spawn", [], body, 9);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 0;
+}
+
+test "effect violation: sfn_serve( and nanosleep( in text body stay clean (#1530)" {
+    // `serve(` inside `sfn_serve(` and `sleep(` inside `nanosleep(` are
+    // both interior matches and must not contribute net/clock.
+    let body = "let s = sfn_serve(handler); let _ = nanosleep(deadline);";
+    let stmt = _make_raw_routine("rt_serve_sleep", [], body, 9);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 0;
+}
+
+test "effect violation: bare spawn( in text body still requires io (#1530)" {
+    // The real surface heuristic must still fire at an identifier
+    // boundary — guard the true-positive direction.
+    let body = "spawn(worker);";
+    let stmt = _make_raw_routine("launch", [], body, 9);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 1;
+    assert violations[0].routine_name == "launch";
+    assert _effects_contains(violations[0].missing_effects, "io");
+}
+
+test "effect violation: bare serve( and sleep( in text body still require net/clock (#1530)" {
+    let body = "serve(handler); sleep(ms);";
+    let stmt = _make_raw_routine("srv", [], body, 9);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 1;
+    assert _effects_contains(violations[0].missing_effects, "net");
+    assert _effects_contains(violations[0].missing_effects, "clock");
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The effect-checker's text-fallback heuristics (`collect_effects_from_text`) used a plain substring matcher (`contains_code`) that matched a needle like `spawn(` **inside a longer identifier** such as `sfn_spawn(`, spuriously demanding `[io]`/`[net]`/`[clock]` from any routine whose body reached the `Raw` text-fallback path. This is the latent false-positive that bit #1475 / PR #1519.
- `contains_code` now requires a **left identifier boundary** when the needle begins with an identifier char, so `sfn_spawn(` no longer matches `spawn(` (and `nanosleep(` no longer matches `sleep(`, `sprint(` no longer matches `print(`, etc.). Bare surface forms (`spawn(`, `serve(`, `sleep(`, `print.`) still fire.
- Aligned with the heuristic's own stated intent (`effect_checker.sfn`: "false positives are worse than missing a hint").

Closes #1530

## Acceptance Criteria
- [x] A function whose text-fallback body calls `sfn_spawn(...)` / `sfn_serve(...)` / a `…sleep(...)`-suffixed identifier gets **no** spurious io/net/clock requirement.
- [x] The real surface heuristics still fire: bare `spawn(...)` / `serve(...)` / `sleep(...)` / `print.(…)` in the text-fallback path still contribute their effect (regression tests, both directions).
- [x] Self-hosting holds (`make compile` clean). Full `make check` runs in CI — see note below.

## Verification
```text
make compile                               → self-hosts clean (exit 0)
sailfin test effect_checker_test.sfn       → PASS (all 28 tests, incl. 4 new #1530 cases)
full suite: unit 161/161, integration 36/36, capsules 36/36 all PASS
            e2e 140/141 — only work_dir_parity_test.sfn (Error 124 = timeout)
```
The single e2e timeout is `work_dir_parity_test.sfn`, which triggers up to **three full compiler self-host builds** (`sfn build -p compiler` + `--check-determinism`) in one test and exceeds the wall-clock budget on the constrained CI-on-web container. It is unrelated to this change (the effect checker plays no role in `--work-dir` parity or binary determinism) and passes on standard runners. CI's `make check` is authoritative.

## Files Changed
- `compiler/src/effect_checker.sfn` — add `_is_effect_ident_char`; left-boundary guard in `contains_code`.
- `compiler/tests/unit/effect_checker_test.sfn` — `#1530` boundary regression tests (false-positive + true-positive, both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG1iWgA5yA943bqaBpA2Ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01CG1iWgA5yA943bqaBpA2Ue)_