### PR TITLE
perf(scheduler): raise default worker-pool ceiling from 4 to 32

### DIFF
--- a/compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn
+++ b/compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn
@@ -372,3 +372,49 @@ test "scheduler: detached tasks are reclaimed by the worker (#1203)" ![io] {
     assert contains(worker_body, "@sfn_task_destroy(");
     assert contains(worker_body, "br i1 ");
 }
+
+// ---- 8. default auto-pool ceiling raised to 32 (#1584) ----
+// `_sfn_scheduler_default_max` is the upper clamp in
+// `sfn_scheduler_resolve_thread_count` (`clamp(cores, 2, default_max)`), so its
+// value IS the default in-flight worker ceiling. #1584 (epic #1540 gap B5
+// cap-raise) lifted it from the original `4` to `32` so an I/O-bound
+// proxy/server is no longer throttled to four concurrent in-flight connections
+// regardless of host core count. The helper folds to a single `ret i64 32`;
+// pin it as a host-independent emit-shape invariant.
+test "scheduler: default auto-pool ceiling is 32 (#1584)" ![io] {
+    let ir = _emit_scheduler_ir();
+    assert ir != "EMIT_FAILED";
+    let body = _define_body(ir, "_sfn_scheduler_default_max");
+    assert body.length > 0;
+    assert contains(body, "ret i64 32");
+    // The original `4` must be gone — a regression back to the throttled cap.
+    assert ! contains(body, "ret i64 4");
+}
+
+// ---- 9. SAILFIN_THREADS override + 1024 hard ceiling unchanged (#1584) ----
+// The cap-raise must leave the explicit-override path untouched: an
+// `SAILFIN_THREADS=N` is still read (`getenv` + `atoi`) and still clamped to
+// the `1024` sanity ceiling (`_sfn_scheduler_max_thread_count`), which the
+// resolve body consults BEFORE the auto path. The auto path still clamps the
+// detected core count to the (now `32`) default-ceiling helper. Pins both
+// helpers and the override read so a future cap tweak can't silently drop the
+// override or move the hard ceiling.
+test "scheduler: SAILFIN_THREADS override + 1024 ceiling intact (#1584)" ![io] {
+    let ir = _emit_scheduler_ir();
+    assert ir != "EMIT_FAILED";
+
+    // The 1024 explicit-override sanity ceiling is unchanged.
+    let ceil = _define_body(ir, "_sfn_scheduler_max_thread_count");
+    assert ceil.length > 0;
+    assert contains(ceil, "ret i64 1024");
+
+    // The resolve body still reads the SAILFIN_THREADS override (getenv +
+    // atoi) and clamps it against the 1024 ceiling helper before the auto path.
+    let resolve = _define_body(ir, "sfn_scheduler_resolve_thread_count");
+    assert resolve.length > 0;
+    assert contains(resolve, "@getenv(");
+    assert contains(resolve, "@atoi(");
+    assert contains(resolve, "@_sfn_scheduler_max_thread_count(");
+    // And the auto path still clamps to the (now 32) default-ceiling helper.
+    assert contains(resolve, "@_sfn_scheduler_default_max(");
+}

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -892,8 +892,10 @@ declarations in `runtime/sfn/platform/pthread.sfn`. No C wrapper is involved.
 `PthreadMutex` and `PthreadCond` are declared as opaque byte arrays sized to
 the target platform's `sizeof(pthread_mutex_t)` / `sizeof(pthread_cond_t)`.
 
-**Pool size:** `min(available_cores, 4)` by default, overridable with
-`SAILFIN_THREADS=N`.
+**Pool size:** `min(available_cores, 32)` by default, overridable with
+`SAILFIN_THREADS=N` (raised from the original `4`-cap in #1584 so an I/O-bound
+proxy/server is not throttled to four in-flight connections; the `1024`
+explicit-override ceiling is unchanged).
 
 #### 2.6.2 Spawn
 

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -8,7 +8,7 @@
 // `sfn_taskqueue_*` section below implements the mutex-guarded
 // enqueue/dequeue surface that producers and consumers share. The
 // `sfn_scheduler_*` section spins up the fixed worker pool —
-// `pthread_create` worker loop, `min(cores, 4)` / `SAILFIN_THREADS`
+// `pthread_create` worker loop, `min(cores, 32)` / `SAILFIN_THREADS`
 // sizing, and atomic shutdown that drains + joins (§2.6.2). The
 // remaining runtime behaviour — task invocation and the spawn/await
 // result surface (§2.6.3) — lands in follow-up M4 issues and is
@@ -171,7 +171,7 @@ struct TaskQueue {
 // `threads_addr` points at a `thread_count`-slot array of `pthread_t`
 // ids (each written by `pthread_create`; `pthread_t` is pointer-sized —
 // modelled as `usize` in `pthread.sfn`). `thread_count` is the pool
-// size, defaulting to `min(available_cores, 4)` and overridable via
+// size, defaulting to `min(available_cores, 32)` and overridable via
 // `SAILFIN_THREADS` (see `sfn_scheduler_resolve_thread_count`).
 // `queue_addr` is the shared `* TaskQueue`. `processed` counts tasks
 // pulled off the queue, incremented under the queue mutex (so a plain
@@ -472,8 +472,19 @@ fn _sfn_scheduler_sc_nprocessors_onln() -> i32 {
     return sailfin_intrinsic_sc_nprocessors_onln();
 }
 
-// Default pool-size ceiling: `min(available_cores, 4)` per §2.6.1.
-fn _sfn_scheduler_default_max() -> i64 { return 4; }
+// Default auto-pool ceiling: `min(available_cores, 32)`. Raised from the
+// original `4` (#1584, epic #1540 gap B5 cap-raise): the 4-cap throttled an
+// I/O-bound proxy/server to four concurrent in-flight connections regardless
+// of how many cores the host had, since `sfn_scheduler_resolve_thread_count`
+// clamps the auto-detected core count to this value. `32` lets the auto-pool
+// size to the host's real core count on typical server hardware (≤ 32 cores →
+// all cores) while still bounding the eagerly-spun pthread pool — and its
+// thread-stack overhead — well below the `1024` explicit-`SAILFIN_THREADS`
+// sanity ceiling on very-large-core boxes. This is a fixed-pool cap raise
+// only; true per-connection scale for thousands of idle long-lived sessions
+// still needs the deferred epoll/kqueue event loop (#1540 B5). The
+// `SAILFIN_THREADS` override and the `1024` hard ceiling are unchanged.
+fn _sfn_scheduler_default_max() -> i64 { return 32; }
 
 // Sanity ceiling for an explicit `SAILFIN_THREADS` override. The value
 // is honoured verbatim up to this cap; the cap only guards against an
@@ -484,7 +495,7 @@ fn _sfn_scheduler_max_thread_count() -> i64 { return 1024; }
 
 // Resolve the worker count. An explicit `SAILFIN_THREADS=N` (N >= 1)
 // wins, clamped to the sanity ceiling; a missing, empty, non-numeric,
-// or non-positive value falls through to `clamp(online_cores, 2, 4)`. A
+// or non-positive value falls through to `clamp(online_cores, 2, 32)`. A
 // `sysconf` failure (returns -1) or a single-core box both clamp up to
 // the two-worker floor — the minimum a producer/consumer pair needs to
 // avoid the bounded-pool deadlock (see the clamp comment below).
@@ -517,7 +528,7 @@ fn sfn_scheduler_resolve_thread_count() -> i64 {
     // `_sfn_scheduler_sc_nprocessors_onln`'s
     // `sailfin_intrinsic_sc_nprocessors_onln` intrinsic (#1480), so macOS
     // no longer fails closed to `-1` and the pool sizes to
-    // `min(realcores, 4)` rather than collapsing to this floor.
+    // `min(realcores, 32)` rather than collapsing to this floor.
     // Oversubscribing a genuine
     // single-core box with two pool threads is safe — the OS time-slices
     // the blocked worker out. An explicit `SAILFIN_THREADS=1` still wins


### PR DESCRIPTION
## Summary
- Raise `_sfn_scheduler_default_max()` from `4` → `32` (`runtime/sfn/concurrency/scheduler.sfn`). It is the upper clamp in `sfn_scheduler_resolve_thread_count` (`clamp(cores, 2, default_max)`), so the old `4`-cap throttled an I/O-bound proxy/server to four concurrent in-flight connections regardless of host core count. `min(cores, 32)` sizes the auto-pool to the host's real core count on typical server hardware while bounding the eagerly-spun pthread pool far below the `1024` explicit-override sanity ceiling on very-large-core boxes.
- `SAILFIN_THREADS` override and the `1024` hard ceiling are **unchanged** (verified in emitted IR + a new regression).
- Cap-raise only (epic #1540 gap B5 cap-raise half); the true event-loop scale path (epoll/kqueue) stays deferred.

Closes #1584

## Acceptance Criteria
- [x] Default worker count is raised from 4 with a documented rationale (now `32`; rationale in the helper comment + `docs/runtime_architecture.md` §2.6.1).
- [x] `SAILFIN_THREADS` override and the 1024 hard ceiling are unchanged (pinned by the new emit-shape regression).
- [x] `make compile` passes (self-hosts); `make test` passes; `sfn fmt --check` clean.

## Verification
```text
make compile  → {"target":"compile","status":"pass"}
make test     → unit 163/163, integration 37/37, e2e 151/151, capsules 36/36
                {"target":"test","status":"pass"}
sfn fmt --check runtime/sfn/concurrency/scheduler.sfn \
                compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn  → exit 0

emitted IR (scheduler.sfn):
  @_sfn_scheduler_default_max      → ret i64 32
  @_sfn_scheduler_max_thread_count → ret i64 1024   (unchanged)
  @sfn_scheduler_resolve_thread_count body still calls
    @getenv / @atoi / @_sfn_scheduler_max_thread_count / @_sfn_scheduler_default_max

runtime_scheduler_skeleton_test.sfn → PASS (all 10 tests, incl. 2 new #1584 regressions)
```

## Files Changed
- `runtime/sfn/concurrency/scheduler.sfn` — `_sfn_scheduler_default_max()` 4 → 32 + rationale; 4 stale `min(..., 4)` comment refs updated.
- `compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn` — two emit-shape regressions (default ceiling is 32; `SAILFIN_THREADS` override + 1024 ceiling intact).
- `docs/runtime_architecture.md` — §2.6.1 pool-size note updated to `min(available_cores, 32)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6buK9V5hXsEz1W5fVvnZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6buK9V5hXsEz1W5fVvnZo)_