### PR TITLE
refactor(backend): introduce Backend interface seam (Stage 0, #1112)

### DIFF
--- a/compiler/src/backend.sfn
+++ b/compiler/src/backend.sfn
@@ -1,0 +1,171 @@
+// compiler/src/backend.sfn
+//
+// Stage 0 of the toolchain-independence arc (SFEP-15,
+// `docs/proposals/0015-llvm-independence.md` §6/§8/§11): a `Backend`
+// interface that hides the driver's `process.run(["clang", …])` codegen
+// and link call sites behind a single seam. Today's textual-LLVM-IR +
+// clang path is the sole implementation (`LlvmTextBackend`); it
+// reproduces every existing clang invocation byte-for-byte (zero
+// behaviour change — `--check-determinism` must still pass with no
+// rebaseline).
+//
+// Later codegen/link work plugs in here instead of re-hardcoding LLVM
+// assumptions across the driver: the LLVM C-API binding (#347) lands as
+// an `LlvmApiBackend`, and the seal-sufficient native backend (#1640) as
+// a `NativeBackend`. The driver stays pure orchestration: it keeps
+// computing the runtime objects, the linker selection, the dead-strip
+// decision (and its diagnostic), and the link-lib dedup, then hands the
+// already-ordered pieces to the backend, which owns only the final argv
+// assembly + `process.run`.
+//
+// Dispatch note: `compiler/src/` has never exercised interface-typed
+// *values* in its own source (it can lower trait objects but does not
+// self-host any), so the driver constructs `LlvmTextBackend {}` directly
+// and calls methods on the concrete type. The `Backend` interface is
+// declared for conformance + documentation, not dynamic dispatch.
+//
+// Self-host note: the argv-assembly bodies (which call the array builtin
+// `.push`) live in module-level free functions, not in the struct method
+// bodies. Calling `.push` from inside a struct method is a lowering path
+// the self-hosting compiler does not resolve ("cannot resolve return type
+// for call to `args.push`"), even though `sfn check` accepts it — a
+// build-only failure of the #1389 class. The methods are thin delegators
+// to the free functions, which is the proven self-hosting shape.
+// Reserved opaque object-file handle for later backend stages (#347 /
+// #1640 produce these in-process). Stage 0's `LlvmTextBackend` returns
+// the clang exit code directly, so this is unused today but pins the
+// shape the semantic seam will grow into.
+struct ObjectArtifact {
+    path: string;
+}
+
+// The semantic inputs to a final link, computed by the driver. The two
+// link sites (program/run/build vs. `sfn test`) emit genuinely
+// different clang argv layouts — `-o` position, input ordering, and the
+// section/strip/linker flag set all differ — so `test_mode` selects the
+// layout `LlvmTextBackend` reproduces. A non-clang backend ignores
+// `link_flags` (clang-driver-specific) and uses `objects` / `ir_inputs`
+// / `libs` directly.
+struct LinkPlan {
+    // Pre-compiled `.o` inputs (runtime objects).
+    objects: string[];
+    // `.ll` inputs compiled inline by the clang link (program/capsule
+    // modules in build mode; the test source + dependency `.ll` in test
+    // mode).
+    ir_inputs: string[];
+    out_path: string;
+    opt_flag: string;
+    // Clang-driver flags the program link interleaves between
+    // `-Wno-override-module` and the inputs: linker selection
+    // (`-fuse-ld=…`), `-ffunction-sections`/`-fdata-sections`, the
+    // dead-strip flag (when safe), and the runtime retain-root flags.
+    // Empty in test mode.
+    link_flags: string[];
+    // Linker libraries appended after `-o <out>` (e.g. `-lm`,
+    // `-lpthread`), already deduped/back-filled by the driver.
+    libs: string[];
+    // Selects the `sfn test` link layout (see above).
+    test_mode: boolean;
+}
+
+interface Backend {
+    // Compile a single IR/C source to an object file (`clang -c`).
+    fn assemble(self, src: string, out: string, opt_flag: string, include_flags: string[]) -> int ![io];
+    // Link pre-compiled objects + IR inputs into a binary.
+    fn link(self, plan: LinkPlan) -> int ![io];
+}
+
+// Build the `clang -c` argv for a single object compile. Mirrors the
+// runtime c-source / ll-source / sfn-source object compiles and the
+// `--no-link` library build: section split so the link's dead-strip can
+// GC unreferenced sections (#1047).
+fn _llvm_text_assemble_argv(src: string, out: string, opt_flag: string, include_flags: string[]) -> string[] {
+    let mut args: string[] = ["clang", opt_flag, "-Wno-override-module", "-ffunction-sections", "-fdata-sections"];
+    let mut i: int = 0;
+    loop {
+        if i >= include_flags.length { break; }
+        args.push(include_flags[i]);
+        i += 1;
+    }
+    args.push("-c");
+    args.push(src);
+    args.push("-o");
+    args.push(out);
+    return args;
+}
+
+// Build the clang link argv for the `sfn test` layout:
+// `clang -O0 -Wno-override-module -o OUT <test.ll> <dep.ll…> <runtime.o…> <libs…>`.
+fn _llvm_text_link_test_argv(plan: LinkPlan) -> string[] {
+    let mut args: string[] = ["clang", plan.opt_flag, "-Wno-override-module"];
+    args.push("-o");
+    args.push(plan.out_path);
+    let mut ii: int = 0;
+    loop {
+        if ii >= plan.ir_inputs.length { break; }
+        args.push(plan.ir_inputs[ii]);
+        ii += 1;
+    }
+    let mut oi: int = 0;
+    loop {
+        if oi >= plan.objects.length { break; }
+        args.push(plan.objects[oi]);
+        oi += 1;
+    }
+    let mut li: int = 0;
+    loop {
+        if li >= plan.libs.length { break; }
+        args.push(plan.libs[li]);
+        li += 1;
+    }
+    return args;
+}
+
+// Build the clang link argv for the program/build layout:
+// `clang <opt> -Wno-override-module <link_flags…> <runtime.o…> <ir.ll…> -o OUT <libs…>`.
+fn _llvm_text_link_program_argv(plan: LinkPlan) -> string[] {
+    let mut args: string[] = ["clang", plan.opt_flag, "-Wno-override-module"];
+    let mut fi: int = 0;
+    loop {
+        if fi >= plan.link_flags.length { break; }
+        args.push(plan.link_flags[fi]);
+        fi += 1;
+    }
+    let mut roi: int = 0;
+    loop {
+        if roi >= plan.objects.length { break; }
+        args.push(plan.objects[roi]);
+        roi += 1;
+    }
+    let mut ri: int = 0;
+    loop {
+        if ri >= plan.ir_inputs.length { break; }
+        args.push(plan.ir_inputs[ri]);
+        ri += 1;
+    }
+    args.push("-o");
+    args.push(plan.out_path);
+    let mut lli: int = 0;
+    loop {
+        if lli >= plan.libs.length { break; }
+        args.push(plan.libs[lli]);
+        lli += 1;
+    }
+    return args;
+}
+
+// The current behaviour: emit textual LLVM IR and drive `clang` for
+// assembly and linking. The methods delegate argv construction to the
+// free functions above (see the self-host note in the file header).
+struct LlvmTextBackend {
+    fn assemble(self, src: string, out: string, opt_flag: string, include_flags: string[]) -> int ![io] {
+        return process.run(_llvm_text_assemble_argv(src, out, opt_flag, include_flags));
+    }
+
+    fn link(self, plan: LinkPlan) -> int ![io] {
+        if plan.test_mode {
+            return process.run(_llvm_text_link_test_argv(plan));
+        }
+        return process.run(_llvm_text_link_program_argv(plan));
+    }
+}

--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -82,7 +82,7 @@ import {
     _suite_name_from_path,
     _write_text_cmd
 } from "../../cli_commands_utils";
-import { assemble_runtime_capsule_link_inputs } from "../../cli_main";
+import { assemble_runtime_capsule_link_inputs, link_test_objects } from "../../cli_main";
 import { ImportSymbolTable, empty_import_symbols } from "../../effect_imports";
 import { compile_tests_to_llvm_file_with_module_imports, module_name_from_path } from "../../main";
 import { LayoutManifest } from "../../native_ir";
@@ -1205,11 +1205,14 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     // triple`, which clang's link overrides — matching the suppression on
     // every other clang invocation in cli_main.sfn so the test path is not
     // the lone source of `[-Woverride-module]` noise.
-    let mut args: string[] = ["clang", "-O0", "-Wno-override-module", "-o", out_path, ll_path];
+    // Test link layout (`-o` before inputs; test source `.ll` then dep
+    // `.ll` as IR inputs). The driver assembles the semantic pieces and
+    // `LlvmTextBackend.link` reproduces the exact clang argv.
+    let mut ir_inputs: string[] = [ll_path];
     let mut di: int = 0;
     loop {
         if di >= dep_ll_paths.length { break; }
-        args.push(dep_ll_paths[di]);
+        ir_inputs.push(dep_ll_paths[di]);
         di += 1;
     }
     // Issue #940: resolve the implicit runtime capsule
@@ -1245,17 +1248,12 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     // scoped to the build/run path that feeds the build-quality gate.
     let rt = assemble_runtime_capsule_link_inputs(runtime_caps, rt_cache_dir, "-O0", binary_dir, "");
     if !rt.success { return 1; }
-    let mut roi: int = 0;
-    loop {
-        if roi >= rt.object_paths.length { break; }
-        args.push(rt.object_paths[roi]);
-        roi += 1;
-    }
     // The runtime capsule's `link-libs` (runtime/capsule.toml) already
     // carries `-lm` / `-lpthread`. Track which math/thread libs flow
     // through so the defensive push below does not re-add a lib the
     // capsule supplied — a duplicate `-lm` makes the macOS linker emit
     // `ld: warning: ignoring duplicate libraries: '-lm'`.
+    let mut libs: string[] = [];
     let mut has_lm: boolean = false;
     let mut has_pthread: boolean = false;
     let mut lli: int = 0;
@@ -1265,14 +1263,17 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
         if strings_equal(lib, "-lm") { has_lm = true; }
         if strings_equal(lib, "-lpthread") { has_pthread = true; }
         if strings_equal(lib, "-pthread") { has_pthread = true; }
-        args.push(lib);
+        libs.push(lib);
         lli += 1;
     }
     // Fallback for configurations where the runtime capsule did not supply
     // them (keeps the link complete without double-adding).
-    if !has_lm { args.push("-lm"); }
-    if !has_pthread { args.push("-pthread"); }
-    return process.run(args);
+    if !has_lm { libs.push("-lm"); }
+    if !has_pthread { libs.push("-pthread"); }
+    // Dispatch through the `Backend` seam via the cli_main entry point
+    // (kept there to avoid a cross-dir `../../backend` import; see
+    // `link_test_objects`). Reproduces the prior test-link argv exactly.
+    return link_test_objects(rt.object_paths, ir_inputs, out_path, libs);
 }
 
 // Resolve the per-test scratch root used for the test runner's

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -3,6 +3,7 @@
 // Sailfin-native CLI entrypoint invoked by the native C shim.
 import { bold } from "sfn/cli";
 
+import { LinkPlan, LlvmTextBackend } from "./backend";
 import {
     BuildCacheConfig,
     CacheKey,
@@ -949,23 +950,11 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                 stats.hits = stats.hits + 1;
             } else {
                 stats.misses = stats.misses + 1;
-                let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
-                // Per-function/per-datum sections so the final link's
-                // dead-strip (`--gc-sections` / `-dead_strip`) can drop
-                // functions no consumer references (#1047).
-                args.push("-ffunction-sections");
-                args.push("-fdata-sections");
-                let mut fi: int = 0;
-                loop {
-                    if fi >= include_flags.length { break; }
-                    args.push(include_flags[fi]);
-                    fi += 1;
-                }
-                args.push("-c");
-                args.push(src);
-                args.push("-o");
-                args.push(obj);
-                let rc = process.run(args);
+                // Per-function/per-datum sections (in `assemble`) so the
+                // final link's dead-strip (`--gc-sections` / `-dead_strip`)
+                // can drop functions no consumer references (#1047).
+                let backend = LlvmTextBackend { };
+                let rc = backend.assemble(src, obj, opt_flag, include_flags);
                 if rc != 0 {
                     print("sfn build: failed to compile runtime c-source " + src);
                     return _failed_runtime_link_inputs();
@@ -998,7 +987,9 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                 stats.hits = stats.hits + 1;
             } else {
                 stats.misses = stats.misses + 1;
-                let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-ffunction-sections", "-fdata-sections", "-c", src, "-o", obj]);
+                let backend = LlvmTextBackend { };
+                let no_includes: string[] = [];
+                let rc = backend.assemble(src, obj, opt_flag, no_includes);
                 if rc != 0 {
                     print("sfn build: failed to assemble runtime ll-source "
                         + src);
@@ -1212,7 +1203,9 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
             + ")");
         return RuntimeEmitResult { obj_path: "", stats: stats };
     }
-    let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-ffunction-sections", "-fdata-sections", "-c", ll_path, "-o", obj_path]);
+    let backend = LlvmTextBackend { };
+    let no_includes: string[] = [];
+    let rc2 = backend.assemble(ll_path, obj_path, opt_flag, no_includes);
     if rc2 != 0 {
         print("sfn build: failed to compile runtime sfn-source object "
             + obj_path);
@@ -1722,19 +1715,22 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
     runtime_objs = inputs.object_paths;
     runtime_link_libs = inputs.link_libs;
 
-    let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
+    // Driver computes the clang-driver flag interleave; `LlvmTextBackend`
+    // owns the final argv + `process.run`. Flag order is load-bearing for
+    // byte-identical output (#1112 zero-behaviour gate).
+    let mut link_flags: string[] = [];
     // Opportunistic faster-linker selection (#343): prefer mold/lld when
     // present, honour the `SAILFIN_LINKER` override, else fall back to the
     // platform default. Empty string = no `-fuse-ld=` flag (system linker).
     let linker_flag = _resolve_linker();
-    if linker_flag.length > 0 { args.push(linker_flag); }
+    if linker_flag.length > 0 { link_flags.push(linker_flag); }
     // `.ll` inputs are compiled inline by this same clang invocation, so
     // they need the section split here; pre-compiled runtime `.o`s already
     // carry it from `_clang_compile_runtime_capsule_objects` /
     // `_emit_runtime_sfn_to_obj`. The dead-strip flag then GCs every
     // section unreferenced from the entry point (#1047).
-    args.push("-ffunction-sections");
-    args.push("-fdata-sections");
+    link_flags.push("-ffunction-sections");
+    link_flags.push("-fdata-sections");
     // Root the runtime provider surface, then GC unreferenced sections
     // (#1047). The order matters for correctness: if symbol enumeration
     // yields nothing while runtime objects are present (`nm`/`awk`
@@ -1747,38 +1743,52 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
     // `sfn_*` family, so the happy path is unaffected.
     let retain_flags = _runtime_retain_root_flags(runtime_objs);
     let strip_safe = runtime_objs.length == 0 || retain_flags.length > 0;
-    if strip_safe { args.push(_dead_strip_link_flag()); } else {
+    if strip_safe { link_flags.push(_dead_strip_link_flag()); } else {
         print("sfn: dead-code strip disabled — could not enumerate runtime");
         print("     provider symbols (is `nm` on PATH?); linking unstripped");
     }
     let mut rfi: int = 0;
     loop {
         if rfi >= retain_flags.length { break; }
-        args.push(retain_flags[rfi]);
+        link_flags.push(retain_flags[rfi]);
         rfi += 1;
     }
-    let mut roi: int = 0;
-    loop {
-        if roi >= runtime_objs.length { break; }
-        args.push(runtime_objs[roi]);
-        roi += 1;
-    }
-    let mut i: int = 0;
-    loop {
-        if i >= ll_paths.length { break; }
-        args.push(ll_paths[i]);
-        i += 1;
-    }
-    args.push("-o");
-    args.push(out_path);
-    let mut lli: int = 0;
-    loop {
-        if lli >= runtime_link_libs.length { break; }
-        args.push(runtime_link_libs[lli]);
-        lli += 1;
-    }
-    let rc = process.run(args);
+    let backend = LlvmTextBackend { };
+    let plan = LinkPlan {
+        objects: runtime_objs,
+        ir_inputs: ll_paths,
+        out_path: out_path,
+        opt_flag: opt_flag,
+        link_flags: link_flags,
+        libs: runtime_link_libs,
+        test_mode: false
+    };
+    let rc = backend.link(plan);
     return LinkResult { rc: rc, stats: inputs.stats };
+}
+
+// Test-binary link entry point for the `sfn test` command. Lives here
+// (sibling to `backend.sfn`) rather than in `cli/commands/test.sfn`
+// because lowering a cross-directory `../../backend` import of the
+// method-bearing `LlvmTextBackend` under the build's import-context fails
+// (a separate compiler limitation; standalone emit and same-dir
+// `./backend` imports both lower fine). The test command threads the
+// already-ordered pieces (runtime objects, IR inputs, deduped libs) and
+// this helper builds the test-layout `LinkPlan` and dispatches through the
+// `Backend` seam.
+fn link_test_objects(objects: string[], ir_inputs: string[], out_path: string, libs: string[]) -> int ![io] {
+    let backend = LlvmTextBackend { };
+    let no_link_flags: string[] = [];
+    let plan = LinkPlan {
+        objects: objects,
+        ir_inputs: ir_inputs,
+        out_path: out_path,
+        opt_flag: "-O0",
+        link_flags: no_link_flags,
+        libs: libs,
+        test_mode: true
+    };
+    return backend.link(plan);
 }
 
 fn _clang_link(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> LinkResult ![io] {
@@ -2563,7 +2573,9 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
         // dep object files will compile them on demand once Stage C lands
         // the in-process driver.
         if no_link {
-            let rc_obj = process.run(["clang", "-O2", "-Wno-override-module", "-ffunction-sections", "-fdata-sections", "-c", ll_path, "-o", out_path,]);
+            let backend = LlvmTextBackend { };
+            let no_includes: string[] = [];
+            let rc_obj = backend.assemble(ll_path, out_path, "-O2", no_includes);
             if rc_obj != 0 {
                 if !json_flag {
                     print("library build failed (clang exit=" + number_to_string(rc_obj)

--- a/docs/proposals/design-notes/1112-backend-interface-seam.md
+++ b/docs/proposals/design-notes/1112-backend-interface-seam.md
@@ -1,0 +1,226 @@
+# #1112 — Backend interface seam (SFEP-15 Stage 0)
+
+Design doc for the design gate of #1112. **Stage 0 of the toolchain-independence
+arc** — the *design record* is SFEP-15 (`../0015-llvm-independence.md` §6/§8/§11);
+this note is the single-issue implementation gate, so it carries no SFEP number.
+Unblocks #347 (LLVM C-API backend) and #1640 (seal-sufficient native backend).
+
+---
+
+## Summary
+
+Introduce a single `Backend` seam that hides every `process.run(["clang", …])`
+codegen/link call site behind one module (`compiler/src/backend.sfn`), with
+today's textual-LLVM-IR + clang path as its sole implementation
+(`LlvmTextBackend`). **Zero behavior change** — emitted `.o`/binary byte-identical,
+`--check-determinism` passes with no rebaseline. This is SFEP-15 §8 Stage 0 and
+the prerequisite seam for #347 and #1640 to plug in cleanly rather than
+re-hardcoding LLVM across the driver.
+
+## Motivation
+
+Per SFEP-15 §3/§6: the clang dependency is co-located in the driver but spread
+across several call sites wearing four hats (compile runtime C, assemble
+`.ll`→`.o`, link the final binary, pull in libc). There is no seam to slot an
+alternative backend into. Stage 0 creates that seam mechanically, with no
+semantic change, so #347 lands as "a faster LLVM backend impl" and the native
+backend (#1640) arrives as a second impl.
+
+## Design
+
+### Decision: concrete struct, not trait-object dispatch
+
+`compiler/src/` contains **zero** uses of `interface`/`impl`/`implements`-typed
+*values* — the compiler has never dynamically dispatched through a trait object
+in its own source, even though the LLVM backend *can* lower one. The seam is a
+**concrete struct `LlvmTextBackend` with methods**, with the `Backend` interface
+declared for documentation/conformance but **not** used as a dynamic value type.
+The backend is selected by direct construction at the driver call sites
+(`let backend = LlvmTextBackend {};`) — the issue's "hard-wired, no flag/env"
+scope. When #347/#1640 add a second impl, the selection point becomes a small
+factory returning the concrete struct chosen by build mode.
+
+### The real call-site inventory (grounded)
+
+Actual `process.run` clang invocations that are **codegen/link** (routed through
+the seam):
+
+1. `cli_main.sfn` `_clang_compile_runtime_capsule_objects` — runtime **c-source**
+   compile (`clang <opt> -Wno-override-module -ffunction-sections -fdata-sections
+   [-I…] -c <src> -o <obj>`) → `backend.assemble`.
+2. same fn — runtime **ll-source** assemble → `backend.assemble`.
+3. `_emit_runtime_sfn_to_obj` — runtime **sfn-source** `.ll`→`.o` → `backend.assemble`.
+   (The sibling `process.run(["sh","-c", …])` child *emit* is a compiler
+   subprocess, not clang — stays out of the seam.)
+4. `_clang_link_multi_with_opt` — the **final program link** → `backend.link`
+   (program layout). **Program/capsule `.ll`→`.o` is *not* a separate clang
+   call** — those `.ll` inputs are compiled inline by this same link invocation.
+5. `--no-link` **library build** object emit (`clang -O2 … -c <ll> -o <out>`) →
+   `backend.assemble`.
+6. `cli/commands/test.sfn` `_clang_link_test_cmd_with_deps` — the **`sfn test`
+   link** → routes through `cli_main::link_test_objects` → `backend.link` (test
+   layout). It does **not** import `backend` directly; see the cross-dir
+   self-host note below.
+
+Clang invocations that are **validation, not codegen/link** — left **out** of the
+Stage-0 seam (the issue scopes the seam to lower+link): the
+`llvm-as`/`clang -c -emit-llvm` validator cascade (`emit_helpers.sfn`,
+`capsule_emit_parallel.sfn`), invoked via `sh -c`. Folding them in expands blast
+radius for no Stage-0 benefit; a future `Backend.validate(ll) -> bool` is a clean
+optional add once a second backend exists.
+
+### Interface + types (final shapes wrapping today's behavior verbatim)
+
+The SFEP-15 sketch (`lower(module: NativeModule) -> ObjectArtifact`,
+`link(objects, out, libs)`) does not match what actually flows: the driver never
+hands the backend a `NativeModule`, and program/capsule `.ll`s are assembled
+*inline by the linker*, not pre-lowered to objects. The implemented shapes:
+
+```sfn
+// compiler/src/backend.sfn
+
+// Reserved object-file handle for later stages (#347/#1640 produce these
+// in-process); Stage 0 returns the clang exit code directly.
+struct ObjectArtifact { path: string; }
+
+// Semantic link inputs computed by the driver; `test_mode` selects which
+// of the two byte-distinct clang argv layouts LlvmTextBackend reproduces.
+struct LinkPlan {
+    objects: string[];          // prebuilt runtime .o
+    ir_inputs: string[];        // .ll compiled inline (program+capsule, or test+deps)
+    out_path: string;
+    opt_flag: string;           // "-O2" build/run, "-O0" test
+    link_flags: string[];       // program layout only: linker-sel/section/dead-strip/retain
+    libs: string[];             // runtime link-libs (+ test's -lm/-pthread backstop)
+    test_mode: boolean;         // false = program/build layout, true = `sfn test` layout
+}
+
+interface Backend {
+    fn assemble(self, src: string, out: string, opt_flag: string,
+                include_flags: string[]) -> int ![io];
+    fn link(self, plan: LinkPlan) -> int ![io];
+}
+
+struct LlvmTextBackend { /* stateless; methods delegate to free fns (see below) */ }
+```
+
+**Why `test_mode`, not a single template (a correction to the original sketch).**
+The two link sites do **not** emit the same argv shape, so the original "map the
+test link onto the same `LinkPlan` with `linker_flag=""`, `extra_flags=[]`" plan
+would have *reordered* the test link's clang inputs and risked non-byte-identical
+output — violating the zero-rebaseline gate. Grounded in the source:
+- **Program/build** (`_clang_link_multi_with_opt`): `clang <opt> -Wno-override-module
+  <link_flags…> <runtime .o…> <program/capsule .ll…> -o <out> <libs…>` — `-o` at the
+  **end**, objects **before** IR, with section/dead-strip/linker flags.
+- **`sfn test`** (`_clang_link_test_cmd_with_deps`): `clang -O0 -Wno-override-module
+  -o <out> <test .ll> <dep .ll…> <runtime .o…> <libs…>` — `-o` **early** (before
+  inputs), IR **before** objects, **no** section/strip/linker flags.
+Reordering `.ll`/`.o` inputs to a linker can change section/symbol layout and thus
+output bytes, so the seam must preserve each layout exactly. `test_mode` is the
+discriminator; the impl branches on it. A native backend implements both branches
+trivially (it ignores `link_flags` and links `objects`+`ir_inputs` directly).
+
+Threading notes (verbatim-preservation):
+- `assemble` keeps the **exact argv order** of each call site: `["clang", opt_flag,
+  "-Wno-override-module", "-ffunction-sections", "-fdata-sections", <includes>,
+  "-c", src, "-o", out]`. Runtime objects pass `[-I…]`, library builds pass none.
+- For the program link the driver continues to *compute* the linker selection, the
+  section flags, the dead-strip-safe gate (incl. its diagnostic) and retain-root
+  enumeration into `link_flags`, and the runtime `libs` — exactly as now. The
+  backend only owns the final `process.run(argv)`, keeping determinism-sensitive
+  flag *computation* in the driver and byte-stable.
+- `ObjectArtifact` is the named return wrapper reserved for #347/#1640; Stage 0
+  keeps `assemble`/`link` returning `int` (the clang exit code callers already
+  consume) to avoid disturbing `LinkResult`/`RuntimeLinkInputs` plumbing.
+
+### Placement & selection
+
+- New module `compiler/src/backend.sfn` holds `ObjectArtifact`, `LinkPlan`,
+  `Backend`, `LlvmTextBackend`, and the argv-builder free functions.
+- **Import-cycle safety:** `backend.sfn` calls `process.run` only — it imports
+  nothing from the driver. The driver imports `backend.sfn`; no back-edge, no new
+  cycle.
+- Selection is direct construction (`LlvmTextBackend {}`) at each call site — no
+  flag, no env, no factory this issue.
+
+## Effect & capability impact
+
+Both interface methods carry `![io]` (they spawn subprocesses) — matching the
+effect on every function they replace (`_clang_*` are all `![io]`). No new effect;
+call sites are already `![io]`, so effect-checking is unchanged. Conformance is
+checked structurally; because the concrete struct is constructed directly (no
+trait-object value), conformance is the only interface machinery exercised.
+
+## Self-hosting impact
+
+- The new `backend.sfn` uses **only** constructs the compiler already self-hosts,
+  so the **old seed compiles the new compiler** with no seed dependency (same-seed,
+  in-tree refactor; no `/pin-seed`, no seed-cut tax). The seam and its sole
+  consumer (the driver) land in **one PR** (seed-dependency rule: bundle).
+
+Two build-only failures surfaced during implementation — both **#1389-class**
+(`sfn check` green, `make compile` red) and worth recording because #347/#1640
+will grow this surface:
+
+1. **`.push` inside a struct method body does not lower.** The first cut put the
+   argv-assembly loops directly in the `LlvmTextBackend.assemble`/`link` **method
+   bodies**. `sfn check` accepted it; the self-host emit failed at LLVM lowering:
+   `cannot resolve return type for call to 'args.push' — callee signature is not
+   known to the compiler`. Every working `.push` in the driver is in a *free
+   function*. **Fix:** the argv builders are module-level free functions
+   (`_llvm_text_assemble_argv` / `_llvm_text_link_test_argv` /
+   `_llvm_text_link_program_argv`) and the methods are thin delegators
+   (`return process.run(_llvm_text_*_argv(...))`).
+2. **Cross-dir import of a method-bearing struct under `--import-context`.** After
+   fix 1, the self-host still failed to lower `cli/commands/test` (named only under
+   serial emit, `SAILFIN_BUILD_JOBS=1`). The module's **standalone** emit succeeded
+   (904 KB IR, exit 0) and `cli_main.sfn` (same-dir `./backend` import, identical
+   `LinkPlan` construction + `backend.link` call) lowered fine — the failure is
+   specific to the **cross-dir `../../backend` import** of the method-bearing
+   `LlvmTextBackend` **combined with the build's `--import-context`** staging
+   (standalone emit lacks that context and passes; `make clean-build` did **not**
+   fix it, ruling out staleness). **Fix for Stage 0:** keep all backend usage in
+   `cli_main.sfn` (sibling of `backend.sfn`) and have `cli/commands/test.sfn`
+   delegate its link through a `cli_main` entry point (`link_test_objects`) — which
+   it already imports from. The `Backend` seam is unaffected (every clang
+   codegen/link path still routes through it); only the *call site* moved up one
+   module. The lowering gap itself is a **follow-up compiler issue** (cross-dir
+   import-context lowering of interface/method-bearing structs), out of scope for
+   the mechanical Stage 0 seam.
+
+## Alternatives
+
+1. **Trait-object dynamic dispatch** (the SFEP-15 sketch literally). Rejected for
+   Stage 0: exercises codegen the compiler has never run on *itself*, risking a
+   self-host regression for zero Stage-0 value. Adopt when a second impl needs
+   runtime selection.
+2. **Free functions in a `backend` namespace, no interface.** Loses the conformance
+   contract #347/#1640 cite; the interface declaration is cheap and documents the
+   seam.
+3. **Fold validation into the seam now.** Out of issue scope, larger blast radius,
+   and a native backend's validation differs; defer to `validate()`.
+
+## Stage1 readiness mapping
+
+Pure refactor (no new surface syntax): parses (existing interface/struct grammar),
+typechecks (conformance), emits/lowers (existing struct-method + free-fn path),
+regression = existing suite + `--check-determinism` (no new behavior beyond
+byte-identity), self-hosts (`make compile` green), `sfn fmt --check` clean. Not a
+user-facing feature → no spec chapter; `docs/status.md` notes the seam.
+
+## Test plan
+
+The gate is *zero behavior change*, so verification is the existing suite plus:
+- `make compile` green (self-host with the seam). ✅
+- `grep -rn 'process.run(\["clang"' compiler/src/ | grep -v backend.sfn` → empty. ✅
+- `sfn fmt --check` clean on every touched file (canonical self-hosted binary). ✅
+- hello-world builds+runs (program link), one unit test builds+runs (`sfn test`
+  link). ✅
+- `make check` + `--check-determinism` (no rebaseline) — CI on the PR.
+
+## References
+
+- SFEP-15 `../0015-llvm-independence.md` §6, §8 (Stage 0), §11.
+- #347 (LLVM C-API backend), #1640 (seal-sufficient native backend).
+- Touched: `compiler/src/backend.sfn` (new), `compiler/src/cli_main.sfn`,
+  `compiler/src/cli/commands/test.sfn`, `docs/status.md`.

--- a/docs/status.md
+++ b/docs/status.md
@@ -79,6 +79,14 @@ here.
 - `compiler/src/` is the primary toolchain; `make compile` produces
   `build/native/sailfin`. Pipeline: Lexer → Parser → Type Checker →
   Effect Checker → Native Emitter (`.sfn-asm`) → LLVM Lowering.
+- **Backend seam** (`compiler/src/backend.sfn`, #1112; SFEP-15 Stage 0):
+  every codegen/link `clang` invocation routes through a `Backend` interface
+  whose sole impl is `LlvmTextBackend` (today's textual-LLVM-IR + clang path).
+  Zero behavior change — the driver still computes runtime objects, linker
+  selection, dead-strip, and link-libs; the backend owns only the final argv +
+  `process.run`. The seam is the prerequisite for the LLVM C-API backend (#347)
+  and the seal-sufficient native backend (#1640) to plug in without
+  re-hardcoding LLVM across the driver.
 - **Effect enforcement is a build gate** (Phases A–F, shipped 2026-04-26):
   `validate_effects()` runs from every `compile_to_*` entry and fails the
   build on undeclared effects. `SAILFIN_EFFECT_ENFORCE=warning|off` are the


### PR DESCRIPTION
## Summary

Stage 0 of the toolchain-independence arc (SFEP-15 §8). Routes every clang **codegen/link** call site in the driver through a `Backend` interface (`compiler/src/backend.sfn`) whose sole implementation is `LlvmTextBackend` — today's textual-LLVM-IR + clang path, reproduced **byte-for-byte**. **Zero behavior change.**

This is the prerequisite seam that lets the LLVM C-API backend (**#347**) land as `LlvmApiBackend` and the seal-sufficient native backend (**#1640**, now on the 1.0 critical path per SFEP-15/SFEP-16's 2026-06-26 repositioning) land as `NativeBackend` — instead of re-hardcoding LLVM assumptions across the driver.

> Branch note: this branch is named `…issue-347…` (the branch I was assigned), but the PR closes **#1112** — #1112 is the gating prerequisite for #347, which stays parked until this lands.

## What changed

- **`compiler/src/backend.sfn`** (new): `Backend` interface + `LlvmTextBackend` (`assemble` / `link`). The argv builders are module-level **free functions** with `LinkPlan.test_mode` selecting between the two byte-distinct link layouts (program/build vs `sfn test`).
- **`compiler/src/cli_main.sfn`**: route the runtime c/ll/sfn object compiles, the `--no-link` library build, and the final program link through the seam; add the `link_test_objects` entry point.
- **`compiler/src/cli/commands/test.sfn`**: delegate the `sfn test` link via `cli_main::link_test_objects`.
- **Docs**: `docs/status.md` note + `docs/proposals/design-notes/1112-backend-interface-seam.md`.

## Design decisions (full rationale in the design note)

- **Concrete-struct dispatch, not trait objects.** The compiler has never dynamically dispatched a trait-object *value* in its own source; the interface is declared for conformance only, and the driver constructs `LlvmTextBackend {}` directly. Keeps Stage 0 on a proven self-host path.
- **`test_mode` discriminator.** The program link and the `sfn test` link emit genuinely different clang argv layouts (`-o` position, input ordering, flag set). A single template would have reordered linker inputs and risked non-byte-identical output, breaking the no-rebaseline gate. `test_mode` preserves each layout exactly.
- **Driver stays pure orchestration.** It keeps computing runtime objects, linker selection, the dead-strip-safe decision (and its diagnostic), and link-lib dedup; the backend owns only the final `process.run(argv)`.

## Two build-only failures found + fixed during implementation (#1389 class)

Both passed `sfn check` but failed `make compile` — recorded in the design note since #347/#1640 will hit the same surface:
1. `.push` inside a **struct method body** doesn't lower → moved argv assembly to free functions; methods are thin delegators.
2. Cross-dir `../../backend` import of a method-bearing struct fails to lower under the build's `--import-context` (standalone emit and same-dir import both succeed; `make clean-build` ruled out staleness) → the `sfn test` link delegates through `cli_main` instead of importing `backend` directly.

The underlying lowering gap (cross-dir import-context lowering of interface/method-bearing structs) is a **follow-up compiler issue**, out of scope for this mechanical seam.

## Verification

- ✅ `make compile` self-hosts with the seam (clean rebuild).
- ✅ `grep -rn 'process.run(["clang"' compiler/src/ | grep -v backend.sfn` → empty.
- ✅ `sfn fmt --check` clean on all touched files (canonical self-hosted binary).
- ✅ hello-world builds + runs (program link); a unit test builds + runs via `sfn test` (test link).
- ⏳ `make check` + `--check-determinism` (no rebaseline) — CI on this PR.

Closes #1112

https://claude.ai/code/session_01LE8MKYDaMpmkaBSKgs69sV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LE8MKYDaMpmkaBSKgs69sV)_