### PR TITLE
feat(effects): structure ternary `? :` into a Conditional node (#1690)

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -97,6 +97,24 @@ enum Expression {
     // from the statement-level `TryStatement`. Type rules and emission
     // land in R.3 / R.4 — today this is parse-only.
     TryOperator { operand: Expression, span: SourceSpan? },
+    // Ternary conditional `cond ? then : else` (issue #1690, epic #1180,
+    // effect-system hardening). Before #1690 a ternary degraded to
+    // `Expression.Raw` because the expression parser had no ternary form —
+    // and since #1186 a `Raw` node contributes zero effects, so an
+    // effectful branch (`cond ? readFile() : x`) reached codegen
+    // effect-free. Structuring it here lets the effect checker, typecheck
+    // walker, capture/ownership analysis, and lambda-capture rewrite all
+    // recurse into the three children. The formatter serializes it back to
+    // `(cond) ? (then) : (else)` — the exact text the lowering shadow
+    // re-parser (`parse_ternary_expression`) already handles, so no new
+    // lowering arm is needed. `span` is the last field per the variant
+    // convention so positional GEP indexing for prior variants stays stable.
+    Conditional {
+        condition: Expression,
+        then_value: Expression,
+        else_value: Expression,
+        span: SourceSpan?
+    },
     // Concurrency frontend nodes (M4.0, epic #965, issue #1079). Parse-only
     // targets for the structured-concurrency surface; parsing, type rules,
     // effect-checking, and lowering land in follow-up issues. Runtime

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -894,6 +894,18 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
         required = merge_requirements(required, collect_effects_from_expression(expression.right, imports));
         return required;
     }
+    if expression.variant == "Conditional" {
+        // Ternary `cond ? then : else` (#1690). Either branch may run, and
+        // the condition always does, so the requirement is the union of all
+        // three children's effects: `cond ? readFile() : x` requires `![io]`.
+        // Before #1690 the whole ternary degraded to an effect-blind `Raw`,
+        // letting an effectful branch reach codegen with no declared
+        // capability — a fail-open hole in the effects pillar.
+        let mut required = collect_effects_from_expression(expression.condition, imports);
+        required = merge_requirements(required, collect_effects_from_expression(expression.then_value, imports));
+        required = merge_requirements(required, collect_effects_from_expression(expression.else_value, imports));
+        return required;
+    }
     if expression.variant == "Array" {
         let mut required: EffectRequirement[] = [];
         let mut element_index: int = 0;

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -200,6 +200,37 @@ fn format_expression_into(expression: Expression, out: string[]) -> string[] {
         out.push(expression.target_type.text);
         return out;
     }
+    if expression.variant == "Conditional" {
+        // `(cond) ? (then) : (else)` (#1690) — the exact text the lowering
+        // shadow re-parser `parse_ternary_expression` consumes (it scans for
+        // the first top-level `?` then the first top-level `:`). Each operand
+        // is fully parenthesized so a nested ternary or any embedded operator
+        // stays at depth ≥ 1 and the scan splits on the outer `?`/`:` only,
+        // preserving right-associativity through the re-parse. No dedicated
+        // lowering arm is needed; this serialization IS the bridge.
+        out.push("(");
+        format_expression_into(expression.condition, out);
+        out.push(") ? (");
+        format_expression_into(expression.then_value, out);
+        out.push(") : (");
+        format_expression_into(expression.else_value, out);
+        out.push(")");
+        return out;
+    }
+    if expression.variant == "TryOperator" {
+        // `<operand>?` (#1690). Normally every try operator is desugared by
+        // `desugar_try_in_block` before formatting, so this arm does not fire
+        // for the ordinary `a()?` path. It fires only for a try that the
+        // desugarer deliberately leaves in place — one nested inside a
+        // ternary branch (`cond ? readFile()? : x`), where the desugarer's
+        // statement-level hoist would wrongly evaluate the branch
+        // unconditionally. Serializing back to `operand?` text lets the
+        // shadow re-parser lower it with correct conditional semantics, the
+        // same path the construct took as a `Raw` node before #1690.
+        format_expression_into(expression.operand, out);
+        out.push("?");
+        return out;
+    }
     if expression.variant == "Await" {
         // Bridge the structured `Await` node (#1080) to the legacy text form
         // the `async`/`await` lowering keys on (a leading `"await "`). Use the

--- a/compiler/src/emitter_sailfin_expr.sfn
+++ b/compiler/src/emitter_sailfin_expr.sfn
@@ -134,6 +134,17 @@ fn format_expression(expression: Expression) -> string {
         let operand_text = format_expression(expression.operand);
         return operand_text + " as " + expression.target_type.text;
     }
+    if expression.variant == "Conditional" {
+        // Ternary `cond ? then : else` (#1690). Human-friendly source
+        // rendering (no operand parens) — like the `Cast` arm above, this
+        // emitter feeds the Sailfin-to-Sailfin path, not the .sfn-asm
+        // re-parse, so the parens the native formatter adds are unnecessary
+        // here.
+        let condition_text = format_expression(expression.condition);
+        let then_text = format_expression(expression.then_value);
+        let else_text = format_expression(expression.else_value);
+        return condition_text + " ? " + then_text + " : " + else_text;
+    }
     if expression.variant == "Lambda" {
         return format_lambda_expression(expression);
     }

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -575,6 +575,23 @@ fn _rewrite_expression(ctx: LiftContext, expression: Expression) -> ExpressionRe
             }
         };
     }
+    if expression.variant == "Conditional" {
+        // Ternary `cond ? then : else` (#1690). Rewrite all three children
+        // so a capture reference inside any branch is lifted to the captured
+        // environment, threading `ctx` left-to-right.
+        let cond = _rewrite_expression(ctx, expression.condition);
+        let then_value = _rewrite_expression(cond.ctx, expression.then_value);
+        let else_value = _rewrite_expression(then_value.ctx, expression.else_value);
+        return ExpressionRewriteResult {
+            ctx: else_value.ctx,
+            expression: Expression.Conditional {
+                condition: cond.expression,
+                then_value: then_value.expression,
+                else_value: else_value.expression,
+                span: expression.span
+            }
+        };
+    }
     // Lift lambdas nested inside spawn/await operands (#1090). A lambda
     // operand is a spawn target — its captured env crosses the thread
     // boundary and the worker frees it (#1475), so lift it with

--- a/compiler/src/ownership_checker.sfn
+++ b/compiler/src/ownership_checker.sfn
@@ -933,6 +933,17 @@ fn _scope_after_expression(expression: Expression?, scope: OwnershipScope) -> Ow
     if expression.variant == "TryOperator" {
         return _scope_after_expression(expression.operand, scope);
     }
+    if expression.variant == "Conditional" {
+        // Ternary `cond ? then : else` (#1690). Thread the scope through all
+        // three children so a move inside any branch (`flag ? consume(buf) :
+        // x`) is recorded and a later use of the moved binding is still
+        // caught. Sequencing condition → then → else is a conservative
+        // over-approximation (the two branches are mutually exclusive at
+        // runtime, but treating both as taken never misses a real move).
+        let after_condition = _scope_after_expression(expression.condition, scope);
+        let after_then = _scope_after_expression(expression.then_value, after_condition);
+        return _scope_after_expression(expression.else_value, after_then);
+    }
     if expression.variant == "Spawn" {
         // A spawned closure captures owned values as moves (#1220). A
         // bare-fn spawn (`spawn foo(buf)`) is an ordinary call whose

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -353,11 +353,145 @@ fn parse_expression_bp(state: ExpressionTokens, min_precedence: int) -> Expressi
         }
     }
 
+    // Ternary conditional `cond ? then : else` (#1690). Lowest precedence,
+    // right-associative. Recognized ONLY at the base precedence
+    // (`min_precedence == 0`) so it binds looser than every binary operator:
+    // `a + b ? c : d` groups as `(a + b) ? c : d` because the climbed
+    // `a + b` is `left_expression` here, and a binary right-hand side
+    // (parsed at `precedence + 1` ≥ 1) never enters this arm. The then- and
+    // else-branches recurse at base precedence, so `a ? b : c ? d : e`
+    // right-associates as `a ? b : (c ? d : e)` and the then-branch may
+    // itself be a ternary (`a ? x ? y : z : w`). The `?` was already
+    // confirmed a ternary (left unconsumed) by `parse_postfix_chain`, but
+    // re-checking `is_ternary_marker` keeps this layer self-contained.
+    if min_precedence == 0 {
+        if !expression_tokens_is_at_end(current_state) {
+            let q_token = expression_tokens_peek(current_state);
+            let mut q_is_question: boolean = false;
+            if q_token.kind.variant == "Symbol" {
+                if strings_equal(q_token.lexeme, "?") { q_is_question = true; }
+            }
+            if q_is_question {
+                let after_q = expression_tokens_advance(current_state);
+                if is_ternary_marker(after_q) {
+                    let then_result = parse_expression_bp(after_q, 0);
+                    if !then_result.success {
+                        return expression_parse_failure(state);
+                    }
+                    let after_then = then_result.state;
+                    if expression_tokens_is_at_end(after_then) {
+                        return expression_parse_failure(state);
+                    }
+                    let colon = expression_tokens_peek(after_then);
+                    if !symbol_matches(colon, ":") {
+                        return expression_parse_failure(state);
+                    }
+                    let after_colon = expression_tokens_advance(after_then);
+                    let else_result = parse_expression_bp(after_colon, 0);
+                    if !else_result.success {
+                        return expression_parse_failure(state);
+                    }
+                    return ExpressionParseResult {
+                        state: else_result.state,
+                        expression: Expression.Conditional {
+                            condition: left_expression,
+                            then_value: then_result.expression,
+                            else_value: else_result.expression,
+                            span: source_span_from_tokens([q_token])
+                        },
+                        success: true
+                    };
+                }
+            }
+        }
+    }
+
     return ExpressionParseResult {
         state: current_state,
         expression: left_expression,
         success: true
     };
+}
+
+// ============================================================================
+// Ternary Disambiguation (#1690)
+// ============================================================================
+// Decide whether a `?` at the current position opens a ternary conditional
+// rather than the postfix try operator. `state` must be positioned at the
+// token immediately AFTER the `?`. A ternary requires BOTH:
+//   (a) the next token can start an expression (the then-branch), and
+//   (b) a top-level `:` appears ahead before a terminator.
+// (a) is essential: a try operator directly before an enclosing ternary's
+// colon (`outer ? inner()? : z`) has `:` immediately after the inner `?`,
+// which cannot start an expression — so the inner `?` stays a try operator.
+// (b) preserves the exact legacy behavior for every non-ternary `?`: with no
+// top-level `:` ahead, the `?` is consumed as a TryOperator as before.
+fn is_ternary_marker(state: ExpressionTokens) -> boolean {
+    if expression_tokens_is_at_end(state) { return false; }
+    if !token_can_start_expression(expression_tokens_peek(state)) {
+        return false;
+    }
+    return ternary_colon_ahead(state);
+}
+
+fn token_can_start_expression(token: Token) -> boolean {
+    if token.kind.variant == "Identifier" { return true; }
+    if token.kind.variant == "NumberLiteral" { return true; }
+    if token.kind.variant == "StringLiteral" { return true; }
+    if token.kind.variant == "BooleanLiteral" { return true; }
+    if token.kind.variant == "Symbol" {
+        let sym = token.lexeme;
+        if strings_equal(sym, "(") { return true; }
+        if strings_equal(sym, "[") { return true; }
+        if strings_equal(sym, "{") { return true; }
+        if strings_equal(sym, "-") { return true; }
+        if strings_equal(sym, "!") { return true; }
+    }
+    return false;
+}
+
+// Scan forward (from the token after `?`) for a `:` at the same nesting
+// level, tracking only `()`/`{}`/`[]` depth. Angle brackets are deliberately
+// NOT tracked: `<`/`>` are comparison operators in expression position
+// (`cond ? a < b : c`), and treating them as nesting would hide the ternary
+// colon. A top-level `,`/`;`, or a closing delimiter that drops below the
+// starting depth, ends the candidate region (no ternary). Object-literal and
+// nested-call colons sit at depth > 0 and are correctly skipped
+// (`cond ? {k: 1} : z`).
+fn ternary_colon_ahead(state: ExpressionTokens) -> boolean {
+    let mut current = state;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
+    loop {
+        if expression_tokens_is_at_end(current) { return false; }
+        let token = expression_tokens_peek(current);
+        if token.kind.variant == "Symbol" {
+            let sym = token.lexeme;
+            let mut at_top: boolean = false;
+            if paren == 0 {
+                if brace == 0 {
+                    if bracket == 0 { at_top = true; }
+                }
+            }
+            if at_top {
+                if strings_equal(sym, ":") { return true; }
+                if strings_equal(sym, ",") { return false; }
+                if strings_equal(sym, ";") { return false; }
+            }
+            if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren == 0 { return false; }
+                paren -= 1;
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace == 0 { return false; }
+                brace -= 1;
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket == 0 { return false; }
+                bracket -= 1;
+            }
+        }
+        current = expression_tokens_advance(current);
+    }
 }
 
 fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
@@ -832,7 +966,22 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             // `((a()?).b())?`. Nullable type annotations (`let x: Config?`)
             // are consumed by the type parser and never reach expression
             // postfix position, so there is no ambiguity here.
-            current_state = expression_tokens_advance(current_state);
+            //
+            // Ternary disambiguation (#1690): a `?` is the ternary operator
+            // — NOT the try operator — when (a) the token after it can start
+            // an expression AND (b) a top-level `:` follows before a
+            // terminator. Condition (a) is what keeps `cond ? maybeFail()? :
+            // x` parsing the inner `?` (followed immediately by `:`, which
+            // cannot start an expression) as a TryOperator, while the outer
+            // `?` (followed by `maybeFail`) is the ternary. When a ternary
+            // `?` is detected, leave it unconsumed and break: the
+            // lowest-precedence ternary layer in `parse_expression_bp`
+            // (gated to the base precedence) wraps the whole climbed
+            // expression. This preserves every existing postfix `a()?` /
+            // `a()?.b()?` use unchanged.
+            let after_question = expression_tokens_advance(current_state);
+            if is_ternary_marker(after_question) { break; }
+            current_state = after_question;
             current_expression = Expression.TryOperator {
                 operand: current_expression,
                 span: source_span_from_tokens([token])

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -1012,6 +1012,15 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         diagnostics = diagnostics.concat(walk_expression(expression.end, bindings, imports));
         return diagnostics;
     }
+    if expression.variant == "Conditional" {
+        // Ternary `cond ? then : else` (#1690) — recurse into all three
+        // children so nested diagnostics (undefined symbols, parse-error
+        // nodes, removed-keyword statements) inside any branch still fire.
+        let mut diagnostics = walk_expression(expression.condition, bindings, imports);
+        diagnostics = diagnostics.concat(walk_expression(expression.then_value, bindings, imports));
+        diagnostics = diagnostics.concat(walk_expression(expression.else_value, bindings, imports));
+        return diagnostics;
+    }
     if expression.variant == "Cast" {
         // The #1627 parser lift only structures a pointer cast target into
         // `Cast` when the operand is NOT a bare identifier (effect-bearing

--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -320,6 +320,15 @@ fn walk_expression(scope: LocalBinding[], expression: Expression?) -> CaptureWal
     if expression.variant == "TryOperator" {
         return walk_expression(scope, expression.operand);
     }
+    if expression.variant == "Conditional" {
+        // Ternary `cond ? then : else` (#1690) — a capture can live in any
+        // branch (`fn() { return flag ? captured_a : captured_b; }`), so
+        // walk all three children and union the discovered captures.
+        let cond = walk_expression(scope, expression.condition);
+        let then_value = walk_expression(scope, expression.then_value);
+        let else_value = walk_expression(scope, expression.else_value);
+        return merge_results(merge_results(cond, then_value), else_value);
+    }
     if expression.variant == "Call" {
         let mut result = walk_expression(scope, expression.callee);
         let mut i: int = 0;

--- a/compiler/tests/unit/effect_conditional_branch_test.sfn
+++ b/compiler/tests/unit/effect_conditional_branch_test.sfn
@@ -1,0 +1,151 @@
+// #1690 — a ternary `cond ? then : else` must not hide a branch's effects.
+//
+// Epic #1180 (effect-system hardening), follows #1627. Before #1690 a ternary
+// had no structured parse: the postfix chain consumed the `?` as a
+// `TryOperator`, leaving `b : c` as leftover tokens, so the whole expression
+// degraded to `Expression.Raw`. Since #1186 deleted `collect_effects_from_text`
+// a `Raw` node contributes ZERO effects, so an effectful branch
+// (`cond ? print.info(x) : y`) reached codegen with no `![io]` declared —
+// confirmed live: `c ? print.info("X") : print.info("Y")` passed `sfn check`
+// with no `[io]` requirement.
+//
+// This pins three things end to end:
+//   (a) the parser structures a ternary into a `Conditional` node with the
+//       correct precedence/associativity (and does NOT regress the postfix
+//       `TryOperator`, which the compiler self-hosts on heavily);
+//   (b) `collect_effects_from_expression` unions the effects of all three
+//       children so any effectful branch surfaces its requirement; and
+//   (c) an effect-free ternary requires nothing (no false positive that would
+//       reject ordinary user code).
+import { Expression } from "../../src/ast";
+import { EffectRequirement, collect_effects_from_expression } from "../../src/effect_checker";
+import { empty_import_symbols } from "../../src/effect_imports";
+import { parse_program } from "../../src/parser/mod";
+
+fn _probe_expr(snippet: string) -> Expression ![io] {
+    let program = parse_program("fn probe() { " + snippet + "; }");
+    assert program.statements.length >= 1;
+    let fn_stmt = program.statements[0];
+    assert fn_stmt.variant == "FunctionDeclaration";
+    assert fn_stmt.body.statements.length >= 1;
+    let stmt = fn_stmt.body.statements[0];
+    assert stmt.variant == "ExpressionStatement";
+    return stmt.expression;
+}
+
+fn _reqs_contain(reqs: EffectRequirement[], effect: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= reqs.length { break; }
+        if reqs[index].effect == effect { return true; }
+        index += 1;
+    }
+    return false;
+}
+
+fn _cond_reqs(snippet: string) -> EffectRequirement[] ![io] {
+    return collect_effects_from_expression(_probe_expr(snippet), empty_import_symbols());
+}
+
+// -------------------------------------------------------------------
+// Structural lift: a ternary parses into a `Conditional` (not `Raw`).
+// -------------------------------------------------------------------
+test "ternary: basic form structures into Conditional" ![io] {
+    let expr = _probe_expr("a ? b : c");
+    assert expr.variant == "Conditional";
+    assert expr.condition.variant == "Identifier";
+    assert expr.condition.name == "a";
+    assert expr.then_value.variant == "Identifier";
+    assert expr.then_value.name == "b";
+    assert expr.else_value.variant == "Identifier";
+    assert expr.else_value.name == "c";
+}
+
+// `a + b ? c : d` groups as `(a + b) ? c : d` — ternary is lower precedence
+// than every binary operator, so the climbed `a + b` is the condition.
+test "ternary: binds looser than binary (right grouping)" ![io] {
+    let expr = _probe_expr("a + b ? c : d");
+    assert expr.variant == "Conditional";
+    assert expr.condition.variant == "Binary";
+    assert expr.condition.operator == "+";
+    assert expr.then_value.name == "c";
+    assert expr.else_value.name == "d";
+}
+
+// `a ? b : c ? d : e` right-associates as `a ? b : (c ? d : e)`.
+test "ternary: right-associative else branch" ![io] {
+    let expr = _probe_expr("a ? b : c ? d : e");
+    assert expr.variant == "Conditional";
+    assert expr.condition.name == "a";
+    assert expr.then_value.name == "b";
+    assert expr.else_value.variant == "Conditional";
+    assert expr.else_value.condition.name == "c";
+    assert expr.else_value.then_value.name == "d";
+    assert expr.else_value.else_value.name == "e";
+}
+
+// A brace-nested `:` (object literal) must not be mistaken for the ternary
+// separator — the nesting-aware lookahead skips colons at depth > 0.
+test "ternary: brace-nested colon does not split the ternary" ![io] {
+    let expr = _probe_expr("cond ? {k: 1} : z");
+    assert expr.variant == "Conditional";
+    assert expr.condition.name == "cond";
+    assert expr.then_value.variant == "Object";
+    assert expr.else_value.name == "z";
+}
+
+// -------------------------------------------------------------------
+// Regression guard: the postfix `?` try operator must NOT be reinterpreted
+// as a ternary. The compiler self-hosts on `a()?` / `a()?.b()?` throughout
+// its own source — a regression here breaks the build.
+// -------------------------------------------------------------------
+test "try-operator: `a()?` still parses as TryOperator" ![io] {
+    let expr = _probe_expr("a()?");
+    assert expr.variant == "TryOperator";
+    assert expr.operand.variant == "Call";
+}
+
+test "try-operator: chained `a()?.b()?` still parses as TryOperator" ![io] {
+    let expr = _probe_expr("a()?.b()?");
+    assert expr.variant == "TryOperator";
+}
+
+// A try operator directly before an enclosing ternary's colon
+// (`cond ? maybeFail()? : x`): the inner `?` is followed immediately by `:`
+// (which cannot start an expression), so it stays a TryOperator; the outer
+// `?` is the ternary. This is the precedence-delicate case the disambiguation
+// is built around.
+test "ternary: try operator inside the then-branch stays a TryOperator" ![io] {
+    let expr = _probe_expr("cond ? g()? : x");
+    assert expr.variant == "Conditional";
+    assert expr.condition.name == "cond";
+    assert expr.then_value.variant == "TryOperator";
+    assert expr.else_value.name == "x";
+}
+
+// -------------------------------------------------------------------
+// Effect attribution: the requirement is the union of all three children.
+// -------------------------------------------------------------------
+test "ternary: effectful then-branch surfaces io" ![io] {
+    assert _reqs_contain(_cond_reqs("c ? print.info(\"X\") : y"), "io");
+}
+
+test "ternary: effectful else-branch surfaces io" ![io] {
+    assert _reqs_contain(_cond_reqs("c ? y : print.info(\"X\")"), "io");
+}
+
+test "ternary: effectful condition surfaces io" ![io] {
+    assert _reqs_contain(_cond_reqs("print.info(\"X\") ? a : b"), "io");
+}
+
+test "ternary: effectful branch surfaces net" ![io] {
+    assert _reqs_contain(_cond_reqs("c ? http.get(\"u\") : y"), "net");
+}
+
+// -------------------------------------------------------------------
+// No false positive: an effect-free ternary requires nothing.
+// -------------------------------------------------------------------
+test "ternary: effect-free ternary requires nothing" ![io] {
+    let reqs = _cond_reqs("a ? b : c");
+    assert reqs.length == 0;
+}

--- a/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
+++ b/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
@@ -230,13 +230,26 @@ Self-host gate: `make compile` + `make check`.
   reuse, and `effect_cast_operand_test`. Bundled (no seed cut). Closes the
   demonstrated cast-shaped effect escape; the constructs below are now tracked
   follow-ons rather than part of this PR.
-- **#1180-a "Structure ternary `? :` into a `Conditional` AST node" — M.**
-  `cond ? readFile() : x` degrades to `Raw` and escapes `![io]` (confirmed live).
-  Needs a new `Conditional` node + `?`/`:` lookahead disambiguation that does
-  **not** regress postfix `TryOperator` (`a()?`, used throughout compiler source —
-  a regression breaks self-host), formatter (→ `cond ? a : b`, shadow parser
-  already lowers it), effect arm. Self-contained but precedence-delicate; its own
-  tested PR. Cite SFEP-0008.
+- **#1180-a "Structure ternary `? :` into a `Conditional` AST node" — M —
+  SHIPPED (#1690).** A ternary now parses into `Conditional { condition,
+  then_value, else_value, span }`; the effect checker unions all three children's
+  effects, closing the `cond ? readFile() : x` escape (`E0400`). The `?`/`:`
+  disambiguation is two-signal: a `?` is ternary only when the token after it can
+  start an expression **and** a nesting-aware top-level `:` follows — the
+  expression-start signal is what keeps a try operator immediately before an
+  enclosing ternary's colon (`outer ? inner()? : z`) parsing the inner `?` as a
+  `TryOperator`. Postfix `a()?` / `a()?.b()?` are untouched (self-host on them is
+  preserved). The formatter serializes `(cond) ? (then) : (else)` — the exact text
+  the shadow `parse_ternary_expression` already lowers (no new lowering arm); a
+  `TryOperator` formatter arm was added for a try left inside a ternary branch
+  (the desugarer correctly does **not** hoist branch-tries). `Conditional` arms
+  were also added to every structural walker (typecheck, capture analysis,
+  ownership scope, lambda-capture rewrite) so the node is fully analyzed, not just
+  effect-checked. Regression coverage: `effect_conditional_branch_test.sfn`. The
+  compiler/runtime source contains no ternaries, so the path is dormant under
+  self-host. **Remaining gap (filed separately):** typecheck does not yet unify
+  the then/else branch types, so `cond ? 1 : "s"` is not rejected — a follow-on.
+  Cite SFEP-0008.
 - **#1180-b "Parser-level parse diagnostic at `Unknown` production sites" — S.**
   A nested `Statement.Unknown` (unparseable statement inside a block) is silently
   dropped — no diagnostic, no effects; top-level gets `E0500`, nested gets

--- a/docs/status.md
+++ b/docs/status.md
@@ -121,11 +121,16 @@ here.
   so a cast can no longer hide its operand's effects (`E0400`). Bare-identifier
   pointer casts (`<fn>`/`<ptr-value> as * u8`) intentionally stay `Raw` — they
   carry no effect, and this preserves the #1147 function-reference diagnostics and
-  the shadow-parser lowering unchanged. The remaining
-  Raw-degraded effect-escapes (ternary `? :`, prefix `*`/`&`, assignment-as-
-  expression) are tracked under epic #1180 (#1180-a/c) behind a blanket
-  fail-closed `Raw` backstop. Effect polymorphism (`!E` variables, polymorphic
-  HOFs) remains post-1.0.
+  the shadow-parser lowering unchanged. The ternary `? :` escape is closed the
+  same way in **#1690**: a ternary now parses into a structured `Conditional`
+  node (`cond ? then : else`) the effect checker walks, unioning the effects of
+  all three children, so `cond ? readFile() : x` can no longer reach codegen
+  effect-free (`E0400`). The disambiguation leaves the postfix `?` try operator
+  (`a()?`, `a()?.b()?`) untouched — a `?` is ternary only when the token after it
+  can start an expression *and* a top-level `:` follows. The remaining
+  Raw-degraded effect-escapes (prefix `*`/`&`, assignment-as-expression) are
+  tracked under epic #1180 (#1180-c) behind a blanket fail-closed `Raw` backstop.
+  Effect polymorphism (`!E` variables, polymorphic HOFs) remains post-1.0.
 - **Undefined free-function rejection** (`E0420`, #616/#812): unresolvable
   bare-identifier callees fail typecheck.
 - **Function references**: a bare fn name in value position lowers to the


### PR DESCRIPTION
## Summary

A ternary `cond ? then : else` had no structured parse: the postfix chain consumed the `?` as a `TryOperator`, leaving `b : c` as leftover tokens, so the whole expression degraded to `Expression.Raw`. Since #1186 a `Raw` node contributes **zero effects**, so an effectful branch (`cond ? readFile() : x`) reached codegen with no `[io]` — a fail-open hole in the effects pillar.

**Confirmed live before the fix:** `c ? print.info("X") : print.info("Y")` passed `sfn check` with no `[io]` requirement. After the fix it reports `E0400` (`[io]` required).

Closes #1690. Epic: #1180 (effect-system hardening). Design: SFEP-0008 + `docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md` (this is the pre-planned `#1180-a`).

## What changed

- **AST** (`ast.sfn`): new `Conditional { condition, then_value, else_value, span }`.
- **Parser** (`parser/expressions.sfn`): a `?` is the **ternary** operator (not the try operator) only when **(a)** the token after it can start an expression **and** **(b)** a nesting-aware top-level `:` follows. Signal (a) is what keeps a try operator immediately before an enclosing ternary's colon (`outer ? inner()? : z`) parsing the inner `?` as a `TryOperator`. Ternary is recognized at the base precedence only, so `a + b ? c : d` groups as `(a + b) ? c : d`; the then/else branches recurse at base precedence for right-associativity. Postfix `a()?` / `a()?.b()?` are untouched.
- **Effect checker** (`effect_checker.sfn`): a `Conditional` arm unions the effects of all three children — the headline fix.
- **Formatter** (`emit_native_format.sfn`): serializes `(cond) ? (then) : (else)` — the exact text the lowering shadow re-parser (`parse_ternary_expression`) already handles, so **no new lowering arm**. Adds a `TryOperator` formatter arm for a try left inside a ternary branch (the desugarer correctly does *not* hoist branch-tries, whose hoist would evaluate a branch unconditionally).
- **All structural walkers** get `Conditional` arms so the node is fully analyzed, not just effect-checked: `typecheck` (recurse for nested diagnostics), `typecheck_captures` (capture detection in branches), `ownership_checker` (scope/move threading), `lambda_lowering` (`_rewrite_expression` capture rewrite), and `emitter_sailfin_expr` (source render for `sfn fmt`).

## Self-host safety

`compiler/src` and `runtime/` contain **no ternaries** (only the postfix `?` try operator), so the `Conditional` path is **dormant under self-host** — `make compile` exercises none of the new arms. The disambiguation's only job is to leave the heavily-used postfix `?` untouched, which is covered by explicit regression guards.

## Test plan

New `compiler/tests/unit/effect_conditional_branch_test.sfn` (12 tests):
- Structural lift `a ? b : c` → `Conditional`.
- Precedence `a + b ? c : d` → `(a + b) ? c : d`; right-assoc `a ? b : c ? d : e`.
- Brace-nested colon `cond ? {k: 1} : z` not mis-split.
- Try-operator regression guards: `a()?`, `a()?.b()?` stay `TryOperator`; `cond ? g()? : x` keeps the inner `?` as a `TryOperator`.
- Effect attribution across condition / then / else (io + net); effect-free negative.

Verified locally: new build self-hosts (`make compile`, exit 0); new test passes (12/12); affected existing tests green (`try_operator_test`, `try_desugar_test`, `effect_checker_test`, `effect_cast_operand_test`, `parser_iife_postfix_test`, …); ternary still lowers/runs correctly; declaring `[io]` makes the effectful ternary pass. Full `make check` is running.

## Stage1 readiness

Parses ✅ · effect-checks ✅ (`E0400`) · emits/lowers (via shadow re-parser, unchanged) ✅ · regression coverage ✅ · self-hosts ✅ · `sfn fmt --check` clean ✅ · docs (`status.md`, design note) ✅.

## Known follow-on gap (to be filed under #1180)

Typecheck does **not** yet unify the then/else branch types, so `cond ? 1 : "s"` is not rejected. Out of scope here (effect-soundness is the issue's focus); filing as a sub-issue under the epic.

https://claude.ai/code/session_01JKxYVEtpKhkHtBLSa1ARSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKxYVEtpKhkHtBLSa1ARSM)_