### PR TITLE
tooling: board-sync scripts self-skip when gh can't reach GitHub

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -349,11 +349,13 @@ Suggest: `/pickup` to start working the queue, or `/triage` to verify hygiene.
 - **Title format follows `docs/conventions/issue-naming.md`** — Conventional Commit shape for sub-tasks, `Epic:` prefix for epics, `Tracking:` for trackers.
 - **Don't create issues for work that's already in progress** — check `gh issue list` first to avoid duplicates.
 - **When grooming an existing epic issue, attach every created issue as a native sub-issue of that epic** via the REST `/sub_issues` endpoint. Body cross-references do not populate the parent's Sub-issues panel and leave the roadmap UI incomplete. Use `-F sub_issue_id=<int>` (not `-f`) — the field must be typed.
-- **Every created or relabeled issue must end Phase 4 with a board sync.** Run
-  `.claude/scripts/sync-project-status.sh <N> --from-labels` after each
-  `gh issue create` and after any follow-up `gh issue edit` that adds
-  `blocked`. The Sailfin Tracker (Project #4) must reflect the labels.
-- **Every created issue must have its GitHub native Type field set.** Run
-  `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` immediately after
-  the board sync. Derive the type from the `type:*` label: `type:feature` →
-  `Feature`, `type:bug` → `Bug`, everything else → `Task`.
+- **Labels drive the board; CI reconciles it.** `sync-project.yml` mirrors
+  Priority/Size/Status from labels on every label event, so creating/relabeling
+  an issue *is* the board update. Optionally nudge sooner with
+  `.claude/scripts/sync-project-status.sh <N> --from-labels` after a
+  `gh issue create` or a `gh issue edit` that adds `blocked`; it self-skips with
+  a `note:` where `gh` can't reach the API (e.g. remote containers).
+- **Set the GitHub native Type field** with
+  `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` (best-effort; it
+  self-skips when `gh` is unavailable). Derive the type from the `type:*` label:
+  `type:feature` → `Feature`, `type:bug` → `Bug`, everything else → `Task`.

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -465,7 +465,8 @@ If anything was deferred or scope was adjusted mid-flight, surface it explicitly
 - The compiler self-caps memory (8 GiB on Linux); see `.claude/rules/compiler-safety.md`.
 - **Never skip Phase 1.5.** The `## Required in pinned seed` precheck (and its legacy fallback) prevents the failure mode that broke the original #489 attempt — a compiler-source migration picked up against a seed that predated its dependency. If the precheck fails, halt and comment; do not attempt to triple-bootstrap a workaround binary.
 - **One issue per session.** Don't try to bundle multiple issues — they were sized to be standalone.
-- **Every label flip must be paired with a board sync.** Run
-  `.claude/scripts/sync-project-status.sh <N> --from-labels` after any
-  `gh issue edit ... --add-label/--remove-label` so the Sailfin Tracker
-  board (Project #4) stays in sync with the labels.
+- **The label flip *is* the board update.** CI (`sync-project.yml`) syncs the
+  Sailfin Tracker (Project #4) from labels on every label event. Optionally
+  nudge sooner with `.claude/scripts/sync-project-status.sh <N> --from-labels`
+  after a `gh issue edit ... --add-label/--remove-label`; it self-skips with a
+  `note:` where `gh` can't reach the API (e.g. remote containers).

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -351,9 +351,12 @@ Dry run: changes <previewed | applied>
 - **Don't modify issue bodies.** Only labels and comments.
 - **Be conservative with prose blockers.** Anything not a hard `#N` reference stays blocked until a human confirms.
 - **Always leave a comment when flipping a label.** Future-you needs the audit trail.
-- **Every label flip must be paired with a board sync** via
-  `.claude/scripts/sync-project-status.sh <N> --from-labels`. Surface any
-  non-zero exit under "Concerns" so a human can reconcile the column.
+- **The label flip *is* the board update.** CI (`sync-project.yml`) reconciles
+  the board from labels on every label event. Optionally nudge Status sooner
+  with `.claude/scripts/sync-project-status.sh <N> --from-labels`; it self-skips
+  (exit 0, `note:`) where `gh` can't reach the API (e.g. remote containers).
+  Surface only a genuine non-zero exit under "Concerns" so a human can reconcile
+  the column — a self-skip is not one.
 - **In `--dry-run` mode, make zero writes.** No labels, no comments, no
   board syncs. Print intended actions only.
 - **Read `.github/AGENTS.md` for cap context.** Default budget = 2 matches the autonomous-pipeline cap; `--greedy` raises it for human-coordinated parallel sessions.

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -279,6 +279,11 @@ Concerns:
   fail an issue on `### In` vs `In:` or a body-only `## Size`. Brittle matching
   is the bug that this pass exists to fix.
 - **If you change a label, leave a comment explaining why.** Audit trail.
-- **Every label flip must be paired with a board sync** via
-  `.claude/scripts/sync-project-status.sh <N> --from-labels`.
-- **Always fix a null GitHub Type field** via `set-issue-type.sh`.
+- **The label flip *is* the board update.** CI (`sync-project.yml`) reconciles
+  Priority/Size/Status from labels on every label event, so no extra step is
+  required. Optionally nudge Status sooner with
+  `.claude/scripts/sync-project-status.sh <N> --from-labels`; it self-skips with
+  a `note:` where `gh` can't reach the API (e.g. remote containers) — expected,
+  not a failure to chase.
+- **Fix a null GitHub Type field** via `set-issue-type.sh` (best-effort; it too
+  self-skips when `gh` is unavailable, so set it from a session where `gh` works).

--- a/.claude/scripts/set-issue-type.sh
+++ b/.claude/scripts/set-issue-type.sh
@@ -42,6 +42,20 @@ case "$type_name" in
     ;;
 esac
 
+# Skip cleanly when gh cannot reach the GitHub API. In sandboxed / proxied
+# environments (e.g. Claude Code remote containers) api.github.com is gated
+# behind the Claude GitHub App and repo/GraphQL calls 403 regardless of any
+# GITHUB_TOKEN. Setting the native issue Type is best-effort; rather than abort
+# under `set -e` with a scary failure, probe once and no-op when the repo isn't
+# readable — the type:* label persists and the Type can be reconciled from a
+# session where gh works. A working gh with an under-scoped token still proceeds
+# and surfaces the real permission error.
+if ! gh api "repos/$REPO" -q .id >/dev/null 2>&1; then
+  echo "note: gh cannot reach $REPO here (sandboxed/proxied env); skipping issue-type set." >&2
+  echo "      The type:* label persists; set the native Type later from a session where gh works." >&2
+  exit 0
+fi
+
 node_id="$(gh api "repos/$REPO/issues/$issue_number" --jq '.node_id')"
 
 gh api graphql -f query="

--- a/.claude/scripts/sync-project-status.sh
+++ b/.claude/scripts/sync-project-status.sh
@@ -32,6 +32,24 @@ fi
 issue_number="$1"
 shift
 
+# Skip cleanly when gh cannot reach the GitHub API.
+#
+# In sandboxed / proxied environments (e.g. Claude Code remote containers) git
+# is rewritten through a localhost proxy but api.github.com is gated behind the
+# Claude GitHub App — repo REST and GraphQL calls 403 regardless of any
+# GITHUB_TOKEN. The org project board is reconciled from labels by CI
+# (.github/workflows/sync-project.yml → scripts/sync-issue-to-project.sh) on
+# every label event, so a local sync here is best-effort, not required. Probe
+# once; if the repo isn't readable, no-op (label remains the source of truth)
+# instead of aborting under `set -e` and surfacing a scary "couldn't update the
+# board" failure. A working gh with an under-scoped token still proceeds and
+# surfaces the real permission error.
+if ! gh api "repos/$REPO" -q .id >/dev/null 2>&1; then
+  echo "note: gh cannot reach $REPO here (sandboxed/proxied env); skipping local board sync." >&2
+  echo "      Status is reconciled from labels by CI (sync-project.yml) on label events." >&2
+  exit 0
+fi
+
 mode="from-labels"
 forced_status=""
 while [[ $# -gt 0 ]]; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,9 +321,17 @@ the session-sized *what*.
 **Labels** are registered in `.github/labels.yml`; conventions and the lifecycle
 diagram are in `docs/conventions/issue-naming.md`. Key ones: `claude-ready`,
 `needs-grooming`, `in-progress`, `blocked`, `type:*`, `size:*`, `priority:*`,
-`area:*`, `epic`/`tracking`. Slash commands that flip labels must follow with
-`.claude/scripts/sync-project-status.sh <N> --from-labels` to move the
-Sailfin Tracker (org project SailfinIO/4) card.
+`area:*`, `epic`/`tracking`. **Labels are the source of truth**; the Sailfin
+Tracker (org project SailfinIO/4) is *derived*. CI owns the board:
+`.github/workflows/sync-project.yml` (→ `scripts/sync-issue-to-project.sh`) runs
+on every `labeled`/`unlabeled` event and reconciles the Priority, Size, and
+Status fields from labels with a project-scoped PAT. So flipping the label *is*
+the board update — no extra step is required. `.claude/scripts/sync-project-status.sh
+<N> --from-labels` remains a **best-effort local nudge** (it just sets Status
+sooner than the next CI run); it self-skips with a `note:` when `gh` can't reach
+the API — e.g. in remote containers, where api.github.com is gated behind the
+Claude GitHub App and only the GitHub MCP tools work — so a "couldn't update the
+board" message there is expected and benign, not a failure to chase.
 
 **Anti-patterns:** don't pick up `needs-grooming` (groom first); don't expand
 scope mid-session (comment and pause); don't bundle issues into one PR; don't


### PR DESCRIPTION
## Problem

`.claude/scripts/sync-project-status.sh` and `set-issue-type.sh` shell out to `gh` against api.github.com. In sandboxed/proxied environments — notably **Claude Code remote containers** — `git` is rewritten through a localhost proxy, but api.github.com is gated behind the Claude GitHub App at the org level, so repo REST and GraphQL calls `403` regardless of any `GITHUB_TOKEN`. Under `set -e`, the first `gh` call aborted the script and surfaced a scary *"couldn't update the board"* failure on every label flip — the recurring friction these sessions hit.

(Diagnostic confirmed in a remote container: `gh auth status` reports the token invalid, `gh api graphql` → *"GraphQL proxying is not enabled"*, `gh api repos/...` → *"GitHub access is not enabled for this session. An org admin must connect the Claude GitHub App."*)

## Change

- **Both scripts** gain a one-shot reachability probe (`gh api repos/<repo>`). If the repo isn't readable, they print a `note:` and `exit 0` instead of aborting. A working `gh` with an *under-scoped* token still proceeds and surfaces the real permission error, so genuine local misconfig is **not** masked.
- **Docs** (`CLAUDE.md` + `/triage`, `/groom`, `/pickup`, `/sweep`) reframe the label flip as *the* board update. The org board is already reconciled from labels by CI (`sync-project.yml` → `sync-issue-to-project.sh`) on every label event — **including the Status field** — so the local sync was always best-effort. The command docs now say so, and that a self-skip in a remote container is expected, not a failure to chase.

## Why this is the right layer

CI already owns the board via a project-scoped PAT. Labels are the source of truth; the project is derived. This PR just stops the redundant local helper from turning an expected "no GitHub here" condition into noise, and aligns the guidance so future sessions don't chase a non-problem.

No `.sfn` files touched — formatter/self-host gates don't apply. Both scripts pass `bash -n` and verified to skip cleanly (`exit 0`) in this environment.

https://claude.ai/code/session_01LqoAjiReCsbp2SQ26DZN4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqoAjiReCsbp2SQ26DZN4F)_