### PR TITLE
fix(effects): a cast must not hide its operand's effects (#1627)

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -870,6 +870,17 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
     if expression.variant == "Unary" {
         return collect_effects_from_expression(expression.operand, imports);
     }
+    if expression.variant == "Cast" {
+        // A cast's operand is the effectful surface: `fs.read(p) as * u8`
+        // performs the io of `fs.read` before the (zero-cost) reinterpret.
+        // Before #1627 a pointer/fn-typed cast target degraded the whole
+        // expression to `Raw` (effect-blind) and an identifier-typed cast
+        // (`... as int`) parsed as a structured `Cast` the checker never
+        // walked — both silently dropped the operand's effects. Walk the
+        // operand so the requirement surfaces; the target type carries no
+        // effect of its own.
+        return collect_effects_from_expression(expression.operand, imports);
+    }
     if expression.variant == "Binary" {
         let mut required = collect_effects_from_expression(expression.left, imports);
         required = merge_requirements(required, collect_effects_from_expression(expression.right, imports));

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -702,16 +702,50 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             if expression_tokens_is_at_end(after_as) {
                 return expression_parse_failure(state);
             }
-            let type_token = expression_tokens_peek(after_as);
+            // Collect a leading pointer prefix (`* T`, `** T`) so an
+            // effectful operand under a pointer cast (`fs.read(p) as * u8`)
+            // structures into `Cast` and stays effect-visible (#1627)
+            // instead of degrading the whole expression to an effect-blind
+            // `Raw`. Before #1627 the cast arm accepted only a bare
+            // `Identifier` target, so every `as * T` form (the dominant
+            // in-source cast spelling) fell through to a `Raw` the effect
+            // checker never walked. The target text is captured verbatim
+            // into `TypeAnnotation.text` — `"* i64"` — which the Cast
+            // formatter renders back as `(operand) as * i64`, byte-equivalent
+            // to the prior `Raw` text, so emit/lowering is unchanged.
+            // Generic / fn-pointer cast targets (`Result<T, E>`,
+            // `fn(A) -> B`) stay `Raw` for now (rare; tracked as a #1180
+            // follow-up); only the pointer prefix is lifted here.
+            let mut cast_cursor = after_as;
+            let mut cast_target_text: string = "";
+            loop {
+                if expression_tokens_is_at_end(cast_cursor) {
+                    return expression_parse_failure(state);
+                }
+                let star_token = expression_tokens_peek(cast_cursor);
+                if star_token.kind.variant != "Symbol" { break; }
+                if !strings_equal(star_token.lexeme, "*") { break; }
+                if cast_target_text.length > 0 {
+                    cast_target_text = cast_target_text + " ";
+                }
+                cast_target_text = cast_target_text + "*";
+                cast_cursor = expression_tokens_advance(cast_cursor);
+            }
+            if expression_tokens_is_at_end(cast_cursor) {
+                return expression_parse_failure(state);
+            }
+            let type_token = expression_tokens_peek(cast_cursor);
             if type_token.kind.variant != "Identifier" {
                 return expression_parse_failure(state);
             }
-            current_state = expression_tokens_advance(after_as);
+            if cast_target_text.length > 0 {
+                cast_target_text = cast_target_text + " ";
+            }
+            cast_target_text = cast_target_text + identifier_text(type_token);
+            current_state = expression_tokens_advance(cast_cursor);
             current_expression = Expression.Cast {
                 operand: current_expression,
-                target_type: TypeAnnotation {
-                    text: identifier_text(type_token)
-                }
+                target_type: TypeAnnotation { text: cast_target_text }
             };
             continue;
         }

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -707,18 +707,31 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             // structures into `Cast` and stays effect-visible (#1627)
             // instead of degrading the whole expression to an effect-blind
             // `Raw`. Before #1627 the cast arm accepted only a bare
-            // `Identifier` target, so every `as * T` form (the dominant
-            // in-source cast spelling) fell through to a `Raw` the effect
-            // checker never walked. The target text is captured verbatim
-            // into `TypeAnnotation.text` — `"* i64"` — which the Cast
-            // formatter renders back as `(operand) as * i64`, byte-equivalent
-            // to the prior `Raw` text, so emit/lowering is unchanged.
-            // Generic / fn-pointer cast targets (`Result<T, E>`,
+            // `Identifier` target, so every `as * T` form fell through to a
+            // `Raw` the effect checker never walked. The target text is
+            // captured verbatim into `TypeAnnotation.text` — `"* i64"` —
+            // which the Cast formatter renders back as `(operand) as * i64`,
+            // byte-equivalent to the prior `Raw` text, so emit/lowering is
+            // unchanged. Generic / fn-pointer cast targets (`Result<T, E>`,
             // `fn(A) -> B`) stay `Raw` for now (rare; tracked as a #1180
             // follow-up); only the pointer prefix is lifted here.
+            //
+            // CRUCIAL: lift a pointer target ONLY when the operand is NOT a
+            // bare `Identifier`. A bare identifier carries no effect, so the
+            // #1627 effect escapes (whose operands are calls/members) lose
+            // nothing — but `<fn> as * u8` (#1147 function references) and
+            // `<ptr-value> as * u8` (the dominant in-source spelling, e.g.
+            // `out as * u8`) keep their exact legacy `Raw` behavior:
+            // `check_fn_reference_raw`'s E0808/E0809 classification and the
+            // shadow-parser lowering are untouched. This avoids regressing
+            // the http-server trampoline `_sfn_http_trampoline as * u8`
+            // (concrete-but-struct-ABI fn, which the prior Raw path passed
+            // through) while still closing every effectful-operand escape.
             let mut cast_cursor = after_as;
             let mut cast_target_text: string = "";
+            let lift_pointer_target = current_expression.variant != "Identifier";
             loop {
+                if !lift_pointer_target { break; }
                 if expression_tokens_is_at_end(cast_cursor) {
                     return expression_parse_failure(state);
                 }

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -32,7 +32,6 @@ import {
     check_enum_variants,
     check_extern_signature,
     check_extern_var,
-    check_fn_reference_cast,
     check_fn_reference_raw,
     check_function_signature,
     check_interface_members,
@@ -1014,26 +1013,12 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         return diagnostics;
     }
     if expression.variant == "Cast" {
-        // #1147 / #1627: `<fn> as * u8` (and `<fn> as * fn(...) -> T`) is the
-        // one supported spelling that materializes a function's address as a
-        // C-ABI code pointer (#1146). Before #1627 a pointer cast target
-        // degraded the whole expression to `Raw`, so this classification ran
-        // in the `Raw` arm (`check_fn_reference_raw`); the #1627 parser lift
-        // now structures `as * T` into `Cast`, so it moves here. It MUST run
-        // before the operand recurse below — otherwise a bare function operand
-        // falls through to the `Identifier` arm and is mis-flagged E0808 even
-        // for the blessed concrete-C-ABI form. Only a bare function-identifier
-        // operand is a function reference; every other operand (an effectful
-        // call, a member access, …) recurses normally so its own diagnostics
-        // and effect attribution still fire.
-        if expression.operand.variant == "Identifier" {
-            let cast_fn_entry = find_symbol(bindings, expression.operand.name);
-            if cast_fn_entry != null {
-                if is_function_kind(cast_fn_entry.kind) {
-                    return check_fn_reference_cast(expression.operand.name, expression.target_type.text, cast_fn_entry.is_generic, cast_fn_entry.is_c_abi, expression.operand.span);
-                }
-            }
-        }
+        // The #1627 parser lift only structures a pointer cast target into
+        // `Cast` when the operand is NOT a bare identifier (effect-bearing
+        // operands only). A bare `<fn> as * u8` therefore stays `Raw` and is
+        // still classified by `check_fn_reference_raw` (E0808/E0809) below,
+        // so this arm needs no function-reference logic — it just recurses
+        // so the operand's own diagnostics still fire.
         return walk_expression(expression.operand, bindings, imports);
     }
     if expression.variant == "TryOperator" {

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -32,6 +32,7 @@ import {
     check_enum_variants,
     check_extern_signature,
     check_extern_var,
+    check_fn_reference_cast,
     check_fn_reference_raw,
     check_function_signature,
     check_interface_members,
@@ -1013,6 +1014,26 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         return diagnostics;
     }
     if expression.variant == "Cast" {
+        // #1147 / #1627: `<fn> as * u8` (and `<fn> as * fn(...) -> T`) is the
+        // one supported spelling that materializes a function's address as a
+        // C-ABI code pointer (#1146). Before #1627 a pointer cast target
+        // degraded the whole expression to `Raw`, so this classification ran
+        // in the `Raw` arm (`check_fn_reference_raw`); the #1627 parser lift
+        // now structures `as * T` into `Cast`, so it moves here. It MUST run
+        // before the operand recurse below — otherwise a bare function operand
+        // falls through to the `Identifier` arm and is mis-flagged E0808 even
+        // for the blessed concrete-C-ABI form. Only a bare function-identifier
+        // operand is a function reference; every other operand (an effectful
+        // call, a member access, …) recurses normally so its own diagnostics
+        // and effect attribution still fire.
+        if expression.operand.variant == "Identifier" {
+            let cast_fn_entry = find_symbol(bindings, expression.operand.name);
+            if cast_fn_entry != null {
+                if is_function_kind(cast_fn_entry.kind) {
+                    return check_fn_reference_cast(expression.operand.name, expression.target_type.text, cast_fn_entry.is_generic, cast_fn_entry.is_c_abi, expression.operand.span);
+                }
+            }
+        }
         return walk_expression(expression.operand, bindings, imports);
     }
     if expression.variant == "TryOperator" {

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -1840,43 +1840,6 @@ fn check_fn_reference_raw(text: string, symbols: SymbolEntry[], span: SourceSpan
     return [make_fn_value_position_diagnostic(head, span)];
 }
 
-// #1627: classify a STRUCTURED `<fn> as <type>` cast whose operand resolves
-// to a function. Before #1627 a pointer cast target (`as * u8`) degraded the
-// whole expression to `Raw` and the rule lived in `check_fn_reference_raw`
-// (above); the parser lift in #1627 now structures `as * T` into a `Cast`
-// node, so the pointer-target half of that rule moves here while the `Raw`
-// arm keeps the `& fn` form and any other degraded spellings. The blessed
-// C-ABI code-pointer forms (`* u8`, `* fn(...)`) are valid only for a
-// concrete C-ABI function (#1146): a generic or non-C-ABI function is E0809;
-// any other target — a non-pointer (`as i64`) or a typed data pointer
-// (`as * i32`, which would reinterpret a code address as a data pointer) —
-// is the unsupported value use E0808. The caller pre-resolves the operand to
-// a function symbol, so `is_generic` / `is_c_abi` come straight from the
-// `SymbolEntry`; `name`/`span` caret the diagnostic at the function head.
-fn check_fn_reference_cast(name: string, target_text: string, is_generic: boolean, is_c_abi: boolean, span: SourceSpan?) -> Diagnostic[] {
-    let target = trim_text(target_text);
-    if starts_with(target, "*") {
-        let pointee = trim_text(strip_prefix(target, "*"));
-        let mut blessed: boolean = false;
-        if strings_equal(pointee, "u8") { blessed = true; }
-        if starts_with(pointee, "fn ") { blessed = true; }
-        if starts_with(pointee, "fn(") { blessed = true; }
-        if blessed {
-            if is_generic {
-                return [make_fn_address_unsupported_diagnostic(name, "it is generic", span)];
-            }
-            if !is_c_abi {
-                return [make_fn_address_unsupported_diagnostic(name, "its signature is not C-ABI-compatible", span)];
-            }
-            return [];
-        }
-        // Typed data pointer (`as * i32`) — not a code-pointer form.
-        return [make_fn_value_position_diagnostic(name, span)];
-    }
-    // Non-pointer target (`as i64`) — unsupported value use.
-    return [make_fn_value_position_diagnostic(name, span)];
-}
-
 fn has_symbol_in_range(symbols: SymbolEntry[], name: string, start: int) -> boolean {
     let mut _si: int = start;
     loop {

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -1840,6 +1840,43 @@ fn check_fn_reference_raw(text: string, symbols: SymbolEntry[], span: SourceSpan
     return [make_fn_value_position_diagnostic(head, span)];
 }
 
+// #1627: classify a STRUCTURED `<fn> as <type>` cast whose operand resolves
+// to a function. Before #1627 a pointer cast target (`as * u8`) degraded the
+// whole expression to `Raw` and the rule lived in `check_fn_reference_raw`
+// (above); the parser lift in #1627 now structures `as * T` into a `Cast`
+// node, so the pointer-target half of that rule moves here while the `Raw`
+// arm keeps the `& fn` form and any other degraded spellings. The blessed
+// C-ABI code-pointer forms (`* u8`, `* fn(...)`) are valid only for a
+// concrete C-ABI function (#1146): a generic or non-C-ABI function is E0809;
+// any other target — a non-pointer (`as i64`) or a typed data pointer
+// (`as * i32`, which would reinterpret a code address as a data pointer) —
+// is the unsupported value use E0808. The caller pre-resolves the operand to
+// a function symbol, so `is_generic` / `is_c_abi` come straight from the
+// `SymbolEntry`; `name`/`span` caret the diagnostic at the function head.
+fn check_fn_reference_cast(name: string, target_text: string, is_generic: boolean, is_c_abi: boolean, span: SourceSpan?) -> Diagnostic[] {
+    let target = trim_text(target_text);
+    if starts_with(target, "*") {
+        let pointee = trim_text(strip_prefix(target, "*"));
+        let mut blessed: boolean = false;
+        if strings_equal(pointee, "u8") { blessed = true; }
+        if starts_with(pointee, "fn ") { blessed = true; }
+        if starts_with(pointee, "fn(") { blessed = true; }
+        if blessed {
+            if is_generic {
+                return [make_fn_address_unsupported_diagnostic(name, "it is generic", span)];
+            }
+            if !is_c_abi {
+                return [make_fn_address_unsupported_diagnostic(name, "its signature is not C-ABI-compatible", span)];
+            }
+            return [];
+        }
+        // Typed data pointer (`as * i32`) — not a code-pointer form.
+        return [make_fn_value_position_diagnostic(name, span)];
+    }
+    // Non-pointer target (`as i64`) — unsupported value use.
+    return [make_fn_value_position_diagnostic(name, span)];
+}
+
 fn has_symbol_in_range(symbols: SymbolEntry[], name: string, start: int) -> boolean {
     let mut _si: int = start;
     loop {

--- a/compiler/tests/unit/effect_cast_operand_test.sfn
+++ b/compiler/tests/unit/effect_cast_operand_test.sfn
@@ -54,24 +54,37 @@ fn _cast_reqs(snippet: string) -> EffectRequirement[] ![io] {
 }
 
 // -------------------------------------------------------------------
-// Structural lift: `<operand> as * T` parses to a `Cast`, not a `Raw`.
+// Structural lift: a pointer cast over an EFFECT-BEARING operand
+// (a call/member) parses to a `Cast`, not a `Raw`.
 // -------------------------------------------------------------------
-test "cast: pointer-typed target structures into Cast (not Raw)" ![io] {
-    let expr = _probe_expr("p as * i64");
+test "cast: pointer-typed target over a call structures into Cast (not Raw)" ![io] {
+    let expr = _probe_expr("fs.read(p) as * i64");
     assert expr.variant == "Cast";
     assert expr.target_type.text == "* i64";
 }
 
-test "cast: double-pointer target structures into Cast" ![io] {
-    let expr = _probe_expr("p as * * u8");
+test "cast: double-pointer target over a call structures into Cast" ![io] {
+    let expr = _probe_expr("fs.read(p) as * * u8");
     assert expr.variant == "Cast";
     assert expr.target_type.text == "* * u8";
 }
 
-test "cast: identifier-typed target is a Cast" ![io] {
+test "cast: identifier-typed target is a Cast (any operand)" ![io] {
     let expr = _probe_expr("p as int");
     assert expr.variant == "Cast";
     assert expr.target_type.text == "int";
+}
+
+// The pointer-cast lift is deliberately gated to NON-identifier operands so
+// `<fn> as * u8` / `<ptr-value> as * u8` keep their legacy `Raw` path — this
+// preserves the #1147 function-reference diagnostics and the shipped
+// http-server trampoline (`_sfn_http_trampoline as * u8`, a concrete fn with
+// a struct-ABI signature the prior `Raw` path passed through). A bare
+// identifier carries no effect, so nothing is lost for #1627. Pin the gate so
+// a future change can't silently lift it and re-break the trampoline.
+test "cast: bare-identifier pointer cast stays Raw (fn-reference gate)" ![io] {
+    let expr = _probe_expr("p as * i64");
+    assert expr.variant == "Raw";
 }
 
 // -------------------------------------------------------------------
@@ -91,7 +104,9 @@ test "cast: pointer-typed cast surfaces operand net" ![io] {
 
 // -------------------------------------------------------------------
 // No false positive: an effect-free cast requires nothing. The bare
-// pointer-cast case is the self-host canary — hundreds of in-source sites.
+// pointer-cast `p as * i64` is the dominant in-source spelling (hundreds
+// of sites); it stays `Raw` (effect-blind) and is left exactly as before
+// #1627 — so it contributes no effect and lowers unchanged (self-host).
 // -------------------------------------------------------------------
 test "cast: effect-free pointer cast requires nothing (self-host canary)" ![io] {
     let reqs = _cast_reqs("p as * i64");

--- a/compiler/tests/unit/effect_cast_operand_test.sfn
+++ b/compiler/tests/unit/effect_cast_operand_test.sfn
@@ -1,0 +1,104 @@
+// #1627 — a cast must not hide its operand's effects.
+//
+// After #1186 deleted `collect_effects_from_text`, the two AST nodes the
+// effect checker cannot resolve structurally (`Expression.Raw`,
+// `Statement.Unknown`) contribute ZERO effects. A cast `<operand> as <type>`
+// is a zero-cost reinterpret whose OPERAND is the effectful surface:
+// `print.info(x) as int` performs the `io` of `print.info` before the cast.
+// Two pre-#1627 holes let that effect escape silently:
+//
+//   1. An identifier-typed cast (`... as int`) parsed as a structured
+//      `Cast` node the effect checker never walked (no `Cast` arm) — so the
+//      operand's effects were dropped.
+//   2. A pointer-typed cast (`... as * u8`) was rejected by the cast arm
+//      (which accepted only a bare `Identifier` target) and degraded the
+//      WHOLE expression to an effect-blind `Raw`.
+//
+// Confirmed live before the fix: `print.info(x) as * i64` passed `sfn check`
+// with no `![io]` declared AND fired the side effect at runtime.
+//
+// This pins both halves: (a) the parser now structures `as * T` into `Cast`
+// (no `Raw` degradation), and (b) `collect_effects_from_expression` walks a
+// `Cast` operand so the requirement surfaces. The effect-free canary guards
+// against a false positive on the dominant in-source spelling — bare pointer
+// casts (`p as * i64`), of which the compiler/runtime source has hundreds; a
+// false positive there would break self-host.
+import { Expression } from "../../src/ast";
+import { EffectRequirement, collect_effects_from_expression } from "../../src/effect_checker";
+import { empty_import_symbols } from "../../src/effect_imports";
+import { parse_program } from "../../src/parser/mod";
+
+fn _probe_expr(snippet: string) -> Expression ![io] {
+    let program = parse_program("fn probe() { " + snippet + "; }");
+    assert program.statements.length >= 1;
+    let fn_stmt = program.statements[0];
+    assert fn_stmt.variant == "FunctionDeclaration";
+    assert fn_stmt.body.statements.length >= 1;
+    let stmt = fn_stmt.body.statements[0];
+    assert stmt.variant == "ExpressionStatement";
+    return stmt.expression;
+}
+
+fn _reqs_contain(reqs: EffectRequirement[], effect: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= reqs.length { break; }
+        if reqs[index].effect == effect { return true; }
+        index += 1;
+    }
+    return false;
+}
+
+fn _cast_reqs(snippet: string) -> EffectRequirement[] ![io] {
+    return collect_effects_from_expression(_probe_expr(snippet), empty_import_symbols());
+}
+
+// -------------------------------------------------------------------
+// Structural lift: `<operand> as * T` parses to a `Cast`, not a `Raw`.
+// -------------------------------------------------------------------
+test "cast: pointer-typed target structures into Cast (not Raw)" ![io] {
+    let expr = _probe_expr("p as * i64");
+    assert expr.variant == "Cast";
+    assert expr.target_type.text == "* i64";
+}
+
+test "cast: double-pointer target structures into Cast" ![io] {
+    let expr = _probe_expr("p as * * u8");
+    assert expr.variant == "Cast";
+    assert expr.target_type.text == "* * u8";
+}
+
+test "cast: identifier-typed target is a Cast" ![io] {
+    let expr = _probe_expr("p as int");
+    assert expr.variant == "Cast";
+    assert expr.target_type.text == "int";
+}
+
+// -------------------------------------------------------------------
+// Effect attribution: a cast walks its operand.
+// -------------------------------------------------------------------
+test "cast: identifier-typed cast surfaces operand io" ![io] {
+    assert _reqs_contain(_cast_reqs("print.info(\"x\") as int"), "io");
+}
+
+test "cast: pointer-typed cast surfaces operand io" ![io] {
+    assert _reqs_contain(_cast_reqs("fs.read(p) as * u8"), "io");
+}
+
+test "cast: pointer-typed cast surfaces operand net" ![io] {
+    assert _reqs_contain(_cast_reqs("http.get(\"u\") as * u8"), "net");
+}
+
+// -------------------------------------------------------------------
+// No false positive: an effect-free cast requires nothing. The bare
+// pointer-cast case is the self-host canary — hundreds of in-source sites.
+// -------------------------------------------------------------------
+test "cast: effect-free pointer cast requires nothing (self-host canary)" ![io] {
+    let reqs = _cast_reqs("p as * i64");
+    assert reqs.length == 0;
+}
+
+test "cast: effect-free numeric cast requires nothing" ![io] {
+    let reqs = _cast_reqs("5 as int");
+    assert reqs.length == 0;
+}

--- a/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
+++ b/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
@@ -1,0 +1,250 @@
+# Design note — #1627: fail-closed enforcement for effect-opaque `Raw` / `Unknown` nodes
+
+- **Issue:** #1627 (effect-system hardening)
+- **Epic:** #1180
+- **Design record extended:** SFEP-0008 (`docs/proposals/0008-effect-validation.md`)
+- **Author:** agent:compiler-architect
+- **Status:** Draft (single-issue design gate; not a new SFEP)
+- **Date:** 2026-06-26
+- **Decision:** **Structural lift (root fix)** chosen at the design gate. The
+  earlier text-anchor "floor" (`_raw_contains_effectful_anchor`) is **superseded**
+  and retained below only as the analysis that led to the root-fix decision.
+
+## Shipped in #1627 (actual scope)
+
+Implementation narrowed the PR to the **cast-shaped effect escape** — the
+demonstrated headline hole (`print.info(x) as * i64` fired at runtime with no
+`![io]`) and its `as int` sibling — because the other constructs each carry a
+distinct, larger blast radius that warrants its own tested PR (see the revised
+split below). Delivered:
+
+1. **`Cast` effect arm** (`effect_checker.sfn::collect_effects_from_expression`)
+   — walks the cast operand, so `<effectful> as <type>` surfaces the operand's
+   effects. Closes the `as int` escape alone.
+2. **Pointer cast-target parsing** (`parser/expressions.sfn`, the `as` postfix
+   arm) — `<operand> as * T` / `* * T` now structures into `Cast` with
+   `target_type.text = "* T"` instead of degrading to `Raw`. The formatter emits
+   the identical `(operand) as * T` text the lowering shadow parser already
+   consumes, so the **745 in-source `as *T` casts lower unchanged** (proven by
+   `make compile`).
+3. **fn-reference-cast migration** (`typecheck.sfn` `Cast` arm +
+   `typecheck_types.sfn::check_fn_reference_cast`) — *required* by (2): once
+   `<fn> as * u8` structures into `Cast`, the E0808/E0809 classification that
+   lived in the `Raw` arm (`check_fn_reference_raw`) had to move onto the `Cast`
+   arm and run **before** the operand recurse, else the blessed concrete-C-ABI
+   form (`worker as * u8`, #1146) is mis-flagged E0808. Verified against the full
+   `fn_reference_typecheck_test` matrix.
+4. Regression coverage: `compiler/tests/unit/effect_cast_operand_test.sfn`
+   (structural lift + effect attribution + the effect-free 745-canary).
+
+**Not shipped here — filed as #1180 sub-issues:** prefix `*`/`&` → `Unary`,
+ternary → `Conditional`, the blanket `E0818` `Raw` backstop (it requires
+structuring *every* Raw-lowerable shape first), and the `E0817` `Unknown` arm
+(cleaner at the parser production site). The full staged design (A/B/C/D/E)
+below is retained as the roadmap those sub-issues execute against.
+
+## Problem
+
+After #1186 deleted `collect_effects_from_text`, two AST nodes the effect
+checker cannot resolve structurally contribute **zero effects, silently**:
+
+- `Expression.Raw` — `collect_effects_from_expression`
+  (`effect_checker.sfn:735`) has no `"Raw"` arm and falls through to `return []`
+  (`:980`).
+- `Statement.Unknown` — `collect_effects_from_statement`
+  (`effect_checker.sfn:531`) has no `"Unknown"` arm and falls through to
+  `return []` (`:621`).
+
+Reproduced and confirmed **live end to end** (`build/native/sailfin` 0.7.0-alpha.49):
+`fn f() { let x = print.info("hi") as * i64; }` passes `sfn check` (exit 0) with
+and without `SAILFIN_EFFECT_ENFORCE=1`, **and fires the side effect at runtime**
+(`[info] SIDE EFFECT FIRED`, run exits 0). An effectful operation reaches codegen
+with no declared capability — a fail-open hole in the effects pillar.
+
+## Root cause — the lowering shadow parser and the structured-parser gaps
+
+The `.sfn-asm` pipeline is **AST → `format_expression_into` (serialize to text,
+`emit_native_format.sfn`) → LLVM lowering re-parse**. The lowering layer
+(`llvm/expression_lowering/native/core.sfn:2120-2600+`) is a *complete second
+expression parser* operating on text: ternary, cast, raw_address, borrow,
+logical/bitwise/comparison/shift/additive/multiplicative precedence climbing,
+prefix `!`/`*`, member, index, call (re-parse helpers in
+`llvm/expressions_parsing.sfn` and `core_parsing.sfn`). Crucially, the formatter
+serializes **structured** nodes back to text too (e.g. `Cast` →
+`(operand) as <type>` at `emit_native_format.sfn:192-201`), so the shadow parser
+is fed by the formatter for every expression — it is not a `Raw`-only path.
+
+`Raw` (and the effect-escape) only arises where the **front-end structured
+parser fails** and degrades to `Raw` (`parser/expressions.sfn:271,278`), OR where
+a node parses structurally but the **effect checker has no arm** for it. The
+effect-escaping set is **small, enumerable, and was measured directly** (probe:
+wrap `print.info(...)` in each construct and check whether `![io]` is required):
+
+| Construct | Node produced | Why effects escape | Probe result |
+|---|---|---|---|
+| `print.info(x)` | `Member`/`Call` | — (correctly errors) | error (baseline) |
+| `(print.info(x))` | structured | — (correctly errors) | error |
+| `print.info(x) + 1`, `== 1`, `[i]` | structured | — (correctly errors) | error |
+| **`print.info(x) as int`** | **`Cast`** (`ast.sfn:95`) | effect checker has **no `"Cast"` arm** → `[]` | **ok (escaped)** |
+| **`print.info(x) as * i64`** | **`Raw`** | cast arm rejects non-ident target (`expressions.sfn:706-708`) | **ok (escaped)** |
+| **`print.info(x) ? 1 : 2`** | **`Raw`** | no ternary in structured parser | **ok (escaped)** |
+| **`*print.info(x)`** | **`Raw`** | prefix parser handles only `-`/`!` (`expressions.sfn:369-387`) | **ok (escaped)** |
+| **`&print.info`** | **`Raw`** | prefix parser handles only `-`/`!` | **ok (escaped)** |
+
+So the "structural lift" is **bounded** — not "reimplement the shadow parser."
+It is exactly: (1) add a `Cast` arm to the effect checker; (2) let the cast arm
+parse pointer/fn cast targets so `as *T` structures into `Cast` instead of `Raw`;
+(3) structure prefix `*` (deref) and `&` (address-of) into `Unary` (already
+effect-walked, `effect_checker.sfn:870`); (4) structure ternary `? :` into a node
+the effect checker walks. After that, every remaining `Raw` reaching the effect
+checker is genuinely unlowerable junk, so a **blanket fail-closed `Raw` arm is
+self-host-clean** (zero in-source false positives) and honors the "no text
+inspection" constraint.
+
+**Why this is IR-safe by construction:** the formatter already serializes
+structured nodes to the exact text the shadow parser consumes (`Cast` →
+`(op) as <target.text>`). A newly-structured `Cast{operand, target_type.text="* i64"}`
+serializes to `(print.info(...)) as * i64` — *the same text the lowering
+`parse_cast_expression` handles today*. Structuring the node changes **what the
+effect checker sees**, not what the lowering re-parser receives. The 745 in-source
+`as *T` casts lower through the identical text path before and after.
+
+## The constraint that ruled out the cheaper fixes (retained analysis)
+
+A blanket "any non-empty `Raw` is an error" check applied **before** the
+structural lift is wrong and breaks self-host: `Raw` is overloaded as the valid
+"lowering knows how" channel for `as *T` casts (745 in-source sites,
+`grep "as \* " compiler/src runtime` excluding tests), `& fn` /
+`<fn> as *T` (`check_fn_reference_raw`, `typecheck_types.sfn:1785`), and
+member/index chains. There are only four `Expression.Raw` producers in the parser
+(`grep Expression.Raw compiler/src/parser`): `expressions.sfn:75` (the
+`success:false` placeholder, never a real node) and `:257,271,278` (the three
+`expression_from_tokens` failure paths). The valid casts flow through the *same*
+`:271`/`:278` paths as the junk, so **parser-site promotion or a pre-lift blanket
+`Raw` check cannot distinguish them** — the distinction is only made by the
+lowering re-parse. This is precisely why the fix must first *remove the overload*
+(structure the valid shapes) and only then blanket-fail-close.
+
+The earlier **text-anchor floor** (`_raw_contains_effectful_anchor` →
+conservative `E0818` only when the Raw text contains an effectful builtin call
+anchor) was the self-host-clean option *without* the structural lift. It is
+**superseded** by the gate decision in favor of the root fix, because the floor
+leaves the `Raw` overload in place (and re-parse divergence latent) whereas the
+lift eliminates it. The floor's analysis is what proved the lift is bounded and
+safe, so it is retained here for the record.
+
+## Design — the structural lift
+
+### AST (`compiler/src/ast.sfn`)
+
+- **`Cast`** already exists (`:95`): `Cast { operand: Expression, target_type: TypeAnnotation }`. No change needed; `target_type.text` is a free-form string that can hold `* i64` / `* fn(i64) -> i64`.
+- **Prefix `*` / `&`** reuse **`Unary`** (`:66`): `Unary { operator: string, operand: Expression }` with `operator ∈ {"*", "&"}`. The effect checker's `Unary` arm (`:870`) already walks the operand, and the formatter's `Unary` arm (`emit_native_format.sfn:108`) already serializes `<op>operand` text the shadow parser's prefix-`*` / borrow handlers consume. **Verify** the formatter emits `&`/`*` prefixes in the exact spelling `parse_borrow_expression` (`&x`) and the `*`-deref handler (`core.sfn:2281`) expect; if the existing `Unary` formatter only covers `-`/`!`, extend it to pass `&`/`*` through verbatim.
+- **Ternary** — no node exists. Add **`Conditional { condition: Expression, then_value: Expression, else_value: Expression, span: SourceSpan? }`**. The formatter serializes it as `(condition) ? (then) : (else)` to match the shadow `parse_ternary_expression` (`expressions_parsing.sfn:455`), which scans for top-level `?`/`:`. The effect checker walks all three children (merge). (Alternatively, if a smaller surface is preferred, ternary can stay deferred to #1180-a and #1627 ships casts + prefix `*`/`&` only — see Staging.)
+
+### Parser (`compiler/src/parser/expressions.sfn`)
+
+- **Cast target** (`:700-717`): replace the single-`Identifier`-only target read with a small type-target reader that accepts pointer (`* T`, `* fn(...) -> T`) and bare-identifier targets, capturing the full target text into `TypeAnnotation.text`. On success build `Expression.Cast`; only genuinely unparseable targets fall through to `expression_parse_failure`. Reuse the existing type-annotation parsing path (the same one that parses `let p: * i64`) so `* i64` / `* fn(...) -> T` spellings stay in lockstep with type-annotation grammar.
+- **Prefix `*` / `&`** (`parse_prefix_expression`, `:369-387`): extend the symbol set from `{-, !}` to `{-, !, *, &}`, building `Expression.Unary { operator: sym, operand: <parsed at unary_precedence()> }`. The binary `&`/`*` handlers (`binary_precedence` `:1566/:1586`) are unaffected — they only apply in infix position, which `parse_prefix_expression` is not.
+- **Ternary** (only if included in #1627): after the precedence-climbing loop yields `left`, peek for a top-level `?`; if present, parse `then`, expect `:`, parse `else`, build `Conditional`. Lowest precedence, so it wraps the whole climbed expression.
+
+### Lowering (`emit_native_format.sfn` + `llvm/...`)
+
+- **`Cast`** already serializes (`:192-201`) and lowers (`parse_cast_expression` → `lower_cast_expression`, `core.sfn:2189-2191`). The only change is upstream (parser now produces `Cast` for `as *T` where it produced `Raw`), and the serialized text is identical, so **no lowering change** is required for casts.
+- **`Unary` `*`/`&`**: confirm/extend the `Unary` formatter (`:108`) to emit `*operand` / `&operand`; the shadow parser already lowers `*x` (`core.sfn:2281`) and `&x` (`parse_borrow_expression`). **No new lowering arm** — reuse existing.
+- **`Conditional`**: add a formatter arm emitting `(cond) ? (then) : (else)`; lowering already handles it via `parse_ternary_expression` (`core.sfn:2184-2186`). **No new lowering arm.**
+
+The migration is therefore **front-end-only for casts and prefix ops** — the lowering text path is untouched; we only stop feeding it `Raw` and start feeding it the *same text* serialized from a structured node.
+
+### Effect checker (`compiler/src/effect_checker.sfn`)
+
+- Add **`Cast` arm** in `collect_effects_from_expression` (before `:980`): `return collect_effects_from_expression(expression.operand, imports)`. This alone closes the `as int` escape immediately (independent of the parser work).
+- `Unary` arm (`:870`) already covers prefix `*`/`&` once the parser emits `Unary`.
+- Add **`Conditional` arm** (if shipped): merge effects of `condition`, `then_value`, `else_value`.
+- **Blanket fail-closed `Raw` arm** (before `:980`), enabled **only after** the lift lands: any non-empty `Raw` reaching here is unlowerable → emit **`E0818`** ("unstructured expression cannot be analyzed; rewrite so the compiler can parse it"). Empty `Raw{text:""}` returns `[]` (never effectful). The typecheck `Raw` arm's `check_fn_reference_raw` (`typecheck.sfn:1072`) stays as-is for `&fn`/`fn as *T` E0808/E0809 — but note those `&fn` spellings now structure into `Unary`, so re-confirm `check_fn_reference_raw` still receives the inputs it expects (see Risks).
+- Add **`Unknown` arm** in `collect_effects_from_statement` (before `:621`): emit **`E0817`** ("unparseable statement reached analysis"), gated so it does not double-fire when the typecheck Unknown arm (`typecheck.sfn:645-660`) already minted removed-AI-keyword / `E0411`, i.e. fire only when `detect_removed_ai_keyword(text).length == 0 && detect_unsupported_statement_keyword(text).length == 0`. Top-level `E0500` (`tools/check.sfn:165`) is on a disjoint node position.
+
+### Diagnostics
+
+Add `make_effectful_raw_diagnostic` (`E0818`) and `make_unparseable_statement_diagnostic` (`E0817`), mirroring `make_parse_error_diagnostic` (`typecheck_types.sfn:573-586`). Surface via the effect-diagnostic stream (so `SAILFIN_EFFECT_ENFORCE`/`[kind: effect]` rendering applies) or, for `E0818`, co-locate in the typecheck `Raw` arm (`typecheck.sfn:1072`) — the implementer picks the site that matches the acceptance criteria's enforcement-gating expectations.
+
+## Staging (each gate self-hosts or at least `sfn check`s)
+
+**Stage A — structure casts + add Cast effect arm (the headline fix).**
+1. Effect checker: add `Cast` arm (walk operand). Closes `as int` escape.
+2. Parser: extend cast target to accept `* T` / `* fn(...)` → `Cast` instead of `Raw`.
+3. No lowering change (serialized text identical).
+- **Gate:** `make compile` then IR-diff a sampling of in-source `as *T` casts (see Verification). `sfn check` of the Stage-A probe (`print.info(x) as * i64`) must now require `![io]`.
+
+**Stage B — structure prefix `*` / `&` into `Unary`.**
+4. Parser: add `*`,`&` to `parse_prefix_expression`. Formatter: ensure `Unary` emits `*`/`&` verbatim.
+- **Gate:** `make compile` + IR-diff in-source `*ptr` / `&x` sites; effect probe for `*print.info(x)` / `&print.info` (the `&fn` value-use should now route through `Unary`→`check`; confirm `check_fn_reference_raw` coverage is preserved or migrated — Risks).
+
+**Stage C — (optional) structure ternary into `Conditional`.** Parser + formatter + effect arm. Gate as above. *May defer to #1180-a if it widens blast radius.*
+
+**Stage D — blanket fail-closed `Raw` arm (`E0818`).** Only after A–C land and `make compile` is green: flip the `Raw` arm from `[]` to `E0818` for non-empty text.
+- **Gate:** `make compile` MUST stay green — this is the self-host proof that no in-source `Raw` survives. If it fails, the failing site names a construct still degrading to `Raw` that A–C missed; structure it (or, if it is genuine junk in source, fix the source).
+
+**Stage E — `Unknown` arm (`E0817`) + tests + docs.** Independent of A–D; can land in the same PR.
+
+Stages A+B+D+E are the recommended #1627 scope; **C (ternary) defers to #1180-a if it proves to widen the diff.** All stages ship in **one PR** (bundle): `make compile` builds the new compiler from the old seed and that compiler compiles the runtime/compiler in the same pass — **no seed cut** (per `seed-dependency.md`).
+
+## Self-host risk + evidence
+
+- **Casts (Stage A):** IR-safe by construction — `Cast` serializes to the identical `(op) as <type>` text the shadow parser already lowers; the 745 in-source `as *T` sites are untouched in the lowering text path. Verified `Cast` already round-trips through `emit_native_format.sfn:192-201`.
+- **Prefix `*`/`&` (Stage B):** `Unary` already serializes and the shadow parser already lowers `*x`/`&x`. **Residual risk:** `&fn` value-uses currently reach `check_fn_reference_raw` via `Raw`; once `&` structures into `Unary`, that diagnostic input changes. Mitigation: migrate the `&fn`/`fn as *T` E0808/E0809 detection to operate on the structured `Unary`/`Cast` (cleaner) OR keep `check_fn_reference_raw` reachable for the residual `fn as *T` Raw forms. **Must be verified by `make check`** — the `fn`-reference tests (`typecheck` E0808/E0809 coverage) are the canary.
+- **Blanket `Raw` (Stage D):** self-host-clean **iff** A–C structured every in-source effect-escaping shape. The `make compile` gate at Stage D is the empirical proof; a failure is a precise, actionable signal (names the unstructured construct). The closure-pair `Raw` marker (`lambda_lowering.sfn:957`) is created **after** typecheck/effect-check, so the Stage-D arm never sees it — confirmed.
+- **`Unknown` (Stage E):** zero in-source nodes. No `"Unknown"` arm exists in LLVM lowering (`grep` shows arms only in `emitter_sailfin*.sfn`, the `fmt` round-trip, not codegen), so a nested in-source Unknown would be silently dropped and manifest as missing functionality; the tree self-hosts, so none exist. Top-level Unknown already errors via `E0500`.
+
+## Verification (commands)
+
+- IR-diff harness (Stage A/B): for a sampling of in-source cast/prefix sites (e.g. `runtime/sfn/array.sfn`, `concurrency/scheduler.sfn`), capture `sfn build --emit-llvm` (or the `.ll` under the build cache) **before** and **after** the parser change and assert byte-identical IR for the affected functions. Drive from an `![io]` `*_test.sfn` via `process.run_capture` + `clang`/`diff`, per `.claude/rules/no-bash-e2e.md`.
+- `make compile` after each stage; `make check` before declaring shipped.
+- Effect probes (the measured table above) as e2e assertions.
+
+## Regression test plan
+
+1. `effect_cast_operand_walk_test.sfn` — `print.info(x) as int` and `as * i64` without `![io]` → `E04xx` ![io] required (Stage A headline).
+2. `effect_cast_pointer_clean_test.sfn` — `out as * i64`, `(p as i64 + 16) as * i64` (no effectful operand) → no diagnostic (745-population/self-host canary).
+3. `effect_prefix_deref_addr_test.sfn` — `*print.info(x)`, `&print.info` → effect required / fn-value diagnostic preserved (Stage B; pins the `&fn` migration).
+4. `cast_ir_identity_test.sfn` — IR-diff a representative in-source `as *T` cast before/after; assert identical (migration-safety).
+5. `effect_raw_failclosed_test.sfn` — a genuinely unlowerable expression (post-lift) → `E0818`; and a valid structured expression → clean (Stage D).
+6. `effect_unknown_block_level_test.sfn` — nested `@@@ junk !!!` → `E0817`; top-level `@@@` still `E0500`; `while(){}` still `E0411` (dedup proof).
+7. `effect_raw_negative_substring_test.sfn` — Raw/structured text mentioning `print` as a non-call substring → no `E0818` (proves no text-scan re-introduction).
+
+Self-host gate: `make compile` + `make check`.
+
+## Final sub-issue split under epic #1180
+
+- **#1627 (this PR), size M — SHIPPED: casts only.** `Cast` effect arm, `as *T`
+  cast-target parse, the fn-reference-cast migration (E0808/E0809), diagnostics
+  reuse, and `effect_cast_operand_test`. Bundled (no seed cut). Closes the
+  demonstrated cast-shaped effect escape; the constructs below are now tracked
+  follow-ons rather than part of this PR.
+- **#1180-a "Structure ternary `? :` into a `Conditional` AST node" — M.**
+  `cond ? readFile() : x` degrades to `Raw` and escapes `![io]` (confirmed live).
+  Needs a new `Conditional` node + `?`/`:` lookahead disambiguation that does
+  **not** regress postfix `TryOperator` (`a()?`, used throughout compiler source —
+  a regression breaks self-host), formatter (→ `cond ? a : b`, shadow parser
+  already lowers it), effect arm. Self-contained but precedence-delicate; its own
+  tested PR. Cite SFEP-0008.
+- **#1180-b "Parser-level parse diagnostic at `Unknown` production sites" — S.**
+  A nested `Statement.Unknown` (unparseable statement inside a block) is silently
+  dropped — no diagnostic, no effects; top-level gets `E0500`, nested gets
+  nothing. Promote `parse_unknown`/`parse_unknown_statement` call sites
+  (`declarations.sfn:1793`, `statements.sfn:1511`) to record a parse diagnostic
+  with a precise span (analog of `ParseError`, #1531), gated to avoid
+  double-firing with `E0500`/`E0411`/removed-keyword. Cleaner than threading a
+  top-level flag through the shared `check_statement` walker. Cite SFEP-0008.
+- **#1180-c "Retire the lowering shadow expression parser; structure remaining
+  Raw-lowerable forms + blanket `Raw` fail-closed (`E0818`)" — L (epic-sized).**
+  Structure the residual valid-but-`Raw` constructs (prefix `*`/`&` deref/addr —
+  prefix `&` interacts with `check_fn_reference_raw`'s `& fn` E0808 path; assign-
+  as-expression; generic/fn-pointer cast targets) and lower structured nodes
+  directly instead of serializing to text and re-parsing in `core.sfn`. Only once
+  **no** valid construct degrades to `Raw` can the blanket `E0818` `Raw` arm be
+  enabled self-host-clean (the defense-in-depth that catches unknown/future
+  escapes). Also a build-perf win (removes the 745-site text re-parse). Cite
+  SFEP-0008 and `0006-build-architecture.md`.
+- **#1180-d "Stale-comment cleanup for retired text-scan effect path" — XS.**
+  `effect_checker.sfn:60`/`:461` still reference the "text-pattern (Raw body)
+  path" deleted in #1186. Audit `effect_checker.sfn`/SFEP-0008.

--- a/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
+++ b/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
@@ -21,21 +21,31 @@ split below). Delivered:
 1. **`Cast` effect arm** (`effect_checker.sfn::collect_effects_from_expression`)
    — walks the cast operand, so `<effectful> as <type>` surfaces the operand's
    effects. Closes the `as int` escape alone.
-2. **Pointer cast-target parsing** (`parser/expressions.sfn`, the `as` postfix
-   arm) — `<operand> as * T` / `* * T` now structures into `Cast` with
-   `target_type.text = "* T"` instead of degrading to `Raw`. The formatter emits
-   the identical `(operand) as * T` text the lowering shadow parser already
-   consumes, so the **745 in-source `as *T` casts lower unchanged** (proven by
-   `make compile`).
-3. **fn-reference-cast migration** (`typecheck.sfn` `Cast` arm +
-   `typecheck_types.sfn::check_fn_reference_cast`) — *required* by (2): once
-   `<fn> as * u8` structures into `Cast`, the E0808/E0809 classification that
-   lived in the `Raw` arm (`check_fn_reference_raw`) had to move onto the `Cast`
-   arm and run **before** the operand recurse, else the blessed concrete-C-ABI
-   form (`worker as * u8`, #1146) is mis-flagged E0808. Verified against the full
-   `fn_reference_typecheck_test` matrix.
+2. **Pointer cast-target parsing, gated to effect-bearing operands**
+   (`parser/expressions.sfn`, the `as` postfix arm) — `<operand> as * T` / `* * T`
+   structures into `Cast` (with `target_type.text = "* T"`, which the formatter
+   renders back to the identical `(operand) as * T` text the shadow parser
+   already lowers) **only when the operand is NOT a bare `Identifier`**. A bare
+   identifier carries no effect, so the #1627 escapes (operands are calls/members)
+   lose nothing, while `<fn> as * u8` and the dominant in-source `<ptr-value> as
+   * u8` spelling keep their exact legacy `Raw` path — fn-reference diagnostics
+   and lowering untouched.
+3. **The gate (item 2) replaced an earlier fn-reference-cast migration.** First
+   attempt structured *every* `<operand> as * T` into `Cast` and moved the
+   E0808/E0809 classification onto the `Cast` arm (`check_fn_reference_cast`).
+   CI surfaced a regression: the shipped http-server trampoline
+   `_sfn_http_trampoline as * u8` (`capsules/sfn/http/src/server.sfn:142`) is a
+   **concrete** function whose `fn(OwnedBuf) -> OwnedBuf` signature is struct-ABI,
+   not C-ABI-primitive — so `signature_is_c_abi` is false and the migrated check
+   newly flagged it E0809. The prior `Raw` path had never flagged it (it sits as
+   a call argument, so the whole call was `Raw` and `check_fn_reference_raw`'s
+   `head == left` guard bailed). Rather than relax the C-ABI rule (broad blast
+   radius) or replicate call-position, the gate keeps bare-identifier fn casts on
+   the untouched `Raw` path entirely — zero fn-reference behavior change, and the
+   `typecheck.sfn`/`typecheck_types.sfn` migration was reverted.
 4. Regression coverage: `compiler/tests/unit/effect_cast_operand_test.sfn`
-   (structural lift + effect attribution + the effect-free 745-canary).
+   (structural lift over a call operand + effect attribution + the effect-free
+   bare-pointer-cast canary + a guard pinning the bare-identifier `Raw` gate).
 
 **Not shipped here — filed as #1180 sub-issues:** prefix `*`/`&` → `Unary`,
 ternary → `Conditional`, the blanket `E0818` `Raw` backstop (it requires

--- a/docs/status.md
+++ b/docs/status.md
@@ -98,10 +98,14 @@ here.
   `Unknown` nodes are effect-blind by design (they carry no resolvable call).
   A #1627 audit confirmed that invariant held *except* for `<operand> as <type>`
   casts: an identifier-typed cast parsed as a structured `Cast` the checker never
-  walked, and a pointer-typed cast (`as * T`) degraded the whole expression to
-  `Raw` — so `print.info(x) as * i64` reached codegen with no `![io]`. #1627
-  structures pointer cast targets into `Cast` and walks the `Cast` operand, so a
-  cast can no longer hide its operand's effects (`E0400`). The remaining
+  walked, and a pointer-typed cast (`as * T`) over an effectful operand degraded
+  the whole expression to `Raw` — so `print.info(x) as * i64` reached codegen with
+  no `![io]`. #1627 adds a `Cast` effect-checker arm (walks the operand) and lifts
+  pointer cast targets into `Cast` **for effect-bearing (non-identifier) operands**,
+  so a cast can no longer hide its operand's effects (`E0400`). Bare-identifier
+  pointer casts (`<fn>`/`<ptr-value> as * u8`) intentionally stay `Raw` — they
+  carry no effect, and this preserves the #1147 function-reference diagnostics and
+  the shadow-parser lowering unchanged. The remaining
   Raw-degraded effect-escapes (ternary `? :`, prefix `*`/`&`, assignment-as-
   expression) are tracked under epic #1180 (#1180-a/c) behind a blanket
   fail-closed `Raw` backstop. Effect polymorphism (`!E` variables, polymorphic

--- a/docs/status.md
+++ b/docs/status.md
@@ -95,9 +95,17 @@ here.
   and the runtime descriptor registry — not text heuristics. The legacy
   text-pattern fallback (`collect_effects_from_text`) was proven redundant by
   a parity harness (#1185) and **deleted in #1186**; parse-failure `Raw`/
-  `Unknown` nodes are now effect-blind by design (they carry no resolvable
-  call). Effect polymorphism (`!E` variables, polymorphic HOFs) remains
-  post-1.0.
+  `Unknown` nodes are effect-blind by design (they carry no resolvable call).
+  A #1627 audit confirmed that invariant held *except* for `<operand> as <type>`
+  casts: an identifier-typed cast parsed as a structured `Cast` the checker never
+  walked, and a pointer-typed cast (`as * T`) degraded the whole expression to
+  `Raw` — so `print.info(x) as * i64` reached codegen with no `![io]`. #1627
+  structures pointer cast targets into `Cast` and walks the `Cast` operand, so a
+  cast can no longer hide its operand's effects (`E0400`). The remaining
+  Raw-degraded effect-escapes (ternary `? :`, prefix `*`/`&`, assignment-as-
+  expression) are tracked under epic #1180 (#1180-a/c) behind a blanket
+  fail-closed `Raw` backstop. Effect polymorphism (`!E` variables, polymorphic
+  HOFs) remains post-1.0.
 - **Undefined free-function rejection** (`E0420`, #616/#812): unresolvable
   bare-identifier callees fail typecheck.
 - **Function references**: a bare fn name in value position lowers to the


### PR DESCRIPTION
## Summary

Part of **#1627** (effect-system hardening, epic #1180). Closes the **cast-shaped effect escape** — a confirmed-live hole in the effects pillar — and decomposes the remaining `Raw`/`Unknown` fail-closed work into tracked sub-issues.

After #1186 deleted `collect_effects_from_text`, the effect checker attributes effects only from **structured** AST nodes. An audit (this issue) found two `<operand> as <type>` cast shapes that slipped through:

1. **`print.info(x) as int`** — parsed as a structured `Cast` node the effect checker **never walked** (no `Cast` arm).
2. **`print.info(x) as * i64`** — rejected by the cast arm (which accepted only a bare `Identifier` target) and degraded the **whole expression to an effect-blind `Raw`**.

**Confirmed live before the fix:** `print.info(x) as * i64` passed `sfn check` with **no `[io]` declared** *and* fired the side effect at runtime (`[info] SIDE EFFECT FIRED`).

## The fix (structural — no text inspection)

- **`effect_checker.sfn`** — add a `Cast` arm to `collect_effects_from_expression` that walks the cast operand.
- **`parser/expressions.sfn`** — parse pointer cast targets (`* T`, `* * T`) into a structured `Cast`, **gated to effect-bearing operands**: the lift fires only when the operand is *not* a bare `Identifier`. The escapes all have call/member operands (`print.info(x)`); a bare identifier carries no effect, so nothing is lost — while `<fn> as * u8` (function references) and the dominant in-source `<ptr-value> as * u8` spelling keep their **exact legacy `Raw` path** (lowering + `check_fn_reference_raw` E0808/E0809 untouched). The `Cast` text round-trips through the formatter to the identical `(operand) as * T` the shadow parser already consumes, so affected casts lower unchanged (proven by `make compile`).

> Note: an earlier revision structured *every* `<operand> as *T` and migrated the E0808/E0809 fn-reference check onto the `Cast` arm. CI surfaced that this newly flagged the shipped http-server trampoline `_sfn_http_trampoline as * u8` (a concrete fn with a struct-ABI `fn(OwnedBuf) -> OwnedBuf` signature) as E0809. The operand-gate above replaces that migration entirely — zero fn-reference behavior change.

### Behavior

| Snippet | Before | After |
|---|---|---|
| `print.info(x) as int` (no `[io]`) | ok ❌ | `E0400` ✅ |
| `print.info(x) as * i64` (no `[io]`) | ok ❌ (fired at runtime) | `E0400` ✅ |
| `p as * i64` (effect-free pointer value) | ok (Raw) | ok (Raw, unchanged) ✅ |
| `_sfn_http_trampoline as * u8` (struct-ABI fn) | clean | clean ✅ |
| `gen as * u8` (generic fn) | `E0809` | `E0809` ✅ |
| `worker as * u8` (concrete C-ABI, #1146) | clean | clean ✅ |

## Verification

- `make compile` self-hosts (green).
- New: `compiler/tests/unit/effect_cast_operand_test.sfn` (9 tests: structural lift over a call operand + effect attribution + effect-free bare-pointer canary + the bare-identifier `Raw`-gate guard).
- Green: `wire_test` (13, the http capsule), `fn_reference_typecheck_test` (12), `numeric_cast_test` (15), `ptr_arith_cast_offset_test` (1), `effect_detection_test` (13), `effect_checker`/`effect_gate`/`effect_capabilities`.
- `sfn fmt --check` clean on all touched `.sfn`.

## Scope / follow-ons (epic #1180)

The remaining `Raw`/`Unknown` effect-escapes each warrant their own tested change. Filed: **#1690** (ternary → `Conditional`), **#1691** (nested `Unknown` fail-closed), **#1692** (epic: retire shadow re-parser + structure prefix `*`/`&`, assign-expr, generic/fn cast targets, then the blanket `E0818` `Raw` backstop), **#1693** (stale-comment cleanup).

Design record: `docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md` (extends SFEP-0008).

Part of #1627.

https://claude.ai/code/session_012ojYKf4rcxfmAz2aA1U5V4