### PR TITLE
feat(test-runner): add deterministic --shard I/N partition to sfn test

### DIFF
--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -8,9 +8,10 @@
 //
 // `test` carries a real flag surface plus a variadic positional:
 //   sfn test [--json] [-k NAME] [--tag TAG] [--update-snapshots]
-//            [--no-test-cache] [--jobs N] <suite...>
+//            [--no-test-cache] [--jobs N] [--shard I/N] <suite...>
 // `--json` / `--update-snapshots` / `--no-test-cache` are boolean flags;
-// `-k` (name substring) and `--tag` (tag filter) are value flags; `--jobs`
+// `-k` (name substring), `--tag` (tag filter), and `--shard` (I/N
+// partition, issue #1237) are value flags; `--jobs`
 // is a `flag_int` (Issue 1.5, #794) so `parse()` rejects a non-integer
 // value as a `type_error` before `run` is reached; `suite` is a variadic
 // positional (Issue 1.11, #800) collecting one or more suite paths (zero
@@ -74,8 +75,11 @@ import {
     _get_env_cmd,
     _has_prefix_cmd,
     _legacy_flag_file,
+    _parse_shard_index,
+    _parse_shard_total,
     _path_join_cmd,
     _sanitize_filename_cmd,
+    _shard_keeps_index,
     _shell_read_cmd,
     _sort_strings_cmd,
     _strip_trailing_slashes_cmd,
@@ -112,10 +116,11 @@ import { resolve_test_bin_identity_for_cache } from "../../version";
 import { CliContext } from "../context";
 
 // The `sfn/cli` definition for `test`, registered on the v2 root via
-// `with_subcommand`. Three boolean flags, two value flags, one int flag,
-// and a variadic `suite` positional.
+// `with_subcommand`. Three boolean flags, three value flags (`-k`,
+// `--tag`, `--shard`), one int flag (`--jobs`), and a variadic `suite`
+// positional.
 fn command_def() -> Command {
-    return with_arg(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(command("test", "Run Sailfin tests"), flag("json", "Emit a JSONL event stream")), flag("update-snapshots", "Re-baseline snapshot golden files this run")), flag("no-test-cache", "Bypass the per-test linked-binary cache")), flag_value_short("k", "k", "Only run tests whose name contains this substring")), flag_value("tag", "Only run tests carrying @tag(\"<value>\")")), flag_int("jobs", "Run up to N per-file children concurrently")), arg_variadic("suite", "One or more suite paths (default: .)"));
+    return with_arg(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(command("test", "Run Sailfin tests"), flag("json", "Emit a JSONL event stream")), flag("update-snapshots", "Re-baseline snapshot golden files this run")), flag("no-test-cache", "Bypass the per-test linked-binary cache")), flag_value_short("k", "k", "Only run tests whose name contains this substring")), flag_value("tag", "Only run tests carrying @tag(\"<value>\")")), flag_int("jobs", "Run up to N per-file children concurrently")), flag_value("shard", "Run only the I-th of N file-count-balanced shards (e.g. 1/3)")), arg_variadic("suite", "One or more suite paths (default: .)"));
 }
 
 fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
@@ -151,6 +156,30 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
             return 2;
         }
     }
+    // `--shard I/N` (issue #1237): run only the I-th of N file-count-
+    // balanced shards of the discovered surface. Absent → no sharding
+    // (the whole surface). A malformed spec (not `I/N` with both sides
+    // positive integers and `1 <= I <= N`) exits 2, mirroring the
+    // `--jobs` range-guard convention. The stable stride partition is
+    // applied to `test_files` after discovery/filtering, below.
+    let mut shard_active: boolean = false;
+    let mut shard_index: int = 1;
+    let mut shard_total: int = 1;
+    let shard_spec_raw: string = get_or(matches, "shard", "");
+    if shard_spec_raw.length > 0 {
+        let s_index: int = _parse_shard_index(shard_spec_raw);
+        let s_total: int = _parse_shard_total(shard_spec_raw);
+        if s_index < 0 || s_total < 0 {
+            print("sfn test: --shard requires I/N with 1 <= I <= N (got '"
+                + shard_spec_raw
+                + "')");
+            return 2;
+        }
+        shard_active = true;
+        shard_index = s_index;
+        shard_total = s_total;
+    }
+
     // Variadic suite positionals: zero or more. Zero defaults to a single
     // "." suite below (the legacy `positional.length == 0` branch).
     let positional: string[] = positionals(matches, "suite");
@@ -268,6 +297,32 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
         }
         test_files = kept_files;
         file_suite_index = kept_suite_index;
+    }
+
+    // `--shard I/N` partition (issue #1237). Keep only the I-th of N
+    // file-count-balanced shards using the stable stride
+    // `i % total == index - 1` over the deterministic (sorted within each
+    // suite) discovery order — mirroring `scripts/test_shards.sh`'s awk
+    // stride so the runner and the legacy bash shard map agree over the
+    // same file list. Applied after the `-k`/`--tag` cut so a shard
+    // partitions exactly the surface that would otherwise run. The
+    // `file_suite_index` parallel array is partitioned in lockstep so
+    // per-suite banner attribution stays aligned. An empty shard (more
+    // shards than files) falls through to the benign 0/0/0 path below.
+    if shard_active {
+        let mut sharded_files: string[] = [];
+        let mut sharded_suite_index: int[] = [];
+        let mut shi: int = 0;
+        loop {
+            if shi >= test_files.length { break; }
+            if _shard_keeps_index(shi, shard_index, shard_total) {
+                sharded_files.push(test_files[shi]);
+                sharded_suite_index.push(file_suite_index[shi]);
+            }
+            shi += 1;
+        }
+        test_files = sharded_files;
+        file_suite_index = sharded_suite_index;
     }
 
     if test_files.length == 0 {

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -42,7 +42,10 @@ export {
     _word_matches_cmd,
     _string_list_contains_cmd,
     _parse_jobs_value,
-    _resolve_linker
+    _resolve_linker,
+    _parse_shard_index,
+    _parse_shard_total,
+    _shard_keeps_index
 };
 
 fn _ends_with_cmd(value: string, suffix: string) -> boolean {
@@ -710,4 +713,90 @@ fn _parse_jobs_value(text: string) -> int {
     }
     if n < 1 { return -1; }
     return n;
+}
+
+// `sailfin test --shard I/N` partitioning (issue #1237, test-infra
+// Phase 4 Track A). Moves shard partitioning out of `scripts/test_shards.sh`'s
+// awk stride into the runner: one tested home for the shard map, reusable
+// by the Makefile / CI / nightly. The partition mirrors that script's
+// `(NR - 1) % n == (i - 1)` stride over the sorted file list, so the
+// runner's `--shard` and the legacy bash shard map agree byte-for-byte
+// over the same discovery surface.
+//
+// API shape note: these helpers return only `int` / `boolean` so their
+// signatures resolve across modules in the pinned seed. A struct-valued
+// `_parse_shard_value(...) -> ShardSpec` and an array-valued
+// `_shard_select_indices(...) -> int[]` were the natural first cut, but a
+// *cross-module* call to a function returning a freshly-declared struct or
+// an `int[]` cannot resolve its return type in the seed
+// (`llvm lowering [fatal]: ... callee signature is not known`) — `int[]`
+// was, in fact, the only such return type in the whole compiler. Tracked
+// as a separate compiler-robustness follow-up; the `int`/`boolean` surface
+// below is exactly as testable.
+// Parse one positive decimal field (the `I` or `N` of `I/N`). Returns -1
+// on an empty string or any non-digit byte, matching `_parse_jobs_value`.
+// No 256 ceiling: a shard total is bounded by the discovered file surface,
+// not by per-child memory like `--jobs`.
+fn _parse_shard_field(text: string) -> int {
+    if text.length == 0 { return -1; }
+    let mut i: int = 0;
+    let mut n: int = 0;
+    loop {
+        if i >= text.length { break; }
+        let c = char_code_at_text(text, i);
+        if c < 48 { return -1; }
+        if c > 57 { return -1; }
+        n = n * 10 + (c - 48);
+        i += 1;
+    }
+    if n < 1 { return -1; }
+    return n;
+}
+
+// Parse and fully validate a `--shard I/N` value, returning the field
+// selected by `which` (0 = I, 1 = N), or -1 when the spec is malformed.
+// A valid spec is exactly one '/', both sides positive integers, and
+// `1 <= I <= N`; any deviation ("", "2", "0/3", "4/3", "a/3", "1/2/3")
+// yields -1. The two public wrappers below expose the I and N fields.
+fn _parse_shard_field_at(text: string, which: int) -> int {
+    let slash = find_char_local(text, "/", 0);
+    if slash < 0 { return -1; }
+    let lhs = substring(text, 0, slash);
+    let rhs = substring(text, slash + 1, text.length);
+    // A second '/' (e.g. "1/2/3") is malformed: the right field must
+    // contain no further slash.
+    if find_char_local(rhs, "/", 0) >= 0 { return -1; }
+    let index = _parse_shard_field(lhs);
+    let total = _parse_shard_field(rhs);
+    if index < 1 { return -1; }
+    if total < 1 { return -1; }
+    if index > total { return -1; }
+    if which == 0 { return index; }
+    return total;
+}
+
+// The shard index I of a valid `--shard I/N`, or -1 if the spec is
+// malformed. The caller treats either field returning -1 as a usage error.
+fn _parse_shard_index(text: string) -> int {
+    return _parse_shard_field_at(text, 0);
+}
+
+// The shard total N of a valid `--shard I/N`, or -1 if the spec is
+// malformed.
+fn _parse_shard_total(text: string) -> int {
+    return _parse_shard_field_at(text, 1);
+}
+
+// Does the 0-based `item_index` belong to shard `shard_index`/`shard_total`?
+// The stable stride `item_index % shard_total == shard_index - 1`
+// (`shard_index` is 1-based) mirrors `scripts/test_shards.sh`'s
+// `(NR - 1) % n == (i - 1)`. `1/1` keeps every index. Over
+// `shard_index = 1..shard_total` each item lands in exactly one residue
+// class mod `shard_total`, so the shards are disjoint, their union is the
+// whole surface, and their sizes differ by at most one (file-count
+// balanced). Deterministic: depends only on its three integer arguments,
+// so it is stable across runs and platforms for a fixed sorted file list.
+fn _shard_keeps_index(item_index: int, shard_index: int, shard_total: int) -> boolean {
+    if shard_total < 1 { return false; }
+    return (item_index % shard_total) == (shard_index - 1);
 }

--- a/compiler/tests/unit/test_shard_partition_test.sfn
+++ b/compiler/tests/unit/test_shard_partition_test.sfn
@@ -1,0 +1,183 @@
+// #1237: unit coverage for `sailfin test --shard I/N`, which moves shard
+// partitioning out of `scripts/test_shards.sh`'s awk stride into the
+// runner. Two surfaces are pinned here:
+//   * `_parse_shard_index` / `_parse_shard_total` — accept exactly a
+//     well-formed `I/N` with both sides positive integers and `1 <= I <= N`
+//     (returning the I or N field), and return -1 for any malformed spec;
+//     `run` maps a -1 to a usage error (exit 2).
+//   * `_shard_keeps_index` — the stable stride predicate
+//     `i % total == index - 1`. The headline acceptance criterion is that
+//     `1/N .. N/N` partition the full surface: disjoint (no file in two
+//     shards), complete (their union is the whole surface), and
+//     file-count-balanced (sizes differ by at most one). The predicate is
+//     deterministic, so the same query always yields the same answer
+//     across runs/platforms.
+import { _parse_shard_index, _parse_shard_total, _shard_keeps_index } from "../../src/cli_commands_utils";
+
+// --- Parse + validation ---
+test "shard: well-formed 1/3 parses to fields" {
+    assert _parse_shard_index("1/3") == 1;
+    assert _parse_shard_total("1/3") == 3;
+}
+
+test "shard: last shard 3/3 parses" {
+    assert _parse_shard_index("3/3") == 3;
+    assert _parse_shard_total("3/3") == 3;
+}
+
+test "shard: 1/1 (whole surface) parses" {
+    assert _parse_shard_index("1/1") == 1;
+    assert _parse_shard_total("1/1") == 1;
+}
+
+test "shard: multi-digit fields parse" {
+    assert _parse_shard_index("7/12") == 7;
+    assert _parse_shard_total("7/12") == 12;
+}
+
+test "shard: index 0 rejected" {
+    assert _parse_shard_index("0/3") == -1;
+    assert _parse_shard_total("0/3") == -1;
+}
+
+test "shard: total 0 rejected" {
+    assert _parse_shard_index("1/0") == -1;
+    assert _parse_shard_total("1/0") == -1;
+}
+
+test "shard: index greater than total rejected" {
+    assert _parse_shard_index("4/3") == -1;
+    assert _parse_shard_total("4/3") == -1;
+}
+
+test "shard: missing slash rejected" {
+    assert _parse_shard_index("2") == -1;
+    assert _parse_shard_total("2") == -1;
+}
+
+test "shard: empty rejected" {
+    assert _parse_shard_index("") == -1;
+    assert _parse_shard_total("") == -1;
+}
+
+test "shard: non-numeric field rejected" {
+    assert _parse_shard_index("a/3") == -1;
+}
+
+test "shard: extra slash rejected" {
+    assert _parse_shard_index("1/2/3") == -1;
+}
+
+test "shard: negative field rejected" {
+    assert _parse_shard_index("-1/3") == -1;
+}
+
+// --- Partition: disjoint + complete (union == full surface) ---
+test "shard: 1/3..3/3 cover every index exactly once" {
+    let count = 20;
+    let total = 3;
+    let mut i: int = 0;
+    loop {
+        if i >= count { break; }
+        // Tally how many shards keep index i; a correct partition keeps it
+        // in exactly one.
+        let mut kept: int = 0;
+        let mut s: int = 1;
+        loop {
+            if s > total { break; }
+            if _shard_keeps_index(i, s, total) { kept += 1; }
+            s += 1;
+        }
+        assert kept == 1;
+        i += 1;
+    }
+}
+
+test "shard: 1/4..4/4 cover every index exactly once" {
+    let count = 37;
+    let total = 4;
+    let mut i: int = 0;
+    loop {
+        if i >= count { break; }
+        let mut kept: int = 0;
+        let mut s: int = 1;
+        loop {
+            if s > total { break; }
+            if _shard_keeps_index(i, s, total) { kept += 1; }
+            s += 1;
+        }
+        assert kept == 1;
+        i += 1;
+    }
+}
+
+test "shard: more shards than files leaves no index uncovered or doubled" {
+    // total > count: the surplus shards keep nothing; each remaining index
+    // is still kept by exactly one shard.
+    let count = 3;
+    let total = 7;
+    let mut i: int = 0;
+    loop {
+        if i >= count { break; }
+        let mut kept: int = 0;
+        let mut s: int = 1;
+        loop {
+            if s > total { break; }
+            if _shard_keeps_index(i, s, total) { kept += 1; }
+            s += 1;
+        }
+        assert kept == 1;
+        i += 1;
+    }
+}
+
+test "shard: 1/1 keeps the whole surface" {
+    let mut i: int = 0;
+    loop {
+        if i >= 6 { break; }
+        assert _shard_keeps_index(i, 1, 1);
+        i += 1;
+    }
+}
+
+// --- Partition: file-count-balanced (sizes differ by at most one) ---
+test "shard: per-shard counts differ by at most one" {
+    let count = 20;
+    let total = 3;
+    let mut min_n: int = count + 1;
+    let mut max_n: int = -1;
+    let mut s: int = 1;
+    loop {
+        if s > total { break; }
+        // Count how many of the `count` indices this shard keeps.
+        let mut n: int = 0;
+        let mut i: int = 0;
+        loop {
+            if i >= count { break; }
+            if _shard_keeps_index(i, s, total) { n += 1; }
+            i += 1;
+        }
+        if n < min_n { min_n = n; }
+        if n > max_n { max_n = n; }
+        s += 1;
+    }
+    // 20 over 3 → sizes {7, 7, 6}: spread is exactly 1.
+    assert max_n - min_n <= 1;
+}
+
+// --- Partition: deterministic stride ---
+test "shard: predicate is stable across calls" {
+    let a = _shard_keeps_index(7, 2, 3);
+    let b = _shard_keeps_index(7, 2, 3);
+    assert a == b;
+}
+
+test "shard: stride residue is correct (2/3 keeps indices 1,4,7,...)" {
+    // Shard 2/3 keeps index i iff i % 3 == 1.
+    assert _shard_keeps_index(1, 2, 3);
+    assert _shard_keeps_index(4, 2, 3);
+    assert _shard_keeps_index(7, 2, 3);
+    assert ! _shard_keeps_index(0, 2, 3);
+    assert ! _shard_keeps_index(2, 2, 3);
+    assert ! _shard_keeps_index(3, 2, 3);
+}


### PR DESCRIPTION
## Summary

Moves shard partitioning out of the bash stride (`scripts/test_shards.sh`) into the runner as `sailfin test --shard I/N`, giving the shard map one tested home reusable by the Makefile / CI / nightly. Implements #1237 (test-infra Phase 4, Track A; parent epic #843).

The partition mirrors `scripts/test_shards.sh`'s `(NR - 1) % n == (i - 1)` awk stride over the deterministic (sorted-within-suite) discovery order, so the runner's `--shard` and the legacy bash shard map agree over the same file list. This is durability (one home for the shard logic), not wall-time — the bash seam keeps working until CI is migrated onto a pinned seed that carries `--shard` (a separate post-pin step, called out in the issue).

## What changed

- **`compiler/src/cli/commands/test.sfn`** — `--shard I/N` value flag on the `test` command, validated like `--jobs` (malformed spec → usage error, exit 2). The stride partition is applied to `test_files` **after** the `-k`/`--tag` cut, so a shard partitions exactly the surface that would otherwise run; the `file_suite_index` parallel array is partitioned in lockstep so per-suite banner attribution stays aligned. An empty shard (more shards than files) falls through to the existing benign `0/0/0` path.
- **`compiler/src/cli_commands_utils.sfn`** — `_parse_shard_index` / `_parse_shard_total` (parse + fully validate `I/N`, return the field or `-1`) and `_shard_keeps_index` (the stable stride predicate).
- **`compiler/tests/unit/test_shard_partition_test.sfn`** — regression coverage.

## Note on the helper API shape (and a compiler follow-up)

The natural first cut was a struct-valued `_parse_shard_value(...) -> ShardSpec` and an array-valued `_shard_select_indices(...) -> int[]`. Both failed self-host: a **cross-module** call to a function returning a freshly-declared struct or an `int[]` cannot resolve its return type in the pinned seed —

```
llvm lowering [fatal]: cannot resolve return type for call to `_shard_select_indices` — callee signature is not known to the compiler
```

`int[]` was, in fact, the only `-> int[]` return type in the whole compiler, so this path had simply never been exercised. Rather than expand this size:S test-runner issue into a compiler-codegen fix, the helpers return only `int`/`boolean` (proven cross-module return types) — exactly as testable. The underlying resolution gap is filed as a separate compiler-robustness follow-up.

## Verification

- `make compile` self-hosts (twice — once after implementation, once after the final `fmt` pass).
- New unit test: **19/19 pass** (`build/native/sailfin test compiler/tests/unit/test_shard_partition_test.sfn`).
- End-to-end over a 5-file temp suite: shard sizes `{2, 2, 1}` sum to `5` = full surface (disjoint + complete + balanced).
- `--shard 4/3` and `--shard bogus` both print a usage error and exit `2`.
- `sfn fmt --check` clean on all touched files (formatted with the freshly-built native compiler).

## Acceptance criteria

- [x] `sailfin test --shard 1/3 ...` runs a disjoint third; union of `1/3,2/3,3/3` == full surface (no gaps/overlaps).
- [x] Partition is stable across runs/platforms (sorted file list, deterministic stride).
- [x] `make compile` self-hosts; new test passes; `sfn fmt --check` clean.

Closes #1237

https://claude.ai/code/session_011XZF4ihNBf8EyjpGRFRLJ1

---
_Generated by [Claude Code](https://claude.ai/code/session_011XZF4ihNBf8EyjpGRFRLJ1)_