### PR TITLE
feat(ci): batch seeds onto cadence + release-critical-seed marker

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -165,7 +165,10 @@ labels:
     description: "Must close before the next seed binary is cut"
   - name: needs-seed-cut
     color: "fbca04"
-    description: "Auto-flagged by seed-cut-advisor: a required-in-seed predecessor merged; cut a new seed before pickup"
+    description: "Auto-flagged by seed-cut-advisor: a required-in-seed predecessor merged; queued for the next cadence seed bump"
+  - name: release-critical-seed
+    color: "b60205"
+    description: "Seed need that breaks the cadence batch: clears the release-critical bar; off-cadence cut may be warranted"
   - name: build-quality-regression
     color: "b60205"
     description: "Auto-filed by build-quality.yml on gate failure; dedup anchor"

--- a/.github/workflows/seed-cut-advisor.yml
+++ b/.github/workflows/seed-cut-advisor.yml
@@ -3,9 +3,15 @@ name: Seed-cut Advisor
 # Surfaces stale-seed risk on PR merge. When a PR merges to `main` and the
 # issue(s) it closes are listed as a required-in-seed predecessor by an open,
 # release-gated, compiler-touching downstream issue, this workflow comments on
-# the active `Release: vX.Y.Z` tracker and applies `needs-seed-cut` so a human
-# knows to cut a fresh alpha + `/pin-seed` before those downstream issues are
-# picked up.
+# the active `Release: vX.Y.Z` tracker and applies `needs-seed-cut`.
+#
+# Seeds advance on the release cadence (SFEP-0026 WS-C), so by default that flag
+# means "queued for the next cadence seed bump" — NOT "cut now." The one thing
+# that breaks the batch is the `release-critical-seed` marker: when a flagged
+# dependent (or one of the just-closed predecessors) carries it, the advisory
+# comment escalates to "off-cadence seed cut may be warranted" (it clears the
+# release-critical bar, SFEP-0026 §3.3). The marker is applied by grooming/humans;
+# the advisor only READS it to decide wording — it stays flag-only.
 #
 # This is the third leg of the #489 stale-seed mitigation, complementing the
 # `## Required in pinned seed` issue-template section and the `/pickup`
@@ -88,10 +94,18 @@ jobs:
               owner, repo, state: 'open', labels: 'release:next-minor', per_page: 100,
             });
 
+            // The `release-critical-seed` marker is the ONLY thing that breaks
+            // the cadence batch (SFEP-0026 §3.3). `listForRepo`/`issues.get`
+            // return labels as objects; a bare-string fallback keeps this robust.
+            const CRIT = 'release-critical-seed';
+            const hasCrit = issue =>
+              (issue.labels || []).some(l => (typeof l === 'string' ? l : l.name) === CRIT);
+
             // 3. Keep those that reference a just-closed issue under
             //    "## Required in pinned seed" or "## Blocked by" AND whose
             //    "## Files Affected" touches compiler-source.
             const dependents = [];
+            const critDependents = [];
             for (const d of downstream) {
               if (d.pull_request) continue; // listForRepo includes PRs
               const body = d.body || '';
@@ -102,12 +116,38 @@ jobs:
               const files = section(body, 'Files Affected');
               if (!/compiler\/src\/|runtime\/prelude\.sfn/.test(files)) continue;
               dependents.push(d.number);
+              if (hasCrit(d)) critDependents.push(d.number);
             }
             if (dependents.length === 0) {
               core.info('No required-in-seed dependents among release:next-minor issues.');
               return;
             }
             core.info(`Dependents needing a seed cut: ${dependents.map(n => '#' + n).join(', ')}`);
+
+            // A just-closed predecessor may itself carry the marker (e.g. a
+            // miscompilation seed-bug that blocks the gate — release-critical by
+            // construction). Fetch the closing issues' labels to catch that case.
+            const critPredecessors = [];
+            for (const n of closing) {
+              try {
+                const { data: iss } = await github.rest.issues.get({
+                  owner, repo, issue_number: n,
+                });
+                if (hasCrit(iss)) critPredecessors.push(n);
+              } catch (e) {
+                core.warning(`Could not fetch labels for #${n}: ${e.message}`);
+              }
+            }
+            const releaseCritical = critDependents.length > 0 || critPredecessors.length > 0;
+            if (releaseCritical) {
+              const who = [
+                ...critDependents.map(n => 'dependent #' + n),
+                ...critPredecessors.map(n => 'predecessor #' + n),
+              ].join(', ');
+              core.info(`Release-critical seed need (${who}) — escalating advisory.`);
+            } else {
+              core.info('No release-critical marker — advisory queues for the next cadence bump.');
+            }
 
             // 4. Resolve the ACTIVE release tracker dynamically: open, labeled
             //    `tracking`, title `Release: vX.Y.Z`. Never hardcoded.
@@ -140,9 +180,17 @@ jobs:
               core.info(`Advisory for PR #${prNumber} already on #${tracker.number}; skipping comment.`);
             } else {
               const depList = dependents.map(n => '#' + n).join(', ');
-              const body =
-                `Auto-advisor: PR #${prNumber} just merged and is required-in-seed by ` +
-                `${depList}. Cut a new alpha and \`/pin-seed\` before pickup of those issues.`;
+              const head =
+                `Auto-advisor: PR #${prNumber} just merged and is required-in-seed by ${depList}.`;
+              const body = releaseCritical
+                ? `${head} This need carries \`${CRIT}\` — it **breaks the cadence batch**: ` +
+                  `an off-cadence seed cut may be warranted. If it clears the release-critical ` +
+                  `bar (SFEP-0026 §3.3), cut a fresh alpha and \`/pin-seed\` now; otherwise it ` +
+                  `queues for the next cadence bump. See docs/conventions/issue-naming.md ` +
+                  `"Seed pinning".`
+                : `${head} **Queued for the next cadence seed bump** (tracker #${tracker.number}); ` +
+                  `\`/pin-seed\` runs on the next train cut — no off-cadence cut needed unless this ` +
+                  `is marked \`${CRIT}\`. See docs/conventions/issue-naming.md "Seed pinning".`;
               await github.rest.issues.createComment({ owner, repo, issue_number: tracker.number, body });
               core.info(`Posted advisory on #${tracker.number}.`);
             }

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -384,6 +384,13 @@ cutting a release** — `release.yml` deliberately doesn't touch
 `.seed-version` because the new binary doesn't exist at tag-creation
 time and most alpha releases shouldn't be pinned.
 
+**Seeds advance on the cadence, batched.** Per SFEP-0026 WS-C, the pin is
+**not** chased reactively per-need (the `0.7.0-alpha.49` treadmill). Routine
+seed needs are collected and the pin advances **once per release cadence
+cycle**, against that cycle's alpha cut — collapsing the N reactive cuts of a
+cycle into ~1 scheduled bump. The one exception is a **release-critical** seed
+need (see below), which may break the batch.
+
 ### `seed-blocker` label
 
 Apply `seed-blocker` to any issue whose fix or feature must land
@@ -397,6 +404,52 @@ Apply `seed-blocker` to any issue whose fix or feature must land
 release-gating set when opening a tracking issue. `/sweep` auto-ticks
 matching checklist items when a `seed-blocker` issue closes via a
 merged PR.
+
+A `seed-blocker` issue does **not** trigger a reactive cut on its own.
+Its seed advance is **batched onto the next cadence bump** (below) unless
+the need clears the release-critical bar.
+
+### Batched-cadence seeds and the `release-critical-seed` marker
+
+Mid-flight seed needs — a `needs-seed-cut` flag from the advisor, or a
+`seed-blocker` issue closing — **queue against the next scheduled cadence
+seed bump** by default. `/pin-seed` runs **once per cadence** against that
+cycle's alpha cut; it is not run reactively for each individual need. This
+is the SFEP-0026 §3.3 batching policy: trade a small latency on
+non-critical seed needs for a large reduction in cut/`pin-seed` overhead.
+
+**The release-critical bar (the only thing that breaks the batch).** A
+mid-flight seed need may force an **off-cadence** seed cut only if **all
+three** hold (SFEP-0026 §3.3):
+
+1. It **unblocks an item on the current `release:next-minor` / `release:1.0`
+   hard gate** — the train cannot ship its committed scope without it; **and**
+2. **No bundle path exists** — per `.claude/rules/seed-dependency.md`, it is a
+   genuine multi-consumer or independent capability that cannot be folded into
+   one PR with its consumer; **and**
+3. Waiting for the next cadence bump would **slip the train's committed scope**
+   (not merely defer a nice-to-have to the next train).
+
+A need that fails **any** clause queues for the next cadence bump. A
+miscompilation / seed-bug that breaks *active* downstream work clears the bar
+by construction — it is release-critical because it blocks the gate.
+
+**`release-critical-seed` marker lifecycle.** Apply `release-critical-seed`
+to a seed need (the dependent issue or, for a seed-bug, the predecessor) that
+clears the bar above. It is the signal that distinguishes "break the batch"
+from "queue for cadence":
+
+- **Applied by** grooming or a human when the three-clause bar is met — never
+  auto-applied. It is orthogonal to `needs-seed-cut`/`seed-blocker` and
+  typically co-exists with them.
+- **Read by** the seed-cut advisor, which escalates its advisory comment from
+  "queued for the next cadence bump" to "off-cadence seed cut may be warranted"
+  when a flagged dependent (or a just-closed predecessor) carries it. The
+  advisor only reads the marker — it stays flag-only and never dispatches a cut.
+- **Consumed by** `/release-plan`, which surfaces release-critical seed needs
+  separately from the batched queue.
+- **Cleared** when the off-cadence cut lands and `/pin-seed` runs, or when the
+  need is reclassified as non-critical (then it rejoins the cadence batch).
 
 ### `## Required in pinned seed` issue section
 
@@ -440,15 +493,27 @@ advisor:
 - applies the `needs-seed-cut` label to the tracker and the dependent
   issues.
 
+By default the advisory comment reads **"queued for the next cadence seed
+bump"** — the `needs-seed-cut` flag means the seed advance is batched onto
+the cadence, not cut now. **Only** when a flagged dependent (or one of the
+just-closed predecessors) carries `release-critical-seed` does the comment
+escalate to **"off-cadence seed cut may be warranted"** (it clears the
+release-critical bar above).
+
 It is idempotent (one advisory per PR per tracker) and **only flags** —
-it never dispatches `release.yml` or bumps `.seed-version`. `/release-plan`
-consumes the `needs-seed-cut` label, surfacing a "Seed cut required"
-checklist section on the per-cycle tracking issue. Clear the flag by
-cutting a fresh alpha and running `/pin-seed`, then removing the label.
+it never dispatches `release.yml` or bumps `.seed-version`, and it never
+applies `release-critical-seed` (that marker is human/grooming-applied; the
+advisor only reads it). `/release-plan` consumes the `needs-seed-cut` label,
+surfacing a "Seed cut required" checklist section on the per-cycle tracking
+issue. A queued flag clears when the cadence `/pin-seed` lands; a
+release-critical flag clears when its off-cadence `/pin-seed` lands. Remove
+the label once pinned.
 
 ### When to bump the pin
 
-Run `/pin-seed [vX.Y.Z]`:
+The routine bump rides the cadence (one batched `/pin-seed` per cycle, above).
+Run `/pin-seed [vX.Y.Z]` off-cadence only when the need clears the
+release-critical bar:
 
 - A `seed-blocker` issue just closed and the fix shipped in the latest
   alpha.


### PR DESCRIPTION
## Summary
- Rework `seed-cut-advisor.yml`: a `needs-seed-cut` flag now reads as **"queued for the next cadence seed bump"** by default; it escalates to **"off-cadence seed cut may be warranted"** only when a flagged dependent (or one of the just-closed predecessors) carries the new `release-critical-seed` marker. The workflow stays deterministic and **flag-only** — it reads the marker but never applies it or dispatches a cut.
- Register the `release-critical-seed` label in `.github/labels.yml` (and reword `needs-seed-cut`'s description to match the cadence semantics).
- Document batched-cadence seeds, the release-critical bar (SFEP-0026 §3.3), and the `release-critical-seed` lifecycle in `docs/conventions/issue-naming.md`.

Implements SFEP-0026 WS-C execution items 13–15 (the WS-C-1 slice). WS-C-2 (the `release-train.yml` cadence workflow + `release-plan` native sub-issues) is out of scope and not touched.

Closes #1660

## Acceptance Criteria
- [x] `.github/labels.yml` registers `release-critical-seed` (color + description).
- [x] `seed-cut-advisor.yml`: a `needs-seed-cut` flag reads as "queued for the next cadence bump"; a `release-critical-seed` dependent escalates to "off-cadence cut may be warranted"; the workflow stays deterministic / flag-only.
- [x] `docs/conventions/issue-naming.md` documents batched-cadence seeds, the release-critical bar (§3.3), and the `release-critical-seed` lifecycle.
- [x] Two-flag rehearsal (§8): an ordinary flag queues; a release-critical flag escalates. Idempotent on double-run.

## Map reconciliation
None — advisory map matched the tree (`.github/workflows/seed-cut-advisor.yml`, `.github/labels.yml`, `docs/conventions/issue-naming.md` all present and current).

## Verification
No `.sfn` files touched → no self-host / `sfn fmt` gate applies. Verified the structural and behavioural invariants directly:

```text
# YAML parses; label registered
YAML OK  (steps: 1)
LABEL OK  (release-critical-seed present)

# Embedded github-script JS parses (async-wrapped, as github-script runs it)
JS SYNTAX OK

# SFEP-0026 §8 two-flag rehearsal + idempotency (simulated advisor logic
# against mocked GitHub APIs):
[PASS] ordinary flag queues                      -> "Queued for the next cadence seed bump", flag applied
[PASS] release-critical dependent escalates      -> "off-cadence seed cut may be warranted"
[PASS] release-critical predecessor escalates    -> "off-cadence seed cut may be warranted"
[PASS] idempotent on double-run                  -> no second comment; labels still flag-only
```

The rehearsal also confirms the advisor only ever applies `needs-seed-cut` (never `release-critical-seed`) and never dispatches a cut — flag-only and deterministic.

## Files Changed
- `.github/labels.yml` — register `release-critical-seed`; reword `needs-seed-cut`.
- `.github/workflows/seed-cut-advisor.yml` — cadence-queue default + release-critical escalation branch (reads dependent and predecessor labels).
- `docs/conventions/issue-naming.md` — batched-cadence seed policy, release-critical bar, marker lifecycle, advisor reword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QggMP7kSByvB65fekMKJ3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01QggMP7kSByvB65fekMKJ3c)_