### PR TITLE
fix(lowering): stringify narrow-width int/bool/f32 `as string` casts

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -507,6 +507,29 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             };
         }
     }
+    if target == "float" {
+        if operand_type == "double" {
+            // #1587 (bundled): float literals lower as `double` constants, so
+            // storing one into an `f32` slot (`let x: f32 = 3.5`) or passing it
+            // to a `float` parameter needs a narrowing `fptrunc`. Without this
+            // arm the coercion returned null and the store defaulted to
+            // `zeroinitializer`, so `let x: f32 = 3.5` silently became 0 (and
+            // `x as string` then printed "0"). This mirrors the `fptrunc`
+            // double→float entry the `as` cast matrix already maps
+            // (type_mapping.sfn) but that was missing from this primitive
+            // coercion helper.
+            let temp_name = format_temp_name(temp_index);
+            current_lines.push("  " + temp_name + " = fptrunc double " + operand.value
+                + " to float");
+            let coerced = LLVMOperand { llvm_type: "float", value: temp_name };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
+        }
+    }
     if target == "i64" {
         if operand_type == "double" {
             let round_temp = format_temp_name(temp_index);
@@ -1070,6 +1093,103 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 operand: coerced,
                 diagnostics: diagnostics
             };
+        }
+        // #1587: the `i64`/`double` arms above only match the source-level
+        // `int`/`float` widths the #1505 fix targeted. Any other scalar
+        // numeric operand (narrow ints, `bool`, `f32`) previously fell
+        // through to the "unable to coerce" diagnostic and a null operand,
+        // which `lower_cast_expression` defaults to `double 0.0` — so
+        // `x as string` silently lowered to "0". Widen each to the `i64` /
+        // `double` an arm above already stringifies, then recurse so the
+        // widened operand reuses the existing number→string + length
+        // recovery chain. Mirrors the `coerce_operand_to_string` precedent
+        // (core_strings.sfn). Signed widening (`sext`) matches the `i64`
+        // arm's `sitofp`; the source-level signed/unsigned cast matrix is a
+        // separate Slice D follow-up (out of scope per the issue).
+        let mut _is_narrow_int: boolean = false;
+        if operand_type == "i32" { _is_narrow_int = true; }
+        if operand_type == "i16" { _is_narrow_int = true; }
+        if operand_type == "i8" { _is_narrow_int = true; }
+        if _is_narrow_int {
+            let widened = format_temp_name(temp_index);
+            current_lines.push("  " + widened + " = sext " + operand_type + " "
+                + operand.value
+                + " to i64");
+            let widened_operand = LLVMOperand {
+                llvm_type: "i64",
+                value: widened
+            };
+            let rec = coerce_pointer_or_struct(widened_operand, "i64", target, temp_index
+                + 1, current_lines);
+            if rec != null {
+                let mut _rd_i: int = 0;
+                loop {
+                    if _rd_i >= rec.diagnostics.length { break; }
+                    diagnostics.push(rec.diagnostics[_rd_i]);
+                    _rd_i += 1;
+                }
+                return CoercionResult {
+                    lines: rec.lines,
+                    temp_index: rec.temp_index,
+                    operand: rec.operand,
+                    diagnostics: diagnostics
+                };
+            }
+        }
+        if operand_type == "i1" {
+            // No runtime bool→string helper exists, and a `true`/`false`
+            // string literal would need the `string_constants` table that
+            // only `ExpressionResult` carries (not `CoercionResult`), so
+            // emit decimal `0`/`1` via the i64 chain — the issue sanctions
+            // 0/1 text for this arm.
+            let widened = format_temp_name(temp_index);
+            current_lines.push("  " + widened + " = zext i1 " + operand.value
+                + " to i64");
+            let widened_operand = LLVMOperand {
+                llvm_type: "i64",
+                value: widened
+            };
+            let rec = coerce_pointer_or_struct(widened_operand, "i64", target, temp_index
+                + 1, current_lines);
+            if rec != null {
+                let mut _rd_i: int = 0;
+                loop {
+                    if _rd_i >= rec.diagnostics.length { break; }
+                    diagnostics.push(rec.diagnostics[_rd_i]);
+                    _rd_i += 1;
+                }
+                return CoercionResult {
+                    lines: rec.lines,
+                    temp_index: rec.temp_index,
+                    operand: rec.operand,
+                    diagnostics: diagnostics
+                };
+            }
+        }
+        if operand_type == "float" {
+            let widened = format_temp_name(temp_index);
+            current_lines.push("  " + widened + " = fpext float " + operand.value
+                + " to double");
+            let widened_operand = LLVMOperand {
+                llvm_type: "double",
+                value: widened
+            };
+            let rec = coerce_pointer_or_struct(widened_operand, "double", target, temp_index
+                + 1, current_lines);
+            if rec != null {
+                let mut _rd_i: int = 0;
+                loop {
+                    if _rd_i >= rec.diagnostics.length { break; }
+                    diagnostics.push(rec.diagnostics[_rd_i]);
+                    _rd_i += 1;
+                }
+                return CoercionResult {
+                    lines: rec.lines,
+                    temp_index: rec.temp_index,
+                    operand: rec.operand,
+                    diagnostics: diagnostics
+                };
+            }
         }
     }
 

--- a/compiler/tests/e2e/numeric_cast_test.sfn
+++ b/compiler/tests/e2e/numeric_cast_test.sfn
@@ -200,6 +200,53 @@ test "string-cast: float → string stringifies via the number→string aggregat
     assert contains(body, "insertvalue {i8*, i64}");
 }
 
+// ---- narrow int / bool / f32 → string stringify (narrow-width arms) — #1587 ----
+// #1505 only added the source-level `int` (i64) and `float` (double) arms;
+// narrower scalar numerics (`i32`/`i16`/`i8`, `bool`/`i1`, `f32`/float) fell
+// through to a null operand and silently lowered to "0". These widen to the
+// i64/double the #1505 arms stringify (`sext`/`zext` to i64, `fpext` to
+// double) then reuse the number→string + length-recovery aggregate.
+test "string-cast: i32 → string widens via sext then stringifies (#1587)" ![io] {
+    let body = _emit_body("fn label(x: i32) -> string { return x as string; }", "define {i8*, i64} @label", "i32_to_string");
+    assert body.length > 0;
+    assert contains(body, "sext i32 %x to i64");
+    assert contains(body, "sitofp i64");
+    assert contains(body, "insertvalue {i8*, i64}");
+}
+
+test "string-cast: i8 → string widens via sext then stringifies (#1587)" ![io] {
+    let body = _emit_body("fn label(x: i8) -> string { return x as string; }", "define {i8*, i64} @label", "i8_to_string");
+    assert body.length > 0;
+    assert contains(body, "sext i8 %x to i64");
+    assert contains(body, "insertvalue {i8*, i64}");
+}
+
+test "string-cast: bool → string widens via zext then stringifies (#1587)" ![io] {
+    let body = _emit_body("fn label(x: bool) -> string { return x as string; }", "define {i8*, i64} @label", "bool_to_string");
+    assert body.length > 0;
+    assert contains(body, "zext i1 %x to i64");
+    assert contains(body, "insertvalue {i8*, i64}");
+}
+
+test "string-cast: f32 → string widens via fpext then stringifies (#1587)" ![io] {
+    let body = _emit_body("fn label(x: f32) -> string { return x as string; }", "define {i8*, i64} @label", "f32_to_string");
+    assert body.length > 0;
+    assert contains(body, "fpext float %x to double");
+    assert contains(body, "insertvalue {i8*, i64}");
+}
+
+// ---- f32 local from a double literal narrows via fptrunc (#1587 bundled) ----
+// Float literals lower as `double` constants; storing one into an `f32` slot
+// needs a narrowing `fptrunc`. Without the `double → float` arm in
+// `coerce_numeric_primitive` the store defaulted to `zeroinitializer`, so
+// `let x: f32 = 3.5` silently became 0 and `x as string` printed "0".
+test "numeric-cast: f32 local from double literal narrows via fptrunc (#1587)" ![io] {
+    let body = _emit_body("fn mk() -> f32 { let x: f32 = 3.5; return x; }", "define float @mk", "f32_local_fptrunc");
+    assert body.length > 0;
+    assert contains(body, "fptrunc double");
+    assert ! contains(body, "store float zeroinitializer");
+}
+
 // ---- pointer → bool is rejected (not ptrtoint) ----
 // Without the early `as bool` check, `ptr as bool` would lower to
 // `ptrtoint ptr to i1`, a low-bit reinterpretation rather than the


### PR DESCRIPTION
## Summary

- Extend the `as string` cast fix from #1505 to the remaining scalar-numeric source types. #1505 added only the `i64`/`double` source arms to the `{i8*, i64}` target block in `coerce_pointer_or_struct`, so narrower widths (`i32`/`i16`/`i8`, `bool`/`i1`, `f32`/float) fell through to a null operand and silently lowered to `0`.
- New source arms: `sext` narrow ints → i64, `zext` bool → i64 (0/1 text), `fpext` f32 → double — each recurses into the existing number→string + length-recovery chain.
- **Bundled prerequisite** (approved scope expansion): added the missing `double → float` (`fptrunc`) arm to `coerce_numeric_primitive`. Float literals lower as `double` constants, so `let x: f32 = 3.5` could not narrow into the `f32` slot and stored `zeroinitializer` — which made the f32 `as string` repro print `0` for a reason *upstream* of the cast. The fix is purely additive (the path previously produced a silent zero), needed to satisfy the issue's f32 end-to-end criterion without a seed cut.

Closes #1587

## Acceptance Criteria

- [x] `i32`/`i8`/`bool`/`f32` `as string` produce correct decimal/text, not `0` (`bool` → `0`/`1` per the issue's sanctioned 0/1 option — no runtime bool→string helper and `CoercionResult` carries no string-constant channel).
- [x] e2e regressions added to `compiler/tests/e2e/numeric_cast_test.sfn` (5 new cases extending the #1505 `string-cast:` set, plus an f32-local fptrunc guard).
- [x] `make compile` self-hosts; `make test` green.

## Verification

```text
$ build/native/sailfin run /tmp/cast1587.sfn   # i32=7, f32=3.5, i8=42, bool=true
[info] 7
[info] 3.5
[info] 42
[info] 1

$ build/native/sailfin test compiler/tests/e2e/numeric_cast_test.sfn
PASS (all 17 tests passed)

$ make test
unit: 163/163 · integration: 36/36 · e2e: 149/149 · capsules: 36/36  (exit 0)
```

Param-form IR confirms the cast arms (e.g. `fpext float %x to double` → `sfn_number_to_str` → `insertvalue {i8*, i64}`).

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_operands.sfn` — narrow-int/bool/f32 arms in the `{i8*, i64}` target block; `double → float` fptrunc arm in `coerce_numeric_primitive`.
- `compiler/tests/e2e/numeric_cast_test.sfn` — 5 new regression tests.

## Notes

- The `double → float` store bug was discovered during verification (the f32 repro printed `0` even with the cast arms in place). It is a separate pre-existing defect bundled here per maintainer approval rather than split into a follow-up, since it's tightly coupled to the f32 acceptance criterion, lives in the same file, and needs no seed cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6f9DLsLkFpNarcjxybVwG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6f9DLsLkFpNarcjxybVwG)_