### PR TITLE
fix(lowering): implement string ordered comparison (<, >, <=, >=) for SfnString

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -155,6 +155,77 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
             }
         }
     }
+    // #1365: string ordered comparison (`<`/`>`/`<=`/`>=`). Route through the
+    // runtime `sfn_str_cmp` helper (lexicographic, strcmp-style i32) then
+    // `icmp <pred> i32 <cmp>, 0`. Without this, ordered string compares fell
+    // through to `comparison_predicate_for_symbol`, which has no `{i8*, i64}`
+    // arm — yielding an empty predicate, a null operand, and a silently dropped
+    // guarded branch. The data-pointer extraction mirrors the equality block
+    // above (covering the mixed `i8*` / `{i8*, i64}` literal-vs-local case).
+    let mut symbol_is_ordered: boolean = false;
+    if symbol == "<" { symbol_is_ordered = true; }
+    if symbol == "<=" { symbol_is_ordered = true; }
+    if symbol == ">" { symbol_is_ordered = true; }
+    if symbol == ">=" { symbol_is_ordered = true; }
+    if symbol_is_ordered {
+        if left_is_string {
+            if right_is_string {
+                if !left_is_null {
+                    if !right_is_null {
+                        let mut next_index = temp_index;
+                        let mut left_ptr_value = left_operand.value;
+                        if left_operand.llvm_type == "{i8*, i64}" {
+                            let lext = format_temp_name(next_index);
+                            current_lines.push("  " + lext
+                                + " = extractvalue {i8*, i64} "
+                                + left_operand.value
+                                + ", 0");
+                            left_ptr_value = lext;
+                            next_index += 1;
+                        }
+                        let mut right_ptr_value = right_operand.value;
+                        if right_operand.llvm_type == "{i8*, i64}" {
+                            let rext = format_temp_name(next_index);
+                            current_lines.push("  " + rext
+                                + " = extractvalue {i8*, i64} "
+                                + right_operand.value
+                                + ", 0");
+                            right_ptr_value = rext;
+                            next_index += 1;
+                        }
+                        let cmp_temp = format_temp_name(next_index);
+                        current_lines.push("  " + cmp_temp
+                            + " = call i32 @sfn_str_cmp(i8* "
+                            + left_ptr_value
+                            + ", i8* "
+                            + right_ptr_value
+                            + ")");
+                        next_index += 1;
+                        let mut pred = "icmp slt";
+                        if symbol == "<=" { pred = "icmp sle"; }
+                        if symbol == ">" { pred = "icmp sgt"; }
+                        if symbol == ">=" { pred = "icmp sge"; }
+                        let result_temp = format_temp_name(next_index);
+                        current_lines.push("  " + result_temp + " = " + pred
+                            + " i32 "
+                            + cmp_temp
+                            + ", 0");
+                        next_index += 1;
+                        let ordered_operand = LLVMOperand {
+                            llvm_type: "i1",
+                            value: result_temp
+                        };
+                        return ComparisonEmission {
+                            lines: current_lines,
+                            temp_index: next_index,
+                            operand: ordered_operand,
+                            diagnostics: diagnostics
+                        };
+                    }
+                }
+            }
+        }
+    }
     let llvm_type = left_operand.llvm_type;
     let predicate = comparison_predicate_for_symbol(symbol, llvm_type);
     if predicate.length == 0 {

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -1102,6 +1102,12 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_eq", c_abi_return_type: null
     });
+    // #1365: lexicographic string ordering (`<`/`>`/`<=`/`>=`). The lowering
+    // emits `call i32 @sfn_str_cmp(i8*, i8*)` then `icmp <pred> i32 ..., 0`.
+    // Auto-declared via the post-lowering line scan, exactly like sfn_str_eq.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "string.compare", symbol: "sfn_str_cmp", return_type: "i32", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_cmp", c_abi_return_type: null
+    });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "char_code", symbol: "char_code", return_type: "i64", parameter_types: ["{i8*, i64}"], effects: [], native_signature: null, c_abi_return_type: null
     });

--- a/compiler/tests/unit/fmt_import_alias_test.sfn
+++ b/compiler/tests/unit/fmt_import_alias_test.sfn
@@ -8,8 +8,8 @@
 // corrupting the binding (a multi-specifier line scrambled across the `as`
 // boundary, e.g. `command_def as run`). The fix treats `A as B` as one
 // sortable unit keyed on the imported name `A`, preserving the pairing.
-import { index_of } from "../../src/string_utils";
 import { format_source } from "../../src/tools/fmt";
+import { index_of } from "../../src/string_utils";
 
 fn _contains(haystack: string, needle: string) -> boolean {
     return index_of(haystack, needle) >= 0;
@@ -38,17 +38,36 @@ test "fmt import-alias: multi-specifier aliased line stays paired" ![io] {
     assert _contains(out, "cdef as command_def") == false;
 }
 
-// ── Misordered aliased specifiers keep their pairing intact ─────────
-test "fmt import-alias: misordered aliased specifiers keep their pairing" ![io] {
+// ── Misordered aliased specifiers sort to exact within-line order ───
+test "fmt import-alias: misordered aliased specifiers sort to exact order" ![io] {
     let src = "import { run as runner, command_def as cdef } from \"./z\";\nimport { x } from \"./a\";\n";
     let out = format_source(src);
-    // The bug being guarded is the side-swap, which is order-independent:
-    // each `imported as local` pairing must survive regardless of the final
-    // within-line ordering (exact ordering is incidental and not asserted).
+    // Pairing must survive (no side-swap, order-independent).
     assert _contains(out, "command_def as cdef");
     assert _contains(out, "run as runner");
     assert _contains(out, "command_def as run") == false;
     assert _contains(out, "run as cdef") == false;
+    // Exact within-line order: sorted by imported name, `command_def` < `run`.
+    // This assertion was relaxed in PR #1362 because string ordered comparison
+    // was miscompiled and the sort silently no-op'd (#1365); re-tightened now
+    // that `<` works and import sorting is live again.
+    let i_cmd = index_of(out, "command_def as cdef");
+    let i_run = index_of(out, "run as runner");
+    assert i_cmd >= 0;
+    assert i_run >= 0;
+    assert i_cmd < i_run;
+}
+
+// ── Cross-import path sort reorders consecutive imports by path ──────
+test "fmt import: cross-import path sort reorders by path" ![io] {
+    // Non-alphabetical path order on input; same import group.
+    let src = "import { b } from \"./z\";\nimport { a } from \"./a\";\n";
+    let out = format_source(src);
+    let i_a = index_of(out, "from \"./a\"");
+    let i_z = index_of(out, "from \"./z\"");
+    assert i_a >= 0;
+    assert i_z >= 0;
+    assert i_a < i_z;  // `./a` sorts before `./z` (#1365)
 }
 
 // ── Idempotency: a second pass changes nothing ──────────────────────

--- a/compiler/tests/unit/string_ordered_compare_test.sfn
+++ b/compiler/tests/unit/string_ordered_compare_test.sfn
@@ -1,0 +1,74 @@
+// Regression coverage for string ordered comparison (`<` `>` `<=` `>=`) on the
+// canonical SfnString representation `{i8*, i64}` (#1365).
+//
+// History: `comparison_predicate_for_symbol`
+// (`compiler/src/llvm/expression_lowering/native/core_operands.sfn`) had no
+// `{i8*, i64}` arm for ordered operators, so they fell through to an empty
+// predicate -> a null comparison operand -> the if-statement lowering SILENTLY
+// DROPPED the guarded branch. `sfn check` passed (lowering isn't run) and the
+// build succeeded, so the miscompile was invisible — it disabled all of
+// `sfn fmt`'s import sorting (its sole consumer of string ordering).
+//
+// These tests MUST observe a distinct value from BOTH arms of an `if`. A bare
+// `assert (a < b)` is a FALSE POSITIVE under the bug: the dropped branch never
+// runs, but `assert` (lowered as `if !cond { abort }`) also never aborts, so
+// it "passes" regardless of the comparison's truth. Returning "lt"/"ge" makes
+// the taken branch observable.
+import { char_at } from "../../src/string_utils";
+
+fn _lt(a: string, b: string) -> string {
+    if a < b { return "lt"; }
+    return "ge";
+}
+
+fn _gt(a: string, b: string) -> string {
+    if a > b { return "gt"; }
+    return "le";
+}
+
+fn _le(a: string, b: string) -> string {
+    if a <= b { return "le"; }
+    return "gt";
+}
+
+fn _ge(a: string, b: string) -> string {
+    if a >= b { return "ge"; }
+    return "lt";
+}
+
+test "string ordered compare: less than selects the taken branch" {
+    assert _lt("apple", "banana") == "lt";
+    assert _lt("banana", "apple") == "ge";
+    assert _lt("apple", "apple") == "ge";  // equal is not-less
+}
+
+test "string ordered compare: greater than selects the taken branch" {
+    assert _gt("banana", "apple") == "gt";
+    assert _gt("apple", "banana") == "le";
+    assert _gt("apple", "apple") == "le";  // equal is not-greater
+}
+
+test "string ordered compare: less equal and greater equal include equality" {
+    assert _le("apple", "apple") == "le";
+    assert _le("apple", "banana") == "le";
+    assert _le("banana", "apple") == "gt";
+    assert _ge("apple", "apple") == "ge";
+    assert _ge("banana", "apple") == "ge";
+    assert _ge("apple", "banana") == "lt";
+}
+
+test "string ordered compare: shared-prefix orders by length" {
+    assert _lt("run", "runner") == "lt";  // prefix sorts before longer
+    assert _lt("runner", "run") == "ge";
+}
+
+// The actual fmt sorters compare single graphemes from `char_at`, then
+// tie-break on length. Exercise that exact operand shape (the live real-vs-real
+// arm of `sfn_str_cmp`).
+test "string ordered compare: char_at grapheme operands compare correctly" {
+    let r = char_at("run", 0);  // 'r'
+    let c = char_at("command_def", 0);  // 'c'
+    assert _lt(c, r) == "lt";  // 'c' < 'r'
+    assert _lt(r, c) == "ge";  // 'r' not < 'c'
+    assert _gt(r, c) == "gt";  // 'r' > 'c'
+}

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -348,6 +348,97 @@ fn sfn_str_eq(a: * u8, b: * u8) -> bool {
     return memcmp(ra, b, la2 as usize) == 0;
 }
 
+// #1365: lexicographic compare of two immediate codepoints by their UTF-8
+// encodings — the ordered analogue of the imm-vs-imm arm of `sfn_str_eq`.
+// Walks `min(na, nb)` bytes via `_sfn_utf8_byte`; first non-zero byte delta
+// (unsigned) decides, else the shorter encoding sorts first.
+fn _sfn_imm_cmp_imm(ca: i64, cb: i64) -> i32 {
+    let na: i64 = _sfn_utf8_byte_len(ca);
+    let nb: i64 = _sfn_utf8_byte_len(cb);
+    let mut m: i64 = na;
+    if nb < m { m = nb; }
+    let mut i: i64 = 0;
+    loop {
+        if i >= m { break; }
+        let ba: i64 = _sfn_utf8_byte(ca, na, i);
+        let bb: i64 = _sfn_utf8_byte(cb, nb, i);
+        if ba < bb { return -1; }
+        if ba > bb { return 1; }
+        i = i + 1;
+    }
+    if na < nb { return -1; }
+    if na > nb { return 1; }
+    return 0;
+}
+
+// #1365: lexicographic compare of an immediate codepoint `cp` against a real,
+// deref-safe string `real` of byte length `len` — the ordered analogue of
+// `_sfn_imm_eq_real`. `cp` is on the LEFT; callers comparing real-vs-immediate
+// invert the sign. Bytes are read unsigned (`sfn_str_read_byte` zero-extends),
+// matching `memcmp`'s unsigned-byte ordering.
+fn _sfn_imm_cmp_real(cp: i64, real: * u8, len: i64) -> i32 {
+    let n: i64 = _sfn_utf8_byte_len(cp);
+    let mut m: i64 = n;
+    if len < m { m = len; }
+    let mut i: i64 = 0;
+    loop {
+        if i >= m { break; }
+        let ba: i64 = _sfn_utf8_byte(cp, n, i);
+        let bb: i64 = sfn_str_read_byte(real, i);
+        if ba < bb { return -1; }
+        if ba > bb { return 1; }
+        i = i + 1;
+    }
+    if n < len { return -1; }
+    if n > len { return 1; }
+    return 0;
+}
+
+// `sfn_str_cmp(a, b)` — #1365: lexicographic ordering for the string `<`/`>`/
+// `<=`/`>=` emission target. Returns <0 / 0 / >0 like libc `strcmp`, ordering
+// by unsigned byte value with the shorter string first on a shared prefix. The
+// lowering (`core_operands.sfn`) calls this and `icmp`s the result against 0 —
+// previously these operators fell through to an empty predicate and the guarded
+// branch was silently dropped (no `{i8*, i64}` arm in
+// `comparison_predicate_for_symbol`). Mirrors `sfn_str_eq` arm-for-arm:
+// pointer-equal (both-null / identical immediates) is 0; a single null sorts
+// first (null < any real string); immediates are classified via the
+// non-allocating `sfn_str_immediate_codepoint` bridge (always -1 post-#1420, so
+// the real-vs-real arm is the live one — the immediate arms are defensive
+// parity). Real operands route through `sfn_str_decode_owned` (identity, no
+// alloc) for the call-seq bump, then `memcmp` over the common length with a
+// length tie-break.
+fn sfn_str_cmp(a: * u8, b: * u8) -> i32 {
+    if (a as i64) == (b as i64) { return 0; }
+    if (a as i64) == 0 { return -1; }
+    if (b as i64) == 0 { return 1; }
+    let ca: i64 = sfn_str_immediate_codepoint(a);
+    let cb: i64 = sfn_str_immediate_codepoint(b);
+    if ca >= 0 {
+        if cb >= 0 { return _sfn_imm_cmp_imm(ca, cb); }
+        let rb: * u8 = sfn_str_decode_owned(b);
+        let lb: i64 = strnlen(rb, 16777216) as i64;
+        return _sfn_imm_cmp_real(ca, rb, lb);
+    }
+    let ra: * u8 = sfn_str_decode_owned(a);
+    if cb >= 0 {
+        let la: i64 = strnlen(ra, 16777216) as i64;
+        let r: i32 = _sfn_imm_cmp_real(cb, ra, la);
+        if r < 0 { return 1; }
+        if r > 0 { return -1; }
+        return 0;
+    }
+    let la2: i64 = strnlen(ra, 16777216) as i64;
+    let lb2: i64 = strnlen(b, 16777216) as i64;
+    let mut m: i64 = la2;
+    if lb2 < m { m = lb2; }
+    let r: i32 = memcmp(ra, b, m as usize);
+    if r != 0 { return r; }
+    if la2 < lb2 { return -1; }
+    if la2 > lb2 { return 1; }
+    return 0;
+}
+
 // `_sfn_substring_unchecked(text, start, end)` — #1308 (M1.A.2): the i64-indexed
 // substring entrypoint, now a real Sailfin body (the C
 // `sailfin_runtime_substring_unchecked` def is `static`, retaining only its two


### PR DESCRIPTION
## Summary

Closes #1365.

String **ordered comparison** (`<` `>` `<=` `>=`) was silently miscompiled for the canonical `{i8*, i64}` `SfnString` representation. `comparison_predicate_for_symbol` (`core_operands.sfn`) has no aggregate-string arm for ordered operators, so they fell through to an empty predicate → a `null` comparison operand → the if-statement lowering **silently dropped the entire guarded branch**. No diagnostic was emitted, `sfn check` passed (lowering isn't run there), and the build succeeded.

This disabled **all** of `sfn fmt`'s import sorting (its only consumer of string ordering), which is what surfaced as #1365 — the within-line aliased-sort "arm64 divergence" was moot because sorting never ran on any platform.

Regressed in the M1.A/M2.4 string-representation flip (the C→Sailfin runtime migration): `==`/`+` got `{i8*, i64}`-aware lowering; ordered comparison did not.

## Fix (3 files)

- **`runtime/sfn/string.sfn`** — new `sfn_str_cmp(a, b) -> i32` (strcmp-style: `<0`/`0`/`>0`, lexicographic by unsigned byte, shorter-on-shared-prefix, null sorts first), mirroring `sfn_str_eq`'s immediate/real arms. Pure native Sailfin (reuses `memcmp`/`strnlen`/the UTF-8 byte helpers); **no C edit**.
- **`compiler/src/llvm/runtime_helpers.sfn`** — register `string.compare` → `sfn_str_cmp`, auto-declared via the post-lowering line scan exactly like `sfn_str_eq`.
- **`compiler/src/llvm/expression_lowering/native/core_operands.sfn`** — route string `<`/`>`/`<=`/`>=` through `sfn_str_cmp` + `icmp <pred> i32 …, 0` (covers the mixed `i8*`/`{i8*, i64}` literal-vs-local case). The equality path is untouched.

## IR before → after

`if a < b { print "lt"; return true } print "ge"; return false`:

```llvm
; before: the entire `a < b` branch vanished
define i1 @go({i8*, i64} %a, {i8*, i64} %b) {
  ... call @sfn_print_info(... "ge" ...)
  ret i1 0
}

; after
  %t2 = call i32 @sfn_str_cmp(i8* %t0, i8* %t1)
  %t3 = icmp slt i32 %t2, 0
  br i1 %t3, label %then0, label %merge1   ; both branches present
```

## Tests

- **`compiler/tests/unit/string_ordered_compare_test.sfn`** (new) — observes a *distinct value from both `if` arms*. A bare `assert (a < b)` is a **false positive** under this bug (the dropped branch never aborts), so the tests return `"lt"`/`"ge"` to make the taken branch observable. Covers `<`/`>`/`<=`/`>=`, the shared-prefix length tie-break, and the single-grapheme `char_at` operand shape the fmt sorters use.
- **`compiler/tests/unit/fmt_import_alias_test.sfn`** — re-tightened the within-line order assertion relaxed in PR #1362; added a cross-import path-sort assertion.

## Validation

- `make compile` self-hosts (first-pass + seedcheck both build). End-to-end: the seedcheck (working-fmt) binary now sorts imports correctly — `./a` before `./z`, `command_def as cdef, run as runner` within-line (the exact #1365 expected output).
- IR spot-check confirms `call i32 @sfn_str_cmp` + `icmp` + a proper `br i1` with both branches.
- Full `make check` (triple-pass self-host + suite + stage2==stage3 fixed-point) was running locally and passed the first-pass build, early-gate suite, and seedcheck build; opening the PR to let CI run the full gate.

## Deferred: tree-wide import reformat (seed-blocker follow-up)

This fix re-enables `sfn fmt` import sorting, but **no `compiler/src`/`runtime` import order changes are in this PR** — the committed source remains a fixed point of the current (broken) fmt, so CI's `fmt --check` stays green.

The tree-wide reformat (~135 files) is **deferred** and tracked as a `seed-blocker` follow-up: CI's `fmt --check` runs the first-pass binary built from the *current seed*, whose built-in `fmt` still has the broken string comparison and therefore *rejects* correctly-sorted imports. The reformat can only land once a released seed carries this fix.

https://claude.ai/code/session_014Go2rd6v5pQxNbQgk8c1S3

---
_Generated by [Claude Code](https://claude.ai/code/session_014Go2rd6v5pQxNbQgk8c1S3)_