### PR TITLE
fix(lowering): stringify `int`/`float` `as string` casts (#1505)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -1586,6 +1586,35 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
         };
     }
 
+    // #1505: an `as string` cast must stringify its operand — the same
+    // int/float→string lowering the `{{ }}` interpolation path uses — rather
+    // than fall through to the numeric/pointer matrices below, which have no
+    // `i64 → {i8*, i64}` arm and previously emitted a non-fatal
+    // "unsupported cast" diagnostic. The null operand that left behind made
+    // the binding default to `double 0.0`, so `n as string` silently printed
+    // "0". The `{i8*, i64}` identity (operand already a string) returned early
+    // above, and pointer→string was consumed by the `_agg_cast` shim, so the
+    // operand here is a scalar numeric value. `coerce_operand_to_type` builds
+    // the proper `{i8*, i64}` aggregate (number.to_string + length recovery),
+    // so the result matches the cast's declared `string` type for both
+    // annotated and inferred bindings.
+    if target_type == "{i8*, i64}" {
+        let str_cast = coerce_operand_to_type(operand, target_type, current_temp, current_lines, true, null);
+        let mut _str_di: int = 0;
+        loop {
+            if _str_di >= str_cast.diagnostics.length { break; }
+            diagnostics.push(str_cast.diagnostics[_str_di]);
+            _str_di += 1;
+        }
+        return ExpressionResult {
+            lines: str_cast.lines,
+            temp_index: str_cast.temp_index,
+            operand: str_cast.operand,
+            diagnostics: diagnostics,
+            string_constants: lowered.string_constants
+        };
+    }
+
     if ends_with_pointer_suffix(operand.llvm_type) {
         if ends_with_pointer_suffix(target_type) {
             current_lines.push("  " + cast_name + " = bitcast " + operand.llvm_type

--- a/compiler/tests/e2e/numeric_cast_test.sfn
+++ b/compiler/tests/e2e/numeric_cast_test.sfn
@@ -178,6 +178,28 @@ test "numeric-cast: double → f32 narrowing lowers as fptrunc" ![io] {
     assert contains(body, "fptrunc double %x to float");
 }
 
+// ---- int → string stringifies (not a silent constant 0) — #1505 ----
+// Regression for #1505: `n as string` previously hit no arm of the cast
+// matrix (there is no `i64 → {i8*, i64}` numeric case), emitted a non-fatal
+// "unsupported cast" diagnostic, and returned a null operand — so the binding
+// defaulted to `double 0.0` and silently printed "0". The fix routes the
+// `as string` cast through the same int→string aggregate lowering the `{{ }}`
+// interpolation path uses: `sitofp i64 → double`, the number→string helper,
+// then `insertvalue {i8*, i64}` to build the SfnString aggregate.
+test "string-cast: int → string stringifies via the number→string aggregate (#1505)" ![io] {
+    let body = _emit_body("fn label(x: int) -> string { return x as string; }", "define {i8*, i64} @label", "int_to_string");
+    assert body.length > 0;
+    assert contains(body, "sitofp i64 %x to double");
+    assert contains(body, "insertvalue {i8*, i64}");
+}
+
+// ---- float → string stringifies (double source arm) — #1505 ----
+test "string-cast: float → string stringifies via the number→string aggregate (#1505)" ![io] {
+    let body = _emit_body("fn label(x: float) -> string { return x as string; }", "define {i8*, i64} @label", "float_to_string");
+    assert body.length > 0;
+    assert contains(body, "insertvalue {i8*, i64}");
+}
+
 // ---- pointer → bool is rejected (not ptrtoint) ----
 // Without the early `as bool` check, `ptr as bool` would lower to
 // `ptrtoint ptr to i1`, a low-bit reinterpretation rather than the


### PR DESCRIPTION
## Summary

- `int as string` (and `float as string`) silently produced `"0"` instead of the number's decimal text — a wrong-output footgun (exit 0, no diagnostic).
- Root cause: `lower_cast_expression` had no arm for a scalar-numeric operand targeting the `{i8*, i64}` SfnString aggregate, so the cast fell through to the numeric/pointer matrices, emitted a non-fatal "unsupported cast" diagnostic, and returned a **null** operand. The binding then defaulted to `double 0.0`, printed as `"0"`.
- Fix: route an `as string` cast through `coerce_operand_to_type(operand, "{i8*, i64}", …)` — the same int/float→string aggregate lowering the `{{ }}` interpolation path already uses (`sitofp` → `number.to_string` → length recovery → `insertvalue {i8*, i64}`). The new branch sits **after** the `{i8*, i64}` identity return and the pointer↔string `_agg_cast` shim, so it only catches scalar-numeric→string and yields a proper aggregate matching the cast's declared `string` type.

Closes #1505

## Acceptance Criteria
- [x] `n as string` yields `"42"`; `"C" + (n as string)` yields `"C42"` (was `"0"`/`"0"`).
- [x] No diagnostic regression; `{{ }}` interpolation path unchanged.
- [x] `make compile` self-hosts with the change.
- [x] Regression coverage added.

## Verification
```text
# Before: AB / 0 / 0 / interp 42      After: AB / C42 / 42 / interp 42
$ build/native/sailfin run repro.sfn
AB
C42
42
interp 42

# Emitted IR for `fn label(x: int) -> string { return x as string; }`
define {i8*, i64} @label(i64 %x) {
  %t1 = sitofp i64 %x to double
  %t2 = call i8* @sfn_number_to_str(double %t1)
  ...
  %t4 = insertvalue {i8*, i64} undef, i8* %t2, 0
  %t5 = insertvalue {i8*, i64} %t4, i64 %t3, 1

$ build/native/sailfin test compiler/tests/e2e/numeric_cast_test.sfn
PASS (all 12 tests passed)   # incl. 2 new #1505 regressions

$ make compile   # exit 0 — self-hosts
$ make test      # unit 161/161, integration 36/36, capsules 36/36; e2e 143/145
```

**Note on the two e2e failures:** `work_dir_parity_test.sfn` (known-flaky build-heavy test, [#1576](https://github.com/SailfinIO/sailfin/issues/1576)) and `build_json_schema_test.sfn` both **pass in isolation** and are unrelated to cast lowering (neither stringifies integers; `work_dir_parity`'s `--check-determinism` correctness leg passed — only the build-heavy import-context filename-set leg aborted under memory pressure). This change adds no module staging and is deterministic, so it cannot affect either.

## Scope note
Covers the reported source-level `int` (i64) and `float` (double) cases. Narrower numeric widths (`i32`/`i8`/`i1`/`f32`) `as string` remain unstringified — a **pre-existing** gap in `coerce_operand_to_type`'s `{i8*, i64}` target arm — but now surface an explicit diagnostic rather than the silent `"0"`. Left out of scope deliberately (issue named `int`/`float` only); worth a follow-up if narrow widths need stringifying.

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn` — new `target_type == "{i8*, i64}"` branch in `lower_cast_expression`
- `compiler/tests/e2e/numeric_cast_test.sfn` — `int → string` / `float → string` regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvnLJqAvnFE7SJyMeMqBcB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvnLJqAvnFE7SJyMeMqBcB)_