### PR TITLE
fix(build-cache): mktemp-unique tmp path for runtime objkey hashing (fixes macOS nightly self-host flake)

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -493,15 +493,37 @@ fn cache_store_artifact(root: string, key: CacheKey, kind: string, src_path: str
 // or shell metacharacter cannot escape `/tmp/.sfn_build_cache_*`
 // or break the downstream `sha256sum '<path>'` shell invocation.
 //
-// Cross-process race note: two parallel workers calling this with
-// the same sanitized suffix would collide on the same tmp path.
-// Today the cache module is single-process; Stage E's long-lived
-// driver will introduce parallel module compilation and at that
-// point this helper should switch to `mktemp` (or thread a
-// per-worker nonce) — flagged in the proposal's open questions.
+// Cross-process race fix: two parallel workers calling this with the
+// same sanitized suffix used to collide on the single fixed tmp path
+// `/tmp/.sfn_build_cache_hash_<suffix>` — one worker `rm -f`'d the file
+// out from under another's `sha256sum`, surfacing as
+// `sha256sum: /tmp/.sfn_build_cache_hash_…: No such file or directory`
+// and a roaming build-and-run failure under the parallel test pool /
+// `make check --jobs N` (macOS nightly self-host check). The runtime
+// object cache-key path (`runtime_object_entry_key_from_str`) hashes a
+// per-source `hash_suffix` (`cap_prefix + basename + opt_flag`) that is
+// IDENTICAL across concurrent builds of the same runtime source, so the
+// collision is process-global — independent of `SAILFIN_TEST_SCRATCH`.
+//
+// Fix: derive a per-process-unique tmp path via `mktemp` (same pattern
+// as `_cache_atomic_copy`). `mktemp` guarantees a fresh, exclusively
+// created file, so no two workers ever share the path. Falls back to the
+// legacy fixed path when `mktemp` is unavailable (degrades to the prior
+// single-process behaviour rather than failing the hash).
 fn _sha256_of_string(input: string, unique_suffix: string) -> string ![io] {
     let safe_suffix = _sanitize_filename_cmd(unique_suffix);
-    let tmp = "/tmp/.sfn_build_cache_hash_" + safe_suffix;
+    let template = _shell_single_quote_arg("/tmp/.sfn_build_cache_hash_"
+        + safe_suffix
+        + ".XXXXXX");
+    let tmp = _shell_read_cmd("mktemp " + template + " 2>/dev/null");
+    if tmp.length == 0 {
+        // mktemp unavailable — degrade to the legacy fixed path.
+        let fixed = "/tmp/.sfn_build_cache_hash_" + safe_suffix;
+        _write_text_cmd(fixed, input);
+        let fixed_digest = _sha256_of_file_cmd(fixed);
+        process.run(["rm", "-f", fixed]);
+        return fixed_digest;
+    }
     _write_text_cmd(tmp, input);
     let digest = _sha256_of_file_cmd(tmp);
     process.run(["rm", "-f", tmp]);

--- a/compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn
+++ b/compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn
@@ -1,0 +1,117 @@
+// Regression: concurrent cold builds must not race on the runtime
+// object cache-key tmp file.
+//
+// Root cause (the macOS nightly self-host check, roaming build-and-run
+// failures): `_sha256_of_string` (compiler/src/build_cache.sfn) hashed
+// the runtime object cache key by writing to a SINGLE fixed tmp path
+// `/tmp/.sfn_build_cache_hash_<suffix>` and then `rm -f`-ing it. The
+// `<suffix>` (`cap_prefix + basename + opt_flag`, e.g.
+// `sfn__runtime-native__prelude_sfn-O2`) is IDENTICAL across concurrent
+// builds of the same runtime source, so two parallel `sfn run`/`sfn
+// build` workers collided on that path — one `rm`-ed the file out from
+// under the other's `sha256sum` (`No such file or directory`), and the
+// poisoned key flipped a cache hit into a partial/wrong result, ending
+// in a nested-build failure (assert abort, exit 134). The collision is
+// PROCESS-GLOBAL — it bites even when each test's nested build is
+// otherwise isolated via its own `SAILFIN_TEST_SCRATCH` (which is the
+// case under `make check`'s per-file `sub-<i>` scratch + `--jobs N`).
+//
+// The fix routes that tmp file through `mktemp` so every worker gets a
+// unique path. This test models the CI contention exactly: N concurrent
+// cold `sfn run`s, EACH with its own `SAILFIN_TEST_SCRATCH` (so the
+// per-invocation `run.ll`/`.o`/binary are isolated per child, mirroring
+// the per-file `sub-<i>`), all still sharing the one global tmp hash
+// path. Pre-fix this flakes; post-fix every child builds and prints its
+// own marker.
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _scratch_base() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/objkey-race";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// One concurrent round: write N distinct fixtures, build+run them
+// concurrently (each with its OWN per-child scratch), and assert each
+// child exits 0 and prints its own marker with no cross-contamination.
+fn _race_round(base: string, round: int, n: int) -> boolean ![io] {
+    // Build the `bash -c` vehicle: launch N `sfn run`s in the background,
+    // each with a distinct SAILFIN_TEST_SCRATCH, then `wait`. The shared
+    // global /tmp hash path is what concurrency stresses.
+    let bin = _sfn_bin();
+    let mut script = "";
+    let mut k = 0;
+    loop {
+        if k >= n { break; }
+        let tag = number_to_string(round) + "_" + number_to_string(k);
+        let marker = "OBJKEY_MARK_" + tag;
+        let src = base + "/m_" + tag + ".sfn";
+        let outp = base + "/o_" + tag + ".txt";
+        let child_scratch = base + "/s_" + tag;
+        fs.createDirectory(child_scratch, true);
+        fs.writeFile(src, "fn main() ![io] {\n    print.info(\"" + marker
+            + "\");\n}\n");
+        // Each child gets its own scratch so run.ll/.o/binary are isolated;
+        // only the global cache-key tmp path is shared across children.
+        script = script + "( export SAILFIN_TEST_SCRATCH='" + child_scratch
+            + "'; '"
+            + bin
+            + "' run '"
+            + src
+            + "' > '"
+            + outp
+            + "' 2>&1 ) &\n";
+        k += 1;
+    }
+    script = script + "wait\n";
+
+    let exit = process.run_capture(["bash", "-c", script], process.environ());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return false; }
+
+    // Verify every child produced exactly its own marker.
+    let mut ok = true;
+    let mut j = 0;
+    loop {
+        if j >= n { break; }
+        let tag = number_to_string(round) + "_" + number_to_string(j);
+        let marker = "OBJKEY_MARK_" + tag;
+        let outp = base + "/o_" + tag + ".txt";
+        if !fs.exists(outp) { ok = false; } else {
+            let got = fs.readFile(outp);
+            // Own marker present...
+            if !contains(got, marker) { ok = false; }
+            // ...and no sibling's marker leaked in (cross-contamination).
+            let mut s = 0;
+            loop {
+                if s >= n { break; }
+                if s != j {
+                    let other = "OBJKEY_MARK_" + number_to_string(round) + "_"
+                        + number_to_string(s);
+                    if contains(got, other) { ok = false; }
+                }
+                s += 1;
+            }
+        }
+        j += 1;
+    }
+    return ok;
+}
+
+test "concurrent cold builds do not race on the runtime objkey tmp file" ![io] {
+    let base = _scratch_base();
+    // 6 concurrent builds × 2 rounds = 12 cold runtime compiles hammering
+    // the shared cache-key tmp path. Modest fan-out keeps wall-time bounded
+    // while still reliably tripping the pre-fix race.
+    assert _race_round(base, 0, 6);
+    assert _race_round(base, 1, 6);
+}


### PR DESCRIPTION
## Summary

Fixes the **macOS Nightly self-host check** failures (e.g. [run 28163031732](https://github.com/SailfinIO/sailfin/actions/runs/28163031732)) — a flaky, roaming, macos-arm64-only single-test failure that has been red the last several nights and is blocking the release.

**Root cause (not a compiler regression — a build-cache race).** `_sha256_of_string` (`compiler/src/build_cache.sfn`) hashed the runtime-object cache key by writing to a **single fixed tmp path** `/tmp/.sfn_build_cache_hash_<suffix>` and then `rm -f`-ing it. The `<suffix>` (`cap_prefix + basename + opt_flag`, e.g. `sfn__runtime-native__prelude_sfn-O2`) is **identical across concurrent builds of the same runtime source**, so two parallel `sfn run`/`sfn build` workers collided on that path — one `rm`-ed the file out from under another's `sha256sum` (`No such file or directory`), poisoning the key and flipping a cache hit into a wrong/partial result that surfaced as a nested-build failure (assert abort → SIGABRT, exit 134).

The collision is **process-global** (it fires on every cache-key lookup), so it bit the e2e suite even though each test file's nested build is isolated under its own `SAILFIN_TEST_SCRATCH` (`make check`'s per-file `sub-<i>` scratch + `--jobs N`). The reported test **roamed** night to night (`linker_selection`, `run_cache_flags`, `struct_field_separator`, …) because it's whichever build-and-run test the parallel pool reaches first. The `"failure":"crash"` label in the result JSON is just SIGABRT from the failed `assert`. Linux passed every night (`--jobs 4`); the slower `macos-26` builds (`--jobs 2`) widened the race window enough to lose it ~1 in 3.

## Fix

Derive the tmp path via `mktemp` (the same pattern already used by `_cache_atomic_copy` in this file) so every worker gets a unique, exclusively-created file. Falls back to the legacy fixed path when `mktemp` is unavailable.

Scoped deliberately tight: the shared content-addressed cache (`cache_store_artifact`/`cache_copy_artifact_to`) is already atomic via `_cache_atomic_copy`, and the per-invocation `.ll`/`.o`/`run` artifacts route under per-file `SAILFIN_TEST_SCRATCH` on CI — so neither is the active CI surface. The `mktemp` change closes the one process-global, non-atomic, every-lookup file op.

## Validation

- `make compile` self-hosts cleanly with the fix.
- `build_cache` unit suite green (74 tests) — hashing unchanged.
- New regression test `compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn` models the CI contention (N concurrent cold builds, each with its own scratch, sharing only the global tmp path). **Reproduces the flake on the pre-fix binary** (1/3 fail) and is **stable across 20 runs post-fix**.

## Notes

- **Residual observed once:** the very first concurrent run immediately after `make compile` failed once on cold *first-population* of the shared `build/cache/v2` store, then 20/20 stable. On CI that store is warm from building the compiler, whereas the sha256 key race (fixed here) fired on every lookup regardless. If the nightly shows any rarer residual flake after this lands, that cold-shared-cache-population path is the follow-up to harden — but it is a separate, much rarer surface.
- **PR #1617** (scheduler pool 4→32) is **orthogonal**: that's the runtime thread pool for compiled programs, not the build-artifact layer. It cannot cause or aggravate this filesystem race and can merge independently.

## Files
- `compiler/src/build_cache.sfn` — `_sha256_of_string` uses `mktemp` for a per-process-unique tmp path.
- `compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn` — new concurrency regression test.
