### PR TITLE
perf(runtime_helpers): split descriptor registry — 4058→1062 MB (#1512)

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -134,8 +134,18 @@ fn make_push_descriptor(return_type: string, params: string[]) -> RuntimeHelperD
 // =============================================================================
 // Runtime Helper Registry
 // =============================================================================
-fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
-    let mut descriptors: RuntimeHelperDescriptor[] = [];
+//
+// PERFORMANCE: the registry is partitioned into `_rh_descriptors_NN` chunk
+// functions (each appending ~17 descriptors) rather than one ~1400-line
+// function. LLVM-lowering peak RSS is super-linear (~O(n^1.8)) in the number
+// of descriptor struct-literal construction sites in a *single* function body,
+// so one monolithic builder cost ~4 GB to compile (#1512); chunking the same
+// 197 appends across 12 functions cuts that to ~1 GB (−74%) with byte-identical
+// runtime output (the orchestrator `runtime_helper_descriptors()` calls the
+// chunks in order). Do NOT recombine these into one function — it reintroduces
+// the multi-GB regression and pushes this module back over the CI memory gate.
+fn _rh_descriptors_00(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     // Raw print: writes to stdout with no prefix, no decoration.
     // Used by the compiler itself for artifact output and CLI messages.
     // M2.8 (#401): flipped to the Sailfin-native sfn_print symbol via
@@ -282,6 +292,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "intrinsic.errno_location.mingw", symbol: "_errno", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_01(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
 
     // clock-monotonic clk_id sentinel (#908, epic #763). Resolves the
     // `CLOCK_MONOTONIC` `clk_id` immediate, which POSIX leaves
@@ -495,6 +510,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "clock_gettime", symbol: "clock_gettime", return_type: "i32", parameter_types: ["i32", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_02(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
 
     // Monotonic clock for profiling/timing.
     // Support both the prelude binding name and direct calls.
@@ -585,6 +605,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "await_void", symbol: "sfn_await_void", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_03(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "spawn_string", symbol: "sfn_spawn_string", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
@@ -659,6 +684,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "nursery_register", symbol: "sfn_nursery_register", return_type: "i64", parameter_types: ["i64", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_04(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "nursery_exit", symbol: "sfn_nursery_exit", return_type: "i64", parameter_types: ["i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
@@ -751,6 +781,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_char_code_fn", symbol: "sfn_str_codepoint", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_codepoint", c_abi_return_type: "double"
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_05(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
 
     // Process helpers
     // M1.B (#393): SfnArray ABI — heap-boxed `{ T*, i64, i64 }*` with
@@ -869,6 +904,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.handle_read_bytes_stdout", symbol: "sfn_process_handle_read_bytes_stdout", return_type: "i8*", parameter_types: ["i64", "i64"], effects: ["io"], native_signature: "sfn_process_handle_read_bytes_stdout", c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_06(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.handle_write_bytes", symbol: "sfn_process_handle_write_bytes", return_type: "i64", parameter_types: ["i64", "i8*", "i64"], effects: ["io"], native_signature: "sfn_process_handle_write_bytes", c_abi_return_type: null
     });
@@ -971,6 +1011,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs_delete_file", symbol: "sfn_fs_delete", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_07(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs.deleteFile", symbol: "sfn_fs_delete", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
     });
@@ -1074,6 +1119,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "websocket.close", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_08(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "websocket.connect", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
@@ -1204,6 +1254,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "number.to_string", symbol: "sfn_number_to_str", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: "sfn_number_to_str", c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_09(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.to_number", symbol: "sfn_str_to_number", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_to_number", c_abi_return_type: null
     });
@@ -1307,6 +1362,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.repeat", symbol: "sfn_str_repeat", return_type: "i8*", parameter_types: ["{i8*, i64}", "i64"], effects: [], native_signature: "sfn_str_repeat", c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_10(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
 
     // Array/collection helpers (generic using i8* for element type).
     // M2.6 (#399): the three array descriptors below carry a
@@ -1464,6 +1524,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "crypto.sha256", symbol: "sha256__capsules__sfn__crypto__src__mod", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
+    return descriptors;
+}
+
+fn _rh_descriptors_11(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
+    let mut descriptors = descriptors_in;
 
     // Base64 encode. M3 (#817): base64 encode now lives in pure Sailfin under
     // `capsules/sfn/crypto/src/mod.sfn`; the `base64.encode` intrinsic resolves
@@ -1530,6 +1595,23 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "record_eq_flag_message", symbol: "record_eq_flag_message", return_type: "i1", parameter_types: ["i1", "{i8*, i64}", "i1", "{i8*, i64}"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
+    return descriptors;
+}
+
+fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
+    let mut descriptors: RuntimeHelperDescriptor[] = [];
+    descriptors = _rh_descriptors_00(descriptors);
+    descriptors = _rh_descriptors_01(descriptors);
+    descriptors = _rh_descriptors_02(descriptors);
+    descriptors = _rh_descriptors_03(descriptors);
+    descriptors = _rh_descriptors_04(descriptors);
+    descriptors = _rh_descriptors_05(descriptors);
+    descriptors = _rh_descriptors_06(descriptors);
+    descriptors = _rh_descriptors_07(descriptors);
+    descriptors = _rh_descriptors_08(descriptors);
+    descriptors = _rh_descriptors_09(descriptors);
+    descriptors = _rh_descriptors_10(descriptors);
+    descriptors = _rh_descriptors_11(descriptors);
     return descriptors;
 }
 

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -477,7 +477,22 @@ macOS gets a smaller win because the heuristic picks `BUILD_JOBS=1` to fit the 7
 
 **Rejected approach — per-function arena mark/rewind.** A prototype marked the arena before each `emit_llvm_function` and rewound after evacuating the function's output into a survivor arena. It was abandoned: (a) it bought `core` only ~0.4 GB (the loop scratch is small), and (b) it caused **use-after-rewind corruption** — `runtime/sfn/process.sfn` and ~9 other modules emitted garbage, non-deterministic call symbols (`@H�Xos` vs `@H�X=z` across runs; clean with `SAILFIN_USE_ARENA=0`, i.e. rewind no-op), because some lowering output escapes the rewound region by reference. The mangling fixes alone clear the `< 2 GB` AC, so the rewind was dropped. Per-function (and intra-function) rewind for the loop remains a possible future lever **only** with a complete escape audit + a real second allocator for the accumulators.
 
-**Not addressed (tracked follow-ups):** `runtime_helpers.sfn` (3.91 → unchanged) is bound by one ~17k-line function (the descriptor registry, 96% of the module); reducing it needs *intra-function* work or a registry restructure. `core` at 1.64 GB clears `< 2 GB` but not the #340 `< 800 MB` stretch — the floor is the front-end residue (parse/typecheck/emit_native + type context) plus the loop's working set. The `index_of`/`starts_with` substring-allocation is compiler-wide and worth a dedicated allocation-free rewrite.
+**Not addressed (tracked follow-ups):** `core` at 1.64 GB clears `< 2 GB` but not the #340 `< 800 MB` stretch — the floor is the front-end residue (parse/typecheck/emit_native + type context) plus the loop's working set. The `index_of`/`starts_with` substring-allocation is compiler-wide and worth a dedicated allocation-free rewrite. (`runtime_helpers.sfn`, previously flagged here as the worst module at ~4 GB, was fixed by the registry split below.)
+
+### Runtime-Helper Registry Split (June 25, #1512)
+
+**Status: Implemented.** Cut `compiler/src/llvm/runtime_helpers.sfn`'s single-module `emit llvm` peak RSS from **4058 MB → 1062 MB (−74%)** and compile time **12.2s → 3.2s (−74%)**, byte-identical runtime output, self-hosting preserved. This was the heaviest module after the `core` fix and the binding constraint on raising CI `BUILD_JOBS` (7 GB macOS runner / 2 GB-per-job gate).
+
+The module is 96% one function — `runtime_helper_descriptors()`, ~1400 lines of 197 `RuntimeHelperDescriptor` struct-literal appends. A controlled experiment (synthetic modules of K identical struct-literal appends in one function) showed LLVM-lowering peak RSS is **super-linear, ≈O(K^1.8)**, in the number of construction sites *in a single function body* (IR line count itself scales linearly at ~85 lines/descriptor):
+
+| K (appends in one fn) | IR lines | peak RSS |
+|---|---|---|
+| 64 | 5,677 | 466 MB |
+| 128 | 11,053 | 1,483 MB |
+| 256 | 21,805 | 5,494 MB |
+| 256 **split 8×32** | 21,893 | **1,122 MB** |
+
+Doubling the descriptors in one function more than triples RSS; partitioning the same appends across functions collapses it (cost ∝ chunks × chunksize^1.8). The fix partitions the registry into 12 `_rh_descriptors_NN` chunk functions (~17 appends each) called in order by a thin `runtime_helper_descriptors()` orchestrator — every append line preserved verbatim, runtime descriptor table identical (guarded by `runtime_helper_declare_integrity_test`, `runtime_call_dispatch_test`, `lowering_no_bare_runtime_emissions_test`, `runtime_helper_abi_coercion_test`, and the self-host fixed point). A header comment warns against recombining. The underlying super-linear per-function lowering cost is unfixed (a compiler-pass issue, separate lever); chunking is the structural workaround.
 
 ### String Concat Allocation Reduction (April 11)
 


### PR DESCRIPTION
## Summary

Splits `compiler/src/llvm/runtime_helpers.sfn`'s descriptor registry to cut its single-module LLVM-lowering peak RSS from **4058 MB → 1062 MB (−74%)** (compile time 12.2s → 3.2s). This was the heaviest compiler module after the #1512 `core` fix and the binding constraint on raising CI `BUILD_JOBS` (7 GB macOS runner / ~2 GB-per-job gate).

## Root cause (measured)

The module is 96% one function — `runtime_helper_descriptors()`, ~1400 lines of 197 `RuntimeHelperDescriptor` struct-literal appends. A controlled experiment (synthetic modules of K identical struct-literal appends in one function) shows LLVM-lowering peak RSS is **super-linear, ≈O(K^1.8)**, in the number of construction sites *in a single function body* — while IR line count scales linearly (~85 lines/descriptor):

| K (appends in one fn) | IR lines | peak RSS |
|---|---|---|
| 64 | 5,677 | 466 MB |
| 128 | 11,053 | 1,483 MB |
| 256 | 21,805 | 5,494 MB |
| 256 **split 8×32** | 21,893 | **1,122 MB** |

Doubling descriptors in one function more than triples RSS; partitioning the same appends across functions collapses it (cost ∝ chunks × chunksize^1.8).

## Change

Partition the 197 appends into 12 `_rh_descriptors_NN` chunk functions (~17 each), called in order by a thin `runtime_helper_descriptors()` orchestrator. **Every append line is preserved verbatim** — the runtime descriptor table is byte-identical. A header comment warns against recombining (it reintroduces the multi-GB regression). The underlying super-linear per-function lowering cost is a separate compiler-pass lever; chunking is the structural workaround.

## Verification

- `make check` ✅ — triple-pass self-host + full suite (unit 166/166, integration 39/39, e2e 155/155, capsules 37/37).
- Behavior guarded by existing `runtime_helper_declare_integrity_test`, `runtime_call_dispatch_test`, `lowering_no_bare_runtime_emissions_test`, `runtime_helper_abi_coercion_test` + the self-host fixed point.
- `sfn fmt --check` clean.
- Single-module `emit llvm` peak RSS re-measured via `scripts/bench_compile.sh`: 4058 → 1062 MB.

Part of #1512 (memory-footprint reduction to unblock higher CI `BUILD_JOBS`); #1512 stays open for the remaining follow-ups (#340 <800 MB stretch on `core`; systemic `index_of`/`starts_with` allocation-free rewrite).