### PR TITLE
fix(runtime): reap fire-and-forget serve tasks (detached path)

### DIFF
--- a/compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn
+++ b/compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn
@@ -339,3 +339,36 @@ test "scheduler: emit produces the task-invocation surface (#1089)" ![io] {
     assert contains(join_body, "load atomic i64, i64* ");
     assert contains(join_body, "call i32 @pthread_cond_wait(");
 }
+
+// ---- 7. detached fire-and-forget reclaim (#1203) ----
+// A detached task (no joiner — `sfn_serve`'s per-connection tasks) is
+// reclaimed by the pool worker after it runs, instead of leaking one `Task`
+// per fire-and-forget submission. Pins the emit shape of that lifecycle:
+//   - `sfn_task_create_detached` is defined and SETS the detached flag
+//     (a plain `store i64 1` into the `Task.detached` slot — the flag the
+//     worker reads to decide reclaim).
+//   - `sfn_scheduler_worker` runs each task (`@sfn_task_run`) and then
+//     CONDITIONALLY reclaims it (`@sfn_task_destroy` under a `br i1`), so a
+//     joinable task (flag 0) is left for its joiner while a detached task is
+//     freed by the worker.
+test "scheduler: detached tasks are reclaimed by the worker (#1203)" ![io] {
+    let ir = _emit_scheduler_ir();
+    assert ir != "EMIT_FAILED";
+
+    // The detached constructor exists and flips the flag to 1.
+    assert _has_define(ir, "sfn_task_create_detached");
+    let det_body = _define_body(ir, "sfn_task_create_detached");
+    assert det_body.length > 0;
+    assert contains(det_body, "store i64 1");
+    // It builds on the base constructor (which zero-inits `detached`).
+    assert contains(det_body, "@sfn_task_create(");
+
+    // The worker runs the task then conditionally destroys it: the
+    // fire-and-forget reclaim path. A `br i1` guards the destroy so the
+    // joinable path (flag 0) is untouched.
+    let worker_body = _define_body(ir, "sfn_scheduler_worker");
+    assert worker_body.length > 0;
+    assert contains(worker_body, "@sfn_task_run(");
+    assert contains(worker_body, "@sfn_task_destroy(");
+    assert contains(worker_body, "br i1 ");
+}

--- a/compiler/tests/e2e/runtime_serve_test.sfn
+++ b/compiler/tests/e2e/runtime_serve_test.sfn
@@ -211,7 +211,11 @@ test "serve emit: references the M4.1 scheduler/task externs" ![io] {
     let ir = _emit_module("serve", "runtime/sfn/concurrency/serve.sfn");
     assert ir != "EMIT_FAILED";
     assert _references(ir, "sfn_taskqueue_create");
-    assert _references(ir, "sfn_task_create");
+    // Per-connection tasks are fire-and-forget, so serve uses the detached
+    // constructor (#1203) — NOT the joinable `sfn_task_create` — so the pool
+    // worker reclaims each `Task` and the server stops leaking one per
+    // connection.
+    assert _references(ir, "sfn_task_create_detached");
     assert _references(ir, "sfn_taskqueue_enqueue");
     assert _references(ir, "sfn_scheduler_create");
 }

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -945,6 +945,14 @@ spawn+await.
 listening socket, dispatching each connection to the thread pool. Blocking
 accept, thread-pool dispatch. No async I/O in v0.
 
+Per-connection tasks are **detached** (fire-and-forget): the server never
+joins them, so they are created via `sfn_task_create_detached` and the pool
+worker that runs each one reclaims its `Task` after the body returns
+(`sfn_scheduler_worker`, #1203). Without this the server leaked one `Task`
+per connection — unbounded under sustained load. The joinable `spawn`/`await`
+path is unchanged: those tasks set `detached = 0` and are reclaimed by their
+joiner.
+
 #### 2.6.7 Routine Nursery (Structured Concurrency)
 
 `routine { }` is a structured-concurrency boundary, not a plain block. It

--- a/runtime/sfn/concurrency/channel.sfn
+++ b/runtime/sfn/concurrency/channel.sfn
@@ -367,8 +367,14 @@ fn sfn_channel_destroy(ch: * u8) -> void {
 // discipline as the scheduler).
 //
 // Task byte size (max-sized handles): four i64s (32) + PthreadCond (48) +
-// PthreadMutex (64) = 144 bytes.  Mirrors scheduler.sfn's Task.
-fn _sfn_task_struct_size_ch() -> i64 { return 144; }
+// PthreadMutex (64) + `detached` i64 (8) = 152 bytes.  Mirrors
+// scheduler.sfn's Task — MUST stay byte-identical: a task allocated here can
+// be run by the shared pool worker (`sfn_scheduler_worker`), which reads the
+// `detached` flag at offset 144 to decide whether to reclaim it. An
+// undersized (144-byte) allocation would make that read overrun the buffer
+// (#1205-class). Keep this in lockstep with `scheduler.sfn`'s
+// `_sfn_task_struct_size`.
+fn _sfn_task_struct_size_ch() -> i64 { return 152; }
 
 fn sfn_spawn_task(fn_ptr: * u8) -> * u8 {
     // Allocate the task via malloc.
@@ -376,17 +382,22 @@ fn sfn_spawn_task(fn_ptr: * u8) -> * u8 {
     if task_ptr as i64 == 0 { return null; }
 
     // Zero the allocation: fn_ptr at offset 0, ctx at 8, result at 16,
-    // done at 24.  Use offset arithmetic (same split-statement pattern
-    // as sfn_task_run / sfn_task_join in scheduler.sfn).
+    // done at 24, detached at 144.  Use offset arithmetic (same
+    // split-statement pattern as sfn_task_run / sfn_task_join in
+    // scheduler.sfn).  `detached` is zeroed so the shared pool worker treats
+    // this task as joinable and never reclaims it (v0 join-without-destroy),
+    // matching the scheduler's default `sfn_task_create` discipline.
     let base: i64 = task_ptr as i64;
     let fn_slot: * i64 = base as * i64;
     let ctx_slot: * i64 = (base + 8) as * i64;
     let result_slot: * i64 = (base + 16) as * i64;
     let done_slot: * i64 = (base + 24) as * i64;
+    let detached_slot: * i64 = (base + 144) as * i64;
     atomic_store(fn_slot, fn_ptr as i64);
     atomic_store(ctx_slot, 0);
     atomic_store(result_slot, 0);
     atomic_store(done_slot, 0);
+    atomic_store(detached_slot, 0);
 
     return task_ptr;
 }

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -108,8 +108,27 @@ struct PthreadCond {
 // atomic intrinsics (0 = pending, 1 = complete). `cond` / `mutex`
 // are embedded by value: the awaiter blocks on `cond` under
 // `mutex` until the worker sets `done` and signals (§2.6.3).
+//
+// `detached` (#1203) is the fire-and-forget flag: 0 = joinable (a joiner
+// calls `sfn_task_join` then `sfn_task_destroy`), 1 = detached (no joiner —
+// the pool worker that runs it reclaims the handle itself after
+// `sfn_task_run` returns, in `sfn_scheduler_worker`). It is the **last**
+// field so `done` keeps its offset-24 slot (reached by raw offset
+// arithmetic) and the embedded `cond`/`mutex` keep their offsets — adding
+// it disturbs no existing layout dependency. It is written once at create
+// time (before the task is enqueued / made visible to a worker) and read
+// once by the worker before it runs the body, so a plain (non-atomic) load
+// suffices: the enqueue/dequeue queue mutex already establishes the
+// producer→worker happens-before.
+//
+// Shared-layout invariant: `channel.sfn::sfn_spawn_task` allocates a Task by
+// this same layout and `future.sfn` treats it opaquely — any Task a shared
+// pool worker may run MUST carry this `detached` slot (zeroed unless
+// genuinely detached) or the worker's offset-144 read overruns the
+// allocation (#1205-class). Keep `_sfn_task_struct_size` and the
+// `channel.sfn` mirror in lockstep with this struct.
 // Layout (max-sized handles): four i64s (32 B) + PthreadCond (48 B) +
-// PthreadMutex (64 B) = 144 bytes.
+// PthreadMutex (64 B) + `detached` i64 (8 B) = 152 bytes.
 struct Task {
     fn_ptr: i64;
     ctx: i64;
@@ -117,6 +136,7 @@ struct Task {
     done: i64;
     cond: PthreadCond;
     mutex: PthreadMutex;
+    detached: i64;
 }
 
 // Shared MPMC task queue — a fixed-capacity ring buffer of `Task`
@@ -521,9 +541,11 @@ fn sfn_scheduler_resolve_thread_count() -> i64 {
 // signals `Task.cond`. The done flag + cond/mutex live by value in the
 // `Task` (see the struct header) so no extra allocation is needed.
 // `Task` byte size (max-sized handles): four i64s (32 B) +
-// PthreadCond (48 B) + PthreadMutex (64 B) = 144 bytes. Tracks the
-// struct above; the allocator path is the only layout dependency.
-fn _sfn_task_struct_size() -> i64 { return 144; }
+// PthreadCond (48 B) + PthreadMutex (64 B) + `detached` i64 (8 B) = 152
+// bytes. Tracks the struct above; the allocator path is the only layout
+// dependency. The `channel.sfn` mirror (`_sfn_task_struct_size_ch`) must
+// match.
+fn _sfn_task_struct_size() -> i64 { return 152; }
 
 // Byte offset of `Task.done` (field 4) — three leading i64s precede it.
 // `done` is reached by offset arithmetic rather than `& task.done`
@@ -549,6 +571,13 @@ fn sfn_task_create(fn_ptr: i64, ctx: i64) -> * u8 {
     task.ctx = ctx;
     task.result = 0;
     task.done = 0;
+    // Joinable by default — a worker must NOT reclaim it; the joiner does
+    // (`sfn_task_join` + `sfn_task_destroy`). `sfn_task_create_detached`
+    // flips this to 1. Initialising it explicitly is load-bearing: the
+    // malloc'd bytes are otherwise garbage, and a nonzero `detached` would
+    // make the worker free a still-joinable task (use-after-free /
+    // double-free).
+    task.detached = 0;
 
     let mutex_rc: i32 = pthread_mutex_init(task.mutex, null);
     if mutex_rc != 0 {
@@ -561,6 +590,23 @@ fn sfn_task_create(fn_ptr: i64, ctx: i64) -> * u8 {
         free(task_ptr);
         return null;
     }
+    return task_ptr;
+}
+
+// `sfn_task_create_detached(fn_ptr, ctx)` builds a fire-and-forget task
+// (#1203): identical to `sfn_task_create` but with `detached = 1`, so the
+// pool worker that runs it reclaims the handle in `sfn_scheduler_worker`
+// after `sfn_task_run` returns — there is no joiner. Used by `sfn_serve`'s
+// per-connection tasks (`serve.sfn`), which were never joined or destroyed
+// and so leaked one `Task` per connection (unbounded under sustained load).
+// Returns the task address as `* u8`, or null on the same OOM /
+// `pthread_*_init` failure paths as `sfn_task_create`. The `detached` write
+// happens-before the task is enqueued, so the worker observes it.
+fn sfn_task_create_detached(fn_ptr: i64, ctx: i64) -> * u8 {
+    let task_ptr: * u8 = sfn_task_create(fn_ptr, ctx);
+    if task_ptr as i64 == 0 { return task_ptr; }
+    let t: * Task = task_ptr as * Task;
+    t.detached = 1;
     return task_ptr;
 }
 
@@ -643,12 +689,26 @@ fn sfn_task_join(task: * u8) -> * u8 {
 // pulled task is run via `sfn_task_run` (#1089) — invoke `fn_ptr(ctx)`,
 // store the result, set `done`, signal the task cond; the pull itself is
 // recorded in `Scheduler.processed` by `sfn_scheduler_next_task`.
+//
+// Detached reclaim (#1203): a fire-and-forget task has no joiner, so the
+// worker is its last owner and destroys it after running it. The
+// `detached` flag is snapshotted BEFORE `sfn_task_run`: once `sfn_task_run`
+// sets `done` and signals, a JOINABLE task's joiner is free to wake and
+// reclaim the handle, so reading any field of `task` after the run would
+// race that free (use-after-free). Before the run no joiner can be active
+// (it blocks on `done`, still 0), so the pre-run read is safe; the snapshot
+// then decides the reclaim without touching freed memory. Joinable tasks
+// (`detached == 0`) are left untouched — reclaimed by the joiner, exactly
+// as before.
 fn sfn_scheduler_worker(arg: * u8) -> * u8 {
     let scheduler: * u8 = arg;
     loop {
         let task: * u8 = sfn_scheduler_next_task(scheduler);
         if task as i64 == 0 { break; }
+        let t: * Task = task as * Task;
+        let detached: i64 = t.detached;
         sfn_task_run(task);
+        if detached != 0 { sfn_task_destroy(task); }
     }
     return null;
 }

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -54,14 +54,17 @@
 // (post-1.0). The default `sfn_serve` response is always `200 OK` with
 // a `Content-Length`; a null handler return becomes a `500`.
 //
-// v0 limitations (follow-up waves): (1) per-connection `Task`
-// handles are fire-and-forget — never `sfn_task_join`ed or
-// destroyed — so each connection leaks one 144-byte `Task`. Reaping
-// fire-and-forget tasks needs a scheduler-side completion sweep
-// (separate issue); the connection `ctx` pair IS freed by the
-// worker. (2) No keep-alive (`Connection: close` semantics, one
-// request per connection). (3) No request routing / method dispatch
-// — that is the handler's job.
+// v0 limitations (follow-up waves): (1) No keep-alive (`Connection:
+// close` semantics, one request per connection). (2) No request
+// routing / method dispatch — that is the handler's job.
+//
+// (#1203, fixed) Per-connection `Task` handles are fire-and-forget —
+// never `sfn_task_join`ed — so they use the detached constructor
+// (`sfn_task_create_detached`): the pool worker that runs each one reclaims
+// its `Task` after the body returns (`sfn_scheduler_worker`), so a
+// sustained-connection workload no longer leaks one `Task` per connection.
+// The connection `ctx` pair is freed by the worker body; the response
+// `OwnedBuf` is freed by the worker after the send.
 //
 // Effects: `sfn_serve` is `![net, io]`; the flipped `serve_start`
 // descriptor carries the same effects, so calling `serve(...)`
@@ -132,7 +135,11 @@ extern fn sfn_taskqueue_destroy(queue: * u8) -> void;
 
 extern fn sfn_taskqueue_enqueue(queue: * u8, task: * u8) -> void;
 
-extern fn sfn_task_create(fn_ptr: i64, ctx: i64) -> * u8;
+// Per-connection tasks are fire-and-forget: `sfn_serve` never joins them,
+// so they use the detached constructor (#1203). The pool worker that runs a
+// detached task reclaims its `Task` handle after `sfn_task_run` returns —
+// closing the one-`Task`-per-connection leak the v0 server documented.
+extern fn sfn_task_create_detached(fn_ptr: i64, ctx: i64) -> * u8;
 
 extern fn sfn_scheduler_create(queue: * u8) -> * u8;
 
@@ -547,8 +554,8 @@ fn _serve_conn_worker(ctx: * u8) -> * u8 {
 // (`_serve_free_owned`), closing the per-connection response-buffer leak
 // the v0 `* u8`-out ABI could not — the runtime now has a typed last
 // owner that knows the libc/arena discipline. The fire-and-forget `Task`
-// handle leak (a separate concern) is still tracked with the pool-reaping
-// work.
+// handle is now reclaimed by the pool worker via the detached path (#1203 —
+// `sfn_task_create_detached` in the accept loop below).
 fn _serve_conn_worker_framed(ctx: * u8) -> * u8 {
     if ctx as i64 == 0 { return null; }
     let base: i64 = ctx as i64;
@@ -660,7 +667,7 @@ fn sfn_serve(handler: * u8, port: i32) -> void ![net, io] {
         atomic_store(handler_slot, handler as i64);
 
         let worker: * fn (* u8) -> * u8 = _serve_conn_worker as * fn (* u8) -> * u8;
-        let task: * u8 = sfn_task_create(worker as i64, conn_ctx as i64);
+        let task: * u8 = sfn_task_create_detached(worker as i64, conn_ctx as i64);
         if task as i64 == 0 {
             free(conn_ctx);
             close(client_fd);
@@ -713,7 +720,7 @@ fn sfn_serve_framed(handler: * u8, port: i32) -> void ![net, io] {
         atomic_store(handler_slot, handler as i64);
 
         let worker: * fn (* u8) -> * u8 = _serve_conn_worker_framed as * fn (* u8) -> * u8;
-        let task: * u8 = sfn_task_create(worker as i64, conn_ctx as i64);
+        let task: * u8 = sfn_task_create_detached(worker as i64, conn_ctx as i64);
         if task as i64 == 0 {
             free(conn_ctx);
             close(client_fd);


### PR DESCRIPTION
Closes #1203

## Problem

`sfn_serve` / `sfn_serve_framed` create one `Task` per accepted connection via `sfn_task_create` + `sfn_taskqueue_enqueue`, but the connection is never `sfn_task_join`ed or `sfn_task_destroy`ed. `sfn_scheduler_worker` runs the task body (`sfn_task_run`) and then leaves the handle for a joiner who never comes — leaking a `Task` (plus its embedded pthread mutex + cond) per connection. Under sustained load this is an unbounded leak.

The C→Sailfin runtime port (epic #1308) preserved the leak unchanged — the lifecycle was ported verbatim into `runtime/sfn/concurrency/scheduler.sfn`, so the issue is still live.

## Fix — a detached (fire-and-forget) task lifecycle

**`scheduler.sfn`**
- `Task` gains a `detached: i64` flag, appended **last** so `done` keeps its offset-24 slot (reached by raw offset arithmetic) and the embedded `cond`/`mutex` keep their offsets. Size 144 → 152.
- `sfn_task_create` zero-inits `detached` — load-bearing: the malloc'd bytes are otherwise garbage, and a nonzero flag would make the worker free a still-joinable task.
- New `sfn_task_create_detached` sets the flag.
- `sfn_scheduler_worker` **snapshots `detached` before `sfn_task_run`** and destroys only detached tasks. The pre-run read is the correctness crux: once `sfn_task_run` signals `done`, a *joinable* task's joiner is free to wake and free the handle, so reading any field after the run would race that free (UAF). Before the run no joiner can be active (it blocks on `done`, still 0).

**`serve.sfn`** — both accept loops use `sfn_task_create_detached`, so the pool worker reclaims each per-connection `Task`. Leak notes updated.

**`channel.sfn`** — `sfn_spawn_task` mirrors the scheduler `Task` layout; kept byte-identical (152 + zero the new slot) so the shared worker's offset-144 read never overruns the allocation (a #1205-class shared-layout hazard).

The joinable `spawn` / `await` / nursery path is **unchanged**: those tasks set `detached = 0` and are reclaimed by their joiner (v0 join-without-destroy).

## Tests
- New emit-shape pin in `runtime_scheduler_skeleton_test.sfn`: `sfn_task_create_detached` is defined and sets the flag; `sfn_scheduler_worker` runs each task then conditionally calls `sfn_task_destroy` under a `br i1`.
- `runtime_serve_test.sfn` emit pin updated to assert the detached constructor.
- The live `serve_loopback_test` exercises the detached path end-to-end across many connections; the ASAN/LSAN `spawn_capture_env_free_test` confirms the joinable path has no corruption/leak regression.

## Acceptance criteria
- [x] A detached task run by a pool worker is destroyed after it completes, without a join
- [x] `sfn_serve` connections use the detached path; the joinable path is unaffected, double-free guarded (snapshot-before-run)
- [x] `make compile` self-hosts
- [x] `make test` passes — unit 161/161, integration 36/36, e2e 145/145, capsules 36/36
- [x] `sfn fmt --check` clean on every touched `.sfn`

https://claude.ai/code/session_01Dd3ig96f8JanPazVfozsCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd3ig96f8JanPazVfozsCb)_