### PR TITLE
fix(effects): enforce effects inside try/catch/finally, throw, and blocks

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -575,6 +575,25 @@ fn collect_effects_from_statement(statement: Statement, imports: ImportSymbolTab
         required = merge_requirements(required, collect_effects_from_else_branch(else_branch, imports));
         return required;
     }
+    if statement.variant == "TryStatement" {
+        // `try`/`catch`/`finally` is ordinary control flow — every branch runs
+        // in the enclosing function's capability context, so an effectful call
+        // inside any of them must be collected transitively. Wrapping a call in
+        // `try` is not a capability escape hatch.
+        let mut required = collect_effects_from_block(statement.try_block, imports);
+        required = merge_requirements(required, collect_effects_from_optional_block(statement.catch_block, imports));
+        required = merge_requirements(required, collect_effects_from_optional_block(statement.finally_block, imports));
+        return required;
+    }
+    if statement.variant == "ThrowStatement" {
+        return collect_effects_from_expression(statement.expression, imports);
+    }
+    if statement.variant == "BlockStatement" {
+        // A bare `{ }` (or `unsafe { }`) block runs in the enclosing
+        // capability context. `unsafe` relaxes memory-safety checks, not
+        // capability enforcement, so its effects are still required.
+        return collect_effects_from_block(statement.body, imports);
+    }
     if statement.variant == "ReturnStatement" {
         return collect_effects_from_expression(statement.expression, imports);
     }

--- a/compiler/tests/e2e/check_effect_try_block_escape_test.sfn
+++ b/compiler/tests/e2e/check_effect_try_block_escape_test.sfn
@@ -1,0 +1,112 @@
+// End-to-end regression test for the effect-checker soundness hole where
+// `try`/`catch`/`finally`, `throw`, and bare/`unsafe` block statements were
+// not visited by `collect_effects_from_statement` (effect_checker.sfn). An
+// effectful call wrapped in any of those statements escaped `![effect]`
+// enforcement entirely — a silent capability-security bypass of the project's
+// #1 pillar (compile-time capability enforcement).
+//
+// Each fixture wraps an effectful call (`print.info` → `![io]`, `http.get` →
+// `![net]`) in one of the previously-unvisited statements inside a function
+// that does NOT declare the effect. `sfn check` must reject every one with
+// E0400. The final test is a positive control: the same `try`-wrapped call in
+// a function that DOES declare `![io]` must still compile, guarding against an
+// over-broad fix.
+//
+// `sfn check` is a frontend-only pass (no link), so the child is spawned with
+// an empty environment, mirroring `sfn/test`'s own `assert_compiles`. Assert
+// on captured output with `sfn/strings` predicates — the `sfn/test` `expect_*`
+// matchers are `![pure]` and cannot be called from an `![io]` test (#842).
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+struct _CheckRun {
+    exit: int;
+    output: string;
+}
+
+fn _run_check(source: string) -> _CheckRun ![io] {
+    let dir = fs.mkdtemp("sfn-check-effect-escape-");
+    let path = dir + "/leak.sfn";
+    fs.writeFile(path, source);
+    let exit = process.run_capture([_sfn_bin(), "check", path], []);
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    fs.deleteFile(path);
+    fs.removeDirectory(dir);
+    return _CheckRun { exit: exit, output: out + err };
+}
+
+// ---- try block must not hide an effect ----
+test "effect escape: try block ![io] fires E0400" ![io] {
+    let r = _run_check("fn leaky() {\n"
+        + "    try { print.info(\"escaped\"); } catch (e) { print.info(\"x\"); }\n"
+        + "}\n");
+    assert r.exit == 1;
+    assert find(r.output, "E0400", 0) >= 0;
+    assert find(r.output, "io", 0) >= 0;
+}
+
+// ---- catch block must not hide an effect ----
+test "effect escape: catch block ![io] fires E0400" ![io] {
+    let r = _run_check("fn leaky() {\n"
+        + "    try { let x: number = 1; } catch (e) { print.info(\"escaped\"); }\n"
+        + "}\n");
+    assert r.exit == 1;
+    assert find(r.output, "E0400", 0) >= 0;
+    assert find(r.output, "io", 0) >= 0;
+}
+
+// ---- finally block must not hide an effect ----
+test "effect escape: finally block ![io] fires E0400" ![io] {
+    let r = _run_check("fn leaky() {\n"
+        + "    try { let x: number = 1; } finally { print.info(\"escaped\"); }\n"
+        + "}\n");
+    assert r.exit == 1;
+    assert find(r.output, "E0400", 0) >= 0;
+    assert find(r.output, "io", 0) >= 0;
+}
+
+// ---- throw expression must not hide an effect ----
+test "effect escape: throw expression ![net] fires E0400" ![io] {
+    let r = _run_check("fn leaky() {\n"
+        + "    throw http.get(\"http://evil\");\n"
+        + "}\n");
+    assert r.exit == 1;
+    assert find(r.output, "E0400", 0) >= 0;
+    assert find(r.output, "net", 0) >= 0;
+}
+
+// ---- bare block must not hide an effect ----
+test "effect escape: bare block ![io] fires E0400" ![io] {
+    let r = _run_check("fn leaky() {\n" + "    { print.info(\"escaped\"); }\n"
+        + "}\n");
+    assert r.exit == 1;
+    assert find(r.output, "E0400", 0) >= 0;
+    assert find(r.output, "io", 0) >= 0;
+}
+
+// ---- unsafe block must not hide an effect (unsafe relaxes memory safety,
+// not capability enforcement) ----
+test "effect escape: unsafe block ![io] fires E0400" ![io] {
+    let r = _run_check("fn leaky() {\n"
+        + "    unsafe { print.info(\"escaped\"); }\n"
+        + "}\n");
+    assert r.exit == 1;
+    assert find(r.output, "E0400", 0) >= 0;
+    assert find(r.output, "io", 0) >= 0;
+}
+
+// ---- positive control: a declared ![io] satisfies the requirement even
+// when the call is inside a try block (no false positive) ----
+test "effect escape: declared ![io] inside try compiles" ![io] {
+    let r = _run_check("fn ok() ![io] {\n"
+        + "    try { print.info(\"fine\"); } catch (e) { print.info(\"x\"); }\n"
+        + "}\n");
+    assert r.exit == 0;
+    assert find(r.output, "E0400", 0) < 0;
+}


### PR DESCRIPTION
## Bug hunt: a capability-enforcement soundness hole

While hunting (no open issues), I found a **soundness hole in the effect system — the project's #1 pillar**. The effect checker silently failed to enforce `[effect]` annotations on any operation wrapped in a `try`/`catch`/`finally`, a `throw` expression, or a bare/`unsafe` block.

### Root cause

`collect_effects_from_statement` (`compiler/src/effect_checker.sfn`) is a chain of `if statement.variant == "..."` arms with a `return []` default. It had **no arm** for `TryStatement`, `ThrowStatement`, or `BlockStatement` (all real, parser-produced, fully-shipped AST variants — the ownership checker already visits them). Those statements fell through to the default, dropping their entire subtree from effect collection, so `analyze_routine` saw no requirement and emitted no `E0400`.

Wrapping an effectful call in `try { … }`, `throw`, or `{ … }` was therefore a trivial, silent bypass of compile-time capability enforcement.

### Reproduction (pre-fix, against a freshly self-hosted compiler)

```sfn
fn leaky() { try { print.info("escaped"); } catch (e) { print.info("x"); } }  // checked: ok  ❌
fn leaky() { throw http.get("http://evil"); }                                 // checked: ok  ❌
fn leaky() { { print.info("escaped"); } }                                     // checked: ok  ❌
fn leaky() { print.info("should be flagged"); }                              // E0400  ✅ (control)
```

The bare control fires `E0400 (missing [io])`; the three wrapped forms all reported `ok`.

### Fix

Add the missing arms so each statement collects its subtree effects transitively. `unsafe` relaxes memory-safety checks, **not** capability enforcement, so a bare/`unsafe` block still requires the effects it uses. Diagnostics route through the existing call-site trigger plumbing, so the caret lands on the offending call inside the wrapper.

### Verification

- `make compile` (self-host) green — the stricter check effect-checks the entire compiler source tree and it stays clean.
- New regression test `compiler/tests/e2e/check_effect_try_block_escape_test.sfn` (7/7): every previously-unvisited variant (`try`/`catch`/`finally` → `[io]`, `throw http.get` → `[net]`, bare + `unsafe` blocks → `[io]`) plus a positive control guarding against an over-broad fix.
- All six effect-checker unit suites green; full unit suite **163/163**.

### Scope

`collect_effects_from_statement` is the single requirement-collection walker (`required_effects` → `analyze_routine`); no other statement switch in the file needed the variants (the top-level `analyze_statement`/capability walkers only see declarations). `sfn fmt --check` clean on both touched files.

https://claude.ai/code/session_01C8zM6a3DsQhAb14Q9i5m4K

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8zM6a3DsQhAb14Q9i5m4K)_