### PR TITLE
feat(os): per-child cwd on spawn via posix_spawn addchdir_np

### DIFF
--- a/capsules/sfn/os/src/mod.sfn
+++ b/capsules/sfn/os/src/mod.sfn
@@ -185,9 +185,15 @@ fn env_from_current() -> Env ![io] {
 // exit code. `ProcessOutput.exit` is `-1` when the runtime itself
 // couldn't complete the call (invalid argv, OOM, spawn failure),
 // distinct from a legitimate child exit code of 127.
-fn run_capture(args: string[], env: Env) -> ProcessOutput ![io] {
+//
+// `cwd` (#1167) is the child's working directory: `""` inherits the
+// parent's cwd (the prior behaviour), a non-empty path runs the child
+// in that directory via `posix_spawn_file_actions_addchdir_np` — no
+// process-global `chdir`, so it is safe under the concurrent runner.
+// Posix-only; ignored on Windows.
+fn run_capture(args: string[], env: Env, cwd: string) -> ProcessOutput ![io] {
     let env_flat = env_to_flat(env);
-    let exit_code = process.run_capture(args, env_flat);
+    let exit_code = process.run_capture_cwd(args, env_flat, cwd);
     let captured_stdout = process.capture_take_stdout();
     let captured_stderr = process.capture_take_stderr();
     return ProcessOutput {
@@ -203,9 +209,12 @@ fn run_capture(args: string[], env: Env) -> ProcessOutput ![io] {
 // `posix_spawn_file_actions`). Callers must reap the child via
 // `handle_wait`. Returns a handle whose `handle_id` is 0 on spawn
 // failure — call sites can branch on that to surface a typed error.
-fn spawn_with_env(args: string[], env: Env) -> ProcessHandle ![io] {
+//
+// `cwd` (#1167): `""` inherits the parent's working directory; a
+// non-empty path runs the child there (posix-only, no global `chdir`).
+fn spawn_with_env(args: string[], env: Env, cwd: string) -> ProcessHandle ![io] {
     let env_flat = env_to_flat(env);
-    let id = process.spawn_with_env(args, env_flat);
+    let id = process.spawn_with_env_cwd(args, env_flat, cwd);
     return ProcessHandle { handle_id: id };
 }
 

--- a/capsules/sfn/os/tests/run_capture_test.sfn
+++ b/capsules/sfn/os/tests/run_capture_test.sfn
@@ -10,7 +10,7 @@ import {
 } from "../src/mod";
 
 test "run_capture: captures stdout from a simple command" ![io] {
-    let result = run_capture(["sh", "-c", "printf hello"], env_empty());
+    let result = run_capture(["sh", "-c", "printf hello"], env_empty(), "");
     assert result.exit == 0;
     assert strings_equal(result.stdout, "hello");
     assert strings_equal(result.stderr, "");
@@ -18,7 +18,7 @@ test "run_capture: captures stdout from a simple command" ![io] {
 
 test "run_capture: captures stderr separately from stdout" ![io] {
     // printf to stderr only — stdout should be empty, stderr populated.
-    let result = run_capture(["sh", "-c", "printf err 1>&2"], env_empty());
+    let result = run_capture(["sh", "-c", "printf err 1>&2"], env_empty(), "");
     assert result.exit == 0;
     assert strings_equal(result.stdout, "");
     assert strings_equal(result.stderr, "err");
@@ -27,14 +27,14 @@ test "run_capture: captures stderr separately from stdout" ![io] {
 test "run_capture: captures both stdout and stderr from one child" ![io] {
     // Interleaved writes — concurrent drain must keep both streams
     // intact regardless of timing.
-    let result = run_capture(["sh", "-c", "printf out; printf err 1>&2"], env_empty());
+    let result = run_capture(["sh", "-c", "printf out; printf err 1>&2"], env_empty(), "");
     assert result.exit == 0;
     assert strings_equal(result.stdout, "out");
     assert strings_equal(result.stderr, "err");
 }
 
 test "run_capture: non-zero exit code surfaces in ProcessOutput.exit" ![io] {
-    let result = run_capture(["sh", "-c", "exit 7"], env_empty());
+    let result = run_capture(["sh", "-c", "exit 7"], env_empty(), "");
     assert result.exit == 7;
 }
 
@@ -42,14 +42,14 @@ test "run_capture: env overrides propagate to the child" ![io] {
     // `env` SfnArray contains a single KEY=VALUE entry; printenv FOO
     // should print the value followed by a newline.
     let env = env_set(env_empty(), "FOO", "bar");
-    let result = run_capture(["printenv", "FOO"], env);
+    let result = run_capture(["printenv", "FOO"], env, "");
     assert result.exit == 0;
     assert strings_equal(result.stdout, "bar\n");
 }
 
 test "run_capture: env_set replaces existing entries (last write wins)" ![io] {
     let env = env_set(env_set(env_empty(), "FOO", "first"), "FOO", "second");
-    let result = run_capture(["printenv", "FOO"], env);
+    let result = run_capture(["printenv", "FOO"], env, "");
     assert result.exit == 0;
     assert strings_equal(result.stdout, "second\n");
 }
@@ -65,7 +65,7 @@ test "run_capture: drains output larger than the pipe buffer" ![io] {
     // (GNU coreutils' `yes` writes "yes: standard output: Broken pipe"
     // to stderr when its downstream consumer closes the pipe — a real
     // CI hazard since the stderr assertion below would catch it).
-    let result = run_capture(["sh", "-c", "head -c 200000 /dev/zero | tr '\\0' x"], env_empty());
+    let result = run_capture(["sh", "-c", "head -c 200000 /dev/zero | tr '\\0' x"], env_empty(), "");
     assert result.exit == 0;
     assert result.stdout.length == 200000;
     assert strings_equal(result.stderr, "");
@@ -75,6 +75,35 @@ test "run_capture: spawn failure surfaces as exit == -1" ![io] {
     // Distinguishable from a legitimate child exit code of 127
     // ("command not found" in the shell convention) — a non-existent
     // binary makes posix_spawnp fail before the child is ever born.
-    let result = run_capture(["sfn-no-such-binary-12345"], env_empty());
+    let result = run_capture(["sfn-no-such-binary-12345"], env_empty(), "");
     assert result.exit == -1;
+}
+
+test "run_capture: cwd runs the child in the given directory (#1167)" ![io] {
+    // `pwd` in the root directory prints "/" on every POSIX platform,
+    // with no symlink indirection (unlike /tmp -> /private/tmp on
+    // macOS). A non-empty cwd must place the child there.
+    let result = run_capture(["pwd"], env_empty(), "/");
+    assert result.exit == 0;
+    assert strings_equal(result.stdout, "/\n");
+}
+
+test "run_capture: empty cwd inherits parent cwd and leaves it unchanged (#1167)" ![io] {
+    // Baseline: the parent's working directory (the test runner's cwd,
+    // which is not the root "/").
+    let before = run_capture(["pwd"], env_empty(), "");
+    assert before.exit == 0;
+    assert ! strings_equal(before.stdout, "/\n");
+
+    // Run a child rooted at "/". The per-child chdir must NOT leak into
+    // the parent process (no global chdir).
+    let moved = run_capture(["pwd"], env_empty(), "/");
+    assert moved.exit == 0;
+    assert strings_equal(moved.stdout, "/\n");
+
+    // A subsequent inherit-cwd ("") child still reports the original
+    // parent directory — proof the parent cwd was never mutated.
+    let after = run_capture(["pwd"], env_empty(), "");
+    assert after.exit == 0;
+    assert strings_equal(after.stdout, before.stdout);
 }

--- a/capsules/sfn/os/tests/spawn_with_env_test.sfn
+++ b/capsules/sfn/os/tests/spawn_with_env_test.sfn
@@ -14,7 +14,7 @@ import {
 } from "../src/mod";
 
 test "spawn_with_env: cat echoes piped stdin to stdout" ![io] {
-    let h = spawn_with_env(["cat"], env_empty());
+    let h = spawn_with_env(["cat"], env_empty(), "");
     assert h.handle_id != 0;
     let written = handle_write(h, "hello world\n");
     assert written == 12;
@@ -27,7 +27,7 @@ test "spawn_with_env: cat echoes piped stdin to stdout" ![io] {
 }
 
 test "spawn_with_env: multiple writes accumulate before EOF" ![io] {
-    let h = spawn_with_env(["cat"], env_empty());
+    let h = spawn_with_env(["cat"], env_empty(), "");
     assert h.handle_id != 0;
     handle_write(h, "alpha\n");
     handle_write(h, "beta\n");
@@ -40,7 +40,7 @@ test "spawn_with_env: multiple writes accumulate before EOF" ![io] {
 }
 
 test "spawn_with_env: stderr is captured independently of stdout" ![io] {
-    let h = spawn_with_env(["sh", "-c", "printf to_out; printf to_err 1>&2"], env_empty());
+    let h = spawn_with_env(["sh", "-c", "printf to_out; printf to_err 1>&2"], env_empty(), "");
     assert h.handle_id != 0;
     handle_close_stdin(h);
     let out = handle_read_stdout(h);
@@ -53,7 +53,7 @@ test "spawn_with_env: stderr is captured independently of stdout" ![io] {
 
 test "spawn_with_env: env overrides propagate to the spawned child" ![io] {
     let env = env_set(env_empty(), "GREETING", "salve");
-    let h = spawn_with_env(["printenv", "GREETING"], env);
+    let h = spawn_with_env(["printenv", "GREETING"], env, "");
     assert h.handle_id != 0;
     handle_close_stdin(h);
     let out = handle_read_stdout(h);
@@ -63,7 +63,7 @@ test "spawn_with_env: env overrides propagate to the spawned child" ![io] {
 }
 
 test "spawn_with_env: handle_wait surfaces non-zero exit" ![io] {
-    let h = spawn_with_env(["sh", "-c", "exit 3"], env_empty());
+    let h = spawn_with_env(["sh", "-c", "exit 3"], env_empty(), "");
     assert h.handle_id != 0;
     handle_close_stdin(h);
     let exit = handle_wait(h);
@@ -80,13 +80,26 @@ test "spawn_with_env: heavy stderr does not deadlock sequential read_stdout" ![i
     // `head | tr` avoids `yes`'s broken-pipe diagnostic landing on
     // the test's stderr (see the matching note in
     // `run_capture_test.sfn`'s pipe-buffer test).
-    let h = spawn_with_env(["sh", "-c", "head -c 200000 /dev/zero | tr '\\0' E 1>&2; head -c 5000 /dev/zero | tr '\\0' O"], env_empty());
+    let h = spawn_with_env(["sh", "-c", "head -c 200000 /dev/zero | tr '\\0' E 1>&2; head -c 5000 /dev/zero | tr '\\0' O"], env_empty(), "");
     assert h.handle_id != 0;
     handle_close_stdin(h);
     let out = handle_read_stdout(h);
     assert out.length == 5000;
     let err = handle_read_stderr(h);
     assert err.length == 200000;
+    let exit = handle_wait(h);
+    assert exit == 0;
+}
+
+test "spawn_with_env: cwd runs the spawned child in the given directory (#1167)" ![io] {
+    // `pwd` rooted at "/" prints "/" on every POSIX platform. The
+    // per-child chdir happens via posix_spawn_file_actions, never a
+    // process-global chdir.
+    let h = spawn_with_env(["pwd"], env_empty(), "/");
+    assert h.handle_id != 0;
+    handle_close_stdin(h);
+    let out = handle_read_stdout(h);
+    assert strings_equal(out, "/\n");
     let exit = handle_wait(h);
     assert exit == 0;
 }

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -31,7 +31,7 @@
 // (`deleteFile` / `exists` / `listDirectory` / `removeDirectory`). No new
 // C runtime surface is introduced.
 import { remove_all } from "sfn/fs";
-import { Env, run_capture, ProcessOutput } from "sfn/os";
+import { Env, ProcessOutput, run_capture } from "sfn/os";
 
 // Create a fresh temporary directory, hand its absolute path to `body`,
 // and recursively remove the whole tree on scope exit — on both the
@@ -101,6 +101,9 @@ fn with_tmp_dir(body: fn (string) -> int) -> int ![io] {
 // no host resource to release — the override lived only in the child's
 // `environ`, which dies with the child.
 fn with_env(args: string[], env: Env, body: fn (ProcessOutput) -> int) -> int ![io] {
-    let out = run_capture(args, env);
+    // `""` cwd inherits the parent's working directory (#1167); a
+    // cwd-aware `with_env`/`with_cwd` ergonomic wrapper is the
+    // companion follow-up, not this change.
+    let out = run_capture(args, env, "");
     return body(out);
 }

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1093,6 +1093,9 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "env.get");
     helpers = append_unique_effect(helpers, "env.home");
     helpers = append_unique_effect(helpers, "process.run_capture");
+    // #1167: per-child-cwd variants carry the same `io` gate.
+    helpers = append_unique_effect(helpers, "process.run_capture_cwd");
+    helpers = append_unique_effect(helpers, "process.spawn_with_env_cwd");
     helpers = append_unique_effect(helpers, "process.capture_take_stdout");
     helpers = append_unique_effect(helpers, "process.capture_take_stderr");
     // #1520: metered-capture helpers (wall-clock + peak RSS) consumed by

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -802,6 +802,17 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.run_capture", symbol: "sfn_process_run_capture", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_run_capture", c_abi_return_type: null
     });
+    // #1167: `process.run_capture_cwd` — `run_capture` plus a trailing
+    // per-child `cwd` (`i8*`; empty/null = inherit). A SEPARATE target
+    // from `process.run_capture` rather than a widened arity, because
+    // `compiler/src` calls the 2-arg `process.run_capture` and the pinned
+    // seed emits 2-arg calls to it — widening would desync the seed-built
+    // call sites from the 3-arg runtime body (a self-host crash). Only the
+    // freshly-built compiler emits this 3-arg call, exclusively from
+    // `sfn/os`, so no seed cut is required.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.run_capture_cwd", symbol: "sfn_process_run_capture_cwd", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*", "i8*"], effects: ["io"], native_signature: "sfn_process_run_capture_cwd", c_abi_return_type: null
+    });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.capture_take_stdout", symbol: "sfn_process_capture_take_stdout", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: "sfn_process_capture_take_stdout", c_abi_return_type: null
     });
@@ -826,6 +837,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.spawn_with_env", symbol: "sfn_process_spawn_with_env", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_spawn_with_env", c_abi_return_type: null
+    });
+    // #1167: `process.spawn_with_env_cwd` — trailing per-child `cwd`
+    // (`i8*`; empty/null = inherit). Separate target, same rationale as
+    // `process.run_capture_cwd` above: keep the 2-arg `spawn_with_env`
+    // arity stable for the seed-built `compiler/src` call sites.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.spawn_with_env_cwd", symbol: "sfn_process_spawn_with_env_cwd", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*", "i8*"], effects: ["io"], native_signature: "sfn_process_spawn_with_env_cwd", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.handle_write", symbol: "sfn_process_handle_write", return_type: "i64", parameter_types: ["i64", "i8*"], effects: ["io"], native_signature: "sfn_process_handle_write", c_abi_return_type: null

--- a/runtime/sfn/platform/posix.sfn
+++ b/runtime/sfn/platform/posix.sfn
@@ -66,6 +66,13 @@ extern fn posix_spawn_file_actions_addclose(fa: * PosixSpawnFileActions, fd: i32
 
 extern fn posix_spawn_file_actions_adddup2(fa: * PosixSpawnFileActions, fd: i32, newfd: i32) -> i32;
 
+// Per-child working directory: the spawned child `chdir`s to `path`
+// (a NUL-terminated C string) before `exec`, with no process-global
+// `chdir` in the parent (#1167). Portability floor: glibc ≥2.29,
+// macOS ≥10.15, musl ≥1.1.24 — the `_np` (non-portable) suffix marks
+// it as a POSIX extension. Gated behind the posix-only spawn path.
+extern fn posix_spawn_file_actions_addchdir_np(fa: * PosixSpawnFileActions, path: * u8) -> i32;
+
 // ── Clock / sleep ─────────────────────────────────────────────
 // `clk_id` is one of POSIX's `CLOCK_*` constants (e.g.
 // `CLOCK_MONOTONIC = 1` on Linux). Adapters expose the constants

--- a/runtime/sfn/platform/process_windows.sfn
+++ b/runtime/sfn/platform/process_windows.sfn
@@ -619,6 +619,14 @@ fn sfn_process_run_capture(argv: string[], env_flat: string[]) -> i64 ![io] {
     return code as i64;
 }
 
+// `process.run_capture_cwd` (#1167): `cwd` is accepted for ABI parity
+// with the posix runtime but ignored — per-child cwd is a posix-only
+// feature (the issue scopes Windows cwd support Out). The child always
+// inherits the parent's working directory here.
+fn sfn_process_run_capture_cwd(argv: string[], env_flat: string[], cwd: * u8) -> i64 ![io] {
+    return sfn_process_run_capture(argv, env_flat);
+}
+
 // Hand off the captured stream stashed by the preceding `run_capture`,
 // clearing the global so a second take yields empty. A fresh empty string
 // is returned when no capture is pending (mirrors `process.sfn`).
@@ -640,6 +648,13 @@ fn sfn_process_capture_take_stderr() -> * u8 ![io] {
 // `_WIN32` contract (`sailfin_runtime.c:8195`).
 fn sfn_process_spawn_with_env(argv: string[], env_flat: string[]) -> i64 ![io] {
     return 0;
+}
+
+// `process.spawn_with_env_cwd` (#1167): `cwd` accepted for ABI parity
+// but ignored (per-child cwd is posix-only); delegates to the 2-arg
+// stub, which returns the `0` failure sentinel on this platform.
+fn sfn_process_spawn_with_env_cwd(argv: string[], env_flat: string[], cwd: * u8) -> i64 ![io] {
+    return sfn_process_spawn_with_env(argv, env_flat);
 }
 
 fn sfn_process_handle_write(handle_id: i64, data: * u8) -> i64 ![io] {

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -150,6 +150,13 @@ extern fn posix_spawn_file_actions_addclose(fa: * u8, fd: i32) -> i32;
 
 extern fn posix_spawn_file_actions_adddup2(fa: * u8, fd: i32, newfd: i32) -> i32;
 
+// Per-child cwd (#1167): child `chdir`s to `path` before `exec`, no
+// process-global `chdir`. Re-declared inline (typed `* u8`, not the
+// `* PosixSpawnFileActions` of `platform/posix.sfn`) per the #306
+// cross-module-extern limitation. Portability floor: glibc ≥2.29 /
+// macOS ≥10.15 / musl ≥1.1.24; called only on the posix spawn path.
+extern fn posix_spawn_file_actions_addchdir_np(fa: * u8, path: * u8) -> i32;
+
 // POSIX `EINTR` (4 on Linux and macOS) — the only `read`/`write`/
 // `poll` failure that warrants a resume. Read host-portably via the
 // `sailfin_intrinsic_errno_location` sentinel dereferenced by the
@@ -622,7 +629,7 @@ fn sfn_process_exit(code: float) -> void ![io] {
 // NULL makes `wait4` behave exactly like the former `waitpid` — the plain
 // `run_capture` wrapper passes NULL, so its behaviour is byte-for-byte
 // unchanged.
-fn _run_capture_impl(argv: string[], env_flat: string[], rusage_buf: * u8) -> i64 ![io] {
+fn _run_capture_impl(argv: string[], env_flat: string[], rusage_buf: * u8, cwd: * u8) -> i64 ![io] {
     if sfn_capture_stdout_addr != 0 {
         free(sfn_capture_stdout_addr as * u8);
         sfn_capture_stdout_addr = 0;
@@ -710,6 +717,20 @@ fn _run_capture_impl(argv: string[], env_flat: string[], rusage_buf: * u8) -> i6
     posix_spawn_file_actions_addclose(actions, out_wr);
     posix_spawn_file_actions_addclose(actions, err_wr);
 
+    // Per-child cwd (#1167): when a non-empty cwd was supplied, the
+    // child `chdir`s into it before `exec` via the spawn file actions —
+    // never a process-global `chdir`. `cwd` arrives as a NUL-terminated
+    // C string (the descriptor's trailing `i8*`; a Sailfin `string`
+    // coerces to a cstr at the builtin call site, exactly like
+    // `handle_write`'s `data`). A null cwd (the 2-arg builtin call
+    // injects a null operand) or an empty cwd (`os::run_capture` passing
+    // `""` to inherit) leaves the child in the parent's cwd.
+    if cwd as i64 != 0 {
+        if strlen(cwd) as i64 > 0 {
+            posix_spawn_file_actions_addchdir_np(actions, cwd);
+        }
+    }
+
     let mut pid: i32 = 0;
     let pid_ptr: * i32 = & pid;
     let first: string = argv[0];
@@ -792,9 +813,26 @@ fn _run_capture_impl(argv: string[], env_flat: string[], rusage_buf: * u8) -> i6
 }
 
 // Plain `process.run_capture`: the unmetered wrapper. Passes a NULL
-// `rusage` so `wait4` degrades to `waitpid` — behaviour-preserving.
+// `rusage` so `wait4` degrades to `waitpid` — behaviour-preserving. A
+// null `cwd` inherits the parent's working directory. This 2-arg form
+// is the one `compiler/src` and the hundreds of e2e tests call, so its
+// arity must stay stable for self-hosting (the pinned seed emits 2-arg
+// calls to it) — the per-child cwd lives in the separate `_cwd` variant
+// below (#1167), never by widening this signature.
 fn sfn_process_run_capture(argv: string[], env_flat: string[]) -> i64 ![io] {
-    return _run_capture_impl(argv, env_flat, 0 as * u8);
+    return _run_capture_impl(argv, env_flat, 0 as * u8, 0 as * u8);
+}
+
+// `process.run_capture_cwd` (#1167): `run_capture` with a per-child
+// working directory. `cwd` is a NUL-terminated C string (the
+// descriptor's trailing `i8*`; a Sailfin `string` coerces to a cstr at
+// the call site, exactly like `handle_write`'s `data`) — null/empty
+// inherits the parent cwd, non-empty `chdir`s the child before `exec`.
+// A NEW symbol rather than a wider `run_capture` so the existing 2-arg
+// builtin keeps its arity (no seed cut): only the freshly-built
+// compiler emits this 3-arg call, exclusively from `sfn/os`.
+fn sfn_process_run_capture_cwd(argv: string[], env_flat: string[], cwd: * u8) -> i64 ![io] {
+    return _run_capture_impl(argv, env_flat, 0 as * u8, cwd);
 }
 
 // ── process.run_capture_metered ────────────────────────────────
@@ -820,7 +858,9 @@ fn sfn_process_run_capture_metered(argv: string[], env_flat: string[]) -> i64 ![
     if rusage_buf as i64 != 0 { memset(rusage_buf, 0, 256 as usize); }
 
     let start: i64 = _monotonic_nanos();
-    let rc: i64 = _run_capture_impl(argv, env_flat, rusage_buf);
+    // Metered capture keeps its 2-arg descriptor; the child inherits the
+    // parent cwd (null cwd → no per-child `chdir`).
+    let rc: i64 = _run_capture_impl(argv, env_flat, rusage_buf, 0 as * u8);
     let end: i64 = _monotonic_nanos();
 
     let mut elapsed: i64 = end - start;
@@ -891,7 +931,12 @@ fn sfn_process_capture_take_stderr() -> * u8 ![io] {
 // stdin(0)/stdout(1)/stderr(2), then closes the originals. Each pipe's
 // `(read, write)` pair is read through the `PollSlot` overlay
 // (`fd` = read end, `events_revents` = write end).
-fn sfn_process_spawn_with_env(argv: string[], env_flat: string[]) -> i64 ![io] {
+//
+// Shared impl behind the 2-arg `process.spawn_with_env` and the 3-arg
+// `process.spawn_with_env_cwd` (#1167). `cwd` is a NUL-terminated C
+// string (or null): non-empty `chdir`s the child before `exec` via the
+// spawn file actions; null/empty inherits the parent cwd.
+fn _spawn_with_env_impl(argv: string[], env_flat: string[], cwd: * u8) -> i64 ![io] {
     let argc: i64 = argv.length;
     if argc <= 0 { return 0; }
 
@@ -1003,6 +1048,15 @@ fn sfn_process_spawn_with_env(argv: string[], env_flat: string[]) -> i64 ![io] {
     posix_spawn_file_actions_addclose(actions, out_wr);
     posix_spawn_file_actions_addclose(actions, err_wr);
 
+    // Per-child cwd (#1167): same contract as `_run_capture_impl` — a
+    // non-empty cwd (NUL-terminated `i8*`) `chdir`s the child before
+    // `exec` via the spawn file actions; null/empty inherits.
+    if cwd as i64 != 0 {
+        if strlen(cwd) as i64 > 0 {
+            posix_spawn_file_actions_addchdir_np(actions, cwd);
+        }
+    }
+
     let mut pid: i32 = 0;
     let pid_ptr: * i32 = & pid;
     let first: string = argv[0];
@@ -1051,6 +1105,26 @@ fn sfn_process_spawn_with_env(argv: string[], env_flat: string[]) -> i64 ![io] {
     h.stderr_len = 0;
     h.stderr_cap = 0;
     return h as i64;
+}
+
+// Plain `process.spawn_with_env`: the 2-arg form `compiler/src` (the
+// parallel test pool in `cli/commands/test.sfn`) and other callers use.
+// Its arity must stay stable for self-hosting — the pinned seed emits
+// 2-arg calls to this symbol — so the per-child cwd lives in the `_cwd`
+// variant below, never by widening this signature. Inherits the parent
+// cwd (null cwd → no per-child `chdir`).
+fn sfn_process_spawn_with_env(argv: string[], env_flat: string[]) -> i64 ![io] {
+    return _spawn_with_env_impl(argv, env_flat, 0 as * u8);
+}
+
+// `process.spawn_with_env_cwd` (#1167): `spawn_with_env` with a
+// per-child working directory (NUL-terminated `i8*`; null/empty
+// inherits). A NEW symbol, not a wider `spawn_with_env`, so the
+// existing 2-arg builtin keeps its arity (no seed cut) — only the
+// freshly-built compiler emits this 3-arg call, exclusively from
+// `sfn/os`.
+fn sfn_process_spawn_with_env_cwd(argv: string[], env_flat: string[], cwd: * u8) -> i64 ![io] {
+    return _spawn_with_env_impl(argv, env_flat, cwd);
 }
 
 // ── process.handle_write ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds an optional **per-child working directory** to `os::run_capture` / `os::spawn_with_env`: the child `chdir`s into `cwd` before `exec` via `posix_spawn_file_actions_addchdir_np` — **no process-global `chdir`**, so it's safe under the concurrent test runner. `cwd == ""` inherits the parent cwd (back-compat).
- Implemented as **new** 3-arg runtime builtins `process.run_capture_cwd` / `process.spawn_with_env_cwd`, leaving the existing 2-arg `process.run_capture` / `process.spawn_with_env` untouched — **no seed cut**.

Closes #1167

## Design note (why not widen the existing builtins)
The groomed plan was to widen `process.run_capture` / `process.spawn_with_env` to 3 args + inject a default `cwd` at lowering. That **breaks self-hosting**: `compiler/src/cli/commands/test.sfn` (the parallel test pool) calls the 2-arg builtins, and the pinned seed emits 2-arg calls against a would-be 3-arg runtime body → garbage `cwd` register → `strlen` **SIGSEGV** (caught by `make check`, not by `sfn check`/`make compile`). The grooming's "Required in pinned seed: None" rested on the premise that `compiler/src` never calls these builtins — which is false.

Option B (separate `_cwd` symbols, emitted only by the freshly-built compiler, only from `sfn/os`) keeps the 2-arg arity stable so seed-built call sites stay valid → no seed cut, no bootstrap. The user-facing `os::` API is a single clean `cwd: string` param either way.

## Acceptance Criteria
- [x] New extern passes `check_extern_signature` (no E0801–E0805)
- [x] `os::run_capture(args, env, cwd)` runs the child in `cwd`; `cwd == ""` inherits (all inherit-path callers updated)
- [x] Test asserts child cwd via `pwd`; test asserts the parent process cwd is unchanged after the call
- [x] `_np` portability floor (glibc ≥2.29 / macOS ≥10.15 / musl ≥1.1.24) documented at the extern decl; call gated behind the posix-only spawn path
- [x] `sfn fmt --check` clean on every touched `.sfn`
- [x] `make compile` passes (self-hosts)
- [x] `make check` passes (full triple-pass + suite)

## Verification
```
make compile        # self-hosts ✓
make check          # status:pass — unit 163/163, integration 37/37, e2e 151/151, capsules 36/36 ✓
sailfin test capsules/sfn/os/tests --jobs 4   # parallel pool, no segfault ✓
# direct probe: cwd="/" -> pwd prints "/"; cwd="" -> parent cwd; cwd="/tmp" -> "/tmp"; parent cwd unchanged
```

## Files Changed
- `runtime/sfn/platform/posix.sfn` — `addchdir_np` extern (`* PosixSpawnFileActions`)
- `runtime/sfn/process.sfn` — inline extern; shared `_spawn_with_env_impl` / `_run_capture_impl` thread a NUL-terminated `cwd` (null/empty = inherit); new `sfn_process_*_cwd` 3-arg wrappers; 2-arg wrappers pass null
- `compiler/src/llvm/runtime_helpers.sfn` — additive `process.*_cwd` descriptors (effects: `io`); existing 2-arg descriptors unchanged
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — register `_cwd` effects
- `runtime/sfn/platform/process_windows.sfn` — `_cwd` stubs (cwd ignored, posix-only)
- `capsules/sfn/os/src/mod.sfn` — `run_capture` / `spawn_with_env` gain `cwd: string`
- `capsules/sfn/os/tests/{run_capture,spawn_with_env}_test.sfn`, `capsules/sfn/test/src/fixtures.sfn` — tests + inherit-path call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyoXm47iomo8WWkpK2kaYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyoXm47iomo8WWkpK2kaYb)_