### PR TITLE
test(effect-checker): parity harness for descriptor vs text-pattern detection

### DIFF
--- a/compiler/tests/unit/effect_detection_parity_test.sfn
+++ b/compiler/tests/unit/effect_detection_parity_test.sfn
@@ -1,0 +1,208 @@
+// Parity harness: descriptor/name-resolution detector ⊇ text-pattern detector.
+//
+// Issue #1185 (epic #1180, Phase G). This is the SAFETY NET that de-risks
+// G4 (#1186 — deleting `collect_effects_from_text`). It mechanically proves
+// that for every pattern the legacy text-pattern detector recognises, the
+// G1/G1b name-resolution detector (`collect_effects_from_expression`, wired
+// to the runtime descriptor registry in #1183 + symbol resolution in #1184)
+// produces the **same-or-stricter** requirement set. Once this holds for
+// every pattern, the text fallback can be deleted without opening a silent
+// enforcement hole.
+//
+// FAITHFULNESS: each case is parsed from real source through `parse_program`
+// — the exact frontend path the deletion in #1186 will rely on — not from a
+// hand-built AST that could drift from what the parser actually produces.
+//
+// EXHAUSTIVENESS: the canonical pattern table below mirrors EVERY `if
+// contains_code(...)` branch in `collect_effects_from_text`
+// (compiler/src/effect_checker.sfn). There are currently NO in-tree
+// `// effect-ok:` suppressions (the issue's other enumeration target), so
+// the text patterns are the complete surface.
+//
+//   text needle      effect   resolution-path equivalent
+//   -----------      ------   --------------------------
+//   "fs."            io       Member  fs.exists / fs.read   (descriptor + union)
+//   "print("         io       Call    print("…")            (bare builtin)
+//   "print."         io       Member  print.info("…")       (descriptor)
+//   "console."       io       Member  console.log("…")      (descriptor)
+//   "http."          net      Member  http.get("…")         (descriptor + union)
+//   "websocket."     net      Member  websocket.send("…")   (explicit net, #1601)
+//   "spawn("         io       Spawn   spawn(task)           (parser → Spawn node; Call arm also covered)
+//   "serve("         net      Serve   serve(handler)        (parser → Serve node; Call arm also covered)
+//   "sleep("         clock    Call    sleep(1.0)            (descriptor)
+//
+// NOTE on spawn/serve: the parser intercepts `spawn(...)`/`serve(...)` into
+// dedicated `Spawn`/`Serve` AST nodes (concurrency frontend), NOT generic
+// `Call` expressions — so real source is covered by the `Spawn`/`Serve`
+// variant arms of `collect_effects_from_expression`. The detector ALSO keeps
+// defensive `Call`+Identifier arms for `spawn`/`serve` (effect_checker.sfn,
+// the `name == "spawn"` / `name == "serve"` branches); those are exercised
+// here via a hand-built `Call` node so neither arm is left uncovered before
+// the G4 deletion. The parse-based cases pin the parser routing so a future
+// change that re-routes through the generic `Call` path fails loudly here.
+//
+// >>> WHEN YOU ADD A NEW PATTERN TO `collect_effects_from_text`, ADD A
+// >>> MATCHING PARITY CASE HERE. A missed pattern becomes a silent
+// >>> enforcement hole the moment G4 (#1186) lands.
+import { Expression } from "../../src/ast";
+import {
+    EffectRequirement,
+    collect_effects_from_expression,
+    collect_effects_from_text
+} from "../../src/effect_checker";
+import { empty_import_symbols } from "../../src/effect_imports";
+import { parse_program } from "../../src/parser/mod";
+
+// -------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------
+// Parse `snippet` as the sole expression-statement of a probe function and
+// return the resulting `Expression`. Asserts the shape so a parser change
+// fails here with a clear message rather than trapping downstream. The
+// referenced identifiers (`p`, `task`, `handler`) need not be declared —
+// this is parse + effect-collection only, no typecheck.
+fn _probe_expr(snippet: string) -> Expression ![io] {
+    let program = parse_program("fn probe() { " + snippet + "; }");
+    assert program.statements.length >= 1;
+    let fn_stmt = program.statements[0];
+    assert fn_stmt.variant == "FunctionDeclaration";
+    assert fn_stmt.body.statements.length >= 1;
+    let stmt = fn_stmt.body.statements[0];
+    assert stmt.variant == "ExpressionStatement";
+    return stmt.expression;
+}
+
+// A hand-built `Call` over a bare `Identifier` callee — the shape the
+// parser does NOT produce for the keyword forms `spawn`/`serve` (it routes
+// them to `Spawn`/`Serve` nodes), so the only way to exercise the detector's
+// defensive `Call`+Identifier arms for those names is to construct the node
+// directly.
+fn _bare_call(callee: string) -> Expression {
+    let no_args: Expression[] = [];
+    return Expression.Call {
+        callee: Expression.Identifier { name: callee, span: null },
+        arguments: no_args,
+        span: null
+    };
+}
+
+fn _reqs_contain(reqs: EffectRequirement[], effect: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= reqs.length { break; }
+        if reqs[index].effect == effect { return true; }
+        index += 1;
+    }
+    return false;
+}
+
+// Resolution path requirements for a parsed snippet (empty import table —
+// these are all runtime builtins / concurrency anchors, not cross-module
+// imports, so no import symbols are needed).
+fn _resolution_reqs(snippet: string) -> EffectRequirement[] ![io] {
+    return collect_effects_from_expression(_probe_expr(snippet), empty_import_symbols());
+}
+
+// The core parity invariant for one pattern: the text path requires
+// `effect` (so the case is meaningful, not a vacuous pass), AND the
+// resolution path requires the SAME-OR-STRICTER set — i.e. every effect
+// the text path demands is also demanded by the resolution path.
+fn _assert_parity(text_snippet: string, expr_snippet: string, effect: string) ![io] {
+    let text_reqs = collect_effects_from_text(text_snippet);
+    // Guard against a vacuous case: the text detector must actually fire.
+    assert _reqs_contain(text_reqs, effect);
+
+    let expr_reqs = _resolution_reqs(expr_snippet);
+    // Superset check: nothing the text path requires is dropped.
+    let mut index: int = 0;
+    loop {
+        if index >= text_reqs.length { break; }
+        assert _reqs_contain(expr_reqs, text_reqs[index].effect);
+        index += 1;
+    }
+    // And the headline effect is present (explicit, for a clear failure).
+    assert _reqs_contain(expr_reqs, effect);
+}
+
+// -------------------------------------------------------------------
+// Per-pattern parity cases (one per `collect_effects_from_text` branch)
+// -------------------------------------------------------------------
+test "parity: fs.* filesystem helper -> io (exact descriptor)" ![io] {
+    _assert_parity("fs.exists(p)", "fs.exists(p)", "io");
+}
+
+test "parity: fs.* non-exact member -> io (namespace union)" ![io] {
+    // No `fs.read` descriptor row exists; the resolution path must still
+    // attribute `io` via the namespace-union fallback in
+    // `effects_for_callee_target`, matching the text needle "fs.".
+    _assert_parity("fs.read(p)", "fs.read(p)", "io");
+}
+
+test "parity: print(...) bare call -> io" ![io] {
+    _assert_parity("print(\"x\")", "print(\"x\")", "io");
+}
+
+test "parity: print.info(...) member -> io" ![io] {
+    _assert_parity("print.info(\"x\")", "print.info(\"x\")", "io");
+}
+
+test "parity: console.* member -> io" ![io] {
+    _assert_parity("console.log(\"x\")", "console.log(\"x\")", "io");
+}
+
+test "parity: http.* member -> net" ![io] {
+    _assert_parity("http.get(\"u\")", "http.get(\"u\")", "net");
+}
+
+test "parity: websocket.* member -> net" ![io] {
+    _assert_parity("websocket.send(\"m\")", "websocket.send(\"m\")", "net");
+}
+
+test "parity: spawn(...) -> io (Spawn node, real source)" ![io] {
+    // Pin the parser routing: real `spawn(...)` source becomes a `Spawn`
+    // node, so the `Spawn` variant arm carries the effect. If a future
+    // parser change re-routes this through the generic `Call` path, this
+    // assertion fails and forces a re-check of arm coverage.
+    assert _probe_expr("spawn(task)").variant == "Spawn";
+    let text_reqs = collect_effects_from_text("spawn(task)");
+    assert _reqs_contain(text_reqs, "io");
+    let expr_reqs = _resolution_reqs("spawn(task)");
+    assert _reqs_contain(expr_reqs, "io");
+}
+
+test "parity: spawn(...) -> io (defensive Call+Identifier arm)" ![io] {
+    // The detector also keeps a `Call`+Identifier arm for `spawn` that the
+    // parser never reaches; cover it directly so the deletion can't silently
+    // drop it.
+    let reqs = collect_effects_from_expression(_bare_call("spawn"), empty_import_symbols());
+    assert _reqs_contain(reqs, "io");
+}
+
+test "parity: serve(...) -> net (Serve node, real source)" ![io] {
+    assert _probe_expr("serve(handler)").variant == "Serve";
+    let text_reqs = collect_effects_from_text("serve(handler)");
+    assert _reqs_contain(text_reqs, "net");
+    let expr_reqs = _resolution_reqs("serve(handler)");
+    assert _reqs_contain(expr_reqs, "net");
+}
+
+test "parity: serve(...) -> net (defensive Call+Identifier arm)" ![io] {
+    let reqs = collect_effects_from_expression(_bare_call("serve"), empty_import_symbols());
+    assert _reqs_contain(reqs, "net");
+}
+
+test "parity: sleep(...) call -> clock" ![io] {
+    _assert_parity("sleep(1.0)", "sleep(1.0)", "clock");
+}
+
+// -------------------------------------------------------------------
+// Baseline: a non-effectful call requires nothing on EITHER path. Proves
+// the harness is not trivially satisfied and that the resolution path
+// introduces no false positives for ordinary user calls.
+// -------------------------------------------------------------------
+test "parity: non-effectful call requires nothing on either path" ![io] {
+    let text_reqs = collect_effects_from_text("compute(a, b)");
+    assert text_reqs.length == 0;
+    let expr_reqs = _resolution_reqs("compute(a, b)");
+    assert expr_reqs.length == 0;
+}


### PR DESCRIPTION
## Summary

Adds the **parity safety-net** that de-risks deleting the legacy text-pattern effect detector. Mechanically proves the G1/G1b name-resolution detector (`collect_effects_from_expression`, wired to the runtime descriptor registry in #1183 + symbol resolution in #1184) produces a **same-or-stricter** (superset) requirement set than `collect_effects_from_text` for every pattern the text detector recognizes. Once this holds, #1186 (G4) can delete the text fallback without opening a silent enforcement hole.

Part of epic #1180 (Phase G, effect-system hardening). Test-only — **no production code changed**.

## What the harness proves

For each `collect_effects_from_text` needle, the equivalent operation is parsed from **real source** via `parse_program` (the exact frontend path the G4 deletion will rely on — not a hand-built AST that could drift from the parser), then both detectors run and the test asserts `resolution ⊇ text` plus that each case is non-vacuous (the text path actually fires):

| text needle | effect | resolution-path equivalent |
|---|---|---|
| `fs.` | io | `fs.exists` (exact descriptor) + `fs.read` (namespace-union fallback) |
| `print(` | io | bare-call builtin |
| `print.` | io | `print.info` descriptor |
| `console.` | io | `console.log` descriptor |
| `http.` | net | `http.get` descriptor + union |
| `websocket.` | net | explicit-net arm (no descriptor yet, #1601) |
| `spawn(` | io | `Spawn` variant arm (real source) **and** defensive `Call`+Identifier arm |
| `serve(` | net | `Serve` variant arm (real source) **and** defensive `Call`+Identifier arm |
| `sleep(` | clock | `sleep` descriptor |

Plus a non-effectful baseline (`compute(a, b)`) asserting **both** paths require nothing — proving the harness isn't trivially satisfied and the resolution path adds no false positives.

## Notes on faithfulness / drift since the issue was filed

- The issue's second enumeration target — in-tree `// effect-ok:` suppressions — is now **empty** (zero exist under `compiler/` and `runtime/`), so the text needles are the complete surface. Documented in the test header.
- The parser routes `spawn(...)`/`serve(...)` to dedicated `Spawn`/`Serve` AST nodes, not generic `Call`s. The harness covers the real-source variant arms **and pins the routing** (so a future parser re-route fails loudly here), and separately covers the detector's defensive `Call`+Identifier arms via a hand-built node — neither arm is left uncovered before deletion.

## Verification

- `make compile` — self-hosts ✅
- `make test-unit` — **164/164 passed, 0 failed** ✅ (the new file contributes 13 parity tests)
- `sfn fmt --check` — clean ✅

Closes #1185

https://claude.ai/code/session_0176eg6XaYHctMTuvvYjaX4a

---
_Generated by [Claude Code](https://claude.ai/code/session_0176eg6XaYHctMTuvvYjaX4a)_