### PR TITLE
test(check): lock check/build agreement on module-global init (#1389)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,12 @@ and `make check` are different tools, not fast/slow versions of the same one:
 1. **`sfn check <files>`** — fast static analysis (parse + typecheck + effect-check),
    no IR / `clang` / self-host. Seconds for a few files, ~5 min for the whole
    `compiler/src/` tree. Use it as the **inner loop** after every edit. It catches
-   type, effect, and parse errors but does **not** prove self-hosting.
+   type, effect, and parse errors but does **not** prove self-hosting. Because it
+   models no codegen or link, a narrow class of **build-only failures can still pass
+   `check`** — `check` green is not a build guarantee (#1389). The known instance
+   (runtime-evaluated module globals failing at link, #1386) is fixed and guarded by
+   `compiler/tests/e2e/check_build_agree_module_global_test.sfn`; clear the bar with
+   `make compile` before declaring any `compiler/src/*.sfn` change done.
 2. **`make compile`** — self-hosts the compiler. Required before committing any
    `compiler/src/*.sfn` change (the self-host invariant).
 3. **`make check`** — full triple-pass self-host + suite (~15–20 min). Reserve for

--- a/compiler/tests/e2e/check_build_agree_module_global_test.sfn
+++ b/compiler/tests/e2e/check_build_agree_module_global_test.sfn
@@ -1,0 +1,91 @@
+// End-to-end regression for #1389 (P4): `sfn check` must not report a
+// false green on a program that then fails `sfn build` at link.
+//
+// The original symptom (#1386 repro): a module-level global whose
+// initializer needs runtime evaluation — `let mut xs: int[] = [];` —
+// returned `checked 1 files: ok` from `sfn check`, then failed
+// `sfn build` with `use of undefined value '@sailfin_module_init__'`
+// (link failed, clang exit=1). Static analysis does not model the
+// module-global init-emission path, so the gap was invisible to check.
+//
+// #1386 defined `@sailfin_module_init__` end-to-end, so the specific
+// unbuildable-global class disappears: check and build now AGREE on a
+// representative module-global program (both succeed). This test locks
+// that agreement so the false-green cannot silently return.
+//
+// Contract note (the residual, documented gap): `sfn check` is parse +
+// typecheck + effect-check ONLY — it never emits IR or links — so it
+// cannot, by construction, catch every codegen/link-only failure. This
+// test asserts agreement on the once-broken class, not that check is a
+// build oracle (see site .../reference/cli.md and CLAUDE.md's validation
+// ladder for the full contract).
+//
+// Build/parallel-runner hygiene (temp-dir build, full inherited env via
+// `process.environ()` for the nested clang/ld toolchain + per-invocation
+// SAILFIN_TEST_SCRATCH) mirrors module_global_runtime_init_test.sfn —
+// see `.claude/rules/no-bash-e2e.md` for the why. `check` emits no IR,
+// so it needs no build-cache isolation and runs outside `with_tmp_dir`.
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// The representative module-global program: an empty-array-literal global
+// (the #1386/#1389 repro) plus a runtime mutation in `main`. Before the
+// fix this checked green but failed to link.
+fn _repro_src() -> string {
+    return "let mut xs: int[] = [];\n"
+        + "fn main() ![io] { xs.push(1); print(\"ok\"); }\n";
+}
+
+// Inherit the full parent environment so the nested clang/ld the build
+// spawns find their toolchain (a minimal PATH-only set links on Linux but
+// fails on macOS, #1410), and SAILFIN_TEST_SCRATCH routes the build cache
+// per-invocation (#1333). Mirrors module_global_runtime_init_test.sfn.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// A fresh out-of-tree source path for the shared check/build input.
+// (Survives `with_tmp_dir` teardown; this test owns the filename, so no
+// cross-test collision under the parallel pool.)
+fn _scratch_src() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-1389-check-build-agree.sfn";
+    fs.writeFile(path, _repro_src());
+    return path;
+}
+
+test "check/build agree: runtime-initialized module global is not a false green (#1389)" ![io] {
+    let srcpath = _scratch_src();
+
+    // `sfn check`: parse + typecheck + effect-check, no codegen. Safe to
+    // run anywhere — it writes no `program.ll`.
+    let check_exit = process.run_capture([_sfn_bin(), "check", srcpath], _child_env());
+    let _co = process.capture_take_stdout();
+    let _ce = process.capture_take_stderr();
+
+    // `sfn build`: full codegen + link. This is where the missing
+    // `@sailfin_module_init__` definition used to surface as a link
+    // failure while check stayed green. Isolated in a temp dir.
+    let build_exit = with_tmp_dir(fn (dir: string) -> int {
+        let binpath = dir + "/repro";
+        let be = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        return be;
+    });
+
+    if fs.exists(srcpath) { fs.deleteFile(srcpath); }
+
+    // check reports the program clean...
+    assert check_exit == 0;
+    // ...and build agrees by succeeding (pre-#1386 this was the link
+    // failure that made check a false green).
+    assert build_exit == 0;
+    // The agreement itself: check's verdict matches build's outcome.
+    assert check_exit == build_exit;
+}

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -213,6 +213,8 @@ Typecheck codes (`E0001`, `E0301`, `E0302`) are shared with the regular compilat
 
 **Why:** A full `make compile` takes many minutes; `sfn check` gives you the parse/typecheck/effect verdict in seconds. Use it during editing, wire it into pre-commit hooks, or run it from CI as an early-gate before the full build.
 
+**Limitations — `check` is not a build oracle:** `sfn check` runs *parse + typecheck + effect-check only*. It never emits `.sfn-asm`/LLVM IR or invokes `clang`/the linker, so by construction it cannot catch failures that surface only during codegen or linking. A `check` green therefore does **not** guarantee `sfn build` succeeds — run `sfn build` (or `make compile`) for that. The historical instance of this gap (runtime-evaluated module globals such as `let mut xs: int[] = [];` checking green but failing at link with `use of undefined value '@sailfin_module_init__'`) was fixed in the emitter, so `check` and `build` now agree on that class; the agreement is locked by `compiler/tests/e2e/check_build_agree_module_global_test.sfn`.
+
 ---
 
 ### `sfn build <file>`


### PR DESCRIPTION
## Summary

Closes #1389 (P4 of epic #1385).

#1389 asked: stop `sfn check` reporting success on programs that fail `sfn build` at link (false-green inner loop). The original symptom from #1386 — a runtime-initialized module global `let mut xs: int[] = [];` returning `checked 1 files: ok` then failing `sfn build` with `use of undefined value '@sailfin_module_init__'`.

**#1386 has since landed (closed/completed)**, defining `@sailfin_module_init__` end-to-end. Verified against the current self-hosted compiler that the original false-green is gone — `check`, `build`, and `run` now all agree:

```
$ printf 'let mut xs: int[] = [];\nfn main() [io] { xs.push(1); print("ok"); }\n' > /tmp/g.sfn
$ sailfin check /tmp/g.sfn   # checked 1 files: ok   (exit 0)
$ sailfin build /tmp/g.sfn   # built                 (exit 0)
$ /tmp/g.bin                 # ok                     (exit 0)
```

So the issue resolves on the **option (b)** contract from its own Scope: `check` is *parse + typecheck + effect-check, not codegen/link*, with the residual gap documented.

## Changes

- **Regression test** `compiler/tests/e2e/check_build_agree_module_global_test.sfn`: writes the representative module-global program, runs `sfn check` then `sfn build`, and asserts they **agree** (both succeed). Locks the once-broken class so the false-green cannot silently return. Follows the no-bash-e2e build-isolation pattern (`with_tmp_dir` + `process.environ()` + `SAILFIN_TEST_SCRATCH`).
- **Docs**: explicitly document the by-construction check↔build gap (check models no codegen/link, so a narrow class of build-only failures can still pass check) in the CLAUDE.md validation ladder and the `sfn check` CLI reference.

## Acceptance criteria

- [x] After #1386 lands, the original false-green disappears naturally; test asserts `check` and `build` agree on a representative module-global program.
- [x] Remaining check/build divergence is documented in the validation-ladder section of CLAUDE.md / docs.
- [x] No `compiler/src/` changes — self-host invariant untouched; new test + the related `module_global_runtime_init_test` / `check_compiler_src_test` pass.

## Verification

```bash
sailfin test compiler/tests/e2e/check_build_agree_module_global_test.sfn   # PASS (1/1)
sailfin test compiler/tests/e2e/module_global_runtime_init_test.sfn        # PASS (1/1)
sailfin test compiler/tests/e2e/check_compiler_src_test.sfn                # PASS (1/1)
```

https://claude.ai/code/session_012n6nDAhHmP9UqgFUEcijg2

---
_Generated by [Claude Code](https://claude.ai/code/session_012n6nDAhHmP9UqgFUEcijg2)_