### PR TITLE
feat(parser): inline `export &lt;declaration&gt;` syntax (SFEP-0031, closes #1681)

### DIFF
--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -9,7 +9,12 @@
 //   - expressions.sfn:  Expression parsing (Pratt parser, literals, lambdas)
 //   - statements.sfn:   Block statement parsing (control flow, return, match)
 //   - declarations.sfn: Top-level declarations (fn, struct, enum, import, etc.)
-import { Program, Statement } from "../ast";
+import {
+    Decorator,
+    ExportSpecifier,
+    Program,
+    Statement
+} from "../ast";
 import { lex } from "../lexer";
 import { substring } from "../string_utils";
 import { Token, TokenKind } from "../token";
@@ -31,14 +36,16 @@ import {
     parse_variable_with_storage
 } from "./declarations";
 import {
+    consume_keyword,
     identifier_matches,
     is_end_of_file,
     parser_advance_raw,
     parser_peek_raw,
-    skip_trivia
+    skip_trivia,
+    symbol_matches
 } from "./token_utils";
 // Import types from submodules
-import { Parser, StatementParseResult } from "./types";
+import { Parser, ProgramUnitResult, StatementParseResult } from "./types";
 
 // ============================================================================
 // Main Entry Points
@@ -75,9 +82,14 @@ fn parse_tokens(tokens: Token[]) -> Program ![io] {
         if is_end_of_file(parser, token) { break; }
 
         let prev_index = parser.index;
-        let result = parse_statement(parser);
+        let result = parse_program_unit(parser);
         parser = result.parser;
-        statements = append_statement(statements, result.statement);
+        let mut _si: int = 0;
+        loop {
+            if _si >= result.statements.length { break; }
+            statements = append_statement(statements, result.statements[_si]);
+            _si += 1;
+        }
         parser = skip_trivia(parser);
         if parser.index == prev_index {
             print.err("parser: no progress; aborting to avoid infinite loop");
@@ -86,6 +98,151 @@ fn parse_tokens(tokens: Token[]) -> Program ![io] {
     }
 
     return Program { statements: statements };
+}
+
+// A single top-level parse step. The ordinary path wraps `parse_statement`'s
+// one statement in a one-element list; the inline `export <declaration>` form
+// (SFEP-0031) yields two: the declaration plus a synthesized `ExportDeclaration`
+// naming it. Inline-vs-block is decided on the token *after* `export` —
+// `{` keeps the existing block/re-export path untouched; a declaration
+// introducer routes to `parse_inline_export`.
+fn parse_program_unit(initial_parser: Parser) -> ProgramUnitResult {
+    let probe = skip_trivia(initial_parser);
+    let lead = parser_peek_raw(probe);
+    if identifier_matches(lead, "export") {
+        let after_export = skip_trivia(parser_advance_raw(probe));
+        let next = parser_peek_raw(after_export);
+        if !symbol_matches(next, "{") {
+            // Skip any decorators (`export @deco fn ...`) before deciding
+            // whether a declaration introducer follows.
+            let after_decorators = skip_trivia(parse_decorators(after_export).parser);
+            if is_inline_export_introducer(after_decorators) {
+                return parse_inline_export(probe);
+            }
+        }
+    }
+    let result = parse_statement(initial_parser);
+    return ProgramUnitResult {
+        parser: result.parser,
+        statements: [result.statement]
+    };
+}
+
+// True when the parser is positioned at a declaration that may be inline-
+// exported (`export fn`, `export struct`, …). Mirrors the declaration arms of
+// `parse_statement`; `let`/`thread_local`/`async`/`unsafe`/`extern` are handled
+// by their respective declaration parsers in `parse_inline_declaration`.
+fn is_inline_export_introducer(parser: Parser) -> boolean {
+    let token = parser_peek_raw(parser);
+    if identifier_matches(token, "fn") { return true; }
+    if identifier_matches(token, "async") { return true; }
+    if identifier_matches(token, "unsafe") { return true; }
+    if identifier_matches(token, "extern") { return true; }
+    if identifier_matches(token, "struct") { return true; }
+    if identifier_matches(token, "type") { return true; }
+    if identifier_matches(token, "interface") { return true; }
+    if identifier_matches(token, "enum") { return true; }
+    if identifier_matches(token, "let") { return true; }
+    if identifier_matches(token, "thread_local") { return true; }
+    return false;
+}
+
+// Parse `export <declaration>` (SFEP-0031). Consumes `export`, re-enters
+// decorator collection (so `export @deco fn` attaches the decorator to the
+// declaration), parses the declaration with its existing parser, then
+// synthesizes a `Statement.ExportDeclaration` naming the declared symbol —
+// exactly equivalent to `<declaration> export { name };`.
+fn parse_inline_export(initial_parser: Parser) -> ProgramUnitResult {
+    let mut parser: Parser = consume_keyword(initial_parser, "export");
+    parser = skip_trivia(parser);
+    let decorator_result = parse_decorators(parser);
+    parser = skip_trivia(decorator_result.parser);
+    let decl = parse_inline_declaration(parser, decorator_result.decorators);
+    let name = declared_export_name(decl.statement);
+    let export_statement = Statement.ExportDeclaration {
+        export_specifiers: [ExportSpecifier { name: name, alias: null }],
+        source: ""
+    };
+    return ProgramUnitResult {
+        parser: decl.parser,
+        statements: [decl.statement, export_statement]
+    };
+}
+
+// Dispatch the declaration following an inline `export`. Mirrors the
+// declaration arms of `parse_statement` for the exportable forms.
+//
+// `is_inline_export_introducer` has already confirmed `parser` is positioned
+// at one of these forms, so the `async`/`unsafe` arms here are deliberately
+// laxer than `parse_statement`'s (which guard on a following `fn`): a
+// well-formed `export async fn` / `export unsafe fn` / `export unsafe extern`
+// parses identically, and the laxity only affects ill-formed input (e.g.
+// `export async struct`), which the no-progress guard still terminates.
+fn parse_inline_declaration(parser: Parser, decorators: Decorator[]) -> StatementParseResult {
+    let token = parser_peek_raw(parser);
+    if identifier_matches(token, "fn") {
+        return parse_function(parser, false, decorators, false);
+    }
+    if identifier_matches(token, "async") {
+        return parse_function(parser, true, decorators, false);
+    }
+    if identifier_matches(token, "unsafe") {
+        let lookahead = skip_trivia(parser_advance_raw(parser));
+        if identifier_matches(parser_peek_raw(lookahead), "extern") {
+            let after_extern = skip_trivia(parser_advance_raw(lookahead));
+            if identifier_matches(parser_peek_raw(after_extern), "var") {
+                return parse_extern_var(parser, true, decorators);
+            }
+            return parse_extern_function(parser, true, decorators);
+        }
+        return parse_function(parser, false, decorators, true);
+    }
+    if identifier_matches(token, "extern") {
+        let after_extern = skip_trivia(parser_advance_raw(parser));
+        if identifier_matches(parser_peek_raw(after_extern), "var") {
+            return parse_extern_var(parser, false, decorators);
+        }
+        return parse_extern_function(parser, false, decorators);
+    }
+    if identifier_matches(token, "struct") {
+        return parse_struct(parser, decorators);
+    }
+    if identifier_matches(token, "type") {
+        return parse_type_alias(parser, decorators);
+    }
+    if identifier_matches(token, "interface") {
+        return parse_interface(parser, decorators);
+    }
+    if identifier_matches(token, "enum") {
+        return parse_enum(parser, decorators);
+    }
+    if identifier_matches(token, "thread_local") {
+        let after_keyword = skip_trivia(parser_advance_raw(parser));
+        if identifier_matches(parser_peek_raw(after_keyword), "let") {
+            return parse_variable_with_storage(after_keyword, true);
+        }
+        return parse_variable(parser);
+    }
+    return parse_variable(parser);
+}
+
+// Extract the symbol a declaration statement introduces, for synthesizing its
+// inline-export manifest entry. Returns "" for a statement that names nothing
+// (the synthesized export then names nothing and is a harmless no-op).
+fn declared_export_name(statement: Statement) -> string {
+    if statement.variant == "FunctionDeclaration" {
+        return statement.signature.name;
+    }
+    if statement.variant == "ExternFunctionDeclaration" {
+        return statement.signature.name;
+    }
+    if statement.variant == "StructDeclaration" { return statement.name; }
+    if statement.variant == "EnumDeclaration" { return statement.name; }
+    if statement.variant == "InterfaceDeclaration" { return statement.name; }
+    if statement.variant == "TypeAliasDeclaration" { return statement.name; }
+    if statement.variant == "VariableDeclaration" { return statement.name; }
+    if statement.variant == "ExternVarDeclaration" { return statement.name; }
+    return "";
 }
 
 // ============================================================================

--- a/compiler/src/parser/types.sfn
+++ b/compiler/src/parser/types.sfn
@@ -42,6 +42,15 @@ struct StatementParseResult {
     statement: Statement;
 }
 
+// A single top-level parse step that may yield more than one statement.
+// Used by the inline `export <declaration>` form (SFEP-0031), which emits
+// the declaration statement plus a synthesized `ExportDeclaration` naming
+// it. The ordinary path wraps its single statement in a one-element list.
+struct ProgramUnitResult {
+    parser: Parser;
+    statements: Statement[];
+}
+
 struct BlockStatementParseResult {
     parser: Parser;
     statement: Statement?;

--- a/compiler/tests/e2e/inline_export_cross_module_test.sfn
+++ b/compiler/tests/e2e/inline_export_cross_module_test.sfn
@@ -1,0 +1,127 @@
+// End-to-end regression for inline `export <declaration>` across modules
+// (SFEP-0031, issue #1681 / PR #1680).
+//
+// A producer module declares an `export struct` (first struct in the module)
+// and two inline-`export fn`s returning that struct and an `int[]`. A consumer
+// imports all three, calls them, and uses the results. Before SFEP-0031 this
+// failed at LLVM lowering with `cannot resolve return type for call to
+// \`make_spec\`` because inline `export fn`/`export struct` never reached the
+// producer's export manifest. After the fix the binary builds and runs.
+//
+// Native replacement style per `.claude/rules/no-bash-e2e.md`: assert on the
+// subprocess result, thread PATH + SAILFIN_TEST_SCRATCH into the nested build.
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// The nested `sfn build` spawns clang + a linker, so the child needs PATH;
+// SAILFIN_TEST_SCRATCH routes the program.ll build-cache per invocation so
+// the parallel pool does not collide on the fixed build/sailfin.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+fn _scratch_base() -> string ![io] {
+    let base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length > 0 { return base; }
+    return "/tmp";
+}
+
+fn _capsule_root() -> string ![io] {
+    return _scratch_base() + "/sfn-inline-export-xmod";
+}
+
+// Materialize a 2-module capsule whose producer uses the inline export form
+// exclusively (no `export { ... }` block).
+fn _ensure_fixture() ![io] {
+    let root = _capsule_root();
+    fs.createDirectory(root + "/src", true);
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"inline-export-xmod\"\n"
+        + "version = \"0.1.0\"\n"
+        + "description = \"E2E regression for SFEP-0031 inline export (#1681)\"\n\n"
+        + "[capabilities]\n"
+        + "required = [\"io\"]\n\n"
+        + "[build]\n"
+        + "entry = \"src/main.sfn\"\n");
+    fs.writeFile(root + "/src/producer.sfn", "export struct ShardSpec { valid: boolean, index: int, total: int }\n\n"
+        + "export fn make_spec(i: int, t: int) -> ShardSpec {\n"
+        + "    return ShardSpec{ valid: true, index: i, total: t };\n"
+        + "}\n\n"
+        + "export fn select_indices(count: int) -> int[] {\n"
+        + "    let mut out: int[] = [];\n"
+        + "    let mut k = 0;\n"
+        + "    loop {\n"
+        + "        if k >= count { break; }\n"
+        + "        out.push(k);\n"
+        + "        k = k + 1;\n"
+        + "    }\n"
+        + "    return out;\n"
+        + "}\n");
+    // Consumer: index=2, total=5, select_indices(4)=[0,1,2,3] (sum 6, len 4).
+    // Expected total 2+5+6+4 = 17 → exit 0 + marker on the correct path.
+    fs.writeFile(root + "/src/main.sfn", "import { make_spec, select_indices } from \"./producer\";\n\n"
+        + "fn main() -> int ![io] {\n"
+        + "    let spec = make_spec(2, 5);\n"
+        + "    let xs = select_indices(4);\n"
+        + "    let mut sum = 0;\n"
+        + "    let mut i = 0;\n"
+        + "    loop {\n"
+        + "        if i >= xs.length { break; }\n"
+        + "        sum = sum + xs[i];\n"
+        + "        i = i + 1;\n"
+        + "    }\n"
+        + "    let result = spec.index + spec.total + sum + xs.length;\n"
+        + "    if result == 17 {\n"
+        + "        print.info(\"INLINE_EXPORT_XMOD_OK\");\n"
+        + "        return 0;\n"
+        + "    }\n"
+        + "    print.err(\"INLINE_EXPORT_XMOD_BAD\");\n"
+        + "    return 1;\n"
+        + "}\n");
+}
+
+fn _bin_path() -> string ![io] {
+    return _scratch_base() + "/sfn-inline-export-xmod-prog";
+}
+
+test "inline export xmod: producer using only inline `export` builds across modules" ![io] {
+    _ensure_fixture();
+    let out_bin = _bin_path();
+    let exit = process.run_capture([_sfn_bin(), "build", "-p", _capsule_root(), "-o", out_bin], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+
+    // The #1681 symptom is a lowering fatal in the importer; assert it is gone.
+    assert ! contains(out + err, "cannot resolve return type");
+    assert exit == 0;
+    assert fs.exists(out_bin);
+}
+
+test "inline export xmod: the linked binary runs and computes the right result" ![io] {
+    _ensure_fixture();
+    let out_bin = _bin_path();
+    let build_exit = process.run_capture([_sfn_bin(), "build", "-p", _capsule_root(), "-o", out_bin], _child_env());
+    let _bo = process.capture_take_stdout();
+    let _be = process.capture_take_stderr();
+    assert build_exit == 0;
+
+    let run_exit = process.run_capture([out_bin], _child_env());
+    let run_out = process.capture_take_stdout();
+    let run_err = process.capture_take_stderr();
+    assert run_exit == 0;
+    assert contains(run_out + run_err, "INLINE_EXPORT_XMOD_OK");
+}

--- a/compiler/tests/integration/inline_export_manifest_test.sfn
+++ b/compiler/tests/integration/inline_export_manifest_test.sfn
@@ -1,0 +1,56 @@
+// Integration coverage for inline `export <declaration>` manifest parity
+// (SFEP-0031, issue #1681).
+//
+// The inline form must emit the SAME `.export "" { name }` directive in the
+// module's native IR as the block form — that directive is what keeps the
+// symbol externally linkable and signature-resolvable across modules. This
+// asserts the emitted `.sfn-asm` text carries the manifest entry for every
+// inline-exported form, including `export extern fn` / `export extern var`
+// (the one introducer arm with branching `extern`/`unsafe`/`var` lookahead).
+import { emit_native_text_with_module_name } from "../../src/emit_native";
+import { parse_program } from "../../src/parser/mod";
+import { index_of } from "../../src/string_utils";
+
+fn _emit(source: string) -> string ![io] {
+    let program = parse_program(source);
+    return emit_native_text_with_module_name(program, "inline_export_manifest_test");
+}
+
+fn _exports(native: string, symbol: string) -> boolean {
+    return index_of(native, ".export \"\" { " + symbol + " }") >= 0;
+}
+
+test "inline export manifest: `export fn` emits `.export` parity with the block form" ![io] {
+    let inline = _emit("export fn parse(text: string) -> int { return 0; }");
+    let block = _emit("fn parse(text: string) -> int { return 0; } export { parse };");
+    assert _exports(inline, "parse");
+    assert _exports(block, "parse");
+}
+
+test "inline export manifest: struct / enum / interface / type / let all emit `.export`" ![io] {
+    let native = _emit("export struct S { x: int }\n"
+        + "export enum E { A, B }\n"
+        + "export interface I { fn m() -> int; }\n"
+        + "export type T = int;\n"
+        + "export let L: int = 5;\n");
+    assert _exports(native, "S");
+    assert _exports(native, "E");
+    assert _exports(native, "I");
+    assert _exports(native, "T");
+    assert _exports(native, "L");
+}
+
+test "inline export manifest: `export extern fn` emits `.export`" ![io] {
+    let native = _emit("export extern fn write(fd: int, n: int) -> int;");
+    assert _exports(native, "write");
+}
+
+test "inline export manifest: `export extern var` emits `.export`" ![io] {
+    let native = _emit("export extern var errno: int;");
+    assert _exports(native, "errno");
+}
+
+test "inline export manifest: `export thread_local let mut` emits `.export`" ![io] {
+    let native = _emit("export thread_local let mut counter: int = 0;");
+    assert _exports(native, "counter");
+}

--- a/compiler/tests/unit/inline_export_decl_test.sfn
+++ b/compiler/tests/unit/inline_export_decl_test.sfn
@@ -1,0 +1,157 @@
+// Regression coverage for the inline `export <declaration>` syntax
+// (SFEP-0031, issue #1681).
+//
+// Before this feature, the parser routed every `export` token to the
+// block-export parser (`parse_export`), which expects `{`. The inline form
+// `export fn foo() { ... }` was mis-parsed: the declaration was swallowed
+// into a bogus export `source` string and its name never reached the
+// module's export manifest, so cross-module callers hit
+// `llvm lowering [fatal]: cannot resolve return type for call to \`foo\``.
+//
+// The fix (`parser/mod.sfn`) dispatches `export` on the *next* token: `{`
+// keeps the existing block/re-export path; a declaration introducer routes
+// to `parse_inline_export`, which parses the declaration normally AND
+// synthesizes a `Statement.ExportDeclaration` naming it — exactly
+// equivalent to `<declaration> export { name };`.
+//
+// These tests assert the parser emits BOTH the declaration statement and a
+// matching `ExportDeclaration`. Cross-module build+run is covered by
+// `compiler/tests/e2e/inline_export_cross_module_test.sfn`.
+import { Program, Statement } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+// True when the program contains an `ExportDeclaration` whose specifier list
+// names `symbol` with no `from` source (an inline / local export).
+fn _exports_local(program: Program, symbol: string) -> boolean ![io] {
+    let mut i: int = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let stmt = program.statements[i];
+        if stmt.variant == "ExportDeclaration" {
+            if stmt.source.length == 0 {
+                let mut j: int = 0;
+                loop {
+                    if j >= stmt.export_specifiers.length { break; }
+                    if stmt.export_specifiers[j].name == symbol { return true; }
+                    j += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+    return false;
+}
+
+// True when the program contains a declaration statement of `variant`.
+fn _has_decl(program: Program, variant: string) -> boolean ![io] {
+    let mut i: int = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        if program.statements[i].variant == variant { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _count_local_exports(program: Program, symbol: string) -> int ![io] {
+    let mut count: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let stmt = program.statements[i];
+        if stmt.variant == "ExportDeclaration" {
+            if stmt.source.length == 0 {
+                let mut j: int = 0;
+                loop {
+                    if j >= stmt.export_specifiers.length { break; }
+                    if stmt.export_specifiers[j].name == symbol { count += 1; }
+                    j += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+    return count;
+}
+
+test "inline export: `export fn` emits the function and exports it" ![io] {
+    let program = parse_program("export fn foo(x: int) -> int { return x + 1; }");
+    assert _has_decl(program, "FunctionDeclaration");
+    assert _exports_local(program, "foo");
+}
+
+test "inline export: `export async fn` emits the function and exports it" ![io] {
+    let program = parse_program("export async fn fetch(u: string) -> int ![io] { return 0; }");
+    assert _has_decl(program, "FunctionDeclaration");
+    assert _exports_local(program, "fetch");
+}
+
+test "inline export: `export struct` emits the struct and exports it" ![io] {
+    let program = parse_program("export struct Shard { valid: boolean, index: int }");
+    assert _has_decl(program, "StructDeclaration");
+    assert _exports_local(program, "Shard");
+}
+
+test "inline export: `export enum` emits the enum and exports it" ![io] {
+    let program = parse_program("export enum Color { Red, Green, Blue }");
+    assert _has_decl(program, "EnumDeclaration");
+    assert _exports_local(program, "Color");
+}
+
+test "inline export: `export interface` emits the interface and exports it" ![io] {
+    let program = parse_program("export interface Reader { fn read() -> int; }");
+    assert _has_decl(program, "InterfaceDeclaration");
+    assert _exports_local(program, "Reader");
+}
+
+test "inline export: `export type` emits the alias and exports it" ![io] {
+    let program = parse_program("export type Id = int;");
+    assert _has_decl(program, "TypeAliasDeclaration");
+    assert _exports_local(program, "Id");
+}
+
+test "inline export: `export let` emits the global and exports it" ![io] {
+    let program = parse_program("export let MAX: int = 256;");
+    assert _has_decl(program, "VariableDeclaration");
+    assert _exports_local(program, "MAX");
+}
+
+test "inline export: `export thread_local let mut` emits the global and exports it" ![io] {
+    let program = parse_program("export thread_local let mut counter: int = 0;");
+    assert _has_decl(program, "VariableDeclaration");
+    assert _exports_local(program, "counter");
+}
+
+test "inline export: `export @deco fn` parses and exports (decorator leads stay on decl)" ![io] {
+    let program = parse_program("export @logExecution fn traced(x: int) -> int ![io] { return x; }");
+    assert _has_decl(program, "FunctionDeclaration");
+    assert _exports_local(program, "traced");
+}
+
+test "inline export: coexists with a later block export of the same symbol (de-duped no-op)" ![io] {
+    let program = parse_program("export fn f() -> int { return 1; } export { f };");
+    assert _has_decl(program, "FunctionDeclaration");
+    // Two `.export { f }` entries are emitted; the manifest de-dupes them.
+    assert _count_local_exports(program, "f") == 2;
+}
+
+test "inline export: block export form is unchanged" ![io] {
+    let program = parse_program("fn g() -> int { return 1; } export { g };");
+    assert _has_decl(program, "FunctionDeclaration");
+    assert _exports_local(program, "g");
+}
+
+test "inline export: re-export `export { x } from` keeps its source" ![io] {
+    let program = parse_program("export { x } from \"./other\";");
+    let mut found_reexport: boolean = false;
+    let mut i: int = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let stmt = program.statements[i];
+        if stmt.variant == "ExportDeclaration" {
+            if stmt.source.length > 0 { found_reexport = true; }
+        }
+        i += 1;
+    }
+    assert found_reexport;
+}

--- a/docs/proposals/0031-inline-export-decl.md
+++ b/docs/proposals/0031-inline-export-decl.md
@@ -1,0 +1,401 @@
+---
+sfep: 0031
+title: Inline `export <declaration>` syntax
+status: Accepted
+type: language
+created: 2026-06-26
+updated: 2026-06-26
+author: "agent:compiler-architect; human review"
+tracking: "#1681, #1680"
+supersedes:
+superseded-by:
+graduates-to:
+---
+
+# SFEP-0031 — Inline `export <declaration>` syntax
+
+## 1. Summary
+
+Sailfin today supports only the **block** export form — `export { name1, name2 };`
+and the re-export `export { x } from "./mod";`. The **inline** form that
+TypeScript and Rust users (and LLMs) reach for first — `export fn foo() { ... }`,
+`export struct Foo { ... }` — is silently mis-handled: the parser routes *any*
+`export` token to the block parser, which expects `{`. The leading declaration
+keyword is then mis-parsed and, critically, the declaration's name is **never
+added to the module's export manifest**. The declaration is still defined (so it
+is callable within its own module), but it is internalized at LLVM level and its
+signature is invisible to importers — producing the cross-module
+`llvm lowering [fatal]: cannot resolve return type for call to \`...\` — callee
+signature is not known to the compiler` (issue #1681 / PR #1680).
+
+This SFEP makes the inline `export <declaration>` form a real, first-class
+surface that is exactly equivalent to declaring the item and naming it in a
+block export: `export fn f() {}` ≡ `fn f() {} export { f };`. It is additive
+(the block form is unchanged and stays the canonical form the compiler tree
+uses), it touches only the parser plus docs/tests, and it closes a
+"boring-syntax" footgun that today fails with an opaque late-stage error.
+
+## 2. Motivation
+
+### The footgun (root-caused, #1681 / #1680)
+
+A maintainer wrote the natural module API:
+
+```sfn
+export struct ShardSpec { valid: boolean, index: int, total: int }
+export fn _parse_shard_value(text: string) -> ShardSpec { ... }
+export fn _shard_select_indices(count: int, index: int, total: int) -> int[] { ... }
+```
+
+`make compile` failed at LLVM lowering with `cannot resolve return type for call
+to \`_parse_shard_value\` — callee signature is not known to the compiler`. The
+failure is not about the return type (it reproduces for `-> int` too); it is
+about the *export* being dropped. The diagnostic appears at stage 6 (LLVM
+lowering) in a *different module* (the importer), with no pointer back to the
+real cause (the producer's `export fn` was parsed as a no-op export). The
+workaround that shipped (`cli_commands_utils.sfn:718-776`) had to flatten a
+struct-returning / `int[]`-returning API down to `int`/`boolean` returns and
+left a comment blaming a "compiler-robustness follow-up." The real defect is the
+unsupported inline export form.
+
+### Why support it (not reject it)
+
+- **Boring syntax wins.** `export fn` / `export struct` is the dominant form in
+  TypeScript and (modulo `pub`) Rust. Requiring a separate `export { ... }` block
+  is a gratuitous deviation with zero expressiveness gain.
+- **AI agents are users.** LLMs have no `.sfn` training corpus; they emit
+  conventional `export fn` by default. This is *literally* what triggered #1680.
+  Every model-authored module is a latent instance of this bug today.
+- **Silent mis-handling is the worst failure mode.** The current behaviour is not
+  a clean "unsupported syntax" diagnostic at the `export` site — it is a
+  *successful parse* that produces a wrong export manifest and explodes much later
+  in an unrelated module. That violates "don't ship unfinished safety claims"
+  in spirit: the construct *looks* accepted but is silently wrong.
+
+### Current visibility model (verified — load-bearing for this design)
+
+A bare top-level `fn`/`struct` is **module-private by default**. Cross-module
+visibility is opt-in through the export manifest:
+
+- The export manifest is the `.export "..." { name, ... }` directive in a
+  module's `.sfn-asm`, emitted from `Statement.ExportDeclaration`
+  (`emit_native.sfn:224-232`).
+- `collect_exported_symbol_names` (`llvm/rendering_helpers.sfn:393`) reads those
+  directives back into the importer's `exported_symbols` set.
+- `should_internalize_function` (`llvm/rendering_helpers.sfn:443-451`) marks any
+  function that is **not** an entry point, **not** in `exported_symbols`, and not
+  one of a few hardcoded driver-API names as LLVM `internal` — i.e. unlinkable
+  across modules and signature-invisible to importers. Exported module-global
+  `let` bindings are similarly gated (`lowering_phase_imports.sfn:52-76`).
+
+So `export` is **load-bearing, not advisory**: naming a symbol in the export
+manifest is exactly what (a) keeps it externally linkable and (b) makes its
+signature resolvable cross-module. The inline form's job is therefore narrow and
+precise: **parse the declaration normally AND add its name to the same export
+manifest the block form populates.** Once the name is in the manifest, every
+existing downstream consumer — internalization, signature resolution, binding
+inlining — works unchanged, because the producer already emits the full function
+body/signature into its `.sfn-asm` regardless of export status (the export
+directive is what gates visibility, not the presence of the body text).
+
+## 3. Design
+
+### 3.1 Grammar
+
+Add an inline export production that prefixes an existing top-level declaration:
+
+```
+ExportDecl     ::= "export" ExportBlock              // existing: { ... } [from "src"]
+                 | "export" ExportableDeclaration    // NEW: inline
+
+ExportableDeclaration ::=
+       FunctionDeclaration            // export fn / export async fn
+     | StructDeclaration              // export struct
+     | EnumDeclaration                // export enum
+     | InterfaceDeclaration           // export interface
+     | TypeAliasDeclaration           // export type
+     | VariableDeclaration            // export let (module globals; Sailfin has no `const`)
+     | ExternFunctionDeclaration      // export extern fn / export unsafe extern fn
+     | ExternVarDeclaration           // export extern var / export unsafe extern var
+```
+
+**Dispatch:** the inline vs. block decision is made on the token *after* `export`:
+
+- `export` followed by `{` → existing block/re-export parser (unchanged).
+- `export` followed by any declaration-introducer keyword (`fn`, `async`,
+  `struct`, `enum`, `interface`, `type`, `let`, `extern`, `unsafe`,
+  `thread_local`) → inline parser.
+- `export` followed by anything else → existing behaviour (the block parser's
+  `consume_symbol("{")` already produces the current diagnostic for malformed
+  exports; no new error path is introduced).
+
+This is a one-token lookahead with no ambiguity: `{` is never a declaration
+introducer, and no declaration introducer overlaps the re-export `from` keyword.
+
+### 3.2 Semantics — exact equivalence
+
+```sfn
+export fn f() -> int { return 1; }
+```
+
+is **exactly equivalent** to
+
+```sfn
+fn f() -> int { return 1; }
+export { f };
+```
+
+The inline form adds the declared name to the module export manifest with **no
+alias** (`ExportSpecifier { name: "f", alias: null }`). It never carries a
+`from` source (re-export is block-only — there is no declaration to re-export
+*and* define). All declaration semantics (effects, decorators, async,
+visibility-of-the-body) are identical to the un-prefixed declaration; `export`
+adds *only* the manifest entry.
+
+### 3.3 AST representation — lowest blast radius
+
+**Recommended: synthesize the existing `Statement.ExportDeclaration` alongside
+the declaration statement. Do not add a new AST node and do not add an
+`exported: bool` flag.**
+
+The inline parser produces **two** statements from one source construct:
+
+1. the ordinary declaration statement (`FunctionDeclaration`, `StructDeclaration`,
+   …) exactly as the existing declaration parser builds it, and
+2. a `Statement.ExportDeclaration { export_specifiers: [ {name, alias: null} ],
+   source: "" }` naming the declared symbol.
+
+Rationale:
+
+- **Zero downstream change.** `emit_native.sfn`, `emitter_sailfin.sfn`,
+  `reexport_check.sfn`, `collect_exported_symbol_names`,
+  `should_internalize_function`, and the binding-export path already consume
+  exactly this shape. The block form and the inline form converge on the same IR
+  (`.export "..." { f }` + the function body), so the rest of the pipeline cannot
+  tell them apart — which is the goal.
+- **No flag to thread.** An `exported: bool` on every declaration node would touch
+  `ast.sfn`, every constructor site, the native emitter (to translate the flag
+  into a `.export` directive), and `count_exported_symbols`. The synthesized-pair
+  approach keeps the change inside the parser.
+
+**Statement-list plumbing:** the top-level dispatcher
+(`parser/mod.sfn:parse_statement`) returns a single `StatementParseResult`
+(one statement per call). The inline export needs to contribute *two*
+statements. Two equally-valid options for the implementer (pick one at
+implementation, no semantic difference):
+
+- **(A) Emit-order: declaration first, export second.** Have the inline-export
+  parser parse the declaration, then push the synthesized `ExportDeclaration` via
+  the same mechanism the parser already uses to emit a trailing statement. If the
+  statement-collection loop is strictly one-result-per-call, introduce a tiny
+  parser-internal "pending statement" queue drained before the next dispatch.
+- **(B) Wrap in a block-free group.** If a `Statement` group/sequence node
+  already exists for desugaring (check before adding one), reuse it. *Do not add
+  a new public AST node solely for this* — option (A) is preferred precisely to
+  avoid that.
+
+The architect's recommendation is **(A)**, since it keeps the AST surface
+untouched. The export-order (decl before its `.export`) matches what the block
+form already does in practice and what `emit_native` expects.
+
+### 3.4 Interactions
+
+- **Coexistence with the block form.** Both forms may appear in the same module.
+  A symbol exported both inline and via a block (`export fn f(){} ... export { f };`)
+  produces two `.export ... { f }` entries; `collect_exported_symbol_names`
+  already de-dupes (`string_array_contains` guard, `rendering_helpers.sfn:419`),
+  so this is harmless. **No new double-export diagnostic is required** for 1.0;
+  it is a no-op, not an error. (A lint may be added later but is out of scope.)
+- **Re-exports (`from`).** Inline export never has a `from` source — there is a
+  concrete declaration being defined. The `from` clause stays exclusive to the
+  block form. The dispatcher guarantees this: a `from` re-export always starts
+  with `{`.
+- **Decorators.** The canonical order is **`@deco` before `export`** is *not*
+  chosen; instead `export` leads and the decorator attaches to the declaration:
+  `export @logExecution fn f() {}`. Rationale: `parse_statement` already collects
+  decorators *before* dispatching on the keyword (`mod.sfn:99-112`), and it
+  refuses decorators on `export`/`import` today (`mod.sfn:111` →
+  `parse_unknown`). The cleanest path is: the inline-export parser, after
+  consuming `export`, **re-enters decorator collection** for the declaration it is
+  about to parse, so `export @deco fn` works and the decorator lands on the
+  function. The leading-`@deco export fn` order stays rejected (consistent with
+  today's "no decorators on export" rule) to avoid a second decorator-collection
+  site in the top-level dispatcher. **Open question O1** (below) flags this for
+  the gate — if the gate prefers `@deco export fn`, the dispatcher's
+  `decorators.length > 0 → parse_unknown` guard at `mod.sfn:111` is relaxed to
+  forward the already-collected decorators into the inline-export parser instead.
+- **Default visibility unchanged.** Bare `fn`/`struct` remains module-private.
+  This SFEP does **not** introduce export-by-default. `export` continues to mean
+  exactly "add to the manifest"; the inline form is sugar over the existing
+  manifest mechanism, nothing more.
+- **`thread_local`.** `export thread_local let mut x: int = 0;` is supported by
+  routing through the existing `parse_variable_with_storage(..., true)` path
+  (`mod.sfn:123-130`) and synthesizing the export entry for `x`. (Module globals
+  are already exportable via the block form and value-inlined into importers
+  per #1368.)
+
+### 3.5 Worked examples
+
+```sfn
+// All five become manifest entries identical to a trailing `export { ... };`
+export fn parse(text: string) -> Token[] { ... }     // export { parse };
+export async fn fetch(u: string) -> Bytes ![net] {}  // export { fetch };
+export struct ShardSpec { valid: boolean, index: int, total: int } // export { ShardSpec };
+export enum Color { Red, Green, Blue }               // export { Color };
+export type Id = int;                                // export { Id };
+export let MAX: int = 256;                           // export { MAX };
+export interface Reader { fn read() -> Bytes; }      // export { Reader };
+export extern fn write(fd: int, buf: i8*, n: int) -> int;  // export { write };
+```
+
+The #1681 case becomes legal verbatim, and the `cli_commands_utils.sfn` shard
+helpers can return `ShardSpec` / `int[]` as originally intended (a follow-up
+issue, not part of this SFEP's required scope, can restore that API).
+
+### 3.6 Resolved design-gate decisions (2026-06-26)
+
+The three open questions were resolved at the design gate (owner approval):
+
+- **O1 — decorator order: `export @deco fn` (export leads).** The inline-export
+  parser re-enters decorator collection after consuming `export`, so
+  `export @logExecution fn f() {}` attaches the decorator to `f`. The leading
+  `@deco export fn` order stays rejected (the existing `mod.sfn:111` "no
+  decorators on export" guard is unchanged), avoiding a second
+  decorator-collection site in the top-level dispatcher.
+- **O2 — double-export is a harmless de-duped no-op.** A symbol exported both
+  inline and via a block produces two `.export` entries that
+  `collect_exported_symbol_names` already de-dupes. No diagnostic for 1.0.
+- **O3 — all declaration forms ship in the first PR:** `fn` / `async fn`,
+  `struct`, `enum`, `interface`, `type`, `let`,
+  `extern fn` / `extern var`, and `thread_local let mut`.
+
+## 4. Effect & capability impact
+
+**None.** Export is a visibility/manifest concern, orthogonal to the effect
+system. `export fn f() ![io] {}` carries exactly the effects the un-prefixed
+declaration would; the effect checker walks the same `FunctionDeclaration` node.
+No effect is added, removed, or inferred by the presence of `export`. No
+capability surface changes.
+
+## 5. Self-hosting impact
+
+**Passes changed:** parser only (`compiler/src/parser/declarations.sfn`,
+`compiler/src/parser/mod.sfn`). AST (`ast.sfn`) is **unchanged** under the
+recommended synthesized-pair design. Typecheck, effect checker, native emitter,
+and LLVM lowering are unchanged — they already consume `Statement.ExportDeclaration`
+and the declaration nodes the inline form produces.
+
+**Self-host invariant:** the change is **purely additive**. The compiler tree
+uses the block form exclusively (verified: 65 of 175 `compiler/src` files use
+`export { ... }`; **zero** files use any inline `export fn/struct/...`). So:
+
+- The old seed compiles the new compiler with no change to existing source.
+- The new compiler accepts a strict superset of the old grammar.
+- Nothing in `compiler/src/*.sfn` is rewritten to *use* the new form as part of
+  this SFEP, so there is no circular bootstrap dependency.
+
+**Seed dependency (per `.claude/rules/seed-dependency.md`):** the parser change
+alters the compiler binary's behaviour, so it is a compiler-source capability.
+**But there is no in-tree consumer** — no `compiler/src` file needs the inline
+form to self-host. Therefore there is **no bundling decision and no seed-cut
+gate**: this SFEP ships as a single parser PR. The new form simply becomes
+available to user code (and to future compiler-source rewrites, which would only
+land *after* this capability is in the pinned seed). The follow-up that restores
+the `ShardSpec`/`int[]` shard API in `cli_commands_utils.sfn` (a compiler-source
+*consumer*) is the one that must wait for a seed cut — and is explicitly out of
+scope here.
+
+## 6. Alternatives considered
+
+- **(a) Reject inline export with a clean diagnostic (conservative non-feature).**
+  Route `export fn`/`export struct` to `Statement.Unknown` and emit a typecheck
+  diagnostic at the `export` site (the established idiom — cf. `while` → E0411 via
+  `detect_unsupported_statement_keyword`). This *fixes the silent mis-handling*
+  (the real hazard) but **rejects the syntax everyone reaches for**, contradicting
+  "boring syntax wins" and "AI agents are users." It also forces every model and
+  every TS/Rust-trained human to learn a Sailfin-specific export ritual. Rejected:
+  the user decision (approved) is to *support*, not reject. The diagnostic-only
+  fix is strictly worse than supporting, at comparable implementation cost.
+
+- **(b) Export-by-default + explicit `private`/`internal`.** Make bare top-level
+  declarations exported, and add a keyword to hide them. This is a far larger
+  semantic change: it inverts the visibility model, changes the meaning of every
+  existing bare declaration in the tree (175 files), requires auditing what should
+  *not* leak across modules, and risks symbol-collision/over-linkage regressions
+  in the self-host link. It also dilutes the manifest's role and is a much bigger
+  blast radius for a 1.0 timeline. Rejected: out of proportion to the problem;
+  the explicit-`export` model is conventional (TS/Rust) and already shipped.
+
+- **(c) Status quo.** Leave inline export silently mis-handled. Rejected: it is an
+  active footgun that fails late, in the wrong module, with an opaque message, and
+  disproportionately hits LLM-authored code — the exact audience the project
+  optimizes for.
+
+## 7. Stage1 readiness mapping
+
+- [ ] **Parses** — inline-export dispatch + per-declaration parsing in
+  `parser/declarations.sfn` / `parser/mod.sfn`.
+- [ ] **Type-checks / effect-checks** — no change required (declaration + synthesized
+  `ExportDeclaration` are already handled); add tests proving effects survive.
+- [ ] **Emits valid `.sfn-asm`** — no change; the synthesized `ExportDeclaration`
+  emits the existing `.export "..." { name }` directive. Verify the producer's
+  `.sfn-asm` carries the directive for an inline-exported symbol.
+- [ ] **Lowers to LLVM IR** — no change; the manifest entry keeps the symbol
+  external and signature-resolvable cross-module (the #1681 fatal disappears).
+- [ ] **Regression coverage** — parser unit tests per form + cross-module e2e
+  (§8).
+- [ ] **Self-hosts** — `make compile` green (additive; no tree rewrite).
+- [ ] **`sfn fmt --check` clean** — confirm the formatter round-trips
+  `export fn`/`export struct` (formatter is parser-driven; verify it does not
+  reorder `export` away from the declaration).
+- [ ] **Documented** — `docs/status.md` (modules row) + spec
+  `02-modules.md` (new inline-export section).
+
+## 8. Test plan
+
+**Parser unit tests** (`compiler/tests/unit/inline_export_*_test.sfn`), one per
+form, asserting the program yields both the declaration statement **and** an
+`ExportDeclaration` naming it:
+
+- `export fn` and `export async fn`
+- `export struct`, `export enum`, `export interface`, `export type`
+- `export let` (module globals), `export thread_local let mut`
+- `export extern fn` / `export unsafe extern fn` / `export extern var`
+- Decorator case: `export @logExecution fn f() {}` parses, decorator lands on `f`,
+  `f` is exported (resolves open question O1's chosen order).
+- Coexistence: a module with both `export fn f(){}` and a later `export { f };`
+  yields a de-duped manifest (no double-export error).
+- Negative: `export` followed by neither `{` nor a declaration keyword still
+  produces the existing malformed-export behaviour (no regression).
+
+**Integration / emit** (`compiler/tests/integration/`): assert the emitted
+`.sfn-asm` for a module with `export fn parse(...)` contains
+`.export ... { parse }` (manifest parity with the block form).
+
+**E2E cross-module** (`compiler/tests/e2e/inline_export_cross_module_test.sfn`):
+a producer module declares `export struct ShardSpec { ... }`,
+`export fn parse_shard(text: string) -> ShardSpec { ... }`, and
+`export fn select(count: int, index: int, total: int) -> int[] { ... }`; a
+consumer imports all three, calls them, and **builds + runs** to a binary that
+prints a value derived from the `int[]` and the struct fields. This is the direct
+#1681 regression — it must fail on today's compiler (the lowering fatal) and pass
+after the change. Thread `PATH` + `SAILFIN_TEST_SCRATCH` into the nested build per
+`.claude/rules/no-bash-e2e.md`.
+
+**Self-host gate:** `make compile` then `make check`.
+
+## 9. References
+
+- Issue #1681 — inline `export fn`/`export struct` cross-module lowering fatal
+  (the bug this SFEP resolves).
+- PR #1680 — the change that hit it; shipped the `int`/`boolean` shard-helper
+  workaround (`cli_commands_utils.sfn:718-776`) blaming a compiler follow-up.
+- Issue #1237 — `--shard I/N` partitioning (the feature whose natural
+  struct/`int[]` API was flattened by the workaround).
+- Spec `site/src/content/docs/docs/reference/spec/02-modules.md` — current
+  block-only export documentation (to be extended).
+- `compiler/src/parser/declarations.sfn:565-605` (`parse_export`),
+  `compiler/src/parser/mod.sfn:110-112` (dispatch),
+  `compiler/src/llvm/rendering_helpers.sfn:393-451` (export manifest →
+  internalization / visibility model evidence),
+  `compiler/src/emit_native.sfn:224-232` (`.export` directive emission).

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -53,6 +53,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0028](./0028-typed-array-higher-order-fns.md) | Typed / Generic-Element Array Higher-Order Functions (map / filter / reduce) | Draft | language |
 | [0029](./0029-lambda-syntax.md) | Lambda expression syntax for 1.0 — keep, reform, or defer | Accepted | language |
 | [0030](./0030-first-class-function-values.md) | First-Class Function Values | Accepted | language |
+| [0031](./0031-inline-export-decl.md) | Inline `export <declaration>` syntax | Accepted | language |
 
 ## Subdirectories
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -146,6 +146,7 @@ here.
 | Interfaces | Shipped | Trait-style method signatures |
 | Enums / ADTs | Shipped | Payload variants; generic payloads monomorphise per instantiation (#830). >8-byte by-value payload layouts not yet emitted |
 | Type aliases | Shipped | Including generic params |
+| Module exports | **Shipped** | Block form `export { name };` / `export { x } from "./m";` and inline `export <declaration>` (`export fn`/`export struct`/`export enum`/`export interface`/`export type`/`export let`/`export extern …`/`export thread_local let mut`). Inline form added in SFEP-0031 (#1681); equivalent to `<decl> export { name };` |
 | `if`/`else`, `for` | Shipped | |
 | `loop` / `break` / `continue` | Shipped | `while` is intentionally not a keyword (`E0411` with a `loop` fix-it) |
 | `match` | Shipped | Literals, `_`, guards, enum-variant destructuring |

--- a/site/src/content/docs/docs/reference/spec/02-modules.md
+++ b/site/src/content/docs/docs/reference/spec/02-modules.md
@@ -21,3 +21,39 @@ export { helper as publicHelper } from "./internal";
 - **Workspace capsules** (`"core"`) — sibling capsules in a workspace
 
 Modules may re-export items from other modules. Specifiers support aliasing with `as`.
+
+## Exporting declarations
+
+A top-level declaration is module-private until it is named in the module's
+export manifest. There are two equivalent ways to export one:
+
+```sfn
+// Block form — name the symbols in an `export { ... }` list.
+fn parse(text: string) -> Token[] { ... }
+export { parse };
+
+// Inline form — prefix the declaration with `export`.
+export fn parse(text: string) -> Token[] { ... }
+```
+
+`export <declaration>` is exactly equivalent to declaring the item and then
+naming it in a block export — `export fn f() {}` ≡ `fn f() {} export { f };`.
+The inline form works for every top-level declaration:
+
+```sfn
+export fn make(x: int) -> int { return x; }
+export async fn fetch(u: string) -> Bytes ![net] { ... }
+export struct Point { x: int, y: int }
+export enum Color { Red, Green, Blue }
+export interface Reader { fn read() -> Bytes; }
+export type Id = int;
+export let MAX: int = 256;
+export thread_local let mut counter: int = 0;
+export extern fn write(fd: int, buf: i8*, n: int) -> int;
+```
+
+Decorators follow the `export`: `export @logExecution fn traced() ![io] { ... }`.
+A symbol exported both inline and via a block is a harmless de-duplicated no-op.
+The `from` re-export clause is block-only (`export { x } from "./internal";`) —
+an inline export always defines a concrete declaration, so it never carries a
+source.


### PR DESCRIPTION
## Summary

- Adds the inline `export <declaration>` form (`export fn`, `export struct`, …) — the TS/Rust-conventional syntax that LLMs reach for first.
- Root-causes and fixes #1681 / the #1680 workaround: inline `export` was silently mis-parsed, so the declaration's name never reached the module export manifest and cross-module callers hit `llvm lowering [fatal]: cannot resolve return type for call to <fn>`.
- Parser-only, additive — the block form (`export { name };` / `export { x } from "./m";`) is unchanged; no AST node or `Parser` field added.

Closes #1681

## Root cause (confirmed)

`export` was dispatched unconditionally to the block parser, which expects `{`. For `export fn foo()` the declaration was swallowed into a bogus export `source` string and `foo` never entered the `.export` manifest — so the producer internalized it and importers couldn't resolve its signature. It failed for **any** return type (even `-> int`); the struct/`int[]` framing in the issue was incidental (those were the functions #1680 happened to try). The block form works fine for struct/`int[]` returns.

## Design — SFEP-0031

`docs/proposals/0031-inline-export-decl.md` (Accepted). Dispatch `export` on the **next** token: `{` → existing block/re-export path; a declaration introducer (optionally decorator-prefixed) → `parse_inline_export`, which parses the declaration with its existing parser **and** synthesizes a `Statement.ExportDeclaration` naming it. So `export fn f(){}` ≡ `fn f(){} export { f };`. Design-gate decisions: `export @deco fn` (export leads); double-export is a harmless de-duped no-op; all forms ship.

Forms supported: `fn` / `async fn`, `struct`, `enum`, `interface`, `type`, `let`, `extern fn`/`extern var`, `thread_local let mut`.

## Acceptance Criteria

- [x] An imported `fn f(...) -> int[]` is callable cross-module and its result used, self-hosting cleanly (e2e build+run).
- [x] An imported fn returning a producer-first-declared struct resolves cross-module (e2e).
- [x] Regression tests under `compiler/tests/` covering both (unit + integration + e2e).
- [x] `make compile` self-hosts; `make check` (running — see Verification).

## Map reconciliation

The issue's advisory `## Files Affected` pointed at consumer-side LLVM resolution (`core_call_emission.sfn`, `lowering_phase_imports.sfn`). The real fix is upstream in the **parser** (`parser/mod.sfn`, `parser/types.sfn`) — the issue's premise about *where* the bug lived was off (the #1088 mid-pickup pattern). The user approved supporting the inline syntax + an SFEP at the design gate, reframing the work as a language feature. Semantic Goal (cross-module struct/`int[]` returns resolve) is met.

## Verification

```
make compile        # self-hosts ✓
build/native/sailfin test compiler/tests/unit/inline_export_decl_test.sfn          # 12/12 ✓
build/native/sailfin test compiler/tests/integration/inline_export_manifest_test.sfn  # 5/5 ✓
build/native/sailfin test compiler/tests/e2e/inline_export_cross_module_test.sfn   # 2/2 ✓ (direct #1681 regression)
sfn fmt --check <touched files>   # clean ✓
make check          # full triple-pass gate — running
```

## Files Changed

- `compiler/src/parser/mod.sfn` — `parse_program_unit` dispatch + `parse_inline_export` / `parse_inline_declaration` / `declared_export_name` / `is_inline_export_introducer`.
- `compiler/src/parser/types.sfn` — `ProgramUnitResult`.
- `compiler/tests/{unit,integration,e2e}/inline_export_*` — regression coverage.
- `docs/proposals/0031-inline-export-decl.md` + `README.md` — SFEP.
- `site/.../spec/02-modules.md`, `docs/status.md` — docs.

## Notes for reviewers

- A separate, orthogonal bug surfaced during root-cause and is filed as **#1706**: a method call on a local bound from a `struct.field` or array `.length` (`let n = xs.length; n.toString()`) fails return-type resolution, **same-module too**. Not addressed here (different subsystem).
- The SFEP graduates to `Implemented` once `make check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01SAdssM6XtJCAKJBX2s8oWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAdssM6XtJCAKJBX2s8oWS)_