### PR TITLE
feat(runtime): real filter/reduce bodies over the closure-apply seam

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -518,6 +518,17 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                         // falling into the struct-method fusion (which would
                         // form the bogus `<type>map` target).
                         if _pre_field == "map" { _pre_is_array_method = true; }
+                        // #1508: `arr.filter(closure)` / `arr.reduce(init,
+                        // closure)` route identically to `map` — the same
+                        // early fallback reaches the `runtime_array_filter_fn`
+                        // / `runtime_array_reduce_fn` helpers below instead of
+                        // the bogus `<type>filter` / `<type>reduce` fusion.
+                        if _pre_field == "filter" {
+                            _pre_is_array_method = true;
+                        }
+                        if _pre_field == "reduce" {
+                            _pre_is_array_method = true;
+                        }
                         if _pre_is_array_method {
                             if is_simple_identifier(_pre_base) {
                                 let _pre_am_local = find_local_binding(locals, _pre_base);
@@ -619,6 +630,49 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                                 }
                                             }
                                         }
+                                        // #1508: route `arr.filter(closure)` to
+                                        // the `runtime_array_filter_fn` helper.
+                                        // The array is arg0 (injected above); the
+                                        // user's predicate becomes arg1, passed by
+                                        // value as `{i8*, i8*}` (descriptor
+                                        // parameter_types[1]) to the real
+                                        // `sfn_array_sfn_filter` body. Same i64-only
+                                        // element restriction as `map` (the
+                                        // predicate ABI is `i1(i8* env, i64)`);
+                                        // non-i64 elements fall through to the
+                                        // honest "callee signature is not known"
+                                        // diagnostic (gated on generics — #766).
+                                        if _pre_field == "filter" {
+                                            if _pre_am_elem == "i64" {
+                                                let _pre_filter_desc = find_runtime_helper("runtime_array_filter_fn");
+                                                if _pre_filter_desc != null {
+                                                    result_target = "runtime_array_filter_fn";
+                                                    helper_descriptor = _pre_filter_desc;
+                                                }
+                                            }
+                                        }
+                                        // #1508: route `arr.reduce(init, closure)`
+                                        // to the `runtime_array_reduce_fn` helper.
+                                        // The array is arg0 (injected above); the
+                                        // user's `initial` becomes arg1 and the
+                                        // reducer arg2, passed by value as `{i8*,
+                                        // i8*}` (descriptor parameter_types[2]) to
+                                        // the real `sfn_array_sfn_reduce` body. Same
+                                        // i64-only element/accumulator restriction
+                                        // (the reducer ABI is `i64(i8* env, i64
+                                        // acc, i64 elem)`); non-i64 elements fall
+                                        // through to the honest "callee signature is
+                                        // not known" diagnostic (gated on generics —
+                                        // #766).
+                                        if _pre_field == "reduce" {
+                                            if _pre_am_elem == "i64" {
+                                                let _pre_reduce_desc = find_runtime_helper("runtime_array_reduce_fn");
+                                                if _pre_reduce_desc != null {
+                                                    result_target = "runtime_array_reduce_fn";
+                                                    helper_descriptor = _pre_reduce_desc;
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -638,6 +692,13 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                 // would otherwise overwrite the helper target
                                 // with the bogus `<type>map`).
                                 if _pre_field == "map" { _pre_struct = ""; }
+                                // #1508: same for `filter` / `reduce` — already
+                                // routed to their helpers above; clear the struct
+                                // type so the fusion skips them (it would
+                                // otherwise form the bogus `<type>filter` /
+                                // `<type>reduce` target).
+                                if _pre_field == "filter" { _pre_struct = ""; }
+                                if _pre_field == "reduce" { _pre_struct = ""; }
                                 if _pre_struct.length > 0 {
                                     // #1041: fail closed when the base local's
                                     // declared type is a bare struct name that is

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -1002,10 +1002,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime_array_map_fn", symbol: "sfn_array_sfn_map", return_type: "i8*", parameter_types: ["i8*", "{i8*, i8*}"], effects: [], native_signature: "sfn_array_sfn_map", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_filter_fn", symbol: "sfn_array_sfn_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_filter", c_abi_return_type: null
+        target: "runtime_array_filter_fn", symbol: "sfn_array_sfn_filter", return_type: "i8*", parameter_types: ["i8*", "{i8*, i8*}"], effects: [], native_signature: "sfn_array_sfn_filter", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_reduce_fn", symbol: "sfn_array_sfn_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_reduce", c_abi_return_type: null
+        target: "runtime_array_reduce_fn", symbol: "sfn_array_sfn_reduce", return_type: "i64", parameter_types: ["i8*", "i64", "{i8*, i8*}"], effects: [], native_signature: "sfn_array_sfn_reduce", c_abi_return_type: null
     });
 
     // String utility helpers

--- a/compiler/tests/e2e/array_filter_closure_test.sfn
+++ b/compiler/tests/e2e/array_filter_closure_test.sfn
@@ -1,0 +1,51 @@
+// End-to-end test for `arr.filter(closure)` over a capturing lambda (#1508).
+//
+// `.filter` dispatch routes to the `runtime_array_filter_fn` helper, which
+// passes the `{i8*, i8*}` closure pair BY VALUE to `sfn_array_sfn_filter`
+// (descriptor `parameter_types[1] = "{i8*, i8*}"`, in lockstep with the
+// runtime body's `predicate: fn(int) -> bool` signature). The real runtime
+// body in `runtime/sfn/array.sfn` closure-dispatches the predicate per
+// element over the seam landed in #1507 — the same by-value path `map`
+// exercises (array_map_closure).
+//
+// Drives the compiler-under-test as a subprocess with the runtime
+// `process.*` builtins and asserts on captured stdout — the canonical
+// e2e pattern (see `.claude/rules/no-bash-e2e.md`, `array_map_closure_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from. Mirrors
+// `sfn/test`'s `_resolve_sfn_bin` so CI can point the test at any compiler.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, plus SAILFIN_TEST_SCRATCH
+// for per-invocation build-cache isolation under the parallel pool, #1333).
+// Inherit the full parent environment — mirrors array_map_closure_test.sfn.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+// Compile+run a fixture and return its exit code plus the trailing-
+// newline-normalized stdout.
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "array filter: capturing predicate keeps only matching elements (3:12, not 5:15)" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/array_filter_closure/main.sfn");
+    assert r.exit == 0;
+    // count then sum: real body keeps [3,4,5] -> "3\n12"; a stub returning
+    // the input unchanged would print "5\n15".
+    assert r.out == "3\n12";
+}

--- a/compiler/tests/e2e/array_reduce_closure_test.sfn
+++ b/compiler/tests/e2e/array_reduce_closure_test.sfn
@@ -1,0 +1,52 @@
+// End-to-end test for `arr.reduce(initial, closure)` over a capturing
+// reducer (#1508).
+//
+// `.reduce` dispatch routes to the `runtime_array_reduce_fn` helper, which
+// passes the `{i8*, i8*}` closure pair BY VALUE as the third argument
+// (descriptor `parameter_types[2] = "{i8*, i8*}"`, in lockstep with the
+// runtime body's `reducer: fn(int, int) -> int` signature). The real
+// runtime body in `runtime/sfn/array.sfn` threads both the accumulator and
+// the element after the env pointer — the 2-arg closure dispatch over the
+// seam landed in #1507.
+//
+// Drives the compiler-under-test as a subprocess with the runtime
+// `process.*` builtins and asserts on captured stdout — the canonical
+// e2e pattern (see `.claude/rules/no-bash-e2e.md`, `array_map_closure_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from. Mirrors
+// `sfn/test`'s `_resolve_sfn_bin` so CI can point the test at any compiler.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, plus SAILFIN_TEST_SCRATCH
+// for per-invocation build-cache isolation under the parallel pool, #1333).
+// Inherit the full parent environment — mirrors array_map_closure_test.sfn.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+// Compile+run a fixture and return its exit code plus the trailing-
+// newline-normalized stdout.
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "array reduce: capturing reducer folds correctly (14, not the initial 0)" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/array_reduce_closure/main.sfn");
+    assert r.exit == 0;
+    // [1,2,3,4].reduce(0, (acc, x) => acc + x + offset) with offset=1 -> 14.
+    // A stub returning the initial unchanged would print "0".
+    assert r.out == "14";
+}

--- a/compiler/tests/e2e/fixtures/array_filter_closure/capsule.toml
+++ b/compiler/tests/e2e/fixtures/array_filter_closure/capsule.toml
@@ -1,0 +1,4 @@
+[capsule]
+name = "fixture/array-filter-closure"
+version = "0.0.0"
+description = "Isolated capsule manifest for the issue #1508 array.filter(closure) e2e fixture so that `discover_project_root` doesn't walk up into compiler/capsule.toml — that would inherit `sfn/runtime-native`, drag `native_driver.c` (with its own `int main`) into the link, and clobber the fixture's own `fn main()`. Mirrors `fixtures/array_map_closure/capsule.toml`."

--- a/compiler/tests/e2e/fixtures/array_filter_closure/main.sfn
+++ b/compiler/tests/e2e/fixtures/array_filter_closure/main.sfn
@@ -1,0 +1,28 @@
+// compiler/tests/e2e/fixtures/array_filter_closure/main.sfn
+//
+// Issue #1508 acceptance — `arr.filter(closure)` over a capturing lambda
+// returns only the elements for which the predicate is true, not the input
+// unchanged. `.filter` dispatch routes to the `runtime_array_filter_fn`
+// helper, which passes the `{i8*, i8*}` closure pair by value to
+// `sfn_array_sfn_filter`; the real runtime body closure-dispatches the
+// predicate per element over the #1507 seam.
+//
+// threshold = 2, [1,2,3,4,5].filter(x => x > threshold) = [3,4,5],
+// sum = 12, count = 3. (A stub `filter` returning the input unchanged
+// would sum to 15 with count 5.)
+fn main() ![io] {
+    let threshold: int = 2;
+    let xs: int[] = [1, 2, 3, 4, 5];
+    let ys: int[] = xs.filter(fn (x: int) -> bool { return x > threshold; });
+    let mut total: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= ys.length { break; }
+        total = total + ys[i];
+        i = i + 1;
+    }
+    // Print "count:sum" so the test asserts both the kept count and the
+    // kept values — distinguishing the real body (3:12) from the stub (5:15).
+    print(ys.length);
+    print(total);
+}

--- a/compiler/tests/e2e/fixtures/array_reduce_closure/capsule.toml
+++ b/compiler/tests/e2e/fixtures/array_reduce_closure/capsule.toml
@@ -1,0 +1,4 @@
+[capsule]
+name = "fixture/array-reduce-closure"
+version = "0.0.0"
+description = "Isolated capsule manifest for the issue #1508 array.reduce(initial, closure) e2e fixture so that `discover_project_root` doesn't walk up into compiler/capsule.toml — that would inherit `sfn/runtime-native`, drag `native_driver.c` (with its own `int main`) into the link, and clobber the fixture's own `fn main()`. Mirrors `fixtures/array_map_closure/capsule.toml`."

--- a/compiler/tests/e2e/fixtures/array_reduce_closure/main.sfn
+++ b/compiler/tests/e2e/fixtures/array_reduce_closure/main.sfn
@@ -1,0 +1,22 @@
+// compiler/tests/e2e/fixtures/array_reduce_closure/main.sfn
+//
+// Issue #1508 acceptance — `arr.reduce(initial, closure)` over a capturing
+// reducer folds correctly, not returning the initial unchanged. `.reduce`
+// dispatch routes to the `runtime_array_reduce_fn` helper, which passes the
+// `{i8*, i8*}` closure pair by value (descriptor parameter_types[2]) to
+// `sfn_array_sfn_reduce`; the real runtime body threads both the
+// accumulator and the element after the env pointer (2-arg closure
+// dispatch over the #1507 seam).
+//
+// offset = 1, [1,2,3,4].reduce(0, (acc, x) => acc + x + offset):
+//   acc=0 -> 0+1+1=2 -> 2+2+1=5 -> 5+3+1=9 -> 9+4+1=14.
+// (A stub `reduce` returning the initial unchanged would print 0.)
+fn main() ![io] {
+    let offset: int = 1;
+    let initial: int = 0;
+    let xs: int[] = [1, 2, 3, 4];
+    let sum: int = xs.reduce(initial, fn (acc: int, x: int) -> int {
+        return acc + x + offset;
+    });
+    print(sum);
+}

--- a/compiler/tests/e2e/runtime_array_test.sfn
+++ b/compiler/tests/e2e/runtime_array_test.sfn
@@ -101,7 +101,11 @@ test "runtime-array: non-core ops remain sfn_array_sfn_* infix" ![io] {
     assert contains(ir, "define i8* @sfn_array_sfn_slice(i8* ");
     assert contains(ir, "define i8* @sfn_array_sfn_map(i8* ");
     assert contains(ir, "define i8* @sfn_array_sfn_filter(i8* ");
-    assert contains(ir, "define i8* @sfn_array_sfn_reduce(i8* ");
+    // #1508: reduce folds to a pointer-width scalar, so its return type is
+    // `i64` (descriptor return_type), not `i8*` — a scalar in an `i8*`
+    // (`any`) slot would be number-boxed to a string. Still emitted under
+    // the `sfn_array_sfn_*` infix with a bare `define`.
+    assert contains(ir, "define i64 @sfn_array_sfn_reduce(i8* ");
 }
 
 // #1308: the `_v2` entrypoints are now defined in pure Sailfin in

--- a/runtime/sfn/array.sfn
+++ b/runtime/sfn/array.sfn
@@ -493,25 +493,20 @@ fn sfn_array_push_slot(data_ptr: * * u8, len_ptr: * i64, cap_ptr: * i64, elem_si
     }
 }
 
-// `sfn_array_sfn_map(arr, mapper) -> arr` — placeholder per §2.3.3.
-// Real bodies are tracked in #766 and gated on generic constraints
-// (post-1.0). Closures-with-capture (Epic #450 M1.5) has now
-// landed — env-capturing lambda emission shipped via #699 — so
-// the call-site closure surface is available; the remaining
-// blocker is the typed `SfnArray<T>` / `(T) -> U` signature shape,
-// which depends on generics. Until #766 ships real bodies, these
-// stubs return the input unchanged (`map`/`filter` → `arr`,
-// `reduce` → `initial`), matching the legacy C
-// `sailfin_runtime_array_*` bodies' observable behavior.
-//
-// #925: the parameter lists mirror the runtime-helper descriptors'
-// ABI exactly — `map`/`filter` take `(arr, callback)` and `reduce`
-// takes `(arr, initial, reducer)` (the arg order the prelude's
-// `array_reduce(items, initial, reducer)` wrapper emits). The
-// trailing callback/reducer operands are accepted-and-ignored so
-// the descriptor arity (`["i8*","i8*"]` / `["i8*","i8*","i8*"]`)
-// matches the defined symbol's signature one-to-one — no reliance
-// on the SysV/AAPCS "extra args are ignored" rule.
+// Array higher-order helpers `map`/`filter`/`reduce` — real bodies over
+// the runtime-callable closure-apply seam landed in #1507 (epic #1118,
+// closing the #766 gap). Each typed callback param (`mapper: fn(int) ->
+// int`, `predicate: fn(int) -> bool`, `reducer: fn(int, int) -> int`) is
+// invoked as an ordinary closure dispatch: the matching descriptor passes
+// the `{i8*, i8*}` closure pair by value, and the emitter extracts the
+// fn-ptr + env and prepends the env to the call. The parameter lists
+// mirror the runtime-helper descriptors' ABI exactly — `map`/`filter`
+// take `(arr, callback)`, `reduce` takes `(arr, initial, reducer)` (the
+// prelude `array_reduce(items, initial, reducer)` arg order), with the
+// closure operand typed `{i8*, i8*}` in lockstep with these signatures.
+// Pointer-width `i64` elements / accumulator only (the callback ABIs are
+// `iN(i8* env, i64 ...)`); generic / typed element widths are post-1.0
+// (gated on generics — #766).
 // `sfn_array_sfn_map(arr, mapper) -> arr'` — real one-element-at-a-time
 // map (#1507). `mapper` is typed `fn(int) -> int` so the call
 // `mapper(elem)` below is an ordinary closure dispatch: the descriptor
@@ -555,8 +550,85 @@ fn sfn_array_sfn_map(arr: * u8, mapper: fn (int) -> int) -> * u8 {
     }
 }
 
-fn sfn_array_sfn_filter(arr: * u8, predicate: * u8) -> * u8 { return arr; }
+// `sfn_array_sfn_filter(arr, predicate) -> arr'` — real one-element-at-a-
+// time filter (#1508). `predicate` is typed `fn(int) -> bool` so the call
+// `predicate(elem)` below is an ordinary closure dispatch over the seam
+// landed in #1507: the descriptor `runtime_array_filter_fn` passes the
+// `{i8*, i8*}` closure pair by value (parameter_types[1] = `{i8*, i8*}`,
+// in lockstep with this signature), and the emitter extracts the fn-ptr +
+// env and prepends the env to the call — the same path `map` exercises.
+// Pointer-width `i64` elements only (the predicate ABI is
+// `i1(i8* env, i64 arg)`); generic / typed element widths are post-1.0
+// (gated on generics — #766). Over-allocates a fresh `SfnArray`
+// (`{ data @0, len @8, cap @16 }`) of `len` 8-byte slots (the kept count
+// is an upper bound), copies each element for which the predicate is true,
+// then writes the final kept count as `len`. The container is freshly,
+// uniquely owned (#1218 / E9).
+fn sfn_array_sfn_filter(arr: * u8, predicate: fn (int) -> bool) -> * u8 {
+    unsafe {
+        let mut len: i64 = 0;
+        let mut data: i64 = 0;
+        if (arr as i64) != 0 {
+            let l: i64 = atomic_load((arr as i64 + 8) as * i64);
+            if l > 0 { len = l; }
+            data = atomic_load(arr as * i64);
+        }
+        let out: * u8 = _sfn_array_alloc_v2(len, 8);
+        if (out as i64) == 0 { return null; }
+        let buf: i64 = atomic_load(out as * i64);
+        let mut kept: i64 = 0;
+        if buf != 0 {
+            if data != 0 {
+                let mut i: i64 = 0;
+                loop {
+                    if i >= len { break; }
+                    let elem: i64 = atomic_load((data + i * 8) as * i64);
+                    if predicate(elem as int) {
+                        atomic_store((buf + kept * 8) as * i64, elem);
+                        kept = kept + 1;
+                    }
+                    i = i + 1;
+                }
+            }
+        }
+        // out.len = kept (the allocator already wrote cap = len).
+        atomic_store((out as i64 + 8) as * i64, kept);
+        return out;
+    }
+}
 
-fn sfn_array_sfn_reduce(arr: * u8, initial: * u8, reducer: * u8) -> * u8 {
-    return initial;
+// `sfn_array_sfn_reduce(arr, initial, reducer) -> acc` — real left fold
+// (#1508). `reducer` is typed `fn(int, int) -> int` so the call
+// `reducer(acc, elem)` below is an ordinary 2-arg closure dispatch: after
+// the env pointer the emitter threads both the accumulator and the element
+// (descriptor `runtime_array_reduce_fn` parameter_types[2] = `{i8*, i8*}`,
+// in lockstep with this signature). `initial` and the returned accumulator
+// are typed `i64` directly (descriptor parameter_types[1] / return_type),
+// not `i8*`/`any`: a pointer-width scalar coerced into an `i8*` (`any`)
+// slot would be number-boxed to its string representation, destroying the
+// integer value — so the fold value rides the descriptor as a raw `i64`.
+// Pointer-width `i64` elements and accumulator only (the reducer ABI is
+// `i64(i8* env, i64 acc, i64 elem)`); generic / typed widths are post-1.0
+// (gated on generics — #766).
+fn sfn_array_sfn_reduce(arr: * u8, initial: i64, reducer: fn (int, int) -> int) -> i64 {
+    unsafe {
+        let mut len: i64 = 0;
+        let mut data: i64 = 0;
+        if (arr as i64) != 0 {
+            let l: i64 = atomic_load((arr as i64 + 8) as * i64);
+            if l > 0 { len = l; }
+            data = atomic_load(arr as * i64);
+        }
+        let mut acc: i64 = initial;
+        if data != 0 {
+            let mut i: i64 = 0;
+            loop {
+                if i >= len { break; }
+                let elem: i64 = atomic_load((data + i * 8) as * i64);
+                acc = reducer(acc as int, elem as int) as i64;
+                i = i + 1;
+            }
+        }
+        return acc;
+    }
 }


### PR DESCRIPTION
## Summary
- Real `sfn_array_sfn_filter` (predicate → bool) and `sfn_array_sfn_reduce` (2-arg acc/elem fold) bodies in `runtime/sfn/array.sfn`, replacing the no-op stubs, using the closure-dispatch seam landed in #1507.
- Descriptor flips in `runtime_helpers.sfn` in lockstep with the runtime fn signatures (declares derive from the descriptors).
- `.filter`/`.reduce` method-dispatch routing in `core_call_resolution.sfn`, mirroring #1507's `.map` routing — without it `xs.filter(...)`/`xs.reduce(...)` never reached the runtime helpers.

Closes #1508

## Acceptance Criteria
- [x] `filter` returns only elements where the predicate is true; `reduce` folds correctly (with a capturing initial-offset reducer)
- [x] 2-arg dispatch verified: emitted call is `call ... (i8* env, <acc>, <elem>)`
- [x] Descriptor `parameter_types` flips move in lockstep with signatures + registered-helper declares; `nm` relink shows no undefined symbols
- [x] `make compile` self-hosts against the #1507-pinned seed (`make rebuild` passed)
- [ ] `make check` green — **running locally; will confirm. CI also runs the full gate.**
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Two findings beyond the issue's literal scope (called out for review)
1. **`.filter`/`.reduce` method routing was missing.** #1507 only wired `.map` into `core_call_resolution.sfn` (per-method hardcoded, not generic). `xs.filter(...)`/`xs.reduce(...)` fell into struct-method fusion and formed bogus `<type>filter`/`<type>reduce` targets that resolve to nothing. Added the analogous routing (3 small changes mirroring the #1507 map additions). This is a compiler change built by the fresh self-host pass — **no seed cut required**. The issue's Files Affected omitted this file; the addition was approved before implementation.
2. **Reduce's scalar `initial`/return are `i64`, not `i8*`.** A pointer-width scalar coerced into the descriptor's `i8*` (`any`) slot is number-boxed to its *string* representation (`sitofp` → `sfn_number_to_str`), destroying the integer value. So the reduce descriptor moved `parameter_types[1]` → `i64` and `return_type` → `i64` (a small extension beyond the issue's literal "parameter_types closure flip"). The prelude `array_reduce` wrapper still self-hosts with this.

Pointer-width `i64` elements/accumulator only (callback ABIs are `iN(i8* env, i64 ...)`); generic / non-i64 widths stay post-1.0 (#766).

## Verification
```text
make rebuild                                  -> self-host pass (twice)
build/native/sailfin test array_filter_closure_test.sfn -> PASS (3:12, stub would be 5:15)
build/native/sailfin test array_reduce_closure_test.sfn -> PASS (14,  stub would be 0)

reduce body 2-arg dispatch IR:
  %t44 = extractvalue {i8*, i8*} %reducer, 0
  %t45 = extractvalue {i8*, i8*} %reducer, 1
  %t46 = bitcast i8* %t44 to i64 (i8*, i64, i64)*
  %t47 = call i64 %t46(i8* %t45, i64 %t42, i64 %t43)   ; (env, acc, elem)

declares (consumer module), in lockstep with definitions:
  declare i8* @sfn_array_sfn_filter(i8*, {i8*, i8*})
  declare i64 @sfn_array_sfn_reduce(i8*, i64, {i8*, i8*})

nm: sfn_array_sfn_{map,filter,reduce} all `T` (defined), none `U` (undefined)
sfn fmt --check: clean on every touched .sfn
```

## Files Changed
- `runtime/sfn/array.sfn` — real `filter`/`reduce` bodies (+ refreshed the stale shared header comment)
- `compiler/src/llvm/runtime_helpers.sfn` — descriptor flips for filter/reduce
- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — `.filter`/`.reduce` method-dispatch routing
- `compiler/tests/e2e/array_filter_closure_test.sfn` + fixture
- `compiler/tests/e2e/array_reduce_closure_test.sfn` + fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DT7n3nS7tY5FQ1MjLHSZ57

---
_Generated by [Claude Code](https://claude.ai/code/session_01DT7n3nS7tY5FQ1MjLHSZ57)_