### PR TITLE
fix(http): wire recv/send socket timeouts to prevent dead-upstream hangs

### DIFF
--- a/compiler/tests/e2e/socket_recv_timeout_test.sfn
+++ b/compiler/tests/e2e/socket_recv_timeout_test.sfn
@@ -1,0 +1,204 @@
+// Native socket recv/send-timeout regression (#1581 — gap B3 of epic
+// #1540: a dead or slow peer must not hang a worker thread forever).
+//
+// The fix arms SO_RCVTIMEO / SO_SNDTIMEO on the client connect socket
+// (`runtime/sfn/adapters/http.sfn::_set_socket_timeouts`) and on every
+// accepted serve socket (`runtime/sfn/concurrency/serve.sfn::
+// _serve_set_socket_timeouts`). This test guards the LOAD-BEARING part of
+// that mechanism — the exact `struct timeval` byte layout and the
+// dual-platform SOL_SOCKET / SO_*TIMEO option numbers — by mirroring it
+// over a raw libc loopback socket pair and proving:
+//
+//   (A) a recv against a connected-but-silent peer returns (EAGAIN, < 0)
+//       within the configured timeout instead of blocking indefinitely; and
+//   (B) the timeout does NOT break a normal recv — a peer that sends data
+//       is received as usual (the "normal round-trips unaffected" criterion
+//       at the socket level).
+//
+// If the constant numbers or the timeval layout were wrong, setsockopt
+// would be a silent no-op (or reject the buffer) and case (A) would hang
+// forever — caught by the suite-level timeout as a hard failure. Behavioral
+// coverage that the shipped `http.sfn` / `serve.sfn` paths still compile and
+// round-trip lives in `serve_loopback_test.sfn`.
+//
+// Effect note: the libc socket externs carry no effect annotation, so the
+// effect checker infers no `net` requirement for direct callers — the raw
+// helpers are left un-annotated (matching `serve_loopback_test.sfn`), while
+// the test block keeps `![io]` for `print.*`. This compiles under the
+// COMPILER capsule surface (`compiler/capsule.toml` → `["io", "clock"]`,
+// no `net`).
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+
+extern fn bind(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn listen(sockfd: i32, backlog: i32) -> i32;
+
+extern fn accept(sockfd: i32, addr: * u8, addrlen: * i32) -> i32;
+
+extern fn connect(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn send(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn close(fd: i32) -> i32;
+
+extern fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: * u8, optlen: i32) -> i32;
+
+// Fixed loopback port for this test. High + uncommon, distinct from
+// `serve_loopback_test.sfn`'s 18790 so the two cannot collide under
+// `--jobs N`.
+fn _st_port() -> i64 { return 18793; }
+
+fn _st_ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+// Open a stream socket bound to `0.0.0.0:port` and listen. Tries both
+// `sockaddr_in` byte layouts (Linux u16 sin_family at 0; macOS/BSD u8
+// sin_len at 0 + u8 sin_family at 1), first success wins. Mirrors
+// `serve.sfn::_serve_bind_listen`. Returns the listening fd or -1.
+fn _st_bind_listen(port: i64) -> i32 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 { return 0 - 1; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 {
+            close(fd);
+            return 0 - 1;
+        }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            memset(_st_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            memset(_st_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_st_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        memset(_st_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_st_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        let rc: i32 = bind(fd, addr, 16);
+        free(addr);
+        if rc == 0 {
+            if listen(fd, 16) == 0 { return fd; }
+            close(fd);
+            return 0 - 1;
+        }
+        close(fd);
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+// Connect a stream socket to `127.0.0.1:port`. Dual sockaddr layout, first
+// success wins. Mirrors `http.sfn::_connect_tcp` / the loopback test's
+// `_lb_connect`. Returns the connected fd or -1.
+fn _st_connect(port: i64) -> i32 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 { return 0 - 1; }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            memset(_st_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            memset(_st_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_st_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        memset(_st_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_st_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        // sin_addr = 127.0.0.1
+        memset(_st_ptr_off(addr, 4), 127, 1 as usize);
+        memset(_st_ptr_off(addr, 7), 1, 1 as usize);
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 {
+            free(addr);
+            return 0 - 1;
+        }
+        let rc: i32 = connect(fd, addr, 16);
+        free(addr);
+        if rc == 0 { return fd; }
+        close(fd);
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+// Arm SO_RCVTIMEO + SO_SNDTIMEO with a `secs`-second budget — the EXACT
+// `struct timeval` layout (16 bytes, tv_sec as the low byte at offset 0,
+// little-endian, tv_usec zero) and dual-platform option numbers the fix
+// uses. Linux SOL_SOCKET=1 / SO_RCVTIMEO=20 / SO_SNDTIMEO=21; macOS
+// SOL_SOCKET=0xffff / SO_RCVTIMEO=0x1006 / SO_SNDTIMEO=0x1005. The
+// wrong-platform variant returns ENOPROTOOPT (ignored).
+fn _st_set_timeouts(fd: i32, secs: i64) -> void {
+    let tv: * u8 = malloc(16 as usize);
+    if tv as i64 == 0 { return; }
+    memset(tv, 0, 16 as usize);
+    memset(_st_ptr_off(tv, 0), secs as i32, 1 as usize);
+    setsockopt(fd, 1, 20, tv, 16);
+    setsockopt(fd, 1, 21, tv, 16);
+    setsockopt(fd, 65535, 4102, tv, 16);
+    setsockopt(fd, 65535, 4101, tv, 16);
+    free(tv);
+}
+
+fn _st_send_all(fd: i32, buf: * u8, total: i64) -> bool {
+    let mut sent: i64 = 0;
+    loop {
+        if sent >= total { break; }
+        let n: i64 = send(fd, _st_ptr_off(buf, sent), total - sent, 0);
+        if n <= 0 { return false; }
+        sent = sent + n;
+    }
+    return true;
+}
+
+test "socket recv timeout: silent peer times out; normal recv unaffected" ![io] {
+    let port = _st_port();
+    let lfd = _st_bind_listen(port);
+    assert lfd >= 0;
+
+    // Connect a client; the loopback handshake completes via the listen
+    // backlog, so `accept` returns the established server fd immediately.
+    let cfd = _st_connect(port);
+    assert cfd >= 0;
+    let sfd = accept(lfd, null, null);
+    assert sfd >= 0;
+
+    // Arm a short (1s) recv/send budget on the client — the mechanism the
+    // fix installs on real connect/accept sockets.
+    _st_set_timeouts(cfd, 1);
+
+    let buf: * u8 = malloc(64 as usize);
+    assert buf as i64 != 0;
+
+    // Case B — normal recv is unaffected by the armed timeout: the server
+    // sends, the client receives the bytes.
+    let payload: string = "OK";
+    assert _st_send_all(sfd, payload as * u8, 2);
+    let n1: i64 = recv(cfd, buf, 64, 0);
+    print.info("[socket-timeout] normal recv n=" + (n1 as string));
+    assert n1 == 2;
+
+    // Case A — the load-bearing assertion: the server now stays silent, so
+    // the client's recv must return on the SO_RCVTIMEO deadline (< 0,
+    // EAGAIN) rather than blocking forever. A wrong constant / timeval would
+    // hang here (caught by the suite timeout).
+    let n2: i64 = recv(cfd, buf, 64, 0);
+    print.info("[socket-timeout] silent recv n=" + (n2 as string));
+    assert n2 < 0;
+
+    free(buf);
+    close(cfd);
+    close(sfd);
+    close(lfd);
+}

--- a/runtime/sfn/adapters/http.sfn
+++ b/runtime/sfn/adapters/http.sfn
@@ -126,6 +126,15 @@ extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
 
 extern fn close(fd: i32) -> i32;
 
+// `setsockopt` — arm SO_RCVTIMEO / SO_SNDTIMEO (recv/send deadlines) on
+// the client socket (#1581). `optval` is the `struct timeval` byte buffer
+// cast through `* u8` (the `net.sfn` opaque-handle policy — no struct-by-
+// value at the boundary). Identical C ABI to
+// `int setsockopt(int, int, int, const void *, socklen_t)`. Declared
+// inline (not imported) per the same #306 cross-module-extern workaround
+// as the other socket externs above.
+extern fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: * u8, optlen: i32) -> i32;
+
 // ── libc stdio (download write path) ──────────────────────────
 extern fn fopen(path: * u8, mode: * u8) -> * File;
 
@@ -220,6 +229,44 @@ fn _host_ip4(host: * u8, out: * u8) -> bool {
     return true;
 }
 
+// `_http_io_timeout_secs()` — the recv/send socket-timeout budget
+// (seconds) for the client. A dead or slow upstream must not pin a
+// worker thread forever (#1581, gap B3 of epic #1540 — blocker for the
+// ~150 ms hot-path SLA). 10s is generous for a healthy localhost peer yet
+// bounds a black-hole upstream to a clean failure (`null` return).
+fn _http_io_timeout_secs() -> i64 { return 10; }
+
+// `_set_socket_timeouts(fd)` — arm SO_RCVTIMEO + SO_SNDTIMEO on a socket
+// so a recv/send against a non-responsive peer returns (EAGAIN → a clean
+// failure) instead of blocking forever.
+//
+// `struct timeval { tv_sec; tv_usec; }` is 16 bytes on both targets this
+// runtime builds for (Linux x86_64: i64 + i64; macOS arm64: i64 + i32 +
+// 4 pad). `tv_sec` is an i64 at offset 0 on both, so zeroing the 16 bytes
+// and writing the seconds as the low byte at offset 0 (both targets are
+// little-endian) yields `{sec, 0}` portably for any budget < 256s.
+//
+// The SOL_SOCKET / SO_*TIMEO option numbers DIFFER by platform and the
+// platform-agnostic emitted IR cannot branch on the target (the same
+// constraint as the dual `sockaddr_in` layout in `_connect_tcp`), so we
+// issue both the Linux and the macOS variant and ignore failures: the
+// wrong-platform call returns ENOPROTOOPT and leaves the socket at its
+// prior (blocking) state — the pre-fix status quo, never an error
+// surfaced to the caller.
+//   - Linux x86_64: SOL_SOCKET=1,      SO_RCVTIMEO=20,     SO_SNDTIMEO=21.
+//   - macOS arm64:  SOL_SOCKET=0xffff, SO_RCVTIMEO=0x1006, SO_SNDTIMEO=0x1005.
+fn _set_socket_timeouts(fd: i32) -> void {
+    let tv: * u8 = malloc(16 as usize);
+    if tv as i64 == 0 { return; }
+    memset(tv, 0, 16 as usize);
+    memset(_ptr_off(tv, 0), _http_io_timeout_secs() as i32, 1 as usize);
+    setsockopt(fd, 1, 20, tv, 16);
+    setsockopt(fd, 1, 21, tv, 16);
+    setsockopt(fd, 65535, 4102, tv, 16);
+    setsockopt(fd, 65535, 4101, tv, 16);
+    free(tv);
+}
+
 // `_connect_tcp(host, port)` — build an IPv4 `sockaddr_in`, open a
 // stream socket, and connect. Returns the connected fd, or -1 on
 // any failure.
@@ -263,6 +310,9 @@ fn _connect_tcp(host: * u8, port: i64) -> i32 ![net] {
                 free(addr);
                 return 0 - 1;
             }
+            // Bound recv/send so a connected-but-silent upstream cannot
+            // pin this worker forever (#1581).
+            _set_socket_timeouts(fd);
             let rc: i32 = connect(fd, addr, 16);
             free(addr);
             if rc == 0 { return fd; }

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -123,6 +123,14 @@ extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
 
 extern fn close(fd: i32) -> i32;
 
+// `setsockopt` — arm SO_RCVTIMEO / SO_SNDTIMEO (recv/send deadlines) on an
+// accepted connection (#1581). `optval` is the `struct timeval` byte buffer
+// cast through `* u8` (the `net.sfn` opaque-handle policy — no struct-by-
+// value at the boundary). Identical C ABI to
+// `int setsockopt(int, int, int, const void *, socklen_t)`. Declared inline
+// per the same #306 cross-module-extern workaround as the sockets above.
+extern fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: * u8, optlen: i32) -> i32;
+
 // ── Scheduler (M4.1, scheduler.sfn) ───────────────────────────
 // The shared MPMC task queue + fixed worker pool. `sfn_serve`
 // creates one queue + pool, then enqueues a `Task` per connection.
@@ -201,6 +209,33 @@ fn _serve_send_all(fd: i32, buf: * u8, total: i64) -> bool {
     return true;
 }
 
+// `_serve_io_timeout_secs()` — the recv/send socket-timeout budget
+// (seconds) for an accepted connection. A dead or slow client must not pin
+// a pool worker forever (#1581, gap B3 of epic #1540). 10s bounds a
+// slow-loris / black-hole peer while staying generous for a healthy
+// loopback client.
+fn _serve_io_timeout_secs() -> i64 { return 10; }
+
+// `_serve_set_socket_timeouts(fd)` — arm SO_RCVTIMEO + SO_SNDTIMEO on an
+// accepted socket so a worker's recv (awaiting the request) or send
+// (writing the response) cannot block forever on a non-responsive client.
+// Serve-local copy of `http.sfn::_set_socket_timeouts`; see that helper for
+// the `struct timeval` layout + dual-platform constant rationale. A recv
+// timeout surfaces as `recv -> -1` in `_serve_recv_request`, which frees
+// the buffer and returns null → the worker emits a clean `500`, never a
+// hang.
+fn _serve_set_socket_timeouts(fd: i32) -> void {
+    let tv: * u8 = malloc(16 as usize);
+    if tv as i64 == 0 { return; }
+    memset(tv, 0, 16 as usize);
+    memset(_serve_ptr_off(tv, 0), _serve_io_timeout_secs() as i32, 1 as usize);
+    setsockopt(fd, 1, 20, tv, 16);
+    setsockopt(fd, 1, 21, tv, 16);
+    setsockopt(fd, 65535, 4102, tv, 16);
+    setsockopt(fd, 65535, 4101, tv, 16);
+    free(tv);
+}
+
 // `_serve_content_length(buf, header_end)` — extract the declared
 // `Content-Length` from the request head (bytes `[0, header_end)`,
 // where `header_end` is the offset just past the `\r\n\r\n`
@@ -253,6 +288,11 @@ fn _serve_content_length(buf: * u8, header_end: i64) -> i64 {
 // Chunked transfer-encoding is out of scope (post-1.0); only an
 // explicit `Content-Length` body is drained.
 fn _serve_recv_request(fd: i32) -> * u8 {
+    // Bound recv/send so a slow-loris or dead client cannot pin this pool
+    // worker forever (#1581). A recv timeout returns -1 below, which is
+    // handled exactly like any recv error: free + null → the worker emits
+    // a 500 and closes.
+    _serve_set_socket_timeouts(fd);
     let max_header: i64 = 65536;
     let max_body: i64 = 1048576;
     let mut capacity: i64 = 4096;


### PR DESCRIPTION
## Summary
- Arm `SO_RCVTIMEO`/`SO_SNDTIMEO` on the HTTP **client** connect socket (`http.sfn::_connect_tcp`) so a connected-but-silent upstream can no longer pin a worker thread forever — it surfaces as a clean failure (`null` return).
- Arm the same timeouts on every **accepted serve** socket (`serve.sfn::_serve_recv_request`) so a slow-loris / dead client recv (or a stalled response send) times out into the existing error path → a clean `500` + connection close, never a hang.
- Gap B3 of #1540 Track B; unblocks the ~150 ms hot-path SLA.

Closes #1581

## Implementation notes
- The `setsockopt` extern, the `SO_*TIMEO`/`SOL_SOCKET` constants, and the `struct timeval` byte layout are added **inline** in both consuming modules — the #306 cross-module-extern workaround the rest of the runtime uses (the `net.sfn` declarations are in a typecheck-only smoke file, imported nowhere).
- `struct timeval` is 16 bytes on both targets (Linux x86_64 `i64+i64`; macOS arm64 `i64 + i32 + 4 pad`); `tv_sec` is an `i64` at offset 0 on both, so zeroing 16 bytes and writing the seconds as the low byte (both targets little-endian) is portable.
- Option numbers differ by platform (Linux `SOL_SOCKET=1`/`SO_RCVTIMEO=20`/`SO_SNDTIMEO=21`; macOS `0xffff`/`0x1006`/`0x1005`) and the emitted IR can't branch on the target, so both variants are issued — the wrong-platform call is a harmless `ENOPROTOOPT` no-op. This mirrors the established dual `sockaddr_in` layout idiom in `_connect_tcp` / `_serve_bind_listen`.
- No new compiler intrinsic — `setsockopt` is a flat primitive-arg libc call on the E0801–E0805 accept-list — so it self-hosts on the current seed (matching the issue's "Required in pinned seed: None").

## Acceptance Criteria
- [x] A connect/recv against a non-responsive peer returns within the configured timeout instead of blocking indefinitely.
- [x] Normal request/response round-trips are unaffected (`serve_loopback_test.sfn` stays green).
- [x] `make compile` passes; `make test` passes; `sfn fmt --check` clean.

## Verification
```
$ build/native/sailfin test compiler/tests/e2e/socket_recv_timeout_test.sfn
  [socket-timeout] normal recv n=2
  [socket-timeout] silent recv n=-1     # SO_RCVTIMEO fired, no hang
  PASS  (all 1 tests passed)

$ build/native/sailfin test compiler/tests/e2e/serve_loopback_test.sfn
  PASS  (all 1 tests passed)            # happy path unaffected

$ make compile   # self-host: status=pass
$ make test      # unit 162/162, integration 36/36, e2e 146/146, capsules 36/36
$ sfn fmt --check runtime/sfn/adapters/http.sfn runtime/sfn/concurrency/serve.sfn \
      compiler/tests/e2e/socket_recv_timeout_test.sfn   # clean
```

## Files Changed
- `runtime/sfn/adapters/http.sfn` — inline `setsockopt` + `SO_*`/`timeval`; arm timeouts in `_connect_tcp`.
- `runtime/sfn/concurrency/serve.sfn` — same extern + helper; arm recv/send timeout on the accepted fd.
- `compiler/tests/e2e/socket_recv_timeout_test.sfn` — new regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFCBxFoUKfnnEN7AHtVUpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFCBxFoUKfnnEN7AHtVUpc)_