### PR TITLE
refactor(test): with_tmp_dir imports sfn/fs::remove_all (drop inlined copy)

### DIFF
--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -13,6 +13,12 @@ description = "Test assertion helpers and utilities for Sailfin"
 # the same formatter `pure_assert_eq_float` already uses for fractions.
 "sfn/strings" = "*"
 
+# `with_tmp_dir`'s teardown imports `sfn/fs::remove_all` (#976) instead of
+# carrying an inlined copy. The earlier workaround (PR #1110) dropped this
+# dependency to dodge the batched cross-capsule link bug (#1113); that bug
+# is fixed (#873 slug canonicalization), so the import is restored (#1571).
+"sfn/fs" = "*"
+
 [capabilities]
 required = ["io"]
 

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -21,42 +21,11 @@
 //     already ships as the typed `Env` + `os::run_capture` API. A
 //     concurrency-aware redesign is tracked in #1107.
 //
-// Teardown is a pure-Sailfin `rm -rf` composed from the `fs.*` runtime
-// intrinsics (`deleteFile` / `exists` / `listDirectory` / `removeDirectory`).
-// No new C runtime surface is introduced.
-//
-// NOTE — why this does NOT import `sfn/fs::remove_all` (#976): the batched
-// test runner (`sailfin test <many files>`, used by CI's int-e2e-caps
-// shard) miscompiles when a non-inlined capsule is consumed by *two*
-// capsules in one invocation — only the first consumer links the capsule's
-// object; later ones fail with `undefined reference` (sfn/strings, which
-// inlines, is unaffected; sfn/fs is not). Having `sfn/test` depend on
-// `sfn/fs` made every `sfn/test` barrel test a second `sfn/fs` consumer
-// alongside `sfn/fs`'s own tests, breaking the shard (tracked as #1113).
-// Until that harness bug is fixed, `with_tmp_dir` uses `fs.*` directly — the
-// same primitives `#976`'s `remove_all` composes (and the same approach
-// `snapshot.sfn` already uses for `fs.writeFile`/`fs.createDirectory`), so
-// there is no new C and no behavioral difference. `_remove_all` below
-// mirrors `capsules/sfn/fs/src/mod.sfn::remove_all`; once the batched-link
-// bug is resolved this can switch back to importing that helper.
-// Recursively remove `path` and everything beneath it (`rm -rf`), returning
-// true when the path is gone afterward (including the no-op case where it
-// never existed). Mirrors `sfn/fs::remove_all` (#976): try the file/symlink
-// unlink first (removes dangling symlinks directly and never recurses
-// *through* a symlinked directory), treat a missing path as success, then
-// clear a real directory's children before removing the emptied directory.
-fn _remove_all(path: string) -> boolean ![io] {
-    if fs.deleteFile(path) { return true; }
-    if !fs.exists(path) { return true; }
-    let entries = fs.listDirectory(path);
-    let mut i: int = 0;
-    loop {
-        if i >= entries.length { break; }
-        let _ = _remove_all(path + "/" + entries[i]);
-        i += 1;
-    }
-    return fs.removeDirectory(path);
-}
+// Teardown delegates to `sfn/fs::remove_all` (#976) — a pure-Sailfin
+// `rm -rf` composed from the `fs.*` runtime intrinsics
+// (`deleteFile` / `exists` / `listDirectory` / `removeDirectory`). No new
+// C runtime surface is introduced.
+import { remove_all } from "sfn/fs";
 
 // Create a fresh temporary directory, hand its absolute path to `body`,
 // and recursively remove the whole tree on scope exit — on both the
@@ -86,10 +55,10 @@ fn with_tmp_dir(body: fn (string) -> int) -> int ![io] {
     }
     try {
         let result = body(dir);
-        let _ = _remove_all(dir);
+        let _ = remove_all(dir);
         return result;
     } catch (e) {
-        let _ = _remove_all(dir);
+        let _ = remove_all(dir);
         throw e;
     }
 }


### PR DESCRIPTION
## Summary

- `sfn/test`'s `with_tmp_dir` now imports `sfn/fs::remove_all` (#976) instead of carrying an inlined `_remove_all` copy; the inlined fn and its NOTE block are removed.
- `capsules/sfn/test/capsule.toml` gains `"sfn/fs" = "*"`.

PR #1110 inlined the helper to dodge the batched cross-capsule link bug (#1113) — depending on `sfn/fs` made every `sfn/test` barrel test a second `sfn/fs` consumer in the `int-e2e-caps` batch. #1113 is now fixed (#873 slug canonicalization), so the workaround is retired and recursive directory removal (symlink / TOCTOU / partial-failure handling) lives in exactly one place again. The capability surface is unchanged — `with_tmp_dir` is `[io]` either way.

Resolves the issue's `needs-discussion` gate: a first-party stdlib capsule sharing `sfn/fs` (as Go's `testing`→`os.RemoveAll` and Rust's `tempfile`→`std::fs` do) is the production-ready direction; Pike's "copying over dependency" proverb targets volatile third-party deps, not first-party reuse; and the "every test links `sfn/fs`" cost is a build-cache concern, not a coupling/correctness one. Full rationale on #1571.

Closes #1571

## Acceptance Criteria

- [x] `with_tmp_dir` calls `sfn/fs::remove_all`; the inlined `_remove_all` and its NOTE are gone.
- [x] `sfn fmt --check` clean on touched `.sfn` files.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions) — the `int-e2e-caps` batched `sfn/fs` + `sfn/test` link is green.

## Verification

```bash
# Self-host + format
make compile                                           # pass (self-hosts)
build/native/sailfin fmt --check capsules/sfn/test/src/fixtures.sfn   # clean

# The #1113 regression gate — two cross-capsule sfn/fs consumers in one batch:
build/native/sailfin test capsules/sfn/fs/tests capsules/sfn/test/tests
#   fixtures_test.sfn: with_tmp_dir (5/5) PASS, both batches link and run green
```

Full `make test` had one unrelated flaky failure — `work_dir_parity_test.sfn` timing out (`Error 124`) under parallel suite load; it passes deterministically in isolation and does not use `with_tmp_dir`/`remove_all`. Filed as #1576.

## Files Changed

- `capsules/sfn/test/src/fixtures.sfn` — swap inlined `_remove_all` for the `sfn/fs::remove_all` import.
- `capsules/sfn/test/capsule.toml` — add `sfn/fs` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qz5a7W4zr5HPaCQLJeBnt

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qz5a7W4zr5HPaCQLJeBnt)_