### PR TITLE
feat(process): framed/length-aware child stdio builtins

### DIFF
--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1108,6 +1108,10 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "process.handle_close_stdin");
     helpers = append_unique_effect(helpers, "process.handle_read_stdout");
     helpers = append_unique_effect(helpers, "process.handle_read_stderr");
+    // #1578: framed/length-aware child stdio (epic #1540 Track A A1+A4).
+    helpers = append_unique_effect(helpers, "process.handle_read_line_stdout");
+    helpers = append_unique_effect(helpers, "process.handle_read_bytes_stdout");
+    helpers = append_unique_effect(helpers, "process.handle_write_bytes");
     helpers = append_unique_effect(helpers, "process.handle_wait");
     helpers = append_unique_effect(helpers, "process.environ");
     // #1580: `io.poll_readable` lowers to the bare `sfn_io_poll_readable`

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -857,6 +857,21 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.handle_read_stderr", symbol: "sfn_process_handle_read_stderr", return_type: "i8*", parameter_types: ["i64"], effects: ["io"], native_signature: "sfn_process_handle_read_stderr", c_abi_return_type: null
     });
+    // #1578 (epic #1540 Track A, gaps A1 + A4): framed/length-aware child
+    // stdio. `handle_read_line_stdout` returns one `\n`-delimited line and
+    // stashes the remainder in the handle; `handle_read_bytes_stdout`
+    // returns ≤ n bytes preserving the remainder; `handle_write_bytes`
+    // writes exactly `len` bytes (embedded NULs intact). Same Sailfin-native
+    // bodies + always-declare pattern as `handle_read_stdout` above.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.handle_read_line_stdout", symbol: "sfn_process_handle_read_line_stdout", return_type: "i8*", parameter_types: ["i64"], effects: ["io"], native_signature: "sfn_process_handle_read_line_stdout", c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.handle_read_bytes_stdout", symbol: "sfn_process_handle_read_bytes_stdout", return_type: "i8*", parameter_types: ["i64", "i64"], effects: ["io"], native_signature: "sfn_process_handle_read_bytes_stdout", c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.handle_write_bytes", symbol: "sfn_process_handle_write_bytes", return_type: "i64", parameter_types: ["i64", "i8*", "i64"], effects: ["io"], native_signature: "sfn_process_handle_write_bytes", c_abi_return_type: null
+    });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.handle_wait", symbol: "sfn_process_handle_wait", return_type: "i64", parameter_types: ["i64"], effects: ["io"], native_signature: "sfn_process_handle_wait", c_abi_return_type: null
     });

--- a/compiler/tests/integration/process_framed_stdio_test.sfn
+++ b/compiler/tests/integration/process_framed_stdio_test.sfn
@@ -1,0 +1,104 @@
+// Integration coverage for the framed/length-aware child stdio builtins
+// (#1578, epic #1540 Track A gaps A1 + A4). The Sailfin-native bodies
+// live in `runtime/sfn/process.sfn`
+// (`sfn_process_handle_read_line_stdout`,
+// `sfn_process_handle_read_bytes_stdout`,
+// `sfn_process_handle_write_bytes`); the `process.*` descriptor rows in
+// `compiler/src/llvm/runtime_helpers.sfn` flip the builtin surface onto
+// them. These pin the raw builtins independently of any `sfn/os`
+// wrapper, mirroring `process_spawn_with_env_test.sfn`. All assume a
+// POSIX `sh`/`cat`/`printf` (the same platform assumption the sibling
+// `spawn_with_env` tests rely on).
+test "handle_read_line_stdout: reads framed lines and buffers the remainder" ![io] {
+    // One child write delivers three `\n`-framed lines in a single read;
+    // each call returns one line (newline stripped) and stashes the rest.
+    let id = process.spawn_with_env(["sh", "-c", "printf 'one\\ntwo\\nthree\\n'"], []);
+    assert id != 0;
+    let a = process.handle_read_line_stdout(id);
+    assert a == "one";
+    let b = process.handle_read_line_stdout(id);
+    assert b == "two";
+    let c = process.handle_read_line_stdout(id);
+    assert c == "three";
+    // Past the last newline: EOF yields the empty string.
+    let d = process.handle_read_line_stdout(id);
+    assert d == "";
+    let exit = process.handle_wait(id);
+    assert exit == 0;
+}
+
+test "handle_read_line_stdout: returns the final unterminated line then empty" ![io] {
+    // "a\nb" — the trailing "b" has no newline; it is returned on EOF,
+    // then subsequent calls return the empty string.
+    let id = process.spawn_with_env(["sh", "-c", "printf 'a\\nb'"], []);
+    assert id != 0;
+    let a = process.handle_read_line_stdout(id);
+    assert a == "a";
+    let b = process.handle_read_line_stdout(id);
+    assert b == "b";
+    let c = process.handle_read_line_stdout(id);
+    assert c == "";
+    let exit = process.handle_wait(id);
+    assert exit == 0;
+}
+
+test "handle_read_line_stdout: reads from a live child without closing the pipe" ![io] {
+    // `cat` echoes each block as it reads — write one frame, read it back
+    // while the child is still running (stdin not yet closed), then a
+    // second frame, proving the pipe stays open across calls.
+    let id = process.spawn_with_env(["cat"], []);
+    assert id != 0;
+    let w1 = process.handle_write_bytes(id, "ping\n", 5);
+    assert w1 == 5;
+    let l1 = process.handle_read_line_stdout(id);
+    assert l1 == "ping";
+    let w2 = process.handle_write_bytes(id, "pong\n", 5);
+    assert w2 == 5;
+    let l2 = process.handle_read_line_stdout(id);
+    assert l2 == "pong";
+    process.handle_close_stdin(id);
+    let exit = process.handle_wait(id);
+    assert exit == 0;
+}
+
+test "handle_read_bytes_stdout: returns at most n bytes preserving the remainder" ![io] {
+    let id = process.spawn_with_env(["sh", "-c", "printf 'abcdefgh'"], []);
+    assert id != 0;
+    // First call caps at 3 bytes; the remaining 5 stay buffered.
+    let p1 = process.handle_read_bytes_stdout(id, 3);
+    assert p1 == "abc";
+    // n exceeds what is buffered: returns the 5-byte remainder.
+    let p2 = process.handle_read_bytes_stdout(id, 10);
+    assert p2 == "defgh";
+    // Nothing left: EOF yields the empty string.
+    let p3 = process.handle_read_bytes_stdout(id, 4);
+    assert p3 == "";
+    let exit = process.handle_wait(id);
+    assert exit == 0;
+}
+
+test "handle_write_bytes: writes exactly len bytes rather than strlen" ![io] {
+    let id = process.spawn_with_env(["cat"], []);
+    assert id != 0;
+    // An 11-char buffer but len=5: only "hello" must reach the child,
+    // proving the body honors `len` instead of strlen-truncating.
+    let w = process.handle_write_bytes(id, "hello world", 5);
+    assert w == 5;
+    process.handle_close_stdin(id);
+    let out = process.handle_read_stdout(id);
+    assert out == "hello";
+    let exit = process.handle_wait(id);
+    assert exit == 0;
+}
+
+test "handle_write_bytes: a zero length writes nothing and returns 0" ![io] {
+    let id = process.spawn_with_env(["cat"], []);
+    assert id != 0;
+    let w = process.handle_write_bytes(id, "ignored", 0);
+    assert w == 0;
+    process.handle_close_stdin(id);
+    let out = process.handle_read_stdout(id);
+    assert out == "";
+    let exit = process.handle_wait(id);
+    assert exit == 0;
+}

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -1244,6 +1244,184 @@ fn sfn_process_handle_read_stderr(handle_id: i64) -> * u8 ![io] {
     return _handle_drain_one(h, false);
 }
 
+// ── framed stdout reads / exact-length stdin writes (#1578) ─────
+// Epic #1540 Track A, gaps A1 + A4: let a parent read one `\n`-framed
+// JSON-RPC message at a time from a live child's stdout (and write an
+// exact-length frame to its stdin) instead of draining to EOF /
+// `strlen`-truncating. These reuse the handle's stdout stash `GrowBuf`
+// (offset 16) as a persistent unconsumed-bytes buffer: `gb.addr[0..len)`
+// always holds the bytes read-ahead but not yet handed to the caller.
+// `handle_wait` already frees `gb.addr`, so no extra teardown is needed.
+//
+// Unlike `_handle_drain_one`, these poll only stdout — A3 (poll-based
+// fd multiplexing across stdout+stderr) is a separate issue (#1540 A3),
+// and the JSON-RPC use case keeps stderr low-volume (diagnostics). A
+// child flooding stderr while the parent frames stdout is out of scope.
+// Fill the tail of the stash buffer with one `read(2)` chunk (≤ 4096
+// bytes), growing first. Mirrors `_growbuf_read_from` but reserves +8
+// trailing slack (not +1) so the newline scan's i32 low-byte loads
+// (`_framed_find_newline`) never over-read past the allocation on the
+// final 1–3 bytes — there is no i8 load intrinsic. Returns the
+// `read(2)` result: `> 0` appended, `0` EOF, `< 0` error / OOM. EINTR
+// is retried in place. The invariant `gb.cap >= gb.len + 8` holds after
+// every successful fill and is preserved by `_framed_consume`'s compaction.
+fn _framed_fill(gb: * GrowBuf, fd: i32) -> i64 {
+    let chunk: i64 = 4096;
+    let needed: i64 = gb.len + chunk + 8;
+    if needed > gb.cap {
+        let mut new_cap: i64 = gb.cap;
+        if new_cap < 4096 { new_cap = 4096; }
+        loop {
+            if needed <= new_cap { break; }
+            new_cap = new_cap * 2;
+        }
+        let old: * u8 = gb.addr as * u8;
+        let r: * u8 = realloc(old, new_cap as usize);
+        if r as i64 == 0 { return -1; }
+        gb.addr = r as i64;
+        gb.cap = new_cap;
+    }
+    let dst: * u8 = (gb.addr + gb.len) as * u8;
+    loop {
+        let n: i64 = read(fd, dst, chunk as usize);
+        if n < 0 {
+            let err: i32 = sailfin_intrinsic_pointer_read_i32(sailfin_intrinsic_errno_location());
+            if err == SFN_EINTR {
+                // Interrupted before any byte — retry the same read.
+            } else { return n; }
+        } else {
+            if n > 0 { gb.len = gb.len + n; }
+            return n;
+        }
+    }
+}
+
+// Index of the first `'\n'` (10) in `gb.addr[0..len)`, or `-1`. Bytes
+// are read via the i32 low-byte load (no i8 load exists); the +8 fill
+// slack keeps the load in-bounds for the final bytes.
+fn _framed_find_newline(gb: * GrowBuf) -> i64 {
+    let addr: i64 = gb.addr;
+    if addr == 0 { return -1; }
+    let len: i64 = gb.len;
+    let mut i: i64 = 0;
+    loop {
+        if i >= len { break; }
+        let b: i32 = sailfin_intrinsic_pointer_read_i32((addr + i) as * u8) & 255;
+        if b == 10 { return i; }
+        i = i + 1;
+    }
+    return -1;
+}
+
+// Hand `ret_len` bytes from the front of the stash to the caller as a
+// fresh NUL-terminated buffer, then drop `consume_len` bytes from the
+// front (`consume_len >= ret_len`: the line case returns `idx` bytes but
+// consumes `idx + 1` to swallow the newline). The unconsumed remainder
+// `[consume_len..len)` is compacted to the front via a temp buffer (two
+// non-overlapping `memcpy`s — there is no `memmove`). `gb.cap` is
+// unchanged, so the +8 slack invariant is preserved (`len` only shrinks).
+fn _framed_consume(gb: * GrowBuf, ret_len: i64, consume_len: i64) -> * u8 {
+    let addr: i64 = gb.addr;
+    let len: i64 = gb.len;
+    let res: * u8 = malloc((ret_len + 1) as usize);
+    if res as i64 == 0 { return _process_empty_cstr(); }
+    if ret_len > 0 { memcpy(res, addr as * u8, ret_len as usize); }
+    memset((res as i64 + ret_len) as * u8, 0, 1 as usize);
+    let rem: i64 = len - consume_len;
+    if rem > 0 {
+        let tmp: * u8 = malloc(rem as usize);
+        if tmp as i64 != 0 {
+            memcpy(tmp, (addr + consume_len) as * u8, rem as usize);
+            memcpy(addr as * u8, tmp, rem as usize);
+            free(tmp);
+        }
+        gb.len = rem;
+    } else { gb.len = 0; }
+    return res;
+}
+
+// ── process.handle_read_line_stdout ────────────────────────────
+// Return one `'\n'`-delimited line (without the trailing newline) from
+// the child's stdout, buffering any bytes past the newline in the stash
+// for the next call — symmetric with `io.read_line` (#1579). On EOF the
+// final unterminated partial line (if any) is returned, then the empty
+// string. Reads stdout only; closes the fd on EOF/error so a subsequent
+// call returns the buffered tail without re-reading a dead pipe.
+fn sfn_process_handle_read_line_stdout(handle_id: i64) -> * u8 ![io] {
+    if handle_id == 0 { return _process_empty_cstr(); }
+    let h: * SailfinProcessHandle = handle_id as * SailfinProcessHandle;
+    let gb: * GrowBuf = ((h as i64) + 16) as * GrowBuf;
+    loop {
+        let idx: i64 = _framed_find_newline(gb);
+        if idx >= 0 { return _framed_consume(gb, idx, idx + 1); }
+        let fd: i32 = h.stdout_fd;
+        if fd < 0 { return _framed_consume(gb, gb.len, gb.len); }
+        let n: i64 = _framed_fill(gb, fd);
+        if n <= 0 {
+            close(fd);
+            h.stdout_fd = -1;
+            return _framed_consume(gb, gb.len, gb.len);
+        }
+    }
+}
+
+// ── process.handle_read_bytes_stdout ───────────────────────────
+// Return at most `n` bytes from the child's stdout, preserving any
+// unconsumed remainder in the stash for the next call. When the stash
+// is empty, one `read(2)` chunk is pulled from the live fd first; a
+// short read returns fewer than `n`. On EOF the fd is closed and the
+// empty string is returned. `n <= 0` is the empty string.
+fn sfn_process_handle_read_bytes_stdout(handle_id: i64, n: i64) -> * u8 ![io] {
+    if handle_id == 0 { return _process_empty_cstr(); }
+    if n <= 0 { return _process_empty_cstr(); }
+    let h: * SailfinProcessHandle = handle_id as * SailfinProcessHandle;
+    let gb: * GrowBuf = ((h as i64) + 16) as * GrowBuf;
+    if gb.len == 0 {
+        let fd: i32 = h.stdout_fd;
+        if fd >= 0 {
+            let r: i64 = _framed_fill(gb, fd);
+            if r <= 0 {
+                close(fd);
+                h.stdout_fd = -1;
+            }
+        }
+    }
+    let mut take: i64 = n;
+    if take > gb.len { take = gb.len; }
+    if take <= 0 { return _process_empty_cstr(); }
+    return _framed_consume(gb, take, take);
+}
+
+// ── process.handle_write_bytes ─────────────────────────────────
+// Write exactly `len` bytes of `data` to the child's stdin, resuming
+// short writes and EINTR. Unlike `handle_write` (which `strlen`s a
+// NUL-terminated cstring), this honors an explicit length, so embedded
+// NULs in a binary frame are written verbatim. Returns bytes written
+// (`== len` on success), or `-1` on a dead handle / closed stdin /
+// write error. `len <= 0` writes nothing and returns 0.
+fn sfn_process_handle_write_bytes(handle_id: i64, data: * u8, len: i64) -> i64 ![io] {
+    if handle_id == 0 { return -1; }
+    if data as i64 == 0 { return -1; }
+    if len < 0 { return -1; }
+    let h: * SailfinProcessHandle = handle_id as * SailfinProcessHandle;
+    let fd: i32 = h.stdin_fd;
+    if fd < 0 { return -1; }
+    let mut written: i64 = 0;
+    loop {
+        if written >= len { break; }
+        let dst: * u8 = ((data as i64) + written) as * u8;
+        let remaining: i64 = len - written;
+        let nw: i64 = write(fd, dst, remaining as usize);
+        if nw < 0 {
+            let err: i32 = sailfin_intrinsic_pointer_read_i32(sailfin_intrinsic_errno_location());
+            if err == SFN_EINTR {
+                // Interrupted before any byte — retry the same span.
+            } else { return -1; }
+        } else { written = written + nw; }
+    }
+    return written;
+}
+
 // ── process.handle_wait ────────────────────────────────────────
 // Close any still-open fds, reap the child, free the stash buffers
 // and the handle itself, and return the exit code (0..255),


### PR DESCRIPTION
## Summary
- Adds three Sailfin-native `process.*` runtime builtins so a parent can frame a live child's stdio instead of draining to EOF / `strlen`-truncating (epic #1540 Track A, gaps A1 + A4):
  - `handle_read_line_stdout(handle) -> string` — one `\n`-delimited line (newline stripped), buffering the remainder in the handle's stdout stash for the next call; returns the final unterminated line then the empty string on EOF.
  - `handle_read_bytes_stdout(handle, n) -> string` — at most `n` bytes, preserving the unconsumed remainder.
  - `handle_write_bytes(handle, buf, len)` — writes exactly `len` bytes (embedded NULs intact) with short-write/EINTR resume.
- Reuses the handle's stdout stash `GrowBuf` (offset 16) as a persistent unconsumed-bytes buffer via new helpers (`_framed_fill`, `_framed_find_newline`, `_framed_consume`); `handle_wait` already owns/frees it. A +8 fill slack keeps the newline scan's i32 low-byte loads in-bounds; compaction is a temp-buffer double-`memcpy` (no `memmove`).
- Mechanical extension of the existing `process.handle_read_stdout` template: descriptor rows in `runtime_helpers.sfn` + always-declare lines in `lowering_helpers.sfn`. No C edit or Windows stub needed — the handle stdio family is already Sailfin-only.

Closes #1578

## Acceptance Criteria
- [x] `handle_read_line_stdout` returns a single line from a running child without closing the pipe; subsequent calls return subsequent lines.
- [x] `handle_read_bytes_stdout` returns at most `n` bytes and preserves the unconsumed remainder.
- [x] `handle_write_bytes` writes exactly `len` bytes (including embedded NULs) with short-write resume.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Verification
```
make compile   → status:pass (self-hosts)
make test      → unit 164/164 · integration 39/39 · e2e 153/153 · capsules 36/36 · status:pass
sailfin test compiler/tests/integration/process_framed_stdio_test.sfn → PASS (all 6 tests)
sfn fmt --check (4 touched .sfn) → clean
```

## Files Changed
- `runtime/sfn/process.sfn` — three Sailfin-native bodies + `_framed_fill` / `_framed_find_newline` / `_framed_consume` helpers.
- `compiler/src/llvm/runtime_helpers.sfn` — three `RuntimeHelperDescriptor` rows.
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — three always-declare lines.
- `compiler/tests/integration/process_framed_stdio_test.sfn` — regression coverage (line framing, remainder buffering, live round-trip, exact-length write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ca1pXG3m7BVR2zmooR2U5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ca1pXG3m7BVR2zmooR2U5)_