### PR TITLE
fix(build): bust runtime sfn-source .o cache on compiler codegen change (#1197)

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -661,6 +661,42 @@ fn runtime_object_cache_key(src_path: string, opt_flag: string) -> string ![io] 
     return content + "\n" + opt_flag + "\nsecsplit1-strabi1";
 }
 
+// Compiler-identity-aware variant of `runtime_object_cache_key` for the
+// runtime sfn-source emit path (#1197).
+//
+// `runtime_object_cache_key` keys a runtime object purely on its source
+// content + opt flag + a hand-maintained ABI tag. That is correct for the
+// C / LL object path (`clang -c` output does not depend on the Sailfin
+// compiler's codegen), but it is UNSOUND for runtime `.sfn` sources, which
+// are emitted to `.ll`/`.o` BY the Sailfin compiler: a codegen change in
+// `compiler/src` alters the emitted IR of a runtime module WITHOUT touching
+// the module's source bytes, so the source-only key hits and the linker
+// silently reuses a stale object emitted by the previous compiler. That is
+// exactly the failure #1197 documents (a cast-lowering fix never reaching the
+// linked `future.sfn` runtime until a manual `rm`), and the C-runtime
+// deletion (#822/#823) made it the common case — the *entire* runtime now
+// flows through this compiler-emitted path. The historical mitigation was to
+// hand-bump the `secsplit1-strabi1` tag on every codegen-ABI change; folding
+// the compiler identity in makes that automatic.
+//
+// `compiler_identity` is the same value the `.ll` module cache mixes into
+// `cache_key_for` — `cache_compiler_identity(version, binary_path)`: the
+// build stamp (a committed codegen change bumps the `+dev.<hash>` commit
+// hash) plus, for `.dirty` stamps, the emitting binary's SHA-256 (an
+// iterative rebuild at the same commit busts the key). The determinism gate's
+// pass1→pass2 use the SAME binary, so the identity — and therefore the key —
+// is stable across those work-dirs and the shared cache still warm-hits.
+//
+// Returns "" when the base key is unhashable (propagating the
+// always-recompile fallback). An empty `compiler_identity` degrades to the
+// base key byte-for-byte (no worse than the pre-#1197 behaviour).
+fn runtime_object_cache_key_with_identity(src_path: string, opt_flag: string, compiler_identity: string) -> string ![io] {
+    let base = runtime_object_cache_key(src_path, opt_flag);
+    if base.length == 0 { return ""; }
+    if compiler_identity.length == 0 { return base; }
+    return base + "\n" + compiler_identity;
+}
+
 // Derive a content-addressed shared-cache `CacheKey` from a
 // `runtime_object_cache_key` string (#1096). The runtime object layer
 // historically cached `.o` outputs only in the per-build work-dir (a
@@ -972,6 +1008,7 @@ export {
     cache_compiler_identity,
     sha256_of_file,
     runtime_object_cache_key,
+    runtime_object_cache_key_with_identity,
     runtime_object_entry_key_from_str,
     empty_cache_stats,
     merge_cache_stats,

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -28,9 +28,11 @@ import {
     cache_store_artifact,
     cache_lookup_artifact,
     cache_copy_artifact_to,
+    cache_compiler_identity,
     runtime_object_cache_key,
     resolve_build_cache_config,
-    runtime_object_entry_key_from_str
+    runtime_object_entry_key_from_str,
+    runtime_object_cache_key_with_identity
 } from "./build_cache";
 import { emit_compiler_build_stamp_if_applicable } from "./build_stamp";
 import { CliContext, parse_driver_prefix, driver_prefix_length } from "./cli/context";
@@ -1120,7 +1122,7 @@ fn _runtime_obj_key_with_sibling_deps(base_key: string, ctx_root: string, slug: 
     return key;
 }
 
-fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string, shared_cache_root: string, ctx_root: string) -> RuntimeEmitResult ![io] {
+fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string, shared_cache_root: string, ctx_root: string, compiler_identity: string) -> RuntimeEmitResult ![io] {
     let mut stats = empty_cache_stats();
     let slug = module_name_from_path(src);
     let ll_path = _path_join(out_dir, cap_prefix + _path_basename(src)
@@ -1140,7 +1142,11 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
     // surfacing as `Undefined symbols ... link failed` (#969). This
     // mirrors the `_clang_compile_runtime_capsule_objects` c-source
     // path so the sfn-source + prelude emit invalidates identically.
-    let key = _runtime_obj_key_with_sibling_deps(runtime_object_cache_key(src, opt_flag), ctx_root, slug);
+    // #1197: fold the emitting compiler's identity into the key so a
+    // codegen change in `compiler/src` busts the cached runtime object
+    // even when the runtime source bytes are unchanged. See
+    // `runtime_object_cache_key_with_identity`.
+    let key = _runtime_obj_key_with_sibling_deps(runtime_object_cache_key_with_identity(src, opt_flag, compiler_identity), ctx_root, slug);
     if key.length == 0 { stats.invalid_keys = stats.invalid_keys + 1; }
     let shared_suffix = cap_prefix + _path_basename(src) + opt_flag;
     if _runtime_obj_cache_hit(obj_path, key) {
@@ -1244,10 +1250,14 @@ fn _runtime_sfn_ctx_root(out_dir: string) -> string {
 // (#1011) so a concurrent reader never observes a torn artifact.
 // The `native` emit stage is import-context-free by design (#906),
 // so staging order across the sfn-sources list does not matter.
-fn _stage_one_runtime_sfn_import_context(self_path: string, src: string, ctx_root: string) -> boolean ![io] {
+fn _stage_one_runtime_sfn_import_context(self_path: string, src: string, ctx_root: string, compiler_identity: string) -> boolean ![io] {
     let slug = module_name_from_path(src);
     let asm_path = ctx_root + "/" + slug + ".sfn-asm";
-    let key = runtime_object_cache_key(src, "");
+    // #1197: the staged `.sfn-asm` import-context is emitted by the
+    // compiler too, so a codegen change must bust it on the same identity
+    // basis as the `.o` emit below — otherwise a stale staged context
+    // feeds outdated sibling signatures into `_emit_runtime_sfn_to_obj`.
+    let key = runtime_object_cache_key_with_identity(src, "", compiler_identity);
     if _runtime_obj_cache_hit(asm_path, key) { return true; }
     _ensure_dir(_dirname(asm_path));
     let staged = _mktemp_sibling_cmd(asm_path);
@@ -1361,7 +1371,7 @@ fn _write_runtime_sfn_import_deps(asm_path: string, slug: string, ctx_root: stri
 // emit failure does — a missing sibling artifact would otherwise
 // surface later as the far less actionable "cannot resolve return
 // type" fatal in whichever module imports it.
-fn _stage_runtime_sfn_import_context(self_path: string, runtime_capsules: RuntimeCapsuleArtifacts[], ctx_root: string) -> boolean ![io] {
+fn _stage_runtime_sfn_import_context(self_path: string, runtime_capsules: RuntimeCapsuleArtifacts[], ctx_root: string, compiler_identity: string) -> boolean ![io] {
     let mut staged_slugs: string[] = [];
     let mut staged_asm_paths: string[] = [];
     let mut i: int = 0;
@@ -1372,7 +1382,7 @@ fn _stage_runtime_sfn_import_context(self_path: string, runtime_capsules: Runtim
         loop {
             if si >= cap.sfn_sources.length { break; }
             let src = cap.sfn_sources[si];
-            if !_stage_one_runtime_sfn_import_context(self_path, src, ctx_root) {
+            if !_stage_one_runtime_sfn_import_context(self_path, src, ctx_root, compiler_identity) {
                 return false;
             }
             let slug = module_name_from_path(src);
@@ -1435,10 +1445,18 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
             + "\")");
         return _failed_runtime_link_inputs();
     }
+    // #1197: the emitting compiler's identity, computed once and threaded
+    // into every runtime object/import-context cache key so a codegen
+    // change busts the cache without a manual `rm`. `self_path` is the
+    // binary doing the emit, so its content hash (for `.dirty` stamps) is
+    // exactly the right codegen fingerprint; tagged / clean-commit stamps
+    // carry the commit hash in the version. Computed once here (not per
+    // source) so the binary is hashed at most once per build.
+    let compiler_identity = cache_compiler_identity(resolve_compiler_version(""), self_path);
     // #1288: stage every sfn-source's import-context artifacts FIRST
     // so each module's llvm emit below can resolve sibling imports.
     let ctx_root = _runtime_sfn_ctx_root(out_dir);
-    if !_stage_runtime_sfn_import_context(self_path, runtime_capsules, ctx_root) {
+    if !_stage_runtime_sfn_import_context(self_path, runtime_capsules, ctx_root, compiler_identity) {
         return _failed_runtime_link_inputs();
     }
     let mut i: int = 0;
@@ -1450,7 +1468,7 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
         loop {
             if si >= cap.sfn_sources.length { break; }
             let src = cap.sfn_sources[si];
-            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag, shared_cache_root, ctx_root);
+            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag, shared_cache_root, ctx_root, compiler_identity);
             stats = merge_cache_stats(stats, emit.stats);
             if emit.obj_path.length == 0 {
                 return _failed_runtime_link_inputs();
@@ -1527,6 +1545,9 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
                 + "\")");
             return _failed_runtime_link_inputs();
         }
+        // #1197: same compiler-identity fold as the sfn-sources emit, so a
+        // codegen change busts the cached prelude object too.
+        let compiler_identity = cache_compiler_identity(resolve_compiler_version(""), self_path);
         let mut pi: int = 0;
         loop {
             if pi >= runtime_capsules.length { break; }
@@ -1537,7 +1558,7 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
                 // `.import-deps` sidecar — the threaded context root
                 // is inert here and the prelude keeps its legacy
                 // descriptor-based emit byte-for-byte (#940 Risk R2).
-                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag, shared_cache_root, _runtime_sfn_ctx_root(out_dir));
+                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag, shared_cache_root, _runtime_sfn_ctx_root(out_dir), compiler_identity);
                 stats = merge_cache_stats(stats, prelude_emit.stats);
                 if prelude_emit.obj_path.length == 0 {
                     return _failed_runtime_link_inputs();

--- a/compiler/tests/unit/build_cache_c_source_test.sfn
+++ b/compiler/tests/unit/build_cache_c_source_test.sfn
@@ -14,7 +14,7 @@
 // before and after a content edit and asserting key (in)equality.
 // The key is content-addressed, not mtime-addressed: a pure
 // rewrite-with-identical-bytes must reproduce the same key.
-import { runtime_object_cache_key } from "../../src/build_cache";
+import { runtime_object_cache_key, runtime_object_cache_key_with_identity } from "../../src/build_cache";
 
 // Each test gets its own tmp namespace so parallel runs don't
 // collide on `/tmp/sfn_c_source_cache_test_<X>`.
@@ -98,6 +98,78 @@ test "c-source cache: missing source yields empty key" ![io] {
     let src = scratch + "/does_not_exist.c";
 
     let key = runtime_object_cache_key(src, "-O2");
+    assert key.length == 0;
+
+    _cleanup(scratch);
+}
+
+// #1197: the runtime *sfn-source* emit path keys its `.o` via
+// `runtime_object_cache_key_with_identity`, which folds the emitting
+// compiler's identity into the base key. A codegen change in
+// `compiler/src` changes the identity (the build-stamp commit hash, or
+// the binary SHA-256 for a `.dirty` build) WITHOUT touching the runtime
+// source bytes — so the key must change and bust the stale object. The
+// source-only `runtime_object_cache_key` could not see a compiler change,
+// which is the exact stale-runtime-after-codegen-fix bug #1197 fixes.
+test "sfn-source cache: compiler identity participates in the key" ![io] {
+    let scratch = _tmp_root("identity");
+    let src = scratch + "/future.sfn";
+    fs.writeFile(src, "fn f() -> int { return 1; }\n");
+
+    let key_a = runtime_object_cache_key_with_identity(src, "-O2", "0.7.0+dev.aaaa");
+    let key_b = runtime_object_cache_key_with_identity(src, "-O2", "0.7.0+dev.bbbb");
+
+    // Same source + opt flag, different compiler identity -> distinct key.
+    assert key_a != key_b;
+    // The identity is appended after the base key, so each must end with
+    // its own identity and start with the shared base.
+    let base = runtime_object_cache_key(src, "-O2");
+    assert key_a == base + "\n0.7.0+dev.aaaa";
+    assert key_b == base + "\n0.7.0+dev.bbbb";
+
+    _cleanup(scratch);
+}
+
+// A stable identity reproduces the key, so an unchanged compiler still
+// warm-hits the cache (the determinism gate's pass1->pass2 share one
+// binary and must not thrash the runtime object cache).
+test "sfn-source cache: identical identity reproduces the key" ![io] {
+    let scratch = _tmp_root("identity_stable");
+    let src = scratch + "/string.sfn";
+    fs.writeFile(src, "fn g() -> int { return 2; }\n");
+
+    let key_1 = runtime_object_cache_key_with_identity(src, "-O0", "0.7.0+dev.cccc");
+    let key_2 = runtime_object_cache_key_with_identity(src, "-O0", "0.7.0+dev.cccc");
+
+    assert key_1 == key_2;
+
+    _cleanup(scratch);
+}
+
+// An empty identity degrades to the base key byte-for-byte, so the
+// helper is never worse than the pre-#1197 source-only behaviour when
+// the caller cannot resolve a compiler identity.
+test "sfn-source cache: empty identity degrades to the base key" ![io] {
+    let scratch = _tmp_root("identity_empty");
+    let src = scratch + "/arena.sfn";
+    fs.writeFile(src, "fn h() -> int { return 3; }\n");
+
+    let base = runtime_object_cache_key(src, "-O2");
+    let with_empty = runtime_object_cache_key_with_identity(src, "-O2", "");
+
+    assert with_empty == base;
+
+    _cleanup(scratch);
+}
+
+// An unhashable source still yields an empty key even with an identity,
+// preserving the always-recompile fallback (identity can never resurrect
+// a key the base helper rejected).
+test "sfn-source cache: missing source yields empty key despite identity" ![io] {
+    let scratch = _tmp_root("identity_missing");
+    let src = scratch + "/nope.sfn";
+
+    let key = runtime_object_cache_key_with_identity(src, "-O2", "0.7.0+dev.dddd");
     assert key.length == 0;
 
     _cleanup(scratch);

--- a/docs/status.md
+++ b/docs/status.md
@@ -35,7 +35,22 @@ doc, or `docs/runtime_architecture.md`, not here.
   stderr (Stage C PR1–1f, #254–#259). Runtime C/LL/sfn objects share the same
   cache across work-dirs (#915, #1096). `sfn test` content-addresses each
   linked test binary, cross-commit-stable (#1230, #1233); `make check` passes
-  `--no-test-cache` so the full gate always cold-builds.
+  `--no-test-cache` so the full gate always cold-builds. **Runtime object
+  invalidation (#1197):** with the C runtime retired (#822/#823) the entire
+  runtime is now `sfn-sources` (`runtime/capsule.toml`) emitted by the Sailfin
+  compiler, so a codegen change in `compiler/src` alters a runtime module's IR
+  without touching its source bytes. The runtime sfn-source `.o` (and
+  `.sfn-asm` import-context) cache therefore folds the emitting compiler's
+  identity (`cache_compiler_identity` — the build-stamp commit hash, plus the
+  binary SHA-256 for `.dirty` stamps) into its key, so a recompiled compiler
+  busts the cache automatically — no manual `secsplit*` tag bump or
+  `rm build/sailfin/*.o`. Which binary emits the runtime: during a cold
+  `make compile` the *seed* emits the first-pass binary's runtime, so a
+  runtime codegen fix only reaches the linked runtime after the *next* pass
+  emits it (the first-pass binary re-emits for `seedcheck`, and `make check`'s
+  test binaries link those first-pass-emitted objects); a codegen fix that must
+  change the runtime shipped in `build/native` therefore still requires a fresh
+  seed pin (same seed dependency as #1193's E0808 class).
 - **Per-capsule artifacts.** `sfn build -p` writes
   `build/capsules/<scope>/<name>/` with a `manifest.json` sidecar
   (schema v1) enumerating per-module IR + cache keys (Stage C2, #261–#264).


### PR DESCRIPTION
## Summary

Closes #1197.

**The bug is still live — and the C-runtime deletion made it the common case.** The runtime sfn-source object cache keyed each `.o` purely on source content + opt flag + a hand-maintained ABI tag (`runtime_object_cache_key`), with **no input identifying the emitting compiler**. Because the runtime modules are emitted to `.ll`/`.o` *by* the Sailfin compiler, a codegen change in `compiler/src` alters a module's IR without touching its source bytes — so the source-only key hit and the linker silently relinked a stale object from the *previous* compiler. That is exactly #1197's failure (a cast-lowering fix never reaching the linked `future.sfn` runtime until a manual `rm`).

Since `runtime/native/` was deleted (#822/#823), `c-sources`/`ll-sources` are empty and the **entire** runtime (23 sfn modules + the prelude, `runtime/capsule.toml`) now flows through this compiler-emitted, identity-blind cache — so the stale-runtime-after-codegen-fix hazard went from a few modules to the whole runtime.

## Fix

Fold the emitting compiler's identity into the runtime sfn-source `.o` **and** `.sfn-asm` import-context cache keys, reusing the mechanism the `.ll` module cache already proved (`cache_compiler_identity`):

- **`build_cache.sfn`** — new `runtime_object_cache_key_with_identity(src, opt_flag, compiler_identity)` appends `cache_compiler_identity`'s value to the base key: the build-stamp commit hash (a committed codegen change bumps `+dev.<hash>`), plus the binary SHA-256 for `.dirty` stamps (an iterative rebuild at the same commit busts it). An empty identity degrades to the base key byte-for-byte.
- **`cli_main.sfn`** — resolve the identity once per build from the emitting binary (`self_path`) + `resolve_compiler_version`, threaded into `_emit_runtime_sfn_to_obj`, `_stage_runtime_sfn_import_context`/`_stage_one_runtime_sfn_import_context`, and the prelude-entry emit. The C/LL-source path is untouched (clang output doesn't depend on Sailfin codegen; those lists are empty anyway).
- **Tests** — 4 regression tests in `build_cache_c_source_test.sfn` (identity participates, stable identity reproduces, empty degrades to base, missing source stays empty).
- **`docs/status.md`** — AC3 note: which binary emits the runtime cold-build vs tests, and the residual seed dependency for a fix that must change the runtime shipped in `build/native`.

## Determinism / self-host safety

The determinism gate's pass1→pass2 use the **same** binary → identical identity → identical key → the shared cache still warm-hits (no `hit_rate` regression). During cold `make compile` the seed emits the first-pass binary's runtime (seed identity); the first-pass binary re-emits for `seedcheck` under its own identity, so `make check`'s test binaries link runtime objects produced by the first-pass binary — satisfying the issue's AC2.

## Acceptance criteria

- [x] Codegen change + `make compile` re-emits affected runtime sfn-sources without a manual `rm` (identity busts the key).
- [x] `make check`'s test binaries link runtime objects produced by the first-pass binary.
- [x] Documented: which binary emits the runtime cold-build vs tests, and the seed dependency.

## Verification

- `make compile` (self-host) — **pass**.
- `build_cache_c_source_test.sfn` — 8/8 pass; `build_cache_test.sfn` — 66/66 pass.
- `sfn fmt --check` clean on all touched `.sfn` files.
- End-to-end: a real `make compile` writes runtime `.o.key` sidecars carrying `…+dev.<commit>.dirty+bin.<sha256>`, confirming the identity is folded into the live key.

https://claude.ai/code/session_011nupRn6Cs8cFMbxG5bzj2m

---
_Generated by [Claude Code](https://claude.ai/code/session_011nupRn6Cs8cFMbxG5bzj2m)_