### PR TITLE
fix(lexer): support underscore separators (1_000_000) and float exponents (1.0e6)

### DIFF
--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -195,13 +195,16 @@ fn lex(source: string) -> Token[] ![io] {
             state.index += 1;
             state.column += 1;
 
+            // Integer run: digits with optional `_` separators between digits.
             loop {
-                if state.index >= state.source_len { break; }
-                if !is_digit(byte_at(state.source, state.index)) { break; }
+                if !_number_run_byte(state.source, state.source_len, state.index) {
+                    break;
+                }
                 state.index += 1;
                 state.column += 1;
             }
 
+            // Optional fraction: `.` immediately followed by a digit run.
             if state.index < state.source_len {
                 if byte_at(state.source, state.index) == "." {
                     let mut _let43: boolean = false;
@@ -215,8 +218,52 @@ fn lex(source: string) -> Token[] ![io] {
                         state.index += 1;
                         state.column += 1;
                         loop {
-                            if state.index >= state.source_len { break; }
-                            if !is_digit(byte_at(state.source, state.index)) {
+                            if !_number_run_byte(state.source, state.source_len, state.index) {
+                                break;
+                            }
+                            state.index += 1;
+                            state.column += 1;
+                        }
+                    }
+                }
+            }
+
+            // Optional scientific exponent: `e`/`E`, optional `+`/`-` sign, then
+            // a digit run. Consumed only when a digit actually follows, so `1e`
+            // (where `e` begins an identifier) keeps the literal as `1`.
+            if state.index < state.source_len {
+                let exp_marker = byte_at(state.source, state.index);
+                let mut _is_exp: boolean = false;
+                if exp_marker == "e" { _is_exp = true; }
+                if exp_marker == "E" { _is_exp = true; }
+                if _is_exp {
+                    let mut probe = state.index + 1;
+                    if probe < state.source_len {
+                        let sign = byte_at(state.source, probe);
+                        let mut _is_sign: boolean = false;
+                        if sign == "+" { _is_sign = true; }
+                        if sign == "-" { _is_sign = true; }
+                        if _is_sign { probe += 1; }
+                    }
+                    let mut _has_exp_digit: boolean = false;
+                    if probe < state.source_len {
+                        if is_digit(byte_at(state.source, probe)) {
+                            _has_exp_digit = true;
+                        }
+                    }
+                    if _has_exp_digit {
+                        state.index += 1;
+                        state.column += 1;
+                        let sign2 = byte_at(state.source, state.index);
+                        let mut _is_sign2: boolean = false;
+                        if sign2 == "+" { _is_sign2 = true; }
+                        if sign2 == "-" { _is_sign2 = true; }
+                        if _is_sign2 {
+                            state.index += 1;
+                            state.column += 1;
+                        }
+                        loop {
+                            if !_number_run_byte(state.source, state.source_len, state.index) {
                                 break;
                             }
                             state.index += 1;
@@ -351,6 +398,21 @@ fn is_digit(ch: string) -> boolean {
         if c <= 57 { _ret42 = true; }
     }
     return _ret42;
+}
+
+// True when the numeric scanner should consume the byte at `index`: a digit,
+// or a `_` digit separator that sits between two digits (`1_000`). A trailing
+// `_` not followed by a digit is left to start an identifier (`1_foo`).
+fn _number_run_byte(source: string, source_len: int, index: int) -> boolean {
+    if index >= source_len { return false; }
+    let ch = byte_at(source, index);
+    if is_digit(ch) { return true; }
+    if ch == "_" {
+        if index + 1 < source_len {
+            if is_digit(byte_at(source, index + 1)) { return true; }
+        }
+    }
+    return false;
 }
 
 fn is_double_quote(ch: string) -> boolean { return ch == "\""; }

--- a/compiler/src/llvm/expression_lowering/native/core_text.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_text.sfn
@@ -309,6 +309,7 @@ fn is_number_literal(text: string) -> boolean {
     let mut index: int = 0;
     let mut has_digit: boolean = false;
     let mut has_decimal: boolean = false;
+    let mut has_exp: boolean = false;
     let trimmed = trim_text(text);
     if trimmed.length == 0 { return false; }
     if substring(trimmed, 0, 1) == "-" {
@@ -336,8 +337,27 @@ fn is_number_literal(text: string) -> boolean {
         }
         if ch == "." {
             if has_decimal { return false; }
+            if has_exp { return false; }
             has_decimal = true;
             index += 1;
+            continue;
+        }
+        let mut _is_exp_marker: boolean = false;
+        if ch == "e" { _is_exp_marker = true; }
+        if ch == "E" { _is_exp_marker = true; }
+        if _is_exp_marker {
+            if has_exp { return false; }
+            if !has_digit { return false; }
+            has_exp = true;
+            index += 1;
+            if index < trimmed.length {
+                let sign = substring(trimmed, index, index + 1);
+                let mut _is_sign: boolean = false;
+                if sign == "+" { _is_sign = true; }
+                if sign == "-" { _is_sign = true; }
+                if _is_sign { index += 1; }
+            }
+            if index >= trimmed.length { return false; }
             continue;
         }
         return false;

--- a/compiler/src/llvm/expressions_literals.sfn
+++ b/compiler/src/llvm/expressions_literals.sfn
@@ -101,6 +101,7 @@ fn is_number_literal(text: string) -> boolean {
     let mut index: int = 0;
     let mut has_digit: boolean = false;
     let mut has_decimal: boolean = false;
+    let mut has_exp: boolean = false;
     let trimmed = trim_text(text);
     if trimmed.length == 0 { return false; }
     if substring(trimmed, 0, 1) == "-" {
@@ -128,8 +129,27 @@ fn is_number_literal(text: string) -> boolean {
         }
         if ch == "." {
             if has_decimal { return false; }
+            if has_exp { return false; }
             has_decimal = true;
             index += 1;
+            continue;
+        }
+        let mut _is_exp_marker: boolean = false;
+        if ch == "e" { _is_exp_marker = true; }
+        if ch == "E" { _is_exp_marker = true; }
+        if _is_exp_marker {
+            if has_exp { return false; }
+            if !has_digit { return false; }
+            has_exp = true;
+            index += 1;
+            if index < trimmed.length {
+                let sign = substring(trimmed, index, index + 1);
+                let mut _is_sign: boolean = false;
+                if sign == "+" { _is_sign = true; }
+                if sign == "-" { _is_sign = true; }
+                if _is_sign { index += 1; }
+            }
+            if index >= trimmed.length { return false; }
             continue;
         }
         return false;

--- a/compiler/src/llvm/utils.sfn
+++ b/compiler/src/llvm/utils.sfn
@@ -239,6 +239,7 @@ fn is_number_literal(text: string) -> boolean {
     let mut index: int = 0;
     let mut has_digit: boolean = false;
     let mut has_decimal: boolean = false;
+    let mut has_exp: boolean = false;
     let trimmed = trim_text(text);
     if trimmed.length == 0 { return false; }
     if substring(trimmed, 0, 1) == "-" {
@@ -266,8 +267,27 @@ fn is_number_literal(text: string) -> boolean {
         }
         if ch == "." {
             if has_decimal { return false; }
+            if has_exp { return false; }
             has_decimal = true;
             index += 1;
+            continue;
+        }
+        let mut _is_exp_marker: boolean = false;
+        if ch == "e" { _is_exp_marker = true; }
+        if ch == "E" { _is_exp_marker = true; }
+        if _is_exp_marker {
+            if has_exp { return false; }
+            if !has_digit { return false; }
+            has_exp = true;
+            index += 1;
+            if index < trimmed.length {
+                let sign = substring(trimmed, index, index + 1);
+                let mut _is_sign: boolean = false;
+                if sign == "+" { _is_sign = true; }
+                if sign == "-" { _is_sign = true; }
+                if _is_sign { index += 1; }
+            }
+            if index >= trimmed.length { return false; }
             continue;
         }
         return false;

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -23,6 +23,7 @@ import { infer_effects } from "../decorator_semantics";
 import {
     char_at,
     char_code,
+    normalize_number_literal_value,
     strings_equal,
     substring
 } from "../string_utils";
@@ -255,7 +256,9 @@ fn parse_decorator_argument(tokens: Token[]) -> DecoratorArgument? {
         } else if raw_text == "false" {
             expr = Expression.BooleanLiteral { value: "false" };
         } else if looks_like_number(raw_text) {
-            expr = Expression.NumberLiteral { value: raw_text };
+            expr = Expression.NumberLiteral {
+                value: normalize_number_literal_value(raw_text)
+            };
         }
     }
     return DecoratorArgument { name: name_text, expression: expr };

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -12,6 +12,7 @@ import {
 import {
     char_at,
     char_code,
+    normalize_number_literal_value,
     strings_equal,
     substring
 } from "../string_utils";
@@ -285,7 +286,9 @@ fn expression_from_tokens(tokens: Token[]) -> Expression {
 
 fn expression_from_single_token(token: Token) -> Expression? {
     if token.kind.variant == "NumberLiteral" {
-        return Expression.NumberLiteral { value: token.lexeme };
+        return Expression.NumberLiteral {
+            value: normalize_number_literal_value(token.lexeme)
+        };
     }
     if token.kind.variant == "BooleanLiteral" {
         return Expression.BooleanLiteral { value: token.lexeme };
@@ -569,7 +572,9 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
     if token.kind.variant == "NumberLiteral" {
         return ExpressionParseResult {
             state: expression_tokens_advance(state),
-            expression: Expression.NumberLiteral { value: token.lexeme },
+            expression: Expression.NumberLiteral {
+                value: normalize_number_literal_value(token.lexeme)
+            },
             success: true
         };
     }
@@ -1604,7 +1609,9 @@ fn normalize_expression(tokens: Token[], expr: Expression) -> Expression {
                 return Expression.BooleanLiteral { value: token.lexeme };
             }
             if token.kind.variant == "NumberLiteral" {
-                return Expression.NumberLiteral { value: token.lexeme };
+                return Expression.NumberLiteral {
+                    value: normalize_number_literal_value(token.lexeme)
+                };
             }
         }
         let raw_text = trim_text(expr.text);
@@ -1623,7 +1630,9 @@ fn normalize_expression(tokens: Token[], expr: Expression) -> Expression {
             return Expression.BooleanLiteral { value: "false" };
         }
         if looks_like_number_expr(raw_text) {
-            return Expression.NumberLiteral { value: raw_text };
+            return Expression.NumberLiteral {
+                value: normalize_number_literal_value(raw_text)
+            };
         }
     }
     return expr;

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -156,6 +156,59 @@ fn strip_prefix(value: string, prefix: string) -> string {
     return value;
 }
 
+// Normalise a raw numeric lexeme (as scanned by the lexer, e.g. `1_000_000`
+// or `1.0e6`) into the plain decimal form the codegen and int-vs-float
+// classification paths already understand: strip `_` digit separators, and
+// when a scientific exponent is present ensure the mantissa carries a `.`
+// (LLVM rejects `1e6` but accepts `1.0e6`; the `.`-or-not shape then drives
+// the existing float-vs-int classification with no further change). The
+// exponent marker is canonicalised to lowercase `e`. Input is a bare literal
+// with no leading sign — `-3` parses as a `Unary` over a `NumberLiteral`.
+fn normalize_number_literal_value(text: string) -> string {
+    let mut mantissa: string = "";
+    let mut exponent: string = "";
+    let mut seen_exp: boolean = false;
+    let mut exp_has_digit: boolean = false;
+    let mut mantissa_has_dot: boolean = false;
+    let mut i: int = 0;
+    loop {
+        if i >= text.length { break; }
+        let ch = char_at(text, i);
+        if ch == "_" {
+            i += 1;
+            continue;
+        }
+        let mut _is_exp_marker: boolean = false;
+        if ch == "e" { _is_exp_marker = true; }
+        if ch == "E" { _is_exp_marker = true; }
+        if _is_exp_marker {
+            if !seen_exp {
+                seen_exp = true;
+                exponent = "e";
+                i += 1;
+                continue;
+            }
+        }
+        if seen_exp {
+            exponent = exponent + ch;
+            if ch >= "0" {
+                if ch <= "9" { exp_has_digit = true; }
+            }
+        } else {
+            if ch == "." { mantissa_has_dot = true; }
+            mantissa = mantissa + ch;
+        }
+        i += 1;
+    }
+    if !seen_exp { return mantissa; }
+    // A digitless exponent (`1e`) cannot reach here from the lexer or the
+    // `looks_like_number`-gated callers, but the helper is exported: degrade
+    // to the `_`-stripped mantissa rather than emit an LLVM-invalid `1.0e`.
+    if !exp_has_digit { return mantissa; }
+    if !mantissa_has_dot { mantissa = mantissa + ".0"; }
+    return mantissa + exponent;
+}
+
 fn contains_string(values: string[], target: string) -> boolean {
     let mut index: int = 0;
     loop {
@@ -183,5 +236,6 @@ export {
     starts_with,
     ends_with,
     strip_prefix,
-    contains_string
+    contains_string,
+    normalize_number_literal_value
 };

--- a/compiler/tests/unit/numeric_separators_exponent_test.sfn
+++ b/compiler/tests/unit/numeric_separators_exponent_test.sfn
@@ -1,0 +1,92 @@
+// compiler/tests/unit/numeric_separators_exponent_test.sfn
+//
+// Regression coverage for #1620: the lexer must accept `_` digit separators
+// (`1_000_000`) and scientific exponents (`1.0e6` / `1e6`) as single number
+// tokens, and the parser must normalise them into the plain decimal form the
+// codegen and int-vs-float classification paths already understand — strip
+// `_`, and ensure a `.` precedes any exponent (LLVM rejects `1e6` but accepts
+// `1.0e6`). Before the fix, a digit run that hit `_` ended the number token
+// and started an identifier (`1_000` -> `1`, `_000`), collapsing the RHS to
+// `Expression.Raw` — silently wrong.
+import { lex } from "../../src/lexer";
+import { normalize_number_literal_value, strings_equal } from "../../src/string_utils";
+
+// ---- normalisation contract (the literal -> value path) ----
+test "numeric: underscores are stripped from integers" {
+    assert strings_equal(normalize_number_literal_value("1_000"), "1000");
+    assert strings_equal(normalize_number_literal_value("1_000_000"), "1000000");
+}
+
+test "numeric: underscores are stripped from fractions" {
+    assert strings_equal(normalize_number_literal_value("3.141_592"), "3.141592");
+}
+
+test "numeric: an exponent without a dot gains one" {
+    assert strings_equal(normalize_number_literal_value("1e6"), "1.0e6");
+    assert strings_equal(normalize_number_literal_value("1E6"), "1.0e6");
+}
+
+test "numeric: dotted and signed exponents are preserved" {
+    assert strings_equal(normalize_number_literal_value("1.0e6"), "1.0e6");
+    assert strings_equal(normalize_number_literal_value("1.5e-3"), "1.5e-3");
+    assert strings_equal(normalize_number_literal_value("2.5E+4"), "2.5e+4");
+}
+
+test "numeric: plain literals pass through unchanged" {
+    assert strings_equal(normalize_number_literal_value("1000"), "1000");
+    assert strings_equal(normalize_number_literal_value("3.14"), "3.14");
+}
+
+// ---- the lexer scans each form as ONE number token (no split) ----
+fn _first_is_one_number(source: string, expected_lexeme: string) -> boolean ![io] {
+    let tokens = lex(source);
+    if tokens.length == 0 { return false; }
+    let tok = tokens[0];
+    if tok.kind.variant != "NumberLiteral" { return false; }
+    return strings_equal(tok.lexeme, expected_lexeme);
+}
+
+test "numeric: 1_000_000 lexes as a single number token" ![io] {
+    assert _first_is_one_number("1_000_000", "1_000_000");
+}
+
+test "numeric: 1.0e6 lexes as a single number token" ![io] {
+    assert _first_is_one_number("1.0e6", "1.0e6");
+}
+
+test "numeric: 1e6 lexes as a single number token" ![io] {
+    assert _first_is_one_number("1e6", "1e6");
+}
+
+test "numeric: 1.5e-3 lexes as a single number token" ![io] {
+    assert _first_is_one_number("1.5e-3", "1.5e-3");
+}
+
+test "numeric: a trailing e with no digit stays an identifier" ![io] {
+    // `1e` must NOT be misread: `1` is the number, `e` begins an identifier.
+    let tokens = lex("1e");
+    assert tokens.length >= 2;
+    assert tokens[0].kind.variant == "NumberLiteral";
+    assert strings_equal(tokens[0].lexeme, "1");
+    assert tokens[1].kind.variant == "Identifier";
+}
+
+test "numeric: a separator not between digits stops the run" ![io] {
+    // `_` is only a separator between two digits; `1__0` and a trailing `1_`
+    // end the number at the first `_` not flanked by digits.
+    let a = lex("1__0");
+    assert a.length >= 2;
+    assert a[0].kind.variant == "NumberLiteral";
+    assert strings_equal(a[0].lexeme, "1");
+    assert a[1].kind.variant == "Identifier";
+}
+
+test "numeric: a non-digit after e leaves the exponent unscanned" ![io] {
+    // `1.0e_3` has no digit after `e`, so the literal is `1.0` and `e_3`
+    // becomes an identifier rather than a malformed exponent.
+    let b = lex("1.0e_3");
+    assert b.length >= 2;
+    assert b[0].kind.variant == "NumberLiteral";
+    assert strings_equal(b[0].lexeme, "1.0");
+    assert b[1].kind.variant == "Identifier";
+}


### PR DESCRIPTION
## Summary
- The numeric scanner now accepts the spec-documented forms `1_000_000` (underscore separators) and `1.0e6` / `1e6` (scientific notation) as single number tokens with the correct value, instead of silently splitting them into a number + identifier and collapsing the RHS to `Expression.Raw`.
- The token lexeme keeps the **raw** source, so `sfn fmt` preserves separators; normalization happens once at the parser when building `NumberLiteral.value`.

Closes #1620

## Approach
- **Lexer** (`lexer.sfn`): consume `_` separators (only between digits, so `1_foo` still splits) and an optional `e/E[+-]?digits` exponent (only when a digit follows, so `1e` leaves `e` to start an identifier). New `_number_run_byte` helper.
- **Parser** (`expressions.sfn`, `declarations.sfn`): normalize `NumberLiteral.value` via the new `normalize_number_literal_value` (in `string_utils.sfn`) — strip `_`, and ensure the mantissa has a `.` when an exponent is present (LLVM rejects `1e6` but accepts `1.0e6`; verified with `llvm-as`). The existing `.`-based int-vs-float classification (`number_literal_kind`) and float-constant lowering (`normalise_number_literal`) then need **no change**.
- **LLVM lowering**: the three `is_number_literal` classifiers accept the `e/E[+-]` exponent.

## Acceptance Criteria
- [x] `let x = 1_000;` lexes to a single NumberLiteral with value `1000`
- [x] `let y = 1.0e6;` and `let z = 1e6;` lex as single number literals with value `1000000`
- [x] Underscores in the fraction (`3.141_592`) and a signed exponent (`1.5e-3`) parse correctly
- [x] No `Expression.Raw` degradation: expressions type-check and lower to the correct numeric constant
- [x] `make compile` passes (compiler self-hosts; byte-identical work-dir parity confirmed)
- [x] `make test` passes (no regressions)

## Verification
```bash
$ build/native/sailfin run /tmp/lit.sfn
[info] 1000000 1000000 1000000     # 1_000_000, 1.0e6, 1e6
[info] 3.141592 0.0015             # 3.141_592, 1.5e-3

$ build/native/sailfin test compiler/tests/unit/numeric_separators_exponent_test.sfn
PASS  (all 12 tests passed)

# Full suite: unit 165/165, integration 38/38, e2e 154/154, capsules 36/36
# (work_dir_parity_test passed in isolation — the suite-run timeout was the
#  known flaky parallel-pool timeout #1589, not a regression; this change is
#  deterministic and produces byte-identical compilers across work dirs.)
```

## Files Changed
- `compiler/src/lexer.sfn` — numeric scanner: `_` separators + exponent
- `compiler/src/string_utils.sfn` — `normalize_number_literal_value` helper
- `compiler/src/parser/expressions.sfn`, `compiler/src/parser/declarations.sfn` — normalize at `NumberLiteral` construction
- `compiler/src/llvm/utils.sfn`, `compiler/src/llvm/expression_lowering/native/core_text.sfn`, `compiler/src/llvm/expressions_literals.sfn` — `is_number_literal` accepts exponent
- `compiler/tests/unit/numeric_separators_exponent_test.sfn` — regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXHhYYZLuYFK4VM1WYiHtt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXHhYYZLuYFK4VM1WYiHtt)_