### PR TITLE
fix(windows): resolve self/binary path for prelude-entry emit (#1482)

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -665,10 +665,17 @@ fn _do_determinism_check(pass1_out: string, is_library: boolean, cap_capsule_nam
 
     let pass2_work_dir = _derive_pass2_work_dir(work_dir);
     let pass2_out = _pass2_out_path(pass2_work_dir, is_library);
-    let self_exe = binary_dir + "/sailfin";
-    if binary_dir.length == 0 {
+    // #1482: resolve through `_resolve_self_path` so the `.exe`
+    // variants are tried on Windows (and the binary's existence is
+    // verified) instead of blindly concatenating `<dir>/sailfin`. On
+    // POSIX the first candidate (`sailfin`) matches, so this is
+    // behavior-identical there.
+    let self_exe = _resolve_self_path(binary_dir);
+    if self_exe.length == 0 {
         if !json_flag {
-            print.err("[determinism] cannot locate self binary (empty binary_dir)");
+            print.err("[determinism] cannot locate self binary (binary_dir=\""
+                + binary_dir
+                + "\")");
         }
         return 1;
     }
@@ -1043,8 +1050,21 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
 //      always threaded portably.
 fn _resolve_self_path(binary_dir: string) -> string ![io] {
     if binary_dir.length > 0 {
-        let candidate = _path_join(binary_dir, "sailfin");
-        if fs.exists(candidate) { return candidate; }
+        // Try each known compiler-binary name in order. The bare
+        // `sailfin` / `sfn` names cover the dev-tree and installed
+        // POSIX layouts; the `.exe`-suffixed variants cover native
+        // Windows, where `GetModuleFileNameA` resolves the running
+        // binary as `sailfin.exe` and the suffixless join would miss
+        // it (#1482, epic #1485 M2). The Windows variants never match
+        // on POSIX (no such file), so the ordering is host-neutral.
+        let names: string[] = ["sailfin", "sailfin.exe", "sfn", "sfn.exe"];
+        let mut i: int = 0;
+        loop {
+            if i >= names.length { break; }
+            let candidate = _path_join(binary_dir, names[i]);
+            if fs.exists(candidate) { return candidate; }
+            i += 1;
+        }
     }
     return "";
 }
@@ -2981,13 +3001,13 @@ fn main(argv: string[]) -> int ![io, clock] {
     // either way, so the pinned semantics here survive the future
     // shape change without source edits.
     //
-    // `exe_path()` only resolves `/proc/self/exe` (Linux). On macOS
-    // and Windows it returns `""` until `runtime/sfn/platform/exec.sfn`
-    // gains `_NSGetExecutablePath` / `GetModuleFileNameA` bodies (a
-    // follow-up to #468 / #473). The retired C driver covered those
-    // platforms via `realpath(argv[0], ...)` as a fallback; mirror
-    // that here so the runtime-root walk still has a directory to
-    // start from. argv[0] is not guaranteed to be canonical (a bare
+    // `exe_path()` now resolves the running binary on every host via
+    // the `sailfin_intrinsic_exe_path` sentinel (#967): `readlink`
+    // (Linux), `_NSGetExecutablePath` (Darwin), `GetModuleFileNameA`
+    // (Windows). It still returns `""` when the host lookup genuinely
+    // fails, so the retired C driver's `realpath(argv[0], ...)`
+    // fallback is preserved below to give the runtime-root walk a
+    // directory to start from. argv[0] is not guaranteed to be canonical (a bare
     // `$PATH` name fails the walk on its own), but `_runtime_bundle_exists`
     // in `sailfin_cli_main` provides the final CWD-relative
     // `runtime` fallback either way.

--- a/compiler/tests/unit/runtime_exec_path_test.sfn
+++ b/compiler/tests/unit/runtime_exec_path_test.sfn
@@ -75,3 +75,18 @@ test "binary_dir: single-component relative path returns dot" {
     let r: * u8 = binary_dir("hello.sfn" as * u8);
     assert equal_cstr(r, "." as * u8);
 }
+
+// Windows coverage (#1482): `GetModuleFileNameA` returns a
+// backslash-separated path, so `binary_dir` must scan for `\` (92)
+// as well as `/` (47). Before the fix these paths had no `/` and
+// collapsed to the bare-name "." fallback, which aborted self-path
+// resolution on native Windows.
+test "binary_dir: backslash path returns dirname" {
+    let r: * u8 = binary_dir("C:\\dir\\sailfin.exe" as * u8);
+    assert equal_cstr(r, "C:\\dir" as * u8);
+}
+
+test "binary_dir: mixed separators use the rightmost" {
+    let r: * u8 = binary_dir("C:/proj\\build\\sailfin.exe" as * u8);
+    assert equal_cstr(r, "C:/proj\\build" as * u8);
+}

--- a/runtime/sfn/platform/exec.sfn
+++ b/runtime/sfn/platform/exec.sfn
@@ -188,7 +188,18 @@ fn binary_dir(exe: * u8) -> * u8 {
     // string now arrives as a valid non-null pointer to a lone NUL. Without
     // this guard `strrchr` finds no slash and the dir wrongly collapses to ".".
     if strlen(p) == 0 { return ""; }
-    let slash: * u8 = strrchr(p, 47);
+    // Windows `GetModuleFileNameA` returns a backslash-separated path
+    // (`C:\dir\sailfin.exe`), while POSIX uses `/`. Scan for the
+    // rightmost separator of *either* kind so the dirname is correct on
+    // every host: a path with no `/` would otherwise miss the `\` and
+    // collapse to the bare-name "." fallback, which aborted Windows
+    // self-path resolution (#1482). `92` is the ASCII code for `\` (the
+    // seed compiler does not yet accept char literals — same `47`-for-`/`
+    // convention used throughout this file).
+    let fwd: * u8 = strrchr(p, 47);
+    let back: * u8 = strrchr(p, 92);
+    let mut slash: * u8 = fwd;
+    if (back as i64) > (slash as i64) { slash = back; }
     if slash as i64 == 0 { return "."; }
     if slash as i64 == p as i64 { return "/"; }
     let len: i64 = (slash as i64) - (p as i64);


### PR DESCRIPTION
## Summary

Fixes native-Windows self-path resolution (#1482, epic #1485 **M2**). On native Windows, `sfn run`/`build` aborted before linking with:

```
sfn build: cannot resolve self path for runtime prelude-entry emit
           tried: <binary_dir>/sailfin (binary_dir=".")
```

### Root cause (two compounding defects)

1. `exe_path()` → `GetModuleFileNameA` returns a **backslash** path (`C:\…\sailfin.exe`), but `binary_dir` in `runtime/sfn/platform/exec.sfn` scanned only for `/` (ASCII 47). With no `/`, `strrchr` found nothing and the dirname collapsed to `"."`.
2. `_resolve_self_path` in `compiler/src/cli_main.sfn` only tried a suffixless `<dir>/sailfin`, so even a correct directory missed the `.exe` binary.

### Fix

- **`binary_dir`** now takes the rightmost of `/` (47) and `\` (92). Proven **no-op on POSIX** (no backslash present → identical to the prior single-`strrchr` path).
- **`_resolve_self_path`** tries `sailfin`, `sailfin.exe`, `sfn`, `sfn.exe` in order. The first candidate matches on POSIX, so dev/installed behavior is unchanged; the `.exe` variants never match there.
- **`_do_determinism_check`** self-binary lookup routed through `_resolve_self_path` for the same `.exe` handling + an existence check (behavior-identical on Linux).
- Refreshed the stale `fn main` comment claiming `exe_path()` returns `""` on Windows — the `GetModuleFileNameA` leg shipped in #967.
- Added backslash + mixed-separator unit cases to `runtime_exec_path_test.sfn`.

## Acceptance criteria

- [x] `exe_path()` returns the true module path via `GetModuleFileNameA` (leg already shipped; this PR makes the returned backslash path usable downstream).
- [ ] (CI/manual) `sailfin.exe run examples/basics/hello-world.sfn` resolves a real self/binary path — no `cannot resolve self path … binary_dir="."` — and proceeds to the link step.

## Validation

⚠️ **Not self-host-validated by the author locally** — authored on the Windows side where no Windows seed exists and the WSL repo is unreachable from the MinGW shell. The change is constructed to be Linux-self-host-safe (both touched functions are provable no-ops on all-`/` paths) and passed a `code-reviewer` pass (Approve: self-host-safe, effect-clean, seed-cast-quirk-compliant, constructs already proven on the pinned seed).

**Gating before merge:**
- Linux `make check` (self-host triple-pass + suite) — the self-host invariant.
- `sfn fmt --check` on the three touched `.sfn` files.

## Follow-ups (out of scope here)

- The `_resolve_self_path` `.exe` branch is Windows-only and unexercised by current CI (no Windows compile leg; epic #1485 M2). Validated via the `windows-latest` smoke job once a `run` leg is added.
- Extend the `windows-latest` smoke job with a `run` leg **once green** — gated on the C toolchain on the runner and the still-open shell dependency (#1483), per this issue's `Out:` scope.
- `cli_main.sfn:2534` (the `-p` self-host `walk_src` path) still reconstructs `<dir>/sailfin` suffixless; that's the native Windows compiler self-host (M7), left untouched to keep this change minimal.

Closes #1482
