### PR TITLE
docs(sfep): accept SFEP-0030 — First-Class Function Values

### DIFF
--- a/docs/proposals/0030-first-class-function-values.md
+++ b/docs/proposals/0030-first-class-function-values.md
@@ -1,7 +1,7 @@
 ---
-sfep: TBD
+sfep: 0030
 title: First-Class Function Values
-status: Draft
+status: Accepted
 type: language
 created: 2026-06-26
 updated: 2026-06-26
@@ -12,18 +12,20 @@ superseded-by:
 graduates-to:
 ---
 
-# SFEP-0029 — First-Class Function Values
+# SFEP-0030 — First-Class Function Values
 
 > Retroactive design record for epic **#1609** — "First-class function values
 > (named fns, fn-typed struct fields, capturing closures as general params)".
 > The epic was filed 2026-06-24, before the SFEP process (SFEP-0001) landed
 > 2026-06-26; this SFEP is its durable design record, required because the work
 > is a language feature that needs an architect pass before fan-out. See
-> [`0001-sfep-process.md`](./0001-sfep-process.md) for the process. This is a
-> `Draft`: only the v0 baseline (item 2) is built — everything else is designed,
-> not shipped. The four design forks the architect originally flagged for the
-> design gate are **resolved and committed** in §3.5 below (and reflected in
-> §3.1, §4, §5, §7, §8); there are no remaining open forks.
+> [`0001-sfep-process.md`](./0001-sfep-process.md) for the process. **Status:
+> `Accepted`** — the design gate is passed (owner approval, 2026-06-26) and the
+> four forks the architect flagged are **resolved and committed** in §3.5 below
+> (reflected in §3.1, §4, §5, §7, §8); there are no remaining open forks.
+> Implementation has not landed: only the v0 baseline (item 2) is built, so this
+> stays `Accepted` (not `Implemented`) until the work clears the Stage1 Readiness
+> Checklist end-to-end and self-hosts.
 
 ## 1. Summary
 
@@ -369,10 +371,10 @@ foundation — generic type constraints + monomorphization:
   reads the monomorphization-vs-width-tag tradeoff in its §3 (recommended end
   state (A) monomorphized bodies; (C) width-tagged descriptors as a no-generics
   interim).
-- **SFEP-0029** (this SFEP) shares the **closure-dispatch seam** with SFEP-0028
+- **SFEP-0030** (this SFEP) shares the **closure-dispatch seam** with SFEP-0028
   but is a **distinct feature**: SFEP-0028 is about array **element-type
   discipline** (threading typed elements through `sfn_array_sfn_*` runtime
-  bodies); SFEP-0029 is the **general function-value surface** (named fns,
+  bodies); SFEP-0030 is the **general function-value surface** (named fns,
   struct fields, general params) independent of arrays. They intersect at one
   point — both want non-pointer-width signatures through the seam — and that
   intersection is the shared generics gate. The width verdict here is

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -52,6 +52,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0027](./0027-cli-rss-modularization.md) | CLI Modularization — Per-Worker RSS Relief First, Then Migration | Accepted | tooling |
 | [0028](./0028-typed-array-higher-order-fns.md) | Typed / Generic-Element Array Higher-Order Functions (map / filter / reduce) | Draft | language |
 | [0029](./0029-lambda-syntax.md) | Lambda expression syntax for 1.0 — keep, reform, or defer | Accepted | language |
+| [0030](./0030-first-class-function-values.md) | First-Class Function Values | Accepted | language |
 
 ## Subdirectories
 


### PR DESCRIPTION
## What

Transitions the First-Class Function Values design record (merged as a Draft in #1686) from **Draft → Accepted**, and **renumbers it 0029 → 0030**.

- `git mv draft-first-class-function-values.md` → `0030-first-class-function-values.md`
- Front-matter: `sfep: TBD → 0030`, `status: Draft → Accepted`
- Header note updated to reflect the passed design gate (stays `Accepted`, **not** `Implemented` — only the v0 baseline/item 2 is built; it graduates after Stage1 + self-host)
- In-body self-references `SFEP-0029 → SFEP-0030`
- Registry row added to `docs/proposals/README.md`

## Why 0030, not 0029

`0029` was claimed concurrently by `0029-lambda-syntax.md` (#1684, resolving #690), which merged with its registry row. The First-Class Function Values draft merged as an *unnumbered* `draft-*.md` (correct for a Draft, so no file collision), but the number had to move. Next free number is **0030**.

## Design status

The design itself is complete — the four design-gate forks were resolved as committed, performance-first decisions (D1 branchless hybrid dispatch matching Go/Rust, D2 complete type-check coverage, D3 effect-row soundness, D4 deterministic seed-dependency directive) in §3.5 of the document (landed via #1686). This PR is the lifecycle/registry transition only.

## Next steps (after merge)

- `/groom` epic #1609 into XS/S/M sub-issues citing `Design: SFEP-0030`, applying the D4 bundle-default for #1172.
- Flip #1609 `needs-design` → `design-approved`.

Refs #1609, #1610, #1172

https://claude.ai/code/session_013m4f9w7y7tzSt3iPLf9o1C

---
_Generated by [Claude Code](https://claude.ai/code/session_013m4f9w7y7tzSt3iPLf9o1C)_