### PR TITLE
fix(lowering): skip string literals in ternary scanner (#1003)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
@@ -330,15 +330,61 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
         };
     }
 
-    // Find '?' and ':' at the same nesting level (depth 0)
+    // Find '?' and ':' at the same nesting level (depth 0), skipping string
+    // and char literals so a `?`/`:` inside a literal (e.g. `"?a:" + x`) is
+    // never mistaken for a ternary operator (#1003).
     let mut depth: int = 0;
     let mut question_index: int = -1;
     let mut colon_index: int = -1;
     let mut index: int = 0;
+    let mut in_double: boolean = false;
+    let mut in_single: boolean = false;
+    let mut escape_next: boolean = false;
 
     loop {
         if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
+
+        if in_double {
+            if escape_next {
+                escape_next = false;
+                index += 1;
+                continue;
+            }
+            if ch == "\\" {
+                escape_next = true;
+                index += 1;
+                continue;
+            }
+            if ch == "\"" { in_double = false; }
+            index += 1;
+            continue;
+        }
+        if in_single {
+            if escape_next {
+                escape_next = false;
+                index += 1;
+                continue;
+            }
+            if ch == "\\" {
+                escape_next = true;
+                index += 1;
+                continue;
+            }
+            if ch == "'" { in_single = false; }
+            index += 1;
+            continue;
+        }
+        if ch == "\"" {
+            in_double = true;
+            index += 1;
+            continue;
+        }
+        if ch == "'" {
+            in_single = true;
+            index += 1;
+            continue;
+        }
 
         let mut _if117: boolean = false;
         if ch == "(" { _if117 = true; }

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -422,15 +422,11 @@ fn make_try_non_result_fn_diagnostic(return_type: string, span: SourceSpan?) -> 
 // coercion yet (Q2, deferred until generic constraints land). Both types
 // are named in the message.
 fn make_try_error_type_mismatch_diagnostic(operand_error: string, fn_error: string, span: SourceSpan?) -> Diagnostic {
-    // The message is assembled via intermediate `let` bindings rather than
-    // a single inline `+` chain to dodge a string-concatenation codegen
-    // bug (#1003) that lowers certain inline literal chains to an empty
-    // string. Keep the `let`-binding form until #1003 lands.
-    let head = "`?` error type mismatch: the operand's error type `";
-    let mid = "` differs from the enclosing function's error type `";
-    let tail = "`. `?` requires an exact match (no `From` coercion yet).";
-    let message = head + trim_text(operand_error) + mid + trim_text(fn_error)
-        + tail;
+    let message = "`?` error type mismatch: the operand's error type `"
+        + trim_text(operand_error)
+        + "` differs from the enclosing function's error type `"
+        + trim_text(fn_error)
+        + "`. `?` requires an exact match (no `From` coercion yet).";
     return Diagnostic {
         code: "E0812",
         severity: "error",

--- a/compiler/tests/unit/string_concat_ternary_literal_test.sfn
+++ b/compiler/tests/unit/string_concat_ternary_literal_test.sfn
@@ -1,0 +1,42 @@
+// Regression coverage for #1003: an inline string-literal `+` concat chain
+// whose literal content contains a `?` ... `:` sequence (e.g. the E0812 `?`
+// diagnostic message) miscompiled to an empty string. The LLVM-lowering
+// ternary-expression scanner (`parse_ternary_expression`) did not skip string
+// literals, so a `?`/`:` inside a literal operand was mistaken for a real
+// ternary operator; the bogus ternary lowering collapsed the whole expression
+// to `ret zeroinitializer`. The scanner now skips string/char literals.
+//
+// Assigning the segments to `let` bindings first always worked, so each case
+// pins the inline literal form that used to break.
+// Minimal trigger: a `?<x>:` sequence inside a literal that is a `+` operand.
+fn _min(a: string) -> string { return "?a:" + a; }
+
+test "concat: minimal ?<x>: literal in a + chain (#1003)" {
+    let r = _min("X");
+    assert r == "?a:X";
+    assert r.length == 4;
+}
+
+// The exact case from the issue: the E0812 `?`-operator diagnostic message.
+fn _inline(a: string, b: string) -> string {
+    return "`?` error type mismatch: the operand's error type `" + a
+        + "` differs from the enclosing function's error type `"
+        + b
+        + "`";
+}
+
+test "concat: inline ?: diagnostic chain is not empty (#1003)" {
+    let r = _inline("Error", "MyError");
+    assert r.length > 0;
+    assert r == "`?` error type mismatch: the operand's error type `Error` differs from the enclosing function's error type `MyError`";
+}
+
+// A genuine ternary alongside literal `?`/`:` content must still lower.
+fn _real_ternary(flag: boolean, a: string) -> string {
+    return flag? "q? yes:" + a: "no:" + a;
+}
+
+test "concat: real ternary with ?: literal operands still works (#1003)" {
+    assert _real_ternary(true, "X") == "q? yes:X";
+    assert _real_ternary(false, "X") == "no:X";
+}


### PR DESCRIPTION
## Summary

Fixes #1003 — an inline string-literal `+` concat chain whose literal content contains a `?` … `:` sequence miscompiled to a **silent empty string** at runtime.

### Root cause

The bug is purely in the **LLVM-lowering stage**, not the runtime concat path. Confirmed by inspecting the pipeline output for the repro:

- Native `.sfn-asm` IR is **correct** — the `ret` carries the full nested concat.
- The LLVM lowering of that `ret` collapses the whole function body to `ret {i8*, i64} zeroinitializer`.

`parse_ternary_expression` (`compiler/src/llvm/expression_lowering/native/core_parsing.sfn`) scans for a top-level `?`/`:` while tracking bracket depth — but it **did not skip string/char literals**. So for `"?a:" + a`, the `?` and `:` *inside* the string literal were treated as a real ternary operator. The bogus split produced a lone-quote `"` "condition", and the failed ternary lowering fell back to the `zeroinitializer` recovery stub.

Ternary is tried first in the precedence chain (lowest precedence), so this hijacked the entire expression before the concat finder ran.

### Bisection (minimal trigger)

```
"?a:" + a     → EMPTY (bug)
"?:"  + a     → OK     (empty ternary middle already fails the parse)
"?a:"         → OK     (single literal, never enters operator parsing)
"?a" + a + ":z" → OK   (operator chars split across operands, not a single literal)
```

The original issue content (`` `?` error type mismatch: … `` ) needed both the `?` **and** a following `:` in the same literal — exactly the ternary shape.

### Fix

Add the same `in_single` / `in_double` / `escape_next` literal-skipping that the sibling `parse_cast_expression` scanner in the same file already uses. Audited all other operator finders (logical `&&`/`||`, comparison, bitwise `|`/`^`/`&`/`<<`, cast `as`) empirically — they already skip strings; **only the ternary scanner was affected**.

### Also

- Removes the `#1003` workaround in `make_try_error_type_mismatch_diagnostic` (`typecheck_types.sfn`), restoring the inline `+` chain it was forced to split into `let` bindings — which now doubles as a real-world validation of the fix.
- Adds `compiler/tests/unit/string_concat_ternary_literal_test.sfn`: minimal trigger, the exact E0812 message from the issue, and a genuine ternary with `?:` literal operands (must still lower).

## Verification

- `make compile` — self-hosts cleanly with the fix.
- Repro now prints the full string (was `inline=[]`, now `inline=[\`?\` error type mismatch: …]`).
- New regression test: 3/3 pass.
- `string_concat_*`, `string_stress`, `string_append`, `result_question_typecheck`, `try_desugar` suites: pass.
- Full `make check` gate running.

Closes #1003

https://claude.ai/code/session_01WvPiHysnFcYLaqK7oRpznZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvPiHysnFcYLaqK7oRpznZ)_