### PR TITLE
fix(json,toml): decode mandatory string escapes and escape control chars

### DIFF
--- a/capsules/sfn/json/src/mod.sfn
+++ b/capsules/sfn/json/src/mod.sfn
@@ -84,6 +84,49 @@ fn object_val(keys: string[], values: JsonValue[]) -> JsonValue {
     };
 }
 
+// ---- Escape helpers (shared by parse + stringify) ----
+// Real UTF-8 encode of a single code point via the runtime helper
+// (rejects surrogates / out-of-range, returning ""). The `\uXXXX` decoder
+// reuses this rather than hand-rolling UTF-8. Same `* u8 as string` cast
+// surface the prelude's `char_from_code` uses.
+extern fn sfn_str_from_codepoint(cp: i64) -> * u8;
+
+fn _from_codepoint(cp: int) -> string {
+    let bytes: * u8 = sfn_str_from_codepoint(cp);
+    return bytes as string;
+}
+
+fn _hex_val(ch: string) -> int {
+    let c = char_code(ch);
+    if c >= 48 && c <= 57 { return c - 48; }
+    if c >= 97 && c <= 102 { return c - 87; }
+    if c >= 65 && c <= 70 { return c - 55; }
+    return -1;
+}
+
+fn _read_hex(text: string, p: int, n: int) -> int {
+    if p + n > text.length { return -1; }
+    let mut val: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= n { break; }
+        let d = _hex_val(text[p + i]);
+        if d < 0 { return -1; }
+        val = val * 16 + d;
+        i += 1;
+    }
+    return val;
+}
+
+fn _hex_digit_char(n: int) -> string {
+    let digits = "0123456789ABCDEF";
+    return digits[n];
+}
+
+fn _hex2(code: int) -> string {
+    return _hex_digit_char((code / 16) % 16) + _hex_digit_char(code % 16);
+}
+
 // ---- Serialization ----
 fn _escape_json_string(s: string) -> string {
     let mut out: string = "";
@@ -91,11 +134,16 @@ fn _escape_json_string(s: string) -> string {
     loop {
         if i >= s.length { break; }
         let ch = s[i];
+        let code = char_code(ch);
         if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
             out = out + "\\\\";
-        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
-            out = out + "\\r";
-        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        } else if code == 8 { out = out + "\\b"; } else if code == 9 {
+            out = out + "\\t";
+        } else if code == 10 { out = out + "\\n"; } else if code == 12 {
+            out = out + "\\f";
+        } else if code == 13 { out = out + "\\r"; } else if code >= 0 && code < 32 {
+            out = out + "\\u00" + _hex2(code);
+        } else { out = out + ch; }
         i += 1;
     }
     return out;
@@ -212,11 +260,38 @@ fn _parse_string(text: string, start: int) -> _ParseResult {
                 let esc = text[p];
                 if esc == "\"" { out = out + "\""; } else if esc == "\\" {
                     out = out + "\\";
-                } else if esc == "n" { out = out + "\n"; } else if esc == "r" {
-                    out = out + "\r";
-                } else if esc == "t" { out = out + "\t"; } else {
-                    out = out + esc;
-                }
+                } else if esc == "/" { out = out + "/"; } else if esc == "b" {
+                    out = out + _from_codepoint(8);
+                } else if esc == "f" { out = out + _from_codepoint(12); } else if esc == "n" {
+                    out = out + "\n";
+                } else if esc == "r" { out = out + "\r"; } else if esc == "t" {
+                    out = out + "\t";
+                } else if esc == "u" {
+                    let cp = _read_hex(text, p + 1, 4);
+                    if cp < 0 { out = out + esc; } else {
+                        p += 4;
+                        if cp >= 55296 && cp <= 56319 {
+                            // High surrogate: combine with a following low
+                            // surrogate \uXXXX into the astral code point.
+                            let mut combined: int = -1;
+                            if p + 2 < text.length && text[p + 1] == "\\"
+                                && text[p
+                                + 2] == "u" {
+                                let lo = _read_hex(text, p + 3, 4);
+                                if lo >= 56320 && lo <= 57343 {
+                                    combined = 65536 + (cp - 55296) * 1024 + (lo - 56320);
+                                    p += 6;
+                                }
+                            }
+                            if combined >= 0 {
+                                out = out + _from_codepoint(combined);
+                            } else { out = out + _from_codepoint(65533); }
+                        } else if cp >= 56320 && cp <= 57343 {
+                            // Lone low surrogate: emit U+FFFD replacement.
+                            out = out + _from_codepoint(65533);
+                        } else { out = out + _from_codepoint(cp); }
+                    }
+                } else { out = out + esc; }
             }
         } else { out = out + ch; }
         p += 1;

--- a/capsules/sfn/json/tests/json_test.sfn
+++ b/capsules/sfn/json/tests/json_test.sfn
@@ -148,3 +148,48 @@ test "json: moderately-nested document within the cap parses unchanged" {
     assert strings_equal(cur.kind, "number");
     assert cur.number_value == 42;
 }
+
+// -- Escape decode/encode coverage (#1619) --
+test "json: unicode escape decodes to single char" {
+    let a: JsonValue = parse("\"\\u0041\"");
+    assert strings_equal(a.kind, "string");
+    assert a.string_value.length == 1;
+    assert strings_equal(a.string_value, "A");
+}
+
+test "json: backspace and formfeed decode to control chars" {
+    let b: JsonValue = parse("\"\\b\"");
+    assert strings_equal(b.string_value, char_from_code(8));
+    let f: JsonValue = parse("\"\\f\"");
+    assert strings_equal(f.string_value, char_from_code(12));
+}
+
+test "json: escaped slash decodes to slash" {
+    let s: JsonValue = parse("\"\\/\"");
+    assert strings_equal(s.string_value, "/");
+}
+
+test "json: surrogate pair combines to astral code point" {
+    // U+1F600 GRINNING FACE = UTF-8 F0 9F 98 80.
+    let s: JsonValue = parse("\"\\uD83D\\uDE00\"");
+    let expected = char_from_code(240) + char_from_code(159) + char_from_code(152)
+        + char_from_code(128);
+    assert strings_equal(s.string_value, expected);
+}
+
+test "json: control chars stringify to valid re-parseable JSON" {
+    // U+0001 has no shorthand escape, so it must emit a \u00XX escape.
+    let original = char_from_code(1);
+    let encoded = stringify(string_val(original));
+    assert strings_equal(encoded, "\"\\u0001\"");
+    let back: JsonValue = parse(encoded);
+    assert strings_equal(back.string_value, original);
+}
+
+test "json: backspace stringifies to shorthand and round-trips" {
+    let original = char_from_code(8);
+    let encoded = stringify(string_val(original));
+    assert strings_equal(encoded, "\"\\b\"");
+    let back: JsonValue = parse(encoded);
+    assert strings_equal(back.string_value, original);
+}

--- a/capsules/sfn/toml/src/mod.sfn
+++ b/capsules/sfn/toml/src/mod.sfn
@@ -261,6 +261,49 @@ fn _parse_value(raw: string) -> TomlValue {
     return _parse_number(value);
 }
 
+// ---- Escape helpers (shared by parse + serialize) ----
+// Real UTF-8 encode of a single code point via the runtime helper
+// (rejects surrogates / out-of-range, returning ""). The `\uXXXX` /
+// `\UXXXXXXXX` decoders reuse this rather than hand-rolling UTF-8. Same
+// `* u8 as string` cast surface the prelude's `char_from_code` uses.
+extern fn sfn_str_from_codepoint(cp: i64) -> * u8;
+
+fn _from_codepoint(cp: int) -> string {
+    let bytes: * u8 = sfn_str_from_codepoint(cp);
+    return bytes as string;
+}
+
+fn _hex_val(ch: string) -> int {
+    let c = char_code(ch);
+    if c >= 48 && c <= 57 { return c - 48; }
+    if c >= 97 && c <= 102 { return c - 87; }
+    if c >= 65 && c <= 70 { return c - 55; }
+    return -1;
+}
+
+fn _read_hex(text: string, p: int, n: int) -> int {
+    if p + n > text.length { return -1; }
+    let mut val: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= n { break; }
+        let d = _hex_val(text[p + i]);
+        if d < 0 { return -1; }
+        val = val * 16 + d;
+        i += 1;
+    }
+    return val;
+}
+
+fn _hex_digit_char(n: int) -> string {
+    let digits = "0123456789ABCDEF";
+    return digits[n];
+}
+
+fn _hex2(code: int) -> string {
+    return _hex_digit_char((code / 16) % 16) + _hex_digit_char(code % 16);
+}
+
 fn _parse_basic_string(raw: string) -> string {
     // Parse a TOML basic string (double-quoted, with escape sequences).
     if raw.length < 2 { return ""; }
@@ -276,9 +319,23 @@ fn _parse_basic_string(raw: string) -> string {
             let esc = raw[i];
             if esc == "\"" { out = out + "\""; } else if esc == "\\" {
                 out = out + "\\";
+            } else if esc == "b" { out = out + _from_codepoint(8); } else if esc == "f" {
+                out = out + _from_codepoint(12);
             } else if esc == "n" { out = out + "\n"; } else if esc == "r" {
                 out = out + "\r";
-            } else if esc == "t" { out = out + "\t"; } else { out = out + esc; }
+            } else if esc == "t" { out = out + "\t"; } else if esc == "u" {
+                let cp = _read_hex(raw, i + 1, 4);
+                if cp < 0 { out = out + esc; } else {
+                    out = out + _from_codepoint(cp);
+                    i += 4;
+                }
+            } else if esc == "U" {
+                let cp = _read_hex(raw, i + 1, 8);
+                if cp < 0 { out = out + esc; } else {
+                    out = out + _from_codepoint(cp);
+                    i += 8;
+                }
+            } else { out = out + esc; }
         } else { out = out + ch; }
         i += 1;
     }
@@ -857,11 +914,16 @@ fn _escape_string(s: string) -> string {
     loop {
         if i >= s.length { break; }
         let ch = s[i];
+        let code = char_code(ch);
         if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
             out = out + "\\\\";
-        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
-            out = out + "\\r";
-        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        } else if code == 8 { out = out + "\\b"; } else if code == 9 {
+            out = out + "\\t";
+        } else if code == 10 { out = out + "\\n"; } else if code == 12 {
+            out = out + "\\f";
+        } else if code == 13 { out = out + "\\r"; } else if code >= 0 && code < 32 {
+            out = out + "\\u00" + _hex2(code);
+        } else { out = out + ch; }
         i += 1;
     }
     return out;

--- a/capsules/sfn/toml/tests/toml_test.sfn
+++ b/capsules/sfn/toml/tests/toml_test.sfn
@@ -15,7 +15,9 @@ import {
     get_number,
     get_bool,
     get_value,
-    has_key
+    has_key,
+    parse,
+    stringify
 } from "../src/mod";
 
 test "toml: string value construction" {
@@ -84,4 +86,42 @@ test "toml: deeply nested path" {
     let b = table_val(["b"], [c]);
     let root = table_val(["a"], [b]);
     assert strings_equal(get_string(root, "a.b.c"), "deep");
+}
+
+// -- Escape decode/encode coverage (#1619) --
+test "toml: 4-hex unicode escape decodes in basic string" {
+    let config = parse("k = \"\\u0041\"");
+    assert strings_equal(get_string(config, "k"), "A");
+}
+
+test "toml: 8-hex unicode escape decodes astral code point" {
+    // U+1F600 GRINNING FACE = UTF-8 F0 9F 98 80 (single \U, no surrogates).
+    let config = parse("k = \"\\U0001F600\"");
+    let expected = char_from_code(240) + char_from_code(159) + char_from_code(152)
+        + char_from_code(128);
+    assert strings_equal(get_string(config, "k"), expected);
+}
+
+test "toml: backspace and formfeed decode in basic string" {
+    let cb = parse("k = \"\\b\"");
+    assert strings_equal(get_string(cb, "k"), char_from_code(8));
+    let cf = parse("k = \"\\f\"");
+    assert strings_equal(get_string(cf, "k"), char_from_code(12));
+}
+
+test "toml: control chars escape on serialize and round-trip" {
+    let original = char_from_code(1);
+    let doc = stringify(table_val(["k"], [string_val(original)]));
+    // U+0001 has no shorthand escape, so it must emit a unicode escape.
+    assert strings_equal(doc, "k = \"\\u0001\"\n");
+    let back = parse(doc);
+    assert strings_equal(get_string(back, "k"), original);
+}
+
+test "toml: backspace serializes to shorthand and round-trips" {
+    let original = char_from_code(8);
+    let doc = stringify(table_val(["k"], [string_val(original)]));
+    assert strings_equal(doc, "k = \"\\b\"\n");
+    let back = parse(doc);
+    assert strings_equal(get_string(back, "k"), original);
 }


### PR DESCRIPTION
## Summary

- **JSON & TOML decoders** previously handled only `\" \\ \n \r \t` and dropped the backslash on every other escape — so `A` decoded to `"u0041"`, `\b` to `"b"`, `\f` to `"f"`. The JSON path is the "adversarial JSON-RPC proxy hot path", so this was real data corruption.
- **Both encoders** were the mirror image, emitting raw control bytes unescaped (invalid output).
- Added shared escape helpers (`_from_codepoint` over the runtime `sfn_str_from_codepoint`, `_hex_val`/`_read_hex`, `_hex2`) and fixed all four sites, respecting each grammar's quirks (JSON `\/` + surrogate pairs; TOML `\U` 8-hex, no `\/`, no surrogate pairs).

Closes #1619

## Acceptance Criteria

- [x] JSON: `parse("\"\\u0041\"").string_value == "A"` (length 1); `\b`/`\f` → U+0008/U+000C; high+low surrogate pair combines to the astral code point.
- [x] JSON: `stringify` of a string with control chars produces valid, re-parseable JSON (round-trip equals original).
- [x] TOML: `\uXXXX`, `\UXXXXXXXX`, `\b`, `\f` decode correctly in basic strings; `_escape_string` round-trips control chars.
- [x] Each capsule's escape-grammar quirk respected (JSON `\/` + surrogate pairs; TOML `\U` + no `\/`).
- [x] `make compile` passes (compiler self-hosts)
- [x] `make test` passes (no regressions)

## Verification

```bash
make compile                                              # self-host: pass
build/native/sailfin test capsules/sfn/json/tests/json_test.sfn   # PASS (19/19, 6 new)
build/native/sailfin test capsules/sfn/toml/tests/toml_test.sfn   # PASS (15/15, 5 new)
sfn fmt --check <all 4 files>                             # clean
```

## Files Changed

- `capsules/sfn/json/src/mod.sfn` — escape helpers + `_parse_string` / `_escape_json_string`
- `capsules/sfn/json/tests/json_test.sfn` — escape + round-trip coverage
- `capsules/sfn/toml/src/mod.sfn` — escape helpers + `_parse_basic_string` / `_escape_string`
- `capsules/sfn/toml/tests/toml_test.sfn` — escape + round-trip coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9PLBxQY2G6qCBAyLXK3C7

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9PLBxQY2G6qCBAyLXK3C7)_