### PR TITLE
fix(cli): sfn add records dep capabilities; sfn init no longer trips build warning

### DIFF
--- a/compiler/src/cli/commands/add.sfn
+++ b/compiler/src/cli/commands/add.sfn
@@ -46,7 +46,12 @@ import {
 
 import { CliContext } from "../context";
 import { lock_add_entry, lock_get_version } from "../../lock";
-import { toml_add_dependency, toml_add_dev_dependency } from "../../toml_parser";
+import {
+    toml_add_dependency,
+    toml_add_dev_dependency,
+    toml_get_capabilities_required,
+    toml_merge_capabilities_required
+} from "../../toml_parser";
 import { substring, find_char_local } from "../../string_utils";
 import {
     _resolve_registry_url_cmd,
@@ -69,6 +74,20 @@ import {
 // positional.
 fn command_def() -> Command {
     return with_arg(with_flag(with_flag(command("add", "Add a dependency capsule to capsule.toml"), flag("dev", "Add as a dev dependency")), flag("update", "Ignore the lockfile and fetch the latest version")), arg("capsule", "Capsule to add (scope/name)"));
+}
+
+// Join capability names into a human-facing comma-separated list for
+// the propagation notice printed by `run`.
+fn _join_caps_cmd(caps: string[]) -> string {
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= caps.length { break; }
+        if i > 0 { out = out + ", "; }
+        out = out + caps[i];
+        i += 1;
+    }
+    return out;
 }
 
 // Add a dependency capsule: resolve its version (locked or from the
@@ -194,6 +213,25 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
         updated_toml = toml_add_dev_dependency(toml_text, registry_name, resolved_version);
     } else {
         updated_toml = toml_add_dependency(toml_text, registry_name, resolved_version);
+    }
+    // Propagate the dependency's required capability surface into the
+    // consumer manifest so `[capabilities] required` reflects reality
+    // (#1395). The extracted package always carries its own
+    // `capsule.toml` at the cache root (the `SFNPKG/1` payload begins
+    // with `--- path: capsule.toml`, see `publish.sfn`). Dev
+    // dependencies are build/test-time only, so their capabilities are
+    // not folded into the consumer's runtime surface.
+    if !is_dev {
+        let dep_manifest_path = cache_base + "/capsule.toml";
+        if fs.exists(dep_manifest_path) {
+            let dep_caps = toml_get_capabilities_required(fs.readFile(dep_manifest_path));
+            if dep_caps.length > 0 {
+                updated_toml = toml_merge_capabilities_required(updated_toml, dep_caps);
+                print("recorded required capabilities from " + display_name
+                    + ": "
+                    + _join_caps_cmd(dep_caps));
+            }
+        }
     }
     fs.writeFile("capsule.toml", updated_toml);
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -276,8 +276,13 @@ fn _emit_capsule_artifact_sidecar(spec_capsule_name: string, spec_version: strin
     }
     let parts = parse_scope_name(spec_capsule_name);
     if parts.scope.length == 0 {
-        print.err("[capsule-artifact] capsule name \"" + spec_capsule_name
-            + "\" is not in scope/name form; skipping sidecar");
+        // Single-segment (scope-less) names are a legitimate, supported
+        // configuration: the compiler self-host's own `name = "sailfin"`
+        // is one, and `sfn init` scaffolds bare names too (#1395). A bare
+        // name simply means "no per-capsule sidecar" — it is not an error,
+        // so skip silently rather than warning on stderr on every build.
+        // `sfn package` still surfaces a clear, actionable error at
+        // packaging time when a sidecar is genuinely required.
         return;
     }
     // Path-traversal guard: `[capsule].name` is end-user-controlled,

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -592,6 +592,35 @@ fn toml_add_dev_dependency(toml_text: string, capsule: string, version: string) 
     return _write_toml(t);
 }
 
+// Merge a list of required capabilities into an existing capsule.toml
+// text's `[capabilities] required = [...]` set and return the updated
+// text. Used by `sfn add` to propagate a dependency's required
+// capability surface into the consumer manifest (#1395). Existing
+// capabilities are preserved and duplicates are not re-added, so the
+// result is the order-stable union (consumer's existing caps first,
+// then any new caps from `caps` in argument order). Empty entries are
+// ignored; an empty `caps` list returns the text unchanged modulo
+// manifest normalization.
+fn toml_merge_capabilities_required(toml_text: string, caps: string[]) -> string {
+    let t = _parse_toml_internal(toml_text);
+    let mut ci: int = 0;
+    loop {
+        if ci >= caps.length { break; }
+        let cap = caps[ci];
+        ci += 1;
+        if cap.length == 0 { continue; }
+        let mut exists: boolean = false;
+        let mut ei: int = 0;
+        loop {
+            if ei >= t.capabilities.length { break; }
+            if strings_equal(t.capabilities[ei], cap) { exists = true; }
+            ei += 1;
+        }
+        if !exists { t.capabilities.push(cap); }
+    }
+    return _write_toml(t);
+}
+
 // Write a SailToml back to string (internal)
 fn _write_toml(toml: SailToml) -> string {
     let mut out: string = "[capsule]\n";

--- a/compiler/tests/e2e/capsule_artifact_sidecar_test.sfn
+++ b/compiler/tests/e2e/capsule_artifact_sidecar_test.sfn
@@ -313,11 +313,47 @@ test "sidecar: positional sfn build produces the output artifact" ![io] {
     // been written by an earlier test; so we assert that if the build
     // succeeded the output artifact exists.
     if exit == 0 { assert fs.exists(out_o); }
-    // No assert on sidecar absence — that is covered by the
-    // `[capsule-artifact] capsule name ... skipping sidecar` message
-    // from the actual compiler output; the important structural assertion
-    // is that no -p-specific sidecar is synthesized for positional builds,
-    // which the compiler already enforces.
+    // No assert on sidecar absence — a positional build never calls
+    // `_emit_capsule_artifact_sidecar`, so the important structural
+    // assertion is that no -p-specific sidecar is synthesized for
+    // positional builds, which the compiler already enforces.
     let ok = true;
     assert ok;
+}
+
+// Bare (scope-less) capsule name fixture (`barewidget`, binary, no deps).
+// A single-segment name is a legitimate configuration — the compiler
+// self-host's own `name = "sailfin"` is one, and `sfn init` scaffolds
+// bare names from the directory basename. `sfn build -p` must NOT emit a
+// `scope/name form` warning for it (#1395).
+fn _bare_root() -> string { return "build/sfn-sidecar-bare-test"; }
+
+fn _ensure_bare_fixture() ![io] {
+    fs.createDirectory(_bare_root() + "/src", true);
+    fs.writeFile(_bare_root() + "/capsule.toml", "[capsule]\n"
+        + "name = \"barewidget\"\n"
+        + "version = \"0.1.0\"\n\n"
+        + "[capabilities]\n"
+        + "required = [\"io\"]\n\n"
+        + "[build]\n"
+        + "kind = \"binary\"\n"
+        + "entry = \"src/main.sfn\"\n");
+    fs.writeFile(_bare_root() + "/src/main.sfn", "fn main() ![io] {\n"
+        + "    print(\"barewidget ok\");\n"
+        + "}\n");
+}
+
+// ---- Test 18: a bare (scope-less) capsule name builds without the
+// `scope/name form` warning and skips the sidecar silently (#1395) ----
+test "sidecar: bare capsule name builds without scope/name-form warning" ![io] {
+    _ensure_bare_fixture();
+    let exit = process.run_capture([_sfn_bin(), "build", "-p", _bare_root()], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    assert exit == 0;
+    // A legitimate bare name must not trip the stderr warning.
+    assert ! contains(out + err, "is not in scope/name form");
+    assert ! contains(out + err, "skipping sidecar");
+    // No per-capsule sidecar is synthesized for a scope-less name.
+    assert ! fs.exists("build/capsules/barewidget/manifest.json");
 }

--- a/compiler/tests/unit/toml_dependencies_test.sfn
+++ b/compiler/tests/unit/toml_dependencies_test.sfn
@@ -1,6 +1,10 @@
 // Regression tests for toml_get_dependencies() and capsule dependency
 // resolution helpers used by compile-time dependency resolution.
-import { toml_get_dependencies } from "../../src/toml_parser";
+import {
+    toml_get_dependencies,
+    toml_get_capabilities_required,
+    toml_merge_capabilities_required
+} from "../../src/toml_parser";
 
 // -- Local helpers for string assertions --
 fn _str_eq(a: string, b: string) -> boolean { return strings_equal(a, b); }
@@ -128,4 +132,43 @@ test "toml_get_dependencies: quoted keys preserved" {
     let deps = toml_get_dependencies(toml);
     // The toml parser strips quotes, so the key should be "sfn/special"
     assert _str_eq(_test_lookup_dep(deps, "sfn/special"), "0.5.0");
+}
+
+// -- toml_merge_capabilities_required (#1395) --
+test "merge caps: into empty required set records dep capabilities" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\n[capabilities]\nrequired = []\n\n[build]\nentry = \"src/main.sfn\"\n";
+    let merged = toml_merge_capabilities_required(toml, ["io", "net"]);
+    let caps = toml_get_capabilities_required(merged);
+    assert caps.length == 2;
+    assert _contains(merged, "\"io\"");
+    assert _contains(merged, "\"net\"");
+}
+
+test "merge caps: union preserves existing and dedupes" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\n[capabilities]\nrequired = [\"io\"]\n\n[build]\nentry = \"src/main.sfn\"\n";
+    let merged = toml_merge_capabilities_required(toml, ["io", "net"]);
+    let caps = toml_get_capabilities_required(merged);
+    // io already present, net is new — union of size 2, no duplicate io.
+    assert caps.length == 2;
+    assert _str_eq(caps[0], "io");
+    assert _str_eq(caps[1], "net");
+}
+
+test "merge caps: empty list leaves required unchanged" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\n[capabilities]\nrequired = [\"io\"]\n\n[build]\nentry = \"src/main.sfn\"\n";
+    let empty: string[] = [];
+    let merged = toml_merge_capabilities_required(toml, empty);
+    let caps = toml_get_capabilities_required(merged);
+    assert caps.length == 1;
+    assert _str_eq(caps[0], "io");
+}
+
+test "merge caps: dependency surface preserved through write round-trip" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"sfn/http\" = \"0.3.0\"\n\n[capabilities]\nrequired = []\n\n[build]\nentry = \"src/main.sfn\"\n";
+    let merged = toml_merge_capabilities_required(toml, ["io", "net"]);
+    // Dependency must survive the parse/merge/write round-trip.
+    let deps = toml_get_dependencies(merged);
+    assert _contains(deps, "sfn/http=0.3.0");
+    let caps = toml_get_capabilities_required(merged);
+    assert caps.length == 2;
 }

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -310,6 +310,8 @@ sfn add --update acme/router  # force a fresh lookup
 
 If a `capsule.lock` entry already exists and `--update` is not passed, the locked version is used without contacting the registry.
 
+When you add a (non-dev) dependency, its `[capabilities] required` set is merged into your project's `[capabilities] required` so the consumer manifest reflects the capability surface it actually pulls in. Adding an `io`+`net` capsule, for example, records `io` and `net` (deduplicated against what you already declared) and prints the capabilities it propagated. Dev dependencies are build/test-time only and are not folded into the consumer's runtime surface.
+
 ---
 
 ### `sfn publish [path]`


### PR DESCRIPTION
## Summary
- `sfn add` now propagates a (non-dev) dependency's `[capabilities] required` set into the consumer's `capsule.toml`, so the manifest reflects the capability surface it actually pulls in (and prints the propagated set). The dependency's own `capsule.toml` ships at the cache root in the `SFNPKG/1` payload, so it's read after extraction and merged via a new order-stable, deduplicated `toml_merge_capabilities_required`.
- `sfn init` derives a bare (scope-less) capsule name from the directory basename — a legitimate config the compiler self-host itself uses (`name = "sailfin"`). A bare name just means "no per-capsule sidecar", so `_emit_capsule_artifact_sidecar` now skips silently instead of warning on stderr on every build. `sfn package` still surfaces a clear, actionable error when a sidecar is genuinely required.

Closes #1395

## Acceptance Criteria
- [x] After `sfn add` of an io+net capsule, the consumer's required capabilities are recorded (and the propagated set is printed).
- [x] A freshly `sfn init`'d project builds without the scope/name-form warning.
- [x] `make compile` / `make test` pass.

## Verification
```text
build/native/sailfin init  ->  name = "sfn-smoke-1395" (bare)
build/native/sailfin build -p .  ->  "built: build/sailfin/program"  (no scope/name-form warning)

make compile                          ->  status: pass (self-host holds)
make test                             ->  unit 161/161, integration 36/36, e2e 145/145, capsules 36/36
  toml_dependencies_test.sfn          ->  11/11 (4 new merge tests)
  capsule_artifact_sidecar_test.sfn   ->  18/18 (new bare-name no-warning regression)
```

## Files Changed
- `compiler/src/cli/commands/add.sfn` — read the extracted dep manifest, merge + announce its required capabilities (non-dev only)
- `compiler/src/toml_parser.sfn` — `toml_merge_capabilities_required` (order-stable, dedup union)
- `compiler/src/cli_main.sfn` — bare-name sidecar skip is now silent (no stderr warning)
- `compiler/tests/unit/toml_dependencies_test.sfn` — merge unit coverage
- `compiler/tests/e2e/capsule_artifact_sidecar_test.sfn` — bare-name no-warning e2e regression
- `site/src/content/docs/docs/reference/cli.md` — document `sfn add` capability propagation

## Notes
- Grooming: this issue was groomed inline before pickup (added the missing `## Verification` section; `needs-grooming` → `claude-ready`). The Sailfin Tracker board could not be synced — the `sync-project-status.sh` helper shells `gh`, which is unavailable in this remote session (GitHub MCP only). Label state is correct; the project card may need a manual nudge.
- Design choice for the init warning: silencing the bare-name warning (rather than making `init` invent a scope) keeps parity with the self-host's own bare `name = "sailfin"` and avoids picking an arbitrary scope for scaffolds. Capability propagation is scoped to non-dev deps so build/test-time deps don't inflate the consumer's runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Hhu2dupBPtzS5i8jZvh4M

---
_Generated by [Claude Code](https://claude.ai/code/session_015Hhu2dupBPtzS5i8jZvh4M)_