### PR TITLE
perf(numeric): batched int→string emit + ASCII find_char fast path (#1511)

### DIFF
--- a/compiler/tests/unit/string_find_format_fastpath_test.sfn
+++ b/compiler/tests/unit/string_find_format_fastpath_test.sfn
@@ -1,0 +1,47 @@
+// Regression tests for the #1511 runtime fast paths. Both run in-process —
+// the test binary links the prelude, so `find_char` and the `int as string`
+// cast exercise the real runtime bodies directly (no subprocess build).
+//
+//   * `find_char`'s single-byte ASCII scan (`runtime/prelude.sfn`) must return
+//     byte-index parity with the grapheme loop it replaced — including the
+//     absent-needle, mid-string start, escape-shorthand, and end-of-string
+//     cases.
+//   * the batched whole-word integer formatter `_num_emit_int_cstr`
+//     (`runtime/sfn/string.sfn`), reached via `int as string`, must format
+//     zero, negatives, multi-digit values, and widths that straddle the
+//     8-byte word-flush boundary.
+import { find_char } from "runtime/prelude";
+
+test "1511: find_char ASCII fast path returns byte-index parity" {
+    let h = "the quick brown fox";
+    // Absent needle (the `string_find_format` benchmark case): full scan, -1.
+    assert find_char(h, "z", 0) == -1;
+    // Present needles at known byte offsets.
+    assert find_char(h, "q", 0) == 4;
+    assert find_char(h, "t", 0) == 0;
+    assert find_char(h, " ", 0) == 3;
+    // `start` is honoured: no second 't' after index 1.
+    assert find_char(h, "t", 1) == -1;
+    // Match at the final byte.
+    assert find_char("abx", "x", 0) == 2;
+    // Empty haystack.
+    assert find_char("", "a", 0) == -1;
+}
+
+test "1511: find_char escape shorthand still resolves via fast path" {
+    // The "\\n" → "\n" normalization yields a 1-byte ASCII target, so it
+    // takes the fast path too.
+    assert find_char("a\nb", "\\n", 0) == 1;
+    assert find_char("a\tb", "\\t", 0) == 1;
+}
+
+test "1511: int as string batched emit formats edge cases" {
+    assert(0 as string) == "0";
+    assert(7 as string) == "7";
+    assert((0 - 42) as string) == "-42";
+    assert(123456789 as string) == "123456789";
+    // Exactly 8 digits — fills one accumulator word before the final flush.
+    assert(12345678 as string) == "12345678";
+    // 9 digits — straddles the 8-byte word-flush boundary.
+    assert(123456789 as string) == "123456789";
+}

--- a/docs/perf/runtime-performance.md
+++ b/docs/perf/runtime-performance.md
@@ -118,6 +118,44 @@ nested-loop mark stacking are post-1.0. A re-run of the full suite to refresh
 the frozen darwin-arm64 CSV (and the pending Linux x86_64 baseline) will fold
 this number into a stamped baseline.
 
+## Post-fix: int→string + `find_char` fast paths (#1511, Linux x86_64)
+
+`string_find_format` was the slowest per-op workload in the 0.7.0 baseline.
+Profiling on Linux x86_64 isolated the cost: the workload bundles a string scan
+(`find_char`) and an integer format (`i as string`), and the **scan dominated**
+— `find_char` allocated a fresh grapheme string at every scanned byte
+(`grapheme_at` → `runtime_grapheme_at_fn`), ~84 allocations per iteration, which
+is the source of both the CPU cost and the intermediate-string churn. The
+integer format was a distant second (~3% of the loop), though it still paid a
+seq_cst `atomic_load`+`atomic_store` read-modify-write per digit.
+
+Two changes (one PR):
+
+- **`find_char` ASCII fast path** (`runtime/prelude.sfn`): a single-byte ASCII
+  needle now resolves via a non-allocating raw byte scan (the `load_byte`
+  builtin) instead of the grapheme loop. Exact for an ASCII needle (an ASCII
+  byte `< 0x80` can only match a standalone ASCII grapheme in UTF-8).
+- **Batched integer emit** (`runtime/sfn/string.sfn`): `_num_emit_int_cstr`
+  streams digits into an i64 word accumulator and flushes whole 8-byte words
+  with one `atomic_store` each (no per-byte read), used by `sfn_int_to_str` and
+  the exact-integer fast path of `sfn_number_to_str`.
+
+Before/after on this Linux x86_64 host (K=7; baseline `sfn 0.7.0-alpha.49+dev.a7a1599`,
+after `+dev.4eec565`). This is also the first **Linux x86_64** `string_find_format`
+measurement (the prior table is Darwin arm64, not cross-platform comparable):
+
+| Metric | Before | After | Change |
+|---|---|---|---|
+| inner ms (median) | 1567 | 66 | **23.7× faster** |
+| ops/ms | 140.4 | 3333.3 | **23.7×** |
+| peak RSS | 224,676 KB | 30,244 KB | **7.4× lower** |
+| B/op (peak RSS / ops) | ~1,046 | ~141 | **7.4× less garbage** |
+
+The `int as string` cast itself was fixed earlier in #1505 (+ narrow-width
+follow-ups #1587/#1605); #1511 is the performance half of that surface. RSS and
+op-rate numbers vary by host, so treat the table as a same-host before/after, not
+an absolute baseline.
+
 ## Known runtime limitations exercised here
 
 The workloads were written against what the 0.7.0 compiler actually lowers. Two
@@ -131,11 +169,12 @@ regressions):
 - `sfn/strings::find` fails the same way; `string_find_format` uses the prelude
   `find_char` instead.
 
-A third, **untracked** issue surfaced while authoring the workloads and is *not*
-worked around in-language: the `int as string` cast silently produces `0`
-(e.g. `let s = "x" + (n as string)` yields `0`, not `x42`), while `{{ }}`
-interpolation lowers correctly. The workloads use interpolation throughout. See
-the benchmarking notes / open issue.
+A third issue surfaced while authoring the workloads: the `int as string` cast
+silently produced `0` (e.g. `let s = "x" + (n as string)` yields `0`, not `x42`),
+while `{{ }}` interpolation lowered correctly — so the workloads used
+interpolation throughout. This is now **fixed** (#1505, with narrow-width
+follow-ups #1587/#1605); its performance half is #1511 (see the post-fix section
+above).
 
 ## Follow-ups
 

--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -665,6 +665,29 @@ fn find_char(text: string, character: string, start: int = 0) -> int {
         } else if escape == "t" { target = "\t"; }
     }
 
+    // Fast path (#1511): a single-byte ASCII target resolves via a
+    // non-allocating raw byte scan (the `load_byte` builtin — a true
+    // `load i8` + `zext`) instead of the grapheme loop below, which
+    // allocates a fresh grapheme string at every position (the dominant
+    // cost of the `string_find_format` runtime benchmark). For an ASCII
+    // needle this is exact: an ASCII byte (< 0x80) can only match a
+    // standalone ASCII grapheme in UTF-8 (lead and continuation bytes are
+    // all >= 0x80), and for ASCII text the byte offset equals the
+    // grapheme index the slow path returns.
+    if target.length == 1 {
+        let code = char_code(target);
+        if code >= 0 && code < 128 {
+            let addr = (text as * u8) as i64;
+            let mut bi = normalized_start;
+            loop {
+                if bi >= length { break; }
+                if load_byte(addr + bi) == code { return bi; }
+                bi = bi + 1;
+            }
+            return -1;
+        }
+    }
+
     let mut index = normalized_start;
     loop {
         if index >= length { break; }

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -992,6 +992,75 @@ fn _num_emit_uint(base: i64, pos: i64, value: i64, min_digits: i64) -> i64 {
     return p;
 }
 
+// `_num_emit_int_cstr(base, value)` formats a signed i64 as decimal text
+// (optional `-`, digits most-significant-first, trailing NUL) into the
+// 8-aligned scratch buffer at `base`, returning the byte length (NUL
+// excluded). It is the batched-store fast path for the two integer
+// hot paths (`sfn_int_to_str` and the exact-integer arm of
+// `sfn_number_to_str`).
+//
+// Perf (#1511): the per-byte emitters (`_num_emit_char` /
+// `_num_emit_uint` → `_num_put_byte`) pay a seq_cst `atomic_load` +
+// `atomic_store` for *every* digit, so a 6-digit format costs ~7 full
+// memory barriers. This emitter instead streams output bytes into one
+// i64 accumulator and flushes a whole 8-byte word with a single
+// `atomic_store` each time the accumulator fills (and once more at the
+// end) — ~1 barrier per 8 bytes, and no read-back at all. The read is
+// unnecessary because the scratch buffer is 8-aligned with a capacity
+// that is a multiple of 8 (`owned_buf_new` discipline) and every byte of
+// each word is authored sequentially from offset 0: the store overwrites
+// all 8 bytes, and the unwritten high bytes are zero, so the trailing
+// NUL and word padding are emitted for free.
+//
+// INT64_MIN is safe without a magnitude (whose positive has no i64
+// form): digit extraction stays in the operand's own sign domain
+// (`value / divisor` and `% 10` truncate toward zero; negative
+// remainders are negated per digit). Any i64 has at most 19 digits, so
+// the leading divisor `10^(nd-1)` never exceeds `10^18`, which is
+// i64-representable.
+fn _num_emit_int_cstr(base: i64, value: i64) -> i64 {
+    let mut neg: bool = false;
+    if value < 0 { neg = true; }
+    let nd: i64 = _num_count_digits(value);
+    let mut total: i64 = nd;
+    if neg { total = total + 1; }
+
+    let mut word_acc: i64 = 0;
+    let mut word_off: i64 = 0;
+    let mut k: i64 = 0;
+
+    if neg {
+        word_acc = word_acc + (45 << ((k & 7) * 8));
+        k = k + 1;
+    }
+
+    let mut divisor: i64 = _num_pow10_i64(nd - 1);
+    let mut di: i64 = 0;
+    loop {
+        if di >= nd { break; }
+        let mut d: i64 = (value / divisor) % 10;
+        if d < 0 { d = 0 - d; }
+        word_acc = word_acc + ((48 + d) << ((k & 7) * 8));
+        k = k + 1;
+        if (k & 7) == 0 {
+            let slot: * i64 = (base + word_off) as * i64;
+            atomic_store(slot, word_acc);
+            word_off = word_off + 8;
+            word_acc = 0;
+        }
+        divisor = divisor / 10;
+        di = di + 1;
+    }
+
+    // Flush the word holding the final digits and the NUL terminator.
+    // The NUL at position `total` is the zero high byte already present
+    // in `word_acc`; any bytes past it are zero padding inside the owned
+    // scratch buffer, so a single full-word store completes the string.
+    let slot2: * i64 = (base + word_off) as * i64;
+    atomic_store(slot2, word_acc);
+    return total;
+}
+
 // `sfn_number_to_str(value)` — the bare emission target (#1314), render
 // `value` as a `%.15g`-style decimal string into arena/libc storage. See
 // the family comment above for the algorithm and its correctness ceiling.
@@ -1050,9 +1119,12 @@ fn sfn_number_to_str(value: f64) -> * u8 {
     if m < 1000000000000000.0 {
         let ip: i64 = m as i64;
         if (ip as f64) == m {
-            if neg { pos = _num_emit_char(base, pos, 45); }
-            pos = _num_emit_uint(base, pos, ip, 1);
-            return _num_finish(base, pos);
+            // `ip` is the non-negative magnitude (m = |value|); restore
+            // the sign and emit via the batched whole-word fast path.
+            let mut signed_ip: i64 = ip;
+            if neg { signed_ip = 0 - ip; }
+            let _len: i64 = _num_emit_int_cstr(base, signed_ip);
+            return base as * u8;
         }
     }
 
@@ -1231,40 +1303,12 @@ fn sfn_int_to_str(value: i64) -> * u8 {
     let buf: OwnedBuf = owned_buf_new(arena_addr, 32);
     let base: i64 = buf.ptr_addr;
     if base == 0 { return null; }
-    let mut pos: i64 = 0;
 
-    if value == 0 {
-        pos = _num_emit_char(base, pos, 48);
-        return _num_finish(base, pos);
-    }
-
-    let mut neg: bool = false;
-    if value < 0 { neg = true; }
-
-    // Count digits (loop toward zero works for either sign).
-    let mut nd: i64 = 0;
-    let mut t: i64 = value;
-    loop {
-        if t == 0 { break; }
-        t = t / 10;
-        nd = nd + 1;
-    }
-
-    if neg { pos = _num_emit_char(base, pos, 45); }
-
-    // Write digits least-significant first into the reserved span.
-    let mut wp: i64 = pos + nd - 1;
-    let mut x: i64 = value;
-    loop {
-        if x == 0 { break; }
-        let mut d: i64 = x % 10;
-        if d < 0 { d = 0 - d; }
-        _num_put_byte(base + wp, 48 + d);
-        wp = wp - 1;
-        x = x / 10;
-    }
-    pos = pos + nd;
-    return _num_finish(base, pos);
+    // Batched whole-word emit (#1511): one `atomic_store` per 8 bytes
+    // instead of a per-digit read-modify-write. `_num_emit_int_cstr`
+    // handles the zero case, the sign, and the NUL terminator.
+    let _len: i64 = _num_emit_int_cstr(base, value);
+    return base as * u8;
 }
 
 // #925 (sub-issue of #390): Cat-C char-predicate ports. The legacy C


### PR DESCRIPTION
## Summary

Makes the `string_find_format` runtime workload — the slowest per-op workload in the 0.7.0 baseline — **~23.7× faster** and **~7.4× lower RSS** on Linux x86_64, via two fast paths:

- **Batched integer emit** (`runtime/sfn/string.sfn`): new `_num_emit_int_cstr` streams decimal digits into an i64 word accumulator and flushes whole 8-byte words with one `atomic_store` each, replacing the per-digit seq_cst `atomic_load`+`atomic_store` read-modify-write (`_num_put_byte`). Wired into `sfn_int_to_str` and the exact-integer fast path of `sfn_number_to_str`.
- **`find_char` ASCII fast path** (`runtime/prelude.sfn`): a single-byte ASCII needle now resolves via a non-allocating raw byte scan (the `load_byte` builtin) instead of the grapheme loop, which allocated a fresh grapheme string at every scanned byte (~84/iteration). This was the **dominant** cost of the benchmark (~97%) and the source of the intermediate-string churn.

Closes #1511

## Why `find_char` is here

Profiling on Linux x86_64 showed the benchmark is ~97% `find_char` (grapheme-scan allocation) and only ~3% integer formatting. Optimizing only the named `In:` unit (the runtime int→string helpers) could not move the benchmark materially, so the `find_char` fast path was **bundled with maintainer approval** to meet acceptance criterion #1. The `int as string` cast correctness was already fixed in #1505 (+ #1587/#1605); #1511 is its performance half.

## Acceptance Criteria

- [x] `string_find_format` ops/ms and B/op improve materially (recorded in `docs/perf/runtime-performance.md`).
- [x] `int as string` produces correct decimal text (#1505 repro passes; covered by `numeric_cast_test.sfn` + the new regression).
- [x] `make compile` self-hosts; `make test` green.

## Map reconciliation

`## Files Affected` was advisory (`needs grooming`). Reconciled at pickup:
- `runtime/sfn/string.sfn` — ✅ touched (the named `sfn_number_to_str` / `sfn_int_to_str` In: unit).
- `compiler/src/num_format.sfn` — **not touched**. That file's `number_to_string` is the *compiler's* internal int formatter, not the runtime helper on the benchmark hot path; the In: unit names the runtime helpers. (It does use an O(n) repeated-subtraction divide — noted as a separate compile-time follow-up, out of this runtime issue's scope.)
- "cast lowering for `as string`" — already delivered by #1586/#1605; not re-touched.
- Added (in-unit / bundled): `runtime/prelude.sfn` (`find_char` fast path, per the approved scope expansion) and `compiler/tests/unit/string_find_format_fastpath_test.sfn`.

## Verification

```text
# Bench (Linux x86_64, K=7; before = +dev.a7a1599, after = +dev with this change)
string_find_format  median 1567ms → 66ms   (~23.7×)   ops/ms 140.4 → 3333.3
                    peak RSS 224,676 KB → 30,244 KB   (~7.4×)   B/op ~1046 → ~141

# Self-host (clean) + full suite
$ make clean-build && make compile     # status=pass
$ make test                            # unit 168/168 · integration 39/39 · e2e 155/155 · capsules 37/37 (exit 0)

# Correctness (in-process regression)
$ build/native/sailfin test compiler/tests/unit/string_find_format_fastpath_test.sfn   # PASS (3 tests)
# n as string: 0, 7, -42, 12345678 (8-digit word boundary), 123456789 — all correct
# find_char ASCII: absent=-1, q=4, t@0, start-honoured, end-of-string, "\n"/"\t" shorthand — byte-index parity
```

## Files Changed

- `runtime/sfn/string.sfn` — `_num_emit_int_cstr` + wiring into the two integer hot paths.
- `runtime/prelude.sfn` — `find_char` single-byte ASCII `load_byte` scan.
- `compiler/tests/unit/string_find_format_fastpath_test.sfn` — in-process regression.
- `docs/perf/runtime-performance.md` — before/after + Linux x86_64 row.

## Heads-up: pre-existing cold-build bug (#1685)

While iterating I hit a **pre-existing** `invalid redefinition of '@sfn_array_concat'` on cold *incremental* prelude rebuilds (`make rebuild`). It is **not** introduced here and does **not** affect clean builds (`make clean-build` recovers; this PR self-hosts clean). Root-caused and filed as #1685 (needs a small `rendering.sfn` fix + a seed cut to fully land; can ride the next cadence bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Ck8UcTHn8Ksjm71AhBQp

---
_Generated by [Claude Code](https://claude.ai/code/session_0129Ck8UcTHn8Ksjm71AhBQp)_