### PR TITLE
feat(test): scoped env runner over typed Env + run_capture

### DIFF
--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -19,6 +19,11 @@ description = "Test assertion helpers and utilities for Sailfin"
 # is fixed (#873 slug canonicalization), so the import is restored (#1571).
 "sfn/fs" = "*"
 
+# `with_env` (#1166) composes the typed `os::Env` + `os::run_capture` to run
+# a subprocess under a scoped, per-child environment without mutating the
+# parent `environ`. `sfn/os` has no dependencies of its own, so no cycle.
+"sfn/os" = "*"
+
 [capabilities]
 required = ["io"]
 

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -21,11 +21,17 @@
 //     already ships as the typed `Env` + `os::run_capture` API. A
 //     concurrency-aware redesign is tracked in #1107.
 //
+// That concurrency-aware redesign ships here as `with_env` (#1166): a
+// per-child scoped-environment runner over the typed `os::Env` +
+// `os::run_capture` API, with the parent `environ` never mutated. See
+// its doc comment below.
+//
 // Teardown delegates to `sfn/fs::remove_all` (#976) — a pure-Sailfin
 // `rm -rf` composed from the `fs.*` runtime intrinsics
 // (`deleteFile` / `exists` / `listDirectory` / `removeDirectory`). No new
 // C runtime surface is introduced.
 import { remove_all } from "sfn/fs";
+import { Env, run_capture, ProcessOutput } from "sfn/os";
 
 // Create a fresh temporary directory, hand its absolute path to `body`,
 // and recursively remove the whole tree on scope exit — on both the
@@ -61,4 +67,40 @@ fn with_tmp_dir(body: fn (string) -> int) -> int ![io] {
         let _ = remove_all(dir);
         throw e;
     }
+}
+
+// Run `args` as a subprocess under the scoped environment `env`, hand the
+// captured `ProcessOutput` to `body`, and return whatever `body` returns.
+//
+// This is the concurrency-safe successor to the dropped process-global
+// `with_env` / `with_cwd` fixtures (see the note at the top of this file
+// for why those were rejected). Rather than mutating the shared, non
+// thread-safe `environ` with `setenv(3)` — which corrupts sibling tasks
+// the moment the test runner goes parallel — the scoped environment is
+// applied to a *single* child via `os::run_capture(args, env)`. The
+// parent process environment is never read or written, so the scoping is
+// confined to that one child and concurrent tests are unaffected.
+//
+// Build `env` with the typed `os::Env` constructors:
+//
+//   * `env_empty()` — a child with NO environment at all (an empty `Env`
+//     means "empty", not "inherit").
+//   * `env_from_current()` — a snapshot of the parent's environment to
+//     inherit from; layer overrides on top with `env_set(e, name, value)`.
+//
+// `body` is an ordinary closure that may capture the enclosing test's
+// locals (single capture; see `fixtures_test.sfn`). It is typed
+// `fn(ProcessOutput) -> int` with no `![io]` row, for the same reason
+// `with_tmp_dir`'s body is: the effect checker attributes a lambda body's
+// effects to the scope that *defines* the lambda, so an `![io]` test that
+// builds the closure already accounts for any io inside it — the fn-type
+// itself carries no effect row. (`-> int` is the interim return shape
+// shared with `with_tmp_dir`; a generic result type waits on generics.)
+//
+// Unlike `with_tmp_dir` there is no teardown step: a scoped child env owns
+// no host resource to release — the override lived only in the child's
+// `environ`, which dies with the child.
+fn with_env(args: string[], env: Env, body: fn (ProcessOutput) -> int) -> int ![io] {
+    let out = run_capture(args, env);
+    return body(out);
 }

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -393,8 +393,12 @@ export { CompileExpect, assert_compiles, assert_does_not_compile } from "./compi
 // `body` closure against it, and recursively removes the tree on scope
 // exit — including the throwing path — via a pure-Sailfin `rm -rf` over the
 // `fs.*` intrinsics (mirroring `sfn/fs::remove_all` from #976; see the note
-// in `fixtures.sfn` for why it does not import that capsule). The proposed
-// `with_env` / `with_cwd` are intentionally omitted (no runtime
-// setenv/chdir primitive; process-global mutation is unsound under
-// structured concurrency). See `fixtures.sfn`.
-export { with_tmp_dir } from "./fixtures";
+// in `fixtures.sfn` for why it does not import that capsule).
+//
+// `with_env(args, env, body)` (issue #1166) is the concurrency-safe
+// successor to the dropped process-global `with_env`: it runs `args` as a
+// subprocess under a scoped `os::Env` via `os::run_capture` and threads the
+// captured `ProcessOutput` to `body`, never mutating the parent `environ`.
+// (`with_cwd` stays omitted — no per-child cwd primitive yet; tracked in
+// #1107.) See `fixtures.sfn`.
+export { with_env, with_tmp_dir } from "./fixtures";

--- a/capsules/sfn/test/tests/fixtures_test.sfn
+++ b/capsules/sfn/test/tests/fixtures_test.sfn
@@ -25,9 +25,10 @@
 // separate multi-capture lowering bug). Single capture — the path the
 // `closure_single_capture` e2e fixture exercises and that #979 actually
 // rides — works; these tests stay within it deliberately.
+import { env_set, env_empty, ProcessOutput } from "sfn/os";
 import { find } from "sfn/strings";
 
-import { with_tmp_dir } from "../src/mod";
+import { with_env, with_tmp_dir } from "../src/mod";
 
 // Scratch root for marker files. Prefer the runner's
 // `SAILFIN_TEST_SCRATCH`; fall back to `/tmp` for a direct
@@ -131,4 +132,69 @@ test "with_tmp_dir: body captures an enclosing local" ![io] {
         return -1;
     });
     assert r == token.length;
+}
+
+// ---------------------------------------------------------------------------
+// with_env — scoped per-child environment runner (#1166)
+// ---------------------------------------------------------------------------
+// `with_env(args, env, body)` runs `args` as a subprocess under the scoped
+// `os::Env`, capturing stdout/stderr, then threads the `ProcessOutput` to
+// `body`. The parent `environ` is never mutated — the override lives only in
+// the spawned child. These tests prove the three contract points from #1166:
+// the child sees the override, the parent is unchanged, and an empty `Env`
+// yields a child with no environment.
+//
+// Subprocesses use `printenv` / `env` (coreutils). `posix_spawnp` resolves
+// the bare binary name via the *parent's* PATH even when the *child's*
+// environment is empty, so these run without threading PATH into the scoped
+// `Env` — mirroring `sfn/os`'s own `run_capture_test.sfn`. Each body lambda
+// captures nothing (literals + the imported `find`), staying within the
+// single-capture lowering constraint documented above.
+// The child process sees a variable set only in the scoped `Env`.
+test "with_env: child sees the scoped override" ![io] {
+    let r = with_env(["printenv", "SFN_WITH_ENV_CHILD"], env_set(env_empty(), "SFN_WITH_ENV_CHILD", "scoped-value"), fn (out: ProcessOutput) -> int {
+        if out.exit != 0 { return -1; }
+        if find(out.stdout, "scoped-value", 0) >= 0 { return 1; }
+        return 0;
+    });
+    assert r == 1;
+}
+
+// The scoped override never leaks into the parent: reading the same
+// variable before and after the call yields identical (and empty)
+// results, proving `environ` was untouched. The read goes through the
+// builtin `env.get` — exactly the call `os::env(name)` wraps
+// (`sfn/os::env` is `return env.get(name)`); using it directly avoids
+// shadowing the builtin `env` namespace with a same-named import.
+test "with_env: parent environment is unchanged by a scoped child env" ![io] {
+    let before = env.get("SFN_WITH_ENV_PARENT");
+    let r = with_env(["printenv", "SFN_WITH_ENV_PARENT"], env_set(env_empty(), "SFN_WITH_ENV_PARENT", "child-only"), fn (out: ProcessOutput) -> int {
+        // Sanity: the scoping worked at all — the child did see it.
+        if find(out.stdout, "child-only", 0) >= 0 { return 1; }
+        return 0;
+    });
+    let after = env.get("SFN_WITH_ENV_PARENT");
+    assert r == 1;
+    assert before == after;
+    assert after.length == 0;
+}
+
+// An empty `Env` means "empty", not "inherit": the child's environment
+// listing (via the `env` coreutil) is empty.
+test "with_env: empty Env yields a child with no environment" ![io] {
+    let r = with_env(["env"], env_empty(), fn (out: ProcessOutput) -> int {
+        if out.exit != 0 { return -1; }
+        return out.stdout.length;
+    });
+    assert r == 0;
+}
+
+// The captured `ProcessOutput` threads back through the helper: a body
+// returning an extracted value is the helper's return value (mirrors
+// `with_tmp_dir`'s result-threading contract).
+test "with_env: body return value threads back out" ![io] {
+    let r = with_env(["sh", "-c", "exit 7"], env_empty(), fn (out: ProcessOutput) -> int {
+        return out.exit;
+    });
+    assert r == 7;
 }


### PR DESCRIPTION
## Summary
- Adds `with_env(args, env, body)` to `sfn/test` fixtures — the concurrency-safe successor to the dropped process-global `with_env`. It runs `args` as a subprocess under a scoped `os::Env` via `os::run_capture` and threads the captured `ProcessOutput` to a `fn(ProcessOutput) -> int` body, mirroring `with_tmp_dir`'s body-closure shape. The parent `environ` is never mutated, so scoping is confined to the single child.
- Composes only `os::Env` + `os::run_capture` (no new C, no `sfn/fs` import). Adds the `sfn/os` dependency (which has no deps of its own, so no cycle) and re-exports the helper from the barrel.

Closes #1166

## Acceptance Criteria
- [x] New helper in `fixtures.sfn` composes only `os::Env` + `os::run_capture` (no new C, no `sfn/fs` import).
- [x] Test proves parent env unchanged (read a var before/after, assert identical).
- [x] Test proves child sees the scoped override.
- [x] Empty `Env` yields a child with no env.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes.
- [x] `make test` passes (full suite green; targeted `fixtures_test.sfn` = 9/9).

## Verification
```bash
# self-host
make compile                       # pass — built build/native/sailfin

# fmt gate
sfn fmt --check capsules/sfn/test/src/fixtures.sfn \
  capsules/sfn/test/src/mod.sfn \
  capsules/sfn/test/tests/fixtures_test.sfn   # clean

# targeted (self-hosted compiler)
SAILFIN_TEST_SCRATCH=/tmp build/native/sailfin test \
  capsules/sfn/test/tests/fixtures_test.sfn   # PASS (all 9 tests)

make test                          # full suite green
```

## Files Changed
- `capsules/sfn/test/src/fixtures.sfn` — add the `with_env` helper
- `capsules/sfn/test/src/mod.sfn` — re-export `with_env`
- `capsules/sfn/test/capsule.toml` — add `sfn/os` dependency
- `capsules/sfn/test/tests/fixtures_test.sfn` — 4 tests (override seen, parent unchanged, empty-Env, result threading)

## Notes for grooming
- The issue body said `env_from_current` is "still a stub" — it's now real (backed by `process.environ`, #1242). The helper documentation reflects the live API.
- The pinned seed (v0.7.0-alpha.49) cannot directly compile the `strings` capsule (a `char_at` return-type resolution drift), so capsule tests must be validated with the self-hosted compiler, not the seed — they pass cleanly there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqEFM4i2ovaLLdt6KV4FqE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqEFM4i2ovaLLdt6KV4FqE)_