### PR TITLE
Switch compiler-architect and seed-stabilizer agents from Fable to Opus

### DIFF
--- a/.claude/agents/compiler-architect.md
+++ b/.claude/agents/compiler-architect.md
@@ -1,8 +1,8 @@
 ---
 name: compiler-architect
-description: Fable 5-powered architect for designing compiler features, refactors, and fixes that account for self-hosting constraints, the full pipeline, and the 1.0 roadmap. Use when you need a forward-thinking plan before implementing.
+description: Opus-powered architect for designing compiler features, refactors, and fixes that account for self-hosting constraints, the full pipeline, and the 1.0 roadmap. Use when you need a forward-thinking plan before implementing.
 tools: Read, Grep, Glob, Bash, Write
-model: fable
+model: opus
 effort: high
 maxTurns: 30
 color: purple

--- a/.claude/agents/seed-stabilizer.md
+++ b/.claude/agents/seed-stabilizer.md
@@ -1,8 +1,8 @@
 ---
 name: seed-stabilizer
-description: Diagnoses compiler bugs affecting self-hosting correctness and build performance (miscompilation, LLVM IR errors, memory/perf regressions). Use when builds fail, produce wrong output, or regress in speed/memory. Requires deep IR analysis — runs on Fable 5.
+description: Diagnoses compiler bugs affecting self-hosting correctness and build performance (miscompilation, LLVM IR errors, memory/perf regressions). Use when builds fail, produce wrong output, or regress in speed/memory. Requires deep IR analysis — runs on Opus.
 tools: Read, Grep, Glob, Bash
-model: fable
+model: opus
 effort: high
 maxTurns: 25
 color: red


### PR DESCRIPTION
## Summary

Fable 5 has been offline for ~2 weeks. The two subagents that were pinned to it are switched back to the latest Opus model so they remain usable.

## Changes

- `.claude/agents/compiler-architect.md` — `model: fable` → `model: opus`; description "Fable 5-powered" → "Opus-powered"
- `.claude/agents/seed-stabilizer.md` — `model: fable` → `model: opus`; description "runs on Fable 5" → "runs on Opus"

No other agents referenced Fable (`code-reviewer`/opus, `docs-updater`/sonnet, `compiler-explorer`/sonnet, `test-runner`/sonnet, `Sailbot`/inherit are unchanged).

https://claude.ai/code/session_016WvxFpoH9zE7RtKAAZQAZg

---
_Generated by [Claude Code](https://claude.ai/code/session_016WvxFpoH9zE7RtKAAZQAZg)_