### PR TITLE
test(effects): build-path e2e for capability cross-check (E0403)

### DIFF
--- a/compiler/tests/e2e/capability_cross_check_test.sfn
+++ b/compiler/tests/e2e/capability_cross_check_test.sfn
@@ -1,0 +1,118 @@
+// End-to-end test for the capabilities-pillar cross-check (E0403)
+// enforced on the CHECK PATH (`sailfin check <file>`).
+//
+// Contract: a function declaring an effect outside the capsule
+// manifest's `[capabilities] required = [...]` surface must fail with
+// diagnostic `E0403`. The logic lives in
+// `validate_capsule_capabilities` (`compiler/src/effect_checker.sfn`,
+// Phase F) and renders via `compiler/src/diagnostics_render.sfn`; both
+// are already shipped and unit-tested
+// (`compiler/tests/unit/effect_capabilities_test.sfn`). This test closes
+// the build-path asymmetry: the in-module / cross-module gates
+// (E0400 / E0402) have a `process.run_capture`-driven e2e
+// (`effect_gate_build_path_test.sfn`) but E0403 had none.
+//
+// E0403 sources the allowed surface directly from `capsule.toml` via the
+// resolver (`capsule_resolver.sfn` Phase F → `cli_check.sfn`), so — unlike
+// the E0402 model — it needs no `--import-context` staging: a plain
+// `sfn check` over a file whose capsule walks up to a `capsule.toml` with
+// a non-empty `[capabilities] required` is enough.
+//
+// Each test stages its OWN isolated capsule (separate scratch dir keyed
+// by tag) holding a single fixture, so the negative control can never be
+// contaminated by the positive fixture's diagnostic regardless of how the
+// resolver enumerates capsule sources, and the parallel pool never
+// collides.
+//
+// NOTE: assert on captured stdout+stderr with `sfn/strings` predicates —
+// the `sfn/test` `expect_*` matchers are `![pure]` and cannot be called
+// from an `![io]` test. (#842.)
+import { find } from "sfn/strings";
+
+// The compiler-under-test: $SAILFIN_BIN if set, else the self-hosted
+// binary relative to the repo root the runner starts from.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Child env for the spawned `sfn check`: `run_capture`'s `[]` is the
+// EMPTY environment (not "inherit"), so thread through the variables the
+// frontend check may consult. `SAILFIN_TEST_SCRATCH` keeps any
+// per-invocation staging under the runner's scratch in the parallel pool.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// A private capsule dir under the runner's scratch (or /tmp), keyed by
+// `tag` so concurrent tests in the parallel pool never collide.
+fn _scratch(tag: string) -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    let dir = base + "/sfn-capability-cross-check-" + tag;
+    fs.createDirectory(dir + "/src", true);
+    return dir;
+}
+
+// Stage a one-fixture capsule with `[capabilities] required = ["io"]`.
+// Returns the absolute path to the staged fixture for `sfn check`.
+fn _stage_capsule(tag: string, fixture_name: string, fixture_body: string) -> string ![io] {
+    let dir = _scratch(tag);
+    fs.writeFile(dir + "/capsule.toml", "[capsule]\n"
+        + "name = \"cross_check_fixture\"\n"
+        + "version = \"0.0.0\"\n\n"
+        + "[capabilities]\n"
+        + "required = [\"io\"]\n");
+    let fixture_path = dir + "/src/" + fixture_name;
+    fs.writeFile(fixture_path, fixture_body);
+    return fixture_path;
+}
+
+struct CheckRun {
+    exit: int,
+    out: string
+}
+
+// Drive `sfn check <path>` and fold captured stdout+stderr together; the
+// frontend check stops before codegen/link, so no clang/linker is spawned.
+fn _check(path: string) -> CheckRun ![io] {
+    let exit = process.run_capture([_sfn_bin(), "check", path], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return CheckRun { exit: exit, out: out + err };
+}
+
+// ---- Over-declared: ![net] is outside the ["io"] surface → E0403 ----
+// The body needs no other effect, so the only diagnostic is the
+// capability cross-check (no E0400 under-declaration noise).
+test "capability cross-check: rejects effect outside manifest surface with E0403" ![io] {
+    let fixture = _stage_capsule("overdeclared", "reach.sfn", "fn reach(x: number) -> number ![net] {\n"
+        + "    return x + 1;\n"
+        + "}\n");
+    let r = _check(fixture);
+    assert r.exit != 0;
+    assert find(r.out, "E0403", 0) >= 0;
+}
+
+// ---- In-surface control: ![io] is within the ["io"] surface → clean ----
+// Proves the manifest surface is the discriminator — `check` is not
+// rejecting every effectful function. The body exercises `io` so there is
+// no unused-effect concern; `io` is both declared and allowed.
+test "capability cross-check: accepts effect within manifest surface" ![io] {
+    let fixture = _stage_capsule("insurface", "local.sfn", "fn local() ![io] {\n"
+        + "    print.info(\"in surface\");\n"
+        + "}\n");
+    let r = _check(fixture);
+    assert r.exit == 0;
+    assert find(r.out, "E0403", 0) < 0;
+}


### PR DESCRIPTION
## Summary
- Adds `compiler/tests/e2e/capability_cross_check_test.sfn`, a native `[io]` test that drives `sfn check` over a capsule declaring an effect outside its `[capabilities] required` surface and asserts the check fails with `E0403`.
- Closes the last build-path enforcement-test gap in the capabilities pillar — the in-module / cross-module gates (E0400 / E0402) already have `effect_gate_build_path_test.sfn`; E0403 had only unit coverage (`effect_capabilities_test.sfn`).
- Test-only: no compiler-source or runtime change (`validate_capsule_capabilities` and the `E0403` render are already shipped).

Closes #1179

## Design notes
Each test stages its **own isolated capsule** (separate scratch dir keyed by tag under `SAILFIN_TEST_SCRATCH`, falling back to `/tmp`), so the negative control can never be contaminated by the positive fixture's diagnostic regardless of how the resolver enumerates capsule sources, and the parallel pool never collides. `SAILFIN_TEST_SCRATCH` (plus `PATH`/`HOME`/`TMPDIR`) is threaded into the `run_capture` child env. Modeled on `compiler/tests/e2e/effect_gate_build_path_test.sfn`; no `--import-context` needed since E0403 sources the surface directly from `capsule.toml`.

## Acceptance Criteria
- [x] New `compiler/tests/e2e/capability_cross_check_test.sfn` exists; over-declared `[net]` fixture asserts non-zero exit + `E0403` in captured output.
- [x] In-surface `[io]` companion fixture asserts exit 0 and `E0403` absent.
- [x] Test runs under `sailfin test compiler/tests/e2e` with no harness/Makefile edits (auto-discovered).
- [x] Per-test scratch isolated under `SAILFIN_TEST_SCRATCH` (→ `/tmp` fallback); threaded into the child env.
- [x] `sfn fmt --check` clean on the new file.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Verification
```
make compile                                                         # pass (self-hosts)
build/native/sailfin test compiler/tests/e2e -k "capability cross-check"
  # PASS (all 2 tests passed)
build/native/sailfin fmt --check compiler/tests/e2e/capability_cross_check_test.sfn
  # FMT CLEAN
make test                                                            # pass — e2e 155/155, capsules 37/37
```

## Files Changed
- `compiler/tests/e2e/capability_cross_check_test.sfn` — **new** (only file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAbL6ntKMPsFhDZNwoAAia

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAbL6ntKMPsFhDZNwoAAia)_