### PR TITLE
refactor(agents): make issue intent authoritative, file map advisory

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -149,7 +149,8 @@ gh issue create \
 
 ## Scope
 **In:**
-- ...
+- <semantic unit of change — not a file path; e.g. "the effect-checker
+  diagnostic emission for missing ![io]">
 
 **Out:**
 - ...
@@ -159,8 +160,8 @@ gh issue create \
 - [ ] make compile passes
 - [ ] make test passes
 
-## Files Affected
-- compiler/src/... — ...
+## Files Affected (advisory map — non-binding, expected to drift)
+- compiler/src/... — ...   # likely-relevant starting points; non-exhaustive, no line numbers/counts
 
 ## Verification
 \`\`\`bash
@@ -193,6 +194,32 @@ value is `None`. `/pickup` Phase 1.5 treats a missing section as legacy
 and falls back to walking `## Blocked by` against the seed tag — which
 produces false-positive seed-cut requirements on routine work. An
 explicit `None` value is the contract that says "no seed dependency."
+
+### Intent authoritative, file map advisory
+
+A groomed issue's **contract** is its **Goal** plus a **semantic
+`In:`/`Out:` scope**. The `## Files Affected` block is a **non-binding map** —
+a navigation aid that is *expected to drift* and is reconciled at pickup, not
+a checklist that gates correctness. This is the convention of record in
+`docs/conventions/issue-naming.md` ("Intent-authoritative issues"); all four
+issue-lifecycle commands cite it. When emitting an issue body:
+
+- **Express `In:`/`Out:` as semantic units of change, not file paths.** Write
+  "the effect-checker diagnostic emission for missing `![io]`", not
+  "`effect_checker.sfn` lines X-Y". A new sibling file inside that unit (e.g.
+  a split that moved diagnostic emission into `effect_checker/diagnostics.sfn`)
+  is then **in scope by construction** — the unit, not the path, is the boundary.
+- **Mark `## Files Affected` advisory** (the header reword above) and list paths
+  as *likely-relevant starting points*, explicitly non-exhaustive.
+- **Forbid line numbers anywhere** (`L142`, `~L100-135`) and **exact file
+  counts** ("edit these 3 files", "two call sites") in any emitted body. Line
+  numbers rot fastest; a count turns an in-unit Nth sibling into a phantom
+  scope violation.
+
+`/pickup` reconciles cosmetic map drift (a renamed path, an in-unit sibling)
+and pauses only on **semantic** scope growth (a new acceptance criterion or new
+public surface). Grooming a precise-but-brittle map only manufactures pickup
+halts on entropy `/triage` would otherwise refresh.
 
 Capture the issue numbers. After each `gh issue create`:
 

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -277,7 +277,41 @@ Based on the issue's `type:*` label, follow the appropriate workflow. Use the is
 | `type:perf` | Follow `/perf` phases — profile baseline, implement, bench after, verify. |
 | `type:refactor` | Implement directly (one self-hosting step at a time), spawn `code-reviewer`, run `test-runner`. No architect needed if issue body has the plan. |
 
-**During implementation, respect the Scope section.** If you discover the issue's `In:` scope is wrong (missing a needed file, or `Out:` is impossible to honor), STOP and comment on the issue:
+### Reconcile the advisory map, then check for real scope growth
+
+A groomed issue's **contract** is its **Goal** plus the semantic `In:`/`Out:`
+scope. `## Files Affected` is a **non-binding map** (`docs/conventions/issue-naming.md`,
+"Intent-authoritative issues") that is *expected to drift* between grooming and
+pickup. **Before** implementing, re-derive the current surface for each `In:`
+unit (grep/glob for the named symbols/units), compare it against the advisory
+map, and apply the **In/Out semantic boundary contract**:
+
+- **In-scope — reconcile and proceed (do not pause):**
+  - A path in `## Files Affected` was **renamed/moved** → use the new path.
+  - A semantic unit named in `In:` is now spread across **additional sibling
+    files** in the same module/directory → touch them all.
+  - A map file **no longer exists** because its content merged into a sibling
+    already covered by the same `In:` unit → follow the content.
+  - The **same public surface** is reached through a refactored internal call
+    path → follow it.
+- **Out-of-scope — PAUSE, comment, do not proceed:**
+  - A **new acceptance criterion** the issue did not list is required.
+  - A **new public/user-facing surface** (new CLI flag, exported symbol,
+    diagnostic code) not implied by the Goal.
+  - The change must reach a **different semantic unit** than `In:` names (e.g.
+    the issue is scoped to the effect checker but the fix belongs in the parser).
+  - Honoring `Out:` becomes **impossible**.
+
+The discriminator is one question: **does the Goal plus the semantic
+`In:`/`Out:` still hold?** If yes, the drift is cosmetic — **reconcile and
+record it in the PR** (the Phase 5 "Map reconciliation" line); never halt on a
+renamed or missing map path. If a *new* criterion or surface is required, that is
+real scope growth — pause per the guard below.
+
+**During implementation, the semantic scope is the line.** If the work genuinely
+needs a **new acceptance criterion or new public surface** (real growth, per the
+Out-of-scope list above), or `Out:` is **impossible** to honor, STOP and comment
+on the issue:
 
 ```bash
 gh issue comment <N> --body "Scope adjustment needed: <reason>. Pausing for human input."
@@ -291,7 +325,8 @@ gh issue edit <N> --add-label "needs-grooming" --remove-label "in-progress"
 .claude/scripts/sync-project-status.sh <N> --from-labels
 ```
 
-Do not silently expand scope.
+Do not silently expand the *semantic* scope. A renamed/moved/merged map path or
+an in-unit sibling is **not** scope growth — reconcile it and keep going.
 
 **When the blocker is a missing _prerequisite_ (not just a wrong scope line).**
 Sometimes the issue isn't mis-scoped — it depends on a capability that does
@@ -367,6 +402,10 @@ Closes #<N>
 ## Acceptance Criteria
 <copy from issue, with all boxes checked>
 
+## Map reconciliation
+<advisory-map drift reconciled at pickup, or "None — map matched the tree".
+e.g. "`old/path.sfn` → `new/path.sfn` (renamed); added sibling `x.sfn` (same In: unit)">
+
 ## Verification
 \`\`\`bash
 <commands run, with results>
@@ -410,7 +449,13 @@ If anything was deferred or scope was adjusted mid-flight, surface it explicitly
 
 ## Constraints
 
-- **Never expand scope silently.** If the issue's scope is wrong, pause and ask.
+- **Never expand *semantic* scope silently.** A new acceptance criterion, new
+  public surface, or a different `In:` unit means pause and ask. Cosmetic map
+  drift (a renamed/moved/merged path, an in-unit sibling) is **not** scope
+  growth — reconcile it and proceed.
+- **Always record map reconciliation, never silently.** When the advisory
+  `## Files Affected` map drifted from the tree, capture the reconciliation in
+  the PR body's "Map reconciliation" line so the drift is visible and auditable.
 - **Never declare done with unchecked acceptance criteria.** If a criterion can't be met, comment and pause.
 - **Never push to main directly.** Always work on the `claude/<N>-<slug>` branch and open a PR.
 - **Always link the issue in the PR.** `Closes #N` ensures auto-close on merge.

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -159,8 +159,14 @@ For each issue in the `claude-ready` pool:
 1. Parse `## Files Affected` from the body. Extract path-shaped tokens.
 2. For each path not marked "New:", verify it exists in the working tree:
    ```bash
-   test -f <path> || flag "missing-file"
+   test -f <path> || note "stale-map"   # soft note, NOT a defect flag
    ```
+   `## Files Affected` is an **advisory map** (`docs/conventions/issue-naming.md`,
+   "Intent-authoritative issues") that is *expected to drift* — a missing path is
+   not an issue defect. Surface it as a **soft, non-blocking note** ("advisory map
+   may be stale — `/triage` can refresh") and do **not** imply the issue is broken.
+   The semantic `In:`/`Out:` scope is the contract; a stale map on a
+   semantically-scoped issue is expected entropy, not rot.
 3. Sanity-check for "appears already shipped" signals (heuristic only):
    - If the issue's goal mentions a symbol/function to delete or remove, `grep` to confirm it still exists.
    - If the issue describes adding a file/feature, `grep` for evidence the work shipped under a different name.
@@ -232,7 +238,7 @@ Still blocked:
   ⏸ #<N> — <title>      (waiting on: #<X> open, "Slice E" ambiguous)
 
 Audit findings (claude-ready hygiene):
-  ⚠ #<N> — <title>      (missing file: <path>)
+  · #<N> — <title>      (advisory map may be stale: <path> — /triage can refresh)
   ⚠ #<N> — <title>      (symbol "<name>" appears removed — verify scope)
 
 Top picks for free slots:

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -102,6 +102,11 @@ a size entirely (no label AND no `## Size`).
 - **TYPE-FIX** — GitHub native Type field is `null` (always fix, silently).
 - **STALE-GROOM** — `needs-grooming` 14+ days that is NOT a promote candidate
   (still incomplete) → flag for `/groom` or closure review (no label change).
+- **MAP-REFRESH** — `claude-ready` (or just-promoted) issue whose Goal + semantic
+  `In:`/`Out:` scope are intact but whose `## Files Affected` **advisory map** has
+  missing/renamed paths → re-derive and rewrite the advisory map (still
+  non-binding; no line numbers/counts), and note the refresh. A stale map is
+  expected entropy on a semantically-scoped issue — never a DEMOTE trigger.
 
 ---
 
@@ -193,6 +198,24 @@ gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical s
 Apply to all issues with a null type regardless of other state. No label edit,
 no comment, no board sync.
 
+### MAP-REFRESH — rewrite a stale advisory map (the one allowed body edit)
+
+When an issue's Goal + semantic `In:`/`Out:` scope are intact but its
+`## Files Affected` **advisory map** lists missing/renamed paths, re-derive the
+current surface for each `In:` unit (grep/glob the named symbols/units) and
+**rewrite the advisory map** to the current paths. Keep it non-binding and
+**free of line numbers and exact counts**; do not touch Goal, Scope, Acceptance,
+or Verification. Leave a comment recording the refresh:
+
+```bash
+# Edit ONLY the `## Files Affected (advisory map …)` block of the body.
+gh issue edit <N> --body "<updated body with the refreshed advisory map>"
+gh issue comment <N> --body "Auto-triage map refresh: re-derived the advisory \`## Files Affected\` map from the current tree (\`old/path\` → \`new/path\`; added in-unit sibling \`x\`). Map only — Goal and semantic In/Out scope unchanged. The map is non-binding; \`/pickup\` reconciles any remaining drift."
+```
+
+This is the **sole** exception to "don't modify issue bodies" — it edits only
+the advisory map, never the contract. A stale map is never a DEMOTE trigger.
+
 If a sync call exits non-zero, capture the issue number under "Concerns" in the
 report — the label flip stands but the board is out of sync.
 
@@ -219,6 +242,7 @@ Actions taken:
   - Stripped claude-ready from <N> incomplete issues
   - Released <N> orphaned in-progress issues back to queue
   - Unblocked <N> issues whose blockers closed
+  - Refreshed <N> stale advisory maps (Goal/scope intact)
   - Flagged <N> stale claude-ready issues for human review
   - Flagged <N> L-sized issues for breakdown
 
@@ -241,7 +265,10 @@ Concerns:
 ## Constraints
 
 - **Don't close issues automatically.** Closing is a human decision.
-- **Don't modify issue bodies.** Only labels and comments.
+- **Don't modify issue bodies, except the advisory map.** Only labels and
+  comments — with the single MAP-REFRESH exception, which rewrites *only* the
+  `## Files Affected` advisory map (never Goal, Scope, Acceptance, or
+  Verification) and always leaves a comment recording the refresh.
 - **Promote conservatively.** A complete-looking body is necessary but not
   sufficient — the promotion guards (open decision / unmet precondition /
   deferred-by-design) exist because they bit us before. When a guard fires,

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -32,11 +32,21 @@ optional `area:*`).
 ## Scope
 
 **In:**
-<!-- Bullet list of exactly what this issue changes. Be specific. -->
+<!--
+Name the semantic UNITS of change, not file paths — e.g. "the effect-checker
+diagnostic emission for missing ![io]", not "effect_checker.sfn lines X-Y".
+The unit, not the path, defines the boundary: a new sibling file inside that
+unit (after a split) is in scope by construction. Be specific about behaviour;
+never cite line numbers.
+-->
 -
 
 **Out:**
-<!-- Bullet list of what this issue explicitly does NOT touch. Prevents scope creep. -->
+<!--
+What this issue explicitly does NOT touch. Prevents scope creep. A new
+acceptance criterion or a new public/user-facing surface is out of scope by
+definition — if the work needs one, that is real scope growth, not drift.
+-->
 -
 
 ## Acceptance Criteria
@@ -46,9 +56,19 @@ optional `area:*`).
 - [ ] `make compile` passes (compiler self-hosts)
 - [ ] `make test` passes (no regressions)
 
-## Files Affected
+## Files Affected (advisory map — non-binding, expected to drift)
 
-<!-- Every file the implementation will touch, with a short note on what changes. -->
+<!--
+A NON-EXHAUSTIVE navigation aid: likely-relevant starting points, NOT a
+binding checklist. The codebase moves between grooming and pickup (files
+split, get renamed, gain siblings), so this map is expected to drift and is
+reconciled at pickup — it never gates correctness. The authoritative contract
+is the Goal plus the semantic In/Out scope above.
+
+Do NOT write line numbers (`L142`, `~L100-135`) or exact file counts ("these
+3 files", "two call sites"): both rot fastest and turn an in-unit sibling into
+a phantom scope violation. List paths as starting points only.
+-->
 - `compiler/src/...` —
 - `compiler/tests/...` —
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -203,6 +203,73 @@ checks at least one of them:
 
 ---
 
+## Intent-authoritative issues (contract vs. advisory map)
+
+A groomed issue's **contract** is its **Goal** plus a **semantic `In:`/`Out:`
+scope**. The `## Files Affected` block is an **advisory map** — a navigation aid
+that is *expected to drift* and is reconciled at pickup, never a checklist that
+gates correctness. This is the convention of record; `/groom`, `/pickup`,
+`/sweep`, and `/triage` all cite it rather than each restating the rule.
+
+**Why.** Between grooming and pickup the codebase moves — files split, get
+renamed, gain siblings in the same module. If the file map is treated as binding,
+`/pickup` halts on cosmetic drift it cannot distinguish from real scope growth,
+and `/sweep` flags decaying precision as a defect. Making *intent* authoritative
+and the *map* advisory removes that failure mode instead of fighting its entropy.
+
+### Express scope as semantic units, not files
+
+`In:`/`Out:` lines name **semantic units of change**, not paths — e.g. "the
+effect-checker diagnostic emission for missing `![io]`", not "`effect_checker.sfn`
+lines X-Y". A new sibling file *inside* that unit (after a split that moved the
+emission into `effect_checker/diagnostics.sfn`) is then **in scope by
+construction** — the unit, not the path, defines the boundary.
+
+### Banned in any groomed issue body
+
+- **Line numbers** anywhere (`L142`, `~L100-135`) — they rot fastest and carry
+  no semantic weight.
+- **Exact file counts** ("edit these 3 files", "two call sites") — a count turns
+  an in-unit Nth sibling into a phantom scope violation.
+- **Closed file enumerations presented as exhaustive** — `## Files Affected`
+  lists paths as *likely-relevant starting points*, explicitly non-exhaustive.
+
+### The In/Out semantic boundary contract (what `/pickup` applies)
+
+At pickup, before implementing, the agent re-derives the current surface for each
+`In:` unit and compares it against the advisory map:
+
+- **In-scope — reconcile, proceed, and record in the PR (never halt):**
+  - a `## Files Affected` path was **renamed/moved** → use the new path;
+  - an `In:` unit is now spread across **additional sibling files** in the same
+    module → touch them all;
+  - a map file **no longer exists** because its content merged into a sibling
+    already covered by the same `In:` unit → follow the content;
+  - the **same public surface** is reached through a refactored internal call
+    path → follow it.
+- **Out-of-scope — PAUSE, comment, do not proceed:**
+  - a **new acceptance criterion** the issue did not list is required;
+  - a **new public/user-facing surface** (CLI flag, exported symbol, diagnostic
+    code) not implied by the Goal;
+  - the change must reach a **different semantic unit** than `In:` names;
+  - honoring `Out:` becomes **impossible**.
+
+The discriminator is one question: **does the Goal plus the semantic `In:`/`Out:`
+still hold?** If yes, the drift is cosmetic — reconcile and record it (the
+`/pickup` PR-body "Map reconciliation" line). If a new criterion or surface is
+required, that is real growth — pause for human input.
+
+### Command responsibilities
+
+- **`/groom`** emits `## Files Affected` as an advisory, non-exhaustive map and
+  `In:`/`Out:` as semantic units; never line numbers or counts.
+- **`/pickup`** reconciles cosmetic map drift and records it; pauses only on
+  semantic scope growth (the Out-of-scope list above).
+- **`/sweep`** reports a missing `## Files Affected` path as a **soft note**
+  ("advisory map may be stale — `/triage` can refresh"), not a defect flag.
+- **`/triage`** refreshes a stale advisory map (re-derives paths, no line
+  numbers/counts) when Goal + semantic scope are intact.
+
 ## Project board
 
 Every open issue is tracked on the **Sailfin Tracker** project


### PR DESCRIPTION
## Summary
- Demote `## Files Affected` to a **non-binding, drift-tolerant advisory map** across the issue contract (template + `/groom`), with `In:`/`Out:` expressed as **semantic units** and line numbers / exact file counts banned in emitted bodies.
- Teach `/pickup` to **reconcile-not-halt**: a new step applies the In/Out semantic-boundary contract before the scope guard — cosmetic drift (rename, in-unit sibling, content merge) reconciles and is recorded in the PR; only semantic growth (new acceptance criterion / public surface) pauses.
- Downgrade `/sweep`'s missing-map-path from a defect flag to a soft note; add a `/triage` MAP-REFRESH step that rewrites a stale advisory map when Goal + scope are intact; document the contract in `docs/conventions/issue-naming.md` as the convention of record.

Implements **SFEP-0026 WS-A** (`docs/proposals/0026-delivery-process.md`, execution items 1–7).

Closes #1658

## Acceptance Criteria
- [x] The issue template + `/groom` emit `## Files Affected` as an advisory, non-exhaustive map; no line numbers or exact file counts appear in emitted bodies.
- [x] `/pickup` applies the In/Out semantic-boundary contract: a simulated file rename + in-unit sibling addition reconciles (proceeds, records map drift in the PR) without halting; a simulated *new acceptance criterion* still pauses.
- [x] `/sweep` reports a missing `## Files Affected` path as a soft note, not a defect flag.
- [x] `/triage` refreshes a stale advisory map (no line numbers/counts) when Goal + scope are intact.
- [x] `docs/conventions/issue-naming.md` documents the intent-authoritative / map-advisory contract as the convention of record.

## Verification
Process change — no `.sfn` source touched, so no `make compile` / `sfn fmt` / self-host gate applies (SFEP-0026 §5, §7). Validated by dry-run rehearsal of the discriminator per SFEP-0026 §8 (WS-A):

```text
Scenario (rename + in-unit sibling on a scoped issue):
  - map path `effect_checker.sfn` → `effect_checker/diagnostics.sfn` (renamed)
  - emission now spread across an added sibling in the same In: unit
  → pickup.md Phase 3 "In-scope": use new path + touch the siblings →
    RECONCILE + record in PR "Map reconciliation" line. No halt.  ✓

Negative control (inject a new acceptance criterion):
  → pickup.md Phase 3 "Out-of-scope: a new acceptance criterion the issue
    did not list is required" → PAUSE + comment.  ✓

Discriminator: "does Goal + semantic In/Out still hold?" — yes → cosmetic
drift (reconcile); no → real growth (pause). Distinguishes the two cases the
old file-map-as-scope guard could not.
```

## Files Changed
- `.github/ISSUE_TEMPLATE/claude-task.md` — advisory map reword; semantic In/Out help
- `.claude/commands/groom.md` — body skeleton reword + intent-authoritative grooming rule
- `.claude/commands/pickup.md` — reconcile-vs-halt step; reworded guard; PR "Map reconciliation" line + constraint
- `.claude/commands/sweep.md` — missing path → soft note
- `.claude/commands/triage.md` — MAP-REFRESH bucket/action + carve-out to the body-edit constraint
- `docs/conventions/issue-naming.md` — "Intent-authoritative issues" convention of record

https://claude.ai/code/session_01NL9uNVE563qHY52WhQ66Gh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL9uNVE563qHY52WhQ66Gh)_