### PR TITLE
fix(lowering): resolve char_at callee signature in per-module emit

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -1105,6 +1105,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "char_code", symbol: "char_code", return_type: "i64", parameter_types: ["{i8*, i64}"], effects: [], native_signature: null, c_abi_return_type: null
     });
+    // #1572: `char_at(value, index)` — bare-name descriptor mirroring the
+    // `char_from_code` / `char_code` rows below/above. `char_at` is a prelude
+    // free function (`runtime/prelude.sfn`); modules that call it without
+    // importing the prelude (e.g. `sfn/strings`'s `to_upper`/`to_lower`)
+    // resolve through `context_functions` on a normal build, but the test
+    // command path never loads the prelude `.sfn-asm`, so the callee signature
+    // was unknown and lowering emitted a spurious `cannot resolve return type`
+    // [fatal]. This row resolves the return type (`{i8*, i64}`, matching the
+    // prelude's emitted `{i8*, i64} @char_at({i8*, i64}, i64)`) so the call
+    // lowers to `call {i8*, i64} @char_at` and links to the prelude body.
+    // `native_signature: null` — the symbol IS the prelude function; self-host
+    // is unaffected since `find_function_by_name_or_import` resolves `char_at`
+    // before this descriptor is ever consulted.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "char_at", symbol: "char_at", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "i64"], effects: [], native_signature: null, c_abi_return_type: null
+    });
     // #874: `char_from_code(code)` — raw single-byte string constructor, the
     // write counterpart to `char_code`'s read. Bare-name descriptor so user
     // call sites resolve the return type and emit `call i8* @char_from_code`,

--- a/compiler/tests/e2e/cross_module_char_at_signature_test.sfn
+++ b/compiler/tests/e2e/cross_module_char_at_signature_test.sfn
@@ -1,0 +1,104 @@
+// End-to-end regression for #1572: a `-p` sibling that calls the prelude
+// free function `char_at` (without importing the prelude) must resolve the
+// callee's return-type signature during its own per-module lowering and
+// emit cleanly — no spurious `cannot resolve return type for call to
+// `char_at`` `[fatal]`.
+//
+// Root cause (pre-#1572): `char_at` is a `runtime/prelude.sfn` free function.
+// On a normal single-file build the prelude's `.declare` reaches the lowering
+// `context_functions`, but the multi-capsule / per-module emit path does not
+// load the prelude `.sfn-asm`, so the callee signature was unknown and
+// lowering fell through to the `cannot resolve return type` fatal. `char_code`,
+// `substring`, and `strings_equal` already carried bare-name descriptors in
+// `runtime_helpers.sfn` for exactly this case; `char_at` was the lone omission.
+// #1572 adds the `char_at` bare-name descriptor so the call resolves to
+// `call {i8*, i64} @char_at` and links to the prelude body.
+//
+// NOTE: assert on captured stdout+stderr with `sfn/strings` predicates
+// (the `sfn/test` `expect_*` matchers are `![pure]` and cannot be called
+// from an `![io]` test). (#842.)
+import { find, contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// The build spawns a nested `clang` + linker, so the child needs `PATH`
+// (an empty `run_capture` env is the *empty* environment, not "inherit").
+// `SAILFIN_TEST_SCRATCH` routes the `program.ll` build-cache dir per
+// invocation so the parallel pool does not collide on `build/sailfin`.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// A fresh capsule root under the runner's scratch dir (or /tmp), keyed by
+// `tag` so concurrent tests in the parallel pool never collide.
+fn _make_capsule(tag: string) -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    let root = base + "/sfn-charat-sig-" + tag;
+    fs.createDirectory(root + "/src/util", true);
+
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"charat-sig-test\"\n"
+        + "version = \"0.1.0\"\n\n"
+        + "[capabilities]\n"
+        + "required = [\"io\"]\n\n"
+        + "[build]\n"
+        + "kind = \"binary\"\n"
+        + "entry = \"src/main.sfn\"\n");
+
+    // Sibling: calls the prelude free fn `char_at` directly (no import).
+    // This is the lowering site whose callee-signature lookup missed
+    // pre-#1572.
+    fs.writeFile(root + "/src/util/sib.sfn", "fn second_char(text: string) -> string {\n"
+        + "    return char_at(text, 1);\n"
+        + "}\n\n"
+        + "export { second_char };\n");
+
+    // Entry: imports the sibling so the linked binary is runnable and the
+    // sibling's `char_at` call is exercised at runtime.
+    fs.writeFile(root + "/src/main.sfn", "import { second_char } from \"./util/sib\";\n\n"
+        + "fn main() ![io] {\n"
+        + "    let c = second_char(\"hello\");\n"
+        + "    print.info(\"charat-result=\" + c);\n"
+        + "}\n");
+
+    return root;
+}
+
+// Build emits with NO `char_at` unresolved-callee fatal, links, and the
+// linked binary computes `char_at("hello", 1) == "e"`.
+test "cross-module char_at call resolves its signature, links, runs (#1572)" ![io] {
+    let root = _make_capsule("link");
+    let out_bin = root + "/prog";
+    let exit = process.run_capture([_sfn_bin(), "build", "-p", root, "-o", out_bin], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    let log = out + err;
+
+    // The #1572 signal: no spurious lowering fatal for `char_at`.
+    assert ! contains(log, "cannot resolve return type for call to `char_at`");
+    assert exit == 0;
+
+    // The linked binary runs and prints the resolved value. `print.info`
+    // prefixes with `[info] `, pinning the match. `char_at("hello", 1)` is
+    // the second character, "e" — confirms the call lowered correctly, not
+    // merely that the diagnostic was suppressed.
+    let run_exit = process.run_capture([out_bin], _child_env());
+    let run_out = process.capture_take_stdout();
+    let run_err = process.capture_take_stderr();
+    assert run_exit == 0;
+    assert find(run_out + run_err, "[info] charat-result=e", 0) >= 0;
+}


### PR DESCRIPTION
## Summary
- Add a bare-name runtime-helper descriptor for `char_at` so its callee signature resolves during per-module lowering, eliminating the spurious `cannot resolve return type for call to ``char_at`` ` `[fatal]` printed while compiling `sfn/test` (and any multi-capsule build that lowers a module calling `char_at`).
- Add a `-p` synthetic-capsule e2e regression that reproduces the fatal cross-module and asserts it's gone.

Closes #1572

## Root cause
`char_at` is a `runtime/prelude.sfn` free function (`char_at(value: string, index: int) -> string`). On a normal single-file build the prelude's `.declare` reaches the lowering `context_functions`, so `find_function_by_name_or_import` resolves it. But the multi-capsule / `test` command path never loads the prelude's `.sfn-asm` into the lowering context (`prepare_project_capsules_for_test` excludes the `runtime/` prefix), so the callee signature was unknown. Resolution then fell through to `find_runtime_helper`, which **also** missed because `char_at` had no descriptor — emitting the `[fatal]` in `core_call_emission.sfn`. The test still linked and passed (the prelude `@char_at` body is linked in), so the diagnostic was pure stderr noise on a green run.

`char_code`, `substring`, and `strings_equal` already carry bare-name descriptors in `runtime_helpers.sfn` for exactly this cross-module-without-import case (the `char_from_code` row, #874, documents the pattern). **`char_at` was the lone omission.** The fix adds the matching row:

```
target: "char_at", symbol: "char_at", return_type: "{i8*, i64}",
parameter_types: ["{i8*, i64}", "i64"], native_signature: null
```

The ABI matches the prelude's emitted `declare {i8*, i64} @char_at({i8*, i64}, i64)`, so the call lowers to `call {i8*, i64} @char_at` and links to the prelude body. `find_function_by_name_or_import` runs **before** `find_runtime_helper`, so normal builds and the compiler self-host (where `char_at` is in `context_functions`) never consult the descriptor and are unaffected.

## Acceptance Criteria
- [x] `build/native/sailfin test capsules/sfn/test/tests/fixtures_test.sfn` emits **no** `cannot resolve return type for call to ``char_at`` ` line.
- [x] Root cause documented (above).
- [x] Regression test asserting the diagnostic is gone.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Verification
```bash
# Issue's verification command — expect 0:
$ build/native/sailfin test capsules/sfn/test/tests/fixtures_test.sfn 2>&1 | grep -c "cannot resolve return type"
0
#   → PASS  (all 5 tests passed)

# New regression (reproduces the fatal against buggy seed alpha.48, passes post-fix):
$ build/native/sailfin test compiler/tests/e2e/cross_module_char_at_signature_test.sfn
  PASS  (all 1 tests passed)

# Full suite:
unit: 162/162   integration: 36/36   e2e: 150/150   capsules: 36/36   (all pass)
```

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — add the `char_at` bare-name descriptor (+ comment).
- `compiler/tests/e2e/cross_module_char_at_signature_test.sfn` — new regression.

## Notes for grooming
- The issue's hypothesis pointed at a `find_declare_signature` scanning `imported_native_texts`; no such function exists — actual resolution is `resolve_call_signature` → `find_function_by_name_or_import` + `find_runtime_helper`. Worth correcting in future grooming of this area.
- **Out of scope (separate bug):** `sfn/strings`'s `to_upper`/`to_lower` call `char_at(ch, code ± 32)` (line 123/133), treating `char_at`'s **index** arg as a code point — always returns `""`. That's a semantics bug in the *caller*, distinct from this signature-resolution fix; flagging for a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MebdF78PjVH9i1rQuGp9qH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MebdF78PjVH9i1rQuGp9qH)_