### PR TITLE
fix(effect-checker): derive Serve-node effects from registry ([io, net])

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -968,9 +968,13 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
         if expression.port != null {
             required = merge_requirements(required, collect_effects_from_expression(expression.port, imports));
         }
-        required = append_requirement(required, EffectRequirement {
-            effect: "net", description: "serve call", trigger: serve_trigger
-        });
+        // Registry-driven: the live `serve(...)` enforcement path. Derive
+        // the requirement set from the `serve` descriptor row (#1601, #1629)
+        // -> [io, net], replacing the former hardcoded `net`-only literal so
+        // it stays in lockstep with the Call-arm `serve` and a future `serve`
+        // effect change flows through with zero edits. Carets at the `serve`
+        // keyword token.
+        required = _append_builtin_effects(required, "serve", serve_trigger);
         return required;
     }
     return [];

--- a/compiler/tests/unit/concurrency_effect_test.sfn
+++ b/compiler/tests/unit/concurrency_effect_test.sfn
@@ -1,9 +1,11 @@
 // Unit tests for concurrency-node effect requirements (issue #1083,
 // epic #965 M4). The effect checker must produce an `io` violation for
 // `spawn`, channel-send, and channel-receive operations inside a
-// function that does not declare `![io]`, and a `net` violation for
-// `serve` without `![net]`. With the matching effect declared, the
-// checker produces zero violations.
+// function that does not declare `![io]`, and an `io`+`net` violation
+// for `serve` without `![io, net]` (the live `Serve`-node arm is
+// registry-driven off the `serve` descriptor row -> [io, net]; #1601,
+// #1629). With the matching effect(s) declared, the checker produces
+// zero violations.
 //
 // `spawn` and `serve` are first-class AST nodes (Expression.Spawn /
 // Expression.Serve, added in #1079). Channel send/receive are
@@ -25,6 +27,16 @@ import { EffectViolation, validate_effects } from "../../src/effect_checker";
 // -------------------------------------------------------------------
 // Builder helpers
 // -------------------------------------------------------------------
+fn _missing_contains(effects: string[], target: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= effects.length { break; }
+        if effects[i] == target { return true; }
+        i += 1;
+    }
+    return false;
+}
+
 fn _span(line: int, column: int) -> SourceSpan {
     return SourceSpan {
         start_line: line,
@@ -85,7 +97,7 @@ fn _make_spawn_fn(name: string, effects: string[], span_line: int) -> Statement 
 }
 
 // Build a FunctionDeclaration whose body contains a single `serve(handler)`
-// expression node (Expression.Serve). Requires `net`.
+// expression node (Expression.Serve). Requires `io` and `net`.
 fn _make_serve_fn(name: string, effects: string[], span_line: int) -> Statement {
     let handler = Expression.Identifier { name: "my_handler", span: null };
     let serve_expr = Expression.Serve {
@@ -200,20 +212,49 @@ test "concurrency: spawn with ![io] is clean" {
 }
 
 // -------------------------------------------------------------------
-// serve — requires net
+// serve — requires io + net (#1629: live Serve-node arm tightened to
+// match the prelude/capsule `fn serve(...) ![io, net]` signatures and
+// the registry, closing an effect false-negative on the marquee path)
 // -------------------------------------------------------------------
-test "concurrency: serve without ![net] is diagnosed" {
+test "concurrency: serve without any effects is diagnosed for io and net" {
     let mut no_effects: string[] = [];
-    let stmt = _make_serve_fn("server_without_net", no_effects, 1);
+    let stmt = _make_serve_fn("server_without_effects", no_effects, 1);
     let program = Program { statements: [stmt] };
     let violations = validate_effects(program);
     assert violations.length == 1;
-    assert violations[0].routine_name == "server_without_net";
+    assert violations[0].routine_name == "server_without_effects";
+    assert _missing_contains(violations[0].missing_effects, "io");
+    assert _missing_contains(violations[0].missing_effects, "net");
 }
 
-test "concurrency: serve with ![net] is clean" {
+// The headline #1629 case: a `serve(...)` under `[net]` alone must now
+// report the missing `io` effect (previously a false-negative).
+test "concurrency: serve with only ![net] reports missing io" {
     let mut net_effects: string[] = ["net"];
-    let stmt = _make_serve_fn("server_with_net", net_effects, 1);
+    let stmt = _make_serve_fn("server_with_net_only", net_effects, 1);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 1;
+    assert violations[0].routine_name == "server_with_net_only";
+    assert _missing_contains(violations[0].missing_effects, "io");
+    assert ! _missing_contains(violations[0].missing_effects, "net");
+}
+
+// Symmetric guard: `[io]` alone must still flag the missing `net`.
+test "concurrency: serve with only ![io] reports missing net" {
+    let mut io_effects: string[] = ["io"];
+    let stmt = _make_serve_fn("server_with_io_only", io_effects, 1);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 1;
+    assert violations[0].routine_name == "server_with_io_only";
+    assert _missing_contains(violations[0].missing_effects, "net");
+    assert ! _missing_contains(violations[0].missing_effects, "io");
+}
+
+test "concurrency: serve with ![io, net] is clean" {
+    let mut io_net_effects: string[] = ["io", "net"];
+    let stmt = _make_serve_fn("server_with_io_net", io_net_effects, 1);
     let program = Program { statements: [stmt] };
     let violations = validate_effects(program);
     assert violations.length == 0;


### PR DESCRIPTION
## Summary

The live `serve(...)` enforcement path — the `Serve` AST node, which the parser commits real `serve(...)` source to — required only `net`. Every other source of truth says `serve` is `[io, net]`:

- `runtime/prelude.sfn:596` — `fn serve(handler, config?) -> void [io, net]`
- `capsules/sfn/http/src/server.sfn` — `fn serve(...) [net, io]`
- `compiler/src/llvm/runtime_helpers.sfn` — the `serve` / `serve_start` / `serve_handler_dispatch` descriptor rows carry `effects: [io, net]`
- #1601 routed the **Call-arm** `serve` through `effects_for_callee_target("serve")` → `[io, net]`

After #1601 the Call-arm and the live `Serve`-node arm disagreed: a real `serve(...)` under-required `io` — a genuine **effect false-negative on the marquee path**.

## Change

`compiler/src/effect_checker.sfn` — the `Serve` arm in `collect_effects_from_expression` now routes through `_append_builtin_effects(required, "serve", serve_trigger)` → `effects_for_callee_target("serve")` → `[io, net]`, replacing the hardcoded `net`-only literal. The requirement is now registry-derived, so a future `serve` effect change flows through with zero edits — consistent with the Call-arm and #1601.

## Tests

`compiler/tests/unit/concurrency_effect_test.sfn` — rewrote the serve block:
- `serve(...)` with **no** effects → diagnosed for both `io` and `net`
- **headline case:** `serve(...)` under `[net]` alone → now reports missing `io`
- symmetric guard: `[io]` alone → reports missing `net`
- `[io, net]` → clean

All 10 tests in the file pass.

## Verification

- ✅ `make compile` — compiler self-hosts (no in-tree `serve(...)` caller regresses; they already declare `[io, net]`)
- ✅ Targeted unit test green (10/10)
- ✅ `sfn fmt --check` clean on both touched files
- `make test-unit` running for the full regression check

## Acceptance criteria

- [x] A `serve(...)` call inside a routine declaring only `[net]` now reports a missing `io` effect
- [x] A `serve(...)` call inside a routine declaring `[io, net]` is clean
- [x] The `Serve`-node requirement is derived from the descriptor registry (no remaining hardcoded `net`-only literal)
- [x] `make compile` passes (compiler self-hosts)
- [x] Concurrency/effect test asserting the `io`+`net` requirement on the `Serve` node added

## Follow-up

Issue #1629 scoped out the `Spawn` / `Parallel` / channel `send`/`receive` arms. Those remain a genuine latent divergence (the checker hardcodes `io` while the `channel_*` registry rows carry `effects: []`), tracked as a separate sub-issue under epic #1180 — filed alongside this PR.

Closes #1629

🤖 https://claude.ai/code/session_01H64XQrtrMKvBiqymkevjKy

---
_Generated by [Claude Code](https://claude.ai/code/session_01H64XQrtrMKvBiqymkevjKy)_