### PR TITLE
fix(parser): fail closed on the `spawn:` operator form

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -132,6 +132,16 @@ enum Expression {
     // `serve(handler, port)` — accept loop dispatching to the thread pool;
     // `port` is optional to allow a configured default (§2.6.6).
     Serve { handler: Expression, port: Expression?, span: SourceSpan? },
+    // A parser-originated diagnostic node (issue #1531). The expression
+    // parser has no diagnostic channel of its own — a `success: false`
+    // result is silently swallowed into `Raw` by `expression_from_tokens`,
+    // so a malformed construct never reaches the user as an error. When an
+    // arm detects syntax that must fail closed (e.g. the internal-only
+    // `spawn:<type>` operator form), it emits this node instead, carrying
+    // the human-readable message. The typecheck walk turns it into a real
+    // `Diagnostic` (E0816), so `sfn check` exits non-zero. `message` is the
+    // full diagnostic text; `span` locates the offending token.
+    ParseError { message: string, span: SourceSpan? },
     Raw { text: string, span: SourceSpan? }
 }
 

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -411,6 +411,38 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
     if token.kind.variant == "Identifier" {
         if identifier_matches(token, "spawn") {
             let advanced = expression_tokens_advance(state);
+            // `spawn:<type>` is internal native-IR notation (like `channel:`),
+            // not user surface syntax — the future kind is always inferred
+            // from the operand, so there is no `spawn:` grammar (issue #1531).
+            // Committing to the spawn operator and then seeing `:` is a
+            // fail-closed parse error. Emit a `ParseError` node (the parser's
+            // diagnostic channel) rather than a `success: false` that
+            // `expression_from_tokens` would silently swallow into `Raw`,
+            // dropping the whole `spawn … await` statement. This fires ONLY
+            // here, in the spawn prefix-operator context — `spawn` as an
+            // ordinary identifier (`{ spawn: 1 }`, `let spawn: int = 5;`) is
+            // parsed elsewhere and is unaffected. The remaining tokens are
+            // consumed so no leftover degrades the node back to `Raw`.
+            if !expression_tokens_is_at_end(advanced) {
+                if symbol_matches(expression_tokens_peek(advanced), ":") {
+                    let head = "the `spawn:<type>` operator form is not";
+                    let mid = " supported syntax — it is internal native-IR"
+                        + " notation, not user surface syntax. Use bare"
+                        + " `spawn <expr>`; the future kind is inferred from"
+                        + " the operand's return type.";
+                    return ExpressionParseResult {
+                        state: ExpressionTokens {
+                            tokens: advanced.tokens,
+                            index: advanced.tokens.length
+                        },
+                        expression: Expression.ParseError {
+                            message: head + mid,
+                            span: source_span_from_tokens([token])
+                        },
+                        success: true
+                    };
+                }
+            }
             let operand_result = parse_expression_bp(advanced, unary_precedence());
             if !operand_result.success { return operand_result; }
             // Tag the future kind when it is statically derivable from the

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -54,6 +54,7 @@ import {
     check_interface_members,
     check_function_signature,
     detect_removed_ai_keyword,
+    make_parse_error_diagnostic,
     make_removed_keyword_diagnostic,
     make_await_non_future_diagnostic,
     make_fn_value_position_diagnostic,
@@ -1040,6 +1041,13 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
     if expression.variant == "Channel" {
         if expression.capacity == null { return []; }
         return walk_expression(expression.capacity, bindings, imports);
+    }
+    // A parser-originated diagnostic node (issue #1531): the parser emitted
+    // this for syntax that must fail closed (e.g. the internal-only
+    // `spawn:<type>` form). Surface it as a real error so `sfn check` exits
+    // non-zero instead of silently dropping the statement.
+    if expression.variant == "ParseError" {
+        return [make_parse_error_diagnostic(expression.message, expression.span)];
     }
     // #1147: a bare identifier that resolves to a function used in value
     // position (not as a call target — those are handled in the Call arm)

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -574,6 +574,24 @@ fn type_is_future(type_text: string) -> boolean {
 // cannot be determined. Inferring the kind from a bare named-function call or
 // an arbitrary expression body needs symbol/expression-type resolution that
 // is out of scope (#829); annotate the spawned lambda/fn return type instead.
+// E0816 — a parser-originated diagnostic (issue #1531). The expression
+// parser emits an `Expression.ParseError` node carrying the message when it
+// detects syntax that must fail closed (today: the internal-only
+// `spawn:<type>` operator form). The typecheck walk wraps it here so a
+// malformed construct surfaces as a real error and `sfn check` exits
+// non-zero instead of silently dropping the statement. `message` is the
+// full text supplied by the parser arm; `span` locates the offending token.
+fn make_parse_error_diagnostic(message: string, span: SourceSpan?) -> Diagnostic {
+    return Diagnostic {
+        code: "E0816",
+        severity: "error",
+        message: message,
+        file_path: "",
+        primary: token_from_name("spawn", span),
+        suggestion: null
+    };
+}
+
 fn make_spawn_unresolvable_kind_diagnostic(span: SourceSpan?) -> Diagnostic {
     let head = "`spawn` target has no declared return type, so its future";
     let mid = " kind cannot be determined. Annotate the spawned lambda/fn";

--- a/compiler/tests/unit/parser_concurrency_test.sfn
+++ b/compiler/tests/unit/parser_concurrency_test.sfn
@@ -13,7 +13,21 @@
 // convention in `parser_iife_postfix_test.sfn` (the block-scoped `let`
 // initializer path is opaque, tracked separately).
 import { Block, Expression } from "../../src/ast";
+import { typecheck_diagnostics } from "../../src/typecheck";
 import { parse_program } from "../../src/parser/mod";
+
+// True if typechecking `source` produces a diagnostic with `code`.
+fn _produces_diagnostic(source: string, code: string) -> boolean ![io] {
+    let program = parse_program(source);
+    let diags = typecheck_diagnostics(program);
+    let mut index: int = 0;
+    loop {
+        if index >= diags.length { break; }
+        if strings_equal(diags[index].code, code) { return true; }
+        index += 1;
+    }
+    return false;
+}
 
 // Initializer of the first top-level `let` in `source`.
 fn first_let_initializer(source: string) -> Expression ![io] {
@@ -86,6 +100,43 @@ test "concurrency: spawn of a named-fn call leaves kind unresolved" ![io] {
     let expr = first_let_initializer("let f = spawn worker();");
     assert expr.variant == "Spawn";
     assert strings_equal(expr.kind, "");
+}
+
+// -------------------------------------------------------------------
+// `spawn:<type>` is internal native-IR notation, NOT user surface syntax
+// (issue #1531). Committing to the `spawn` operator and then seeing `:`
+// is a fail-closed parse error: the parser emits a `ParseError` node
+// (never `Raw`, which would be silently dropped), so the malformed
+// statement surfaces as a hard error instead of vanishing.
+// -------------------------------------------------------------------
+test "concurrency: spawn-colon operator form parses to ParseError" ![io] {
+    let expr = first_let_initializer("let f = spawn:int fn() -> int { return 1; };");
+    assert expr.variant == "ParseError";
+}
+
+// The `ParseError` node surfaces as a real E0816 diagnostic through the
+// typecheck walk, so `sfn check` exits non-zero rather than silently
+// accepting the dropped statement (the fail-open footgun #1531 fixes).
+test "concurrency: spawn-colon form produces an E0816 diagnostic" ![io] {
+    assert _produces_diagnostic("let f = spawn:int fn() -> int { return 1; };", "E0816");
+}
+
+// Regression guard: `spawn` as an ordinary identifier must NOT trip the
+// `spawn:` guard. An object-literal key `spawn:` still parses to an
+// `Object` (the guard fires only in the spawn prefix-operator context).
+test "concurrency: spawn as an object-literal key is not a ParseError" ![io] {
+    let expr = first_let_initializer("let o = { spawn: 1 };");
+    assert expr.variant == "Object";
+    assert ! _produces_diagnostic("let o = { spawn: 1 };", "E0816");
+}
+
+// Regression guard: `spawn` as a binding name with a type annotation
+// (`let spawn: int = 5;`) still parses — the binding name is not in the
+// expression-prefix-operator context, so the guard does not fire.
+test "concurrency: spawn as a typed binding name is not a ParseError" ![io] {
+    let expr = first_let_initializer("let spawn: int = 5;");
+    assert expr.variant == "NumberLiteral";
+    assert ! _produces_diagnostic("let spawn: int = 5;", "E0816");
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `spawn:<type>` is internal native-IR notation (like `channel:`), **not** user surface syntax — the future kind is always inferred from the operand. Writing `spawn:int fn(){…}` previously misparsed **silently**: the lambda was never lifted, LLVM lowering dropped the whole `spawn … await` statement, and `sfn check` reported `ok` with the awaited result coming back `0`. A fail-open footgun.
- Root cause: the expression parser has **no diagnostic channel** — a `success: false` result is unconditionally swallowed into `Expression.Raw` by `expression_from_tokens`, so no malformed expression ever surfaces as an error (empirically, malformed `channel(1,2)`, garbage tokens, and unbalanced parens all reported `ok` too).
- Fix: add a real one. A first-class **`Expression.ParseError { message, span }`** node. The `spawn` prefix arm emits it when it commits to the operator and then sees `:`; the typecheck walk turns it into a hard **`E0816`** diagnostic, so `sfn check` exits non-zero. The guard fires **only** in the spawn prefix-operator context, so `spawn` as an ordinary identifier (`{ spawn: 1 }`, `let spawn: int = 5;`) is unaffected. The node is reusable by future fail-closed arms (`channel:`, `parallel`).

Closes #1531

> **Note on approach:** the issue scoped the fix to `parser/expressions.sfn` with a "return a parse error in the spawn arm" framing. Verification showed that's not mechanically possible — the parser had no way to surface a diagnostic (`success:false` → silent `Raw`). Per a design decision on this task, the chosen route was to build the **real parser diagnostic channel** the issue's intent implies, rather than the cheaper typecheck-Raw-text guard. This touches `ast.sfn` + `typecheck*.sfn` in addition to the parser.

## Acceptance Criteria
- [x] `let f = spawn:int fn() -> int { return 1; };` produces a parse error (non-zero `sfn check`) — now `error[E0816]` (exit 1)
- [x] Bare `spawn fn() -> T { … }` and `spawn foo()` still parse and run unchanged
- [x] `spawn` as an ordinary identifier still parses: object key `{ spawn: 1 }`, binding `let spawn: int = 5;`
- [x] Self-hosts (`make compile` clean, twice) — full `make check` deferred to CI (resource-bound in the dev container)

## Verification
```
$ build/native/sailfin check spawn_colon.sfn
error[E0816]: the `spawn:<type>` operator form is not supported syntax — it is internal
native-IR notation, not user surface syntax. Use bare `spawn <expr>`; the future kind is
inferred from the operand's return type.
  --> spawn_colon.sfn:4:13
   |
 4 |     let f = spawn:int fn() -> int { return 1; };
   |             ^^^^^
checked 1 files: 1 error   (exit 1)

$ build/native/sailfin test compiler/tests/unit/parser_concurrency_test.sfn
PASS  (all 24 tests passed)   # +4 new: ParseError node, E0816 diagnostic, {spawn:1} guard, `let spawn: int` guard
```
`make compile` self-hosts cleanly. `make check` was started locally but is resource-bound in this container; relying on CI for the full triple-pass gate.

## Files Changed
- `compiler/src/ast.sfn` — new `Expression.ParseError` variant (the diagnostic channel)
- `compiler/src/parser/expressions.sfn` — `spawn:` guard in the prefix arm
- `compiler/src/typecheck.sfn` — `walk_expression` arm emits the diagnostic
- `compiler/src/typecheck_types.sfn` — `make_parse_error_diagnostic` (E0816)
- `compiler/tests/unit/parser_concurrency_test.sfn` — 4 regression tests

https://claude.ai/code/session_01QRrVqmQ4hqaGdpY77Rk3tS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRrVqmQ4hqaGdpY77Rk3tS)_