### PR TITLE
refactor(agents): add seed-dependency rule + bundle-by-default grooming

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -89,25 +89,23 @@ instead of as a planned predecessor). If the probe fails, the prerequisite
 is a **frontend issue that must be groomed first** — make it an explicit
 `Blocked by` / `Required in pinned seed` predecessor, not a surprise.
 
-### Don't over-decompose: bundle a capability with its single consumer
+### Don't over-decompose: bundle a capability with its single consumer (default)
 
-Splitting is not free. Prefer **one issue/PR** for a compiler capability plus
-its first consumer when they are tightly coupled and one agent will work them
-together; only split when the work is genuinely independent **or** the
-capability has multiple consumers that each justify standalone shipping.
+**Bundling is the groom-time default, not a split-time afterthought.** When you
+identify a compiler capability that is tightly coupled to exactly one consumer
+that will be worked in the same session, **produce one issue** (one PR), not two.
+Split only when the capability has **multiple consumers** that each justify
+standalone shipping, or the work is **genuinely independent**. Any split that
+creates a seed-cut gate for a single consumer must be **explicitly justified** in
+the issue body — the default answer is bundle.
 
-The decisive sub-rule — **the seed-cut tax**: when a compiler-source change
-(lowering / parsing / typecheck / intrinsics) and its runtime/consumer change
-land as **separate releases**, the consumer cannot self-host until the
-capability is in the **pinned seed** — forcing a seed cut + `/pin-seed`
-between them (see "Seed dependencies" below). Bundling the capability and its
-consumer in **one PR avoids the seed cut entirely**: `make compile` builds the
-new compiler from the old seed, and that freshly-built compiler then compiles
-the consumer that uses the new capability — all in one self-hosting pass. So
-**splitting a capability away from its only consumer actively manufactures a
-release cycle that bundling would not need.** Factor this into every split
-decision: if a proposed split creates a seed-cut gate and there is a single
-consumer, prefer bundling.
+The full decision tree and the seed-cut-tax rationale live in the shared rule
+**`.claude/rules/seed-dependency.md`** (cited by `/pickup` too, so both apply it
+identically — design record SFEP-0026 WS-B). Apply that rule here rather than
+re-deriving it. When a split is justified, follow "Seed dependencies" below:
+label the predecessor `seed-blocker`, give the consumer
+`## Required in pinned seed: #<predecessor>`, and queue the seed advance against
+the next cadence bump rather than cutting reactively.
 
 ---
 

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -332,25 +332,28 @@ an in-unit sibling is **not** scope growth — reconcile it and keep going.
 Sometimes the issue isn't mis-scoped — it depends on a capability that does
 not exist yet (e.g. a runtime issue that needs a frontend primitive the
 compiler can't emit). Before defaulting to a multi-issue chain (file a
-predecessor → groom → separate PR → seed cut → re-pickup), weigh the cheaper
-path:
+predecessor → groom → separate PR → seed cut → re-pickup), apply the shared
+**`.claude/rules/seed-dependency.md`** decision tree (the same rule `/groom`
+uses — design record SFEP-0026 WS-B). Do not re-derive the tree here; the rule
+is the source of truth. The mid-pickup outcomes it dictates:
 
-- **Single consumer + tightly coupled → propose ONE cohesive PR** that lands
-  the prerequisite *and* the original issue together, and surface the
-  **seed-cut tradeoff** to the user. Bundling a compiler-capability change
-  with its only consumer in one PR avoids the seed cut a split would force
-  (the freshly-built compiler compiles the consumer in the same self-host
-  pass — see `groom.md` "Don't over-decompose"). This is usually faster and
-  cheaper than the file/groom/PR/seed/re-pickup ceremony.
-- **Multiple consumers, or genuinely independent, or large blast radius →**
-  file the predecessor and split (the standard path). A compiler primitive
-  several future issues will want *is* worth shipping standalone.
+- **Single consumer + tightly coupled → BUNDLE:** propose ONE cohesive PR that
+  lands the prerequisite *and* the original issue together. `make compile`
+  builds the new compiler from the old seed, and that compiler compiles the
+  consumer in the same self-host pass — so bundling avoids the seed cut a split
+  would force. This is the default and is usually faster than the
+  file/groom/PR/seed/re-pickup ceremony.
+- **Multiple consumers, or genuinely independent, or large blast radius →
+  SPLIT:** file the predecessor as a standalone `seed-blocker` issue. **A split
+  forces a seed cut — do NOT cut reactively. Queue the seed advance against the
+  next cadence bump** (SFEP-0026 WS-C); the consumer carries
+  `## Required in pinned seed: #<predecessor>` and waits for that bump.
 
-Either way, **pause and present the choice to the user** rather than silently
-picking the heavier multi-issue route — the original #1088 pickup fanned out
-into separate issues/PRs + a seed-cut gate when one bundled PR would have
-delivered the same result with less overhead. State the tradeoff; let the user
-decide.
+Either way, **pause and present the bundle-vs-split choice to the user,
+defaulting to bundle** — do not silently pick the heavier multi-issue route. The
+original #1088 pickup fanned out into separate issues/PRs + a seed-cut gate when
+one bundled PR would have delivered the same result with less overhead. State the
+tradeoff; let the user decide.
 
 ---
 

--- a/.claude/rules/seed-dependency.md
+++ b/.claude/rules/seed-dependency.md
@@ -1,0 +1,80 @@
+When a Sailfin change depends on a compiler-source capability that must be
+present in the **pinned seed**, the decision is always the same: **bundle the
+capability with its single consumer by default; split only when the capability
+has multiple consumers or is genuinely independent.** This rule is the single
+source of truth for that decision — `/groom`, `/pickup`, and any future agent
+cite it instead of restating the tree. Design record: SFEP-0026
+(`docs/proposals/0026-delivery-process.md`) WS-B.
+
+## Why bundling is the default — the seed-cut tax
+
+`make compile` self-hosts against the binary pinned by `.seed-version`, not
+against `main`. So a compiler-source capability (lowering / parsing / typecheck /
+intrinsic / runtime-prelude change that alters the compiler binary's behaviour)
+that lands in a **separate** PR from its consumer cannot self-host until that
+capability is in the **pinned seed** — forcing a seed cut + `/pin-seed` between
+the two merges.
+
+Bundling the capability and its consumer in **one PR avoids the seed cut
+entirely**: `make compile` builds the new compiler from the *old* seed, and that
+freshly-built compiler then compiles the consumer that uses the new capability —
+all in one self-host pass. **Splitting a capability away from its only consumer
+actively manufactures a release cycle that bundling would not need.**
+
+## The decision tree
+
+```
+A seed dependency is discovered (groom-time or mid-pickup):
+│
+├─ Is the dependency a compiler-source capability (lowering / parse /
+│  typecheck / intrinsic / runtime-prelude) that the consumer needs
+│  present in the *pinned seed*?
+│     └─ No  → not a seed dependency. Normal `## Blocked by`. Done.
+│     └─ Yes ↓
+│
+├─ How many consumers need this capability?
+│     ├─ Exactly one, tightly coupled, same session
+│     │     → BUNDLE: one PR lands capability + consumer together.
+│     │       `make compile` builds the new compiler from the old seed;
+│     │       that compiler compiles the consumer in the same self-host
+│     │       pass → NO seed cut, NO `/pin-seed`. (Default.)
+│     └─ Multiple consumers, OR genuinely independent, OR large blast
+│        radius → SPLIT: file the capability as a standalone predecessor
+│        with `seed-blocker`; the consumer carries
+│        `## Required in pinned seed: #<predecessor>`.
+│             └─ The split now REQUIRES a seed cut. Do NOT cut reactively —
+│                QUEUE it against the next scheduled cadence seed bump.
+│                Mid-pickup: pause and present the bundle-vs-split tradeoff
+│                to the user (per pickup.md), defaulting to bundle.
+```
+
+## How each agent applies it
+
+- **`/groom`** — apply the tree at decomposition time. For a capability with
+  exactly one tightly-coupled consumer worked in the same session, produce **one
+  issue** (one PR), not two. Any split that creates a seed-cut gate for a single
+  consumer must be **explicitly justified** in the issue body. When you do split,
+  label the predecessor `seed-blocker`, give the consumer
+  `## Required in pinned seed: #<predecessor>`, and note the queued seed bump.
+
+- **`/pickup`** — when a seed need surfaces **mid-flight** (the issue's premise
+  that there was "no frontend dependency" turns out false — the #1088 failure
+  mode), walk the same tree. **Pause and present the bundle-vs-split tradeoff to
+  the user, defaulting to bundle.** Do not silently fan out into a
+  predecessor-issue → groom → separate-PR → seed-cut → re-pickup chain when one
+  cohesive PR would deliver the same result.
+
+## Split-forced seed cuts queue against the cadence
+
+A split that forces a seed cut **does not trigger a reactive cut**. The
+predecessor lands with `seed-blocker`; the seed advance is **batched onto the
+next scheduled cadence seed bump** (SFEP-0026 WS-C). The `seed-cut-advisor.yml`
+workflow surfaces "this merged PR is required-in-seed by an open downstream
+issue" via the `needs-seed-cut` label — that flag means **queued for the next
+cadence bump**, not "cut now."
+
+**The only thing that breaks the batch** is a *release-critical* seed need: one
+that unblocks an item on the current release hard gate, has no bundle path, and
+would slip the train's committed scope if it waited. A miscompilation or seed-bug
+that breaks *active* downstream work clears that bar by construction. Everything
+else queues. The full release-critical bar is SFEP-0026 §3.3.


### PR DESCRIPTION
## Summary
- New auto-loaded rule `.claude/rules/seed-dependency.md` encodes the seed-cut-tax rationale and the bundle-by-default / split→`seed-blocker`→queue-against-cadence decision tree — one source of truth that `/groom` and `/pickup` both cite.
- `/groom` "Don't over-decompose" reframed from a split-time afterthought to the **groom-time default** (one issue for a capability + its single coupled consumer; any seed-cut-gating split must be explicitly justified); cites the rule instead of re-deriving the tree.
- `/pickup` Phase 3 prerequisite escape now cites the rule, keeps "pause and present the tradeoff, defaulting to bundle", and adds the explicit "a split forces a seed cut → queue against the cadence bump, do not cut reactively" branch.

Closes #1659

Design: SFEP-0026 (`docs/proposals/0026-delivery-process.md`) WS-B, execution items 8–10.

## Acceptance Criteria
- [x] `.claude/rules/seed-dependency.md` exists and is auto-loaded; encodes the bundle-by-default / split→`seed-blocker`→queue tree.
- [x] `/groom` defaults to one issue for a single-consumer capability; any split that creates a seed-cut gate is explicitly justified.
- [x] `/pickup` cites the rule instead of restating it, and includes the queue-against-cadence branch.
- [x] Replaying the #1088-shaped scenario through the rule yields BUNDLE for the single-consumer case and SPLIT+queue for a multi-consumer case.

## Map reconciliation
None — the advisory map (`.claude/rules/seed-dependency.md`, `.claude/commands/groom.md`, `.claude/commands/pickup.md`) matched the tree exactly.

## Verification
SFEP-0026 §8 (WS-B) decision-tree replay:
- **Single-consumer #1088 shape** (runtime issue whose "no frontend dependency" premise is false): compiler-source capability needed in seed → exactly one tightly-coupled consumer → **BUNDLE** (one PR, no seed cut). ✓
- **Multi-consumer variant**: → **SPLIT**, predecessor labeled `seed-blocker`, consumer carries `## Required in pinned seed: #<predecessor>`, seed advance **queued against the next cadence bump**. ✓
- `/groom` "Don't over-decompose" now produces **one** issue for the single-consumer shape by default. ✓

Markdown-only change (`.claude/`) — no `.sfn` source touched, so `sfn fmt` / `make compile` / self-host gate are N/A (SFEP-0026 §5, §7).

## Files Changed
- `.claude/rules/seed-dependency.md` (new)
- `.claude/commands/groom.md`
- `.claude/commands/pickup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnAitvR6BbbEJy2fjJrhu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnAitvR6BbbEJy2fjJrhu5)_