### PR TITLE
fix(lowering): resolve array `.push` in struct-method-only modules (#1700)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -735,9 +735,40 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     }
     let module_struct_methods = flatten_struct_methods(module_structs);
     if debug_lowering { print.err("emit-llvm: phase=struct_methods_done"); }
-    // Site 1 — safe in-place extend: safe_functions is not read after this
-    // line; local_functions aliases safe_functions and is read downstream.
-    let local_functions = extend_native_functions_inplace(safe_functions, module_struct_methods);
+    // #1700: drop any `safe_functions` entry that duplicates a flattened
+    // struct method (same name). A module whose only callables are struct
+    // methods (no free functions) makes `sanitize_functions` take its
+    // empty-parse recovery path, where `recover_native_functions_light`
+    // re-derives the struct methods AS top-level functions. That light
+    // parser does not recognize `.let`, so the recovered copies carry
+    // `Unknown` instructions and never populate locals — a `.push` on a
+    // local array then fails lowering with `cannot resolve return type for
+    // call to '<arr>.push'` (e.g. backend.sfn's argv builders when inlined
+    // into the `LlvmTextBackend` methods). `flatten_struct_methods` above
+    // already produced the authoritative copy of every struct method, so
+    // the recovered duplicate must be dropped; genuine free functions
+    // (distinct names) are kept. The dedup only fires when BOTH copies
+    // exist, so a true empty-parse recovery (structs also corrupt → no
+    // flattened method) keeps its recovered functions.
+    let mut deduped_safe_functions: NativeFunction[] = [];
+    let mut _dsf_i: int = 0;
+    loop {
+        if _dsf_i >= safe_functions.length { break; }
+        let _sf = safe_functions[_dsf_i];
+        let mut _is_dup_method: boolean = false;
+        let mut _msm_i: int = 0;
+        loop {
+            if _msm_i >= module_struct_methods.length { break; }
+            if module_struct_methods[_msm_i].name == _sf.name {
+                _is_dup_method = true;
+                break;
+            }
+            _msm_i += 1;
+        }
+        if !_is_dup_method { deduped_safe_functions.push(_sf); }
+        _dsf_i += 1;
+    }
+    let local_functions = extend_native_functions_inplace(deduped_safe_functions, module_struct_methods);
     if debug_lowering { print.err("emit-llvm: phase=local_functions"); }
     // Site 2 — must stay copying: local_functions is reused by
     // collect_runtime_helper_targets, render_llvm_preamble, and

--- a/compiler/tests/e2e/push_in_struct_method_test.sfn
+++ b/compiler/tests/e2e/push_in_struct_method_test.sfn
@@ -1,0 +1,124 @@
+// End-to-end regression for #1700: the array builtin `.push` called from
+// inside a `struct { fn method(self, …) { … } }` body must lower to LLVM
+// IR and link, not abort with
+//   `cannot resolve return type for call to 'args.push' — callee
+//    signature is not known to the compiler`.
+//
+// History & why this drives a CAPSULE build, not a single file: discovered
+// while implementing the `Backend` interface seam (#1112, merged in #1687).
+// The first cut put the clang-argv assembly `.push` loops directly in the
+// `LlvmTextBackend.assemble`/`link` method bodies; `sfn check` accepted it
+// but the self-host failed at lowering. The failure only surfaces under
+// the compiler's PER-MODULE emit (`capsule_resolver` lowers each module
+// with the other modules' staged `.sfn-asm` as import context) — a
+// standalone single-file `emit`/`build` of the same struct lowers fine, so
+// a single-file test would NOT catch the regression. It also only bites
+// when the struct's module has NO free-function `.push` of the same
+// element type to register a global `push` signature (#1687 worked around
+// it by hoisting the argv builders to free functions; that mask is exactly
+// what made the gap easy to miss). So this test builds a two-module capsule
+// whose `builder` module contains a single struct-method `.push` and no
+// free-function `.push`, mirroring the real failing shape.
+//
+// This is a #1389-class guard: `sfn check` is parse + typecheck +
+// effect-check ONLY (no IR, no link), so it cannot catch a codegen/link
+// lowering gap by construction. The regression must drive a real per-module
+// `build` (and run), not just `check` — see `.claude/rules/no-bash-e2e.md`.
+//
+// Build/parallel-runner hygiene: the capsule lives under a per-invocation
+// `SAILFIN_TEST_SCRATCH` path and the build inherits the full parent env
+// (`process.environ()`) so the nested clang/ld toolchain resolves (#1410)
+// and the build cache routes per-invocation (#1333). Mirrors
+// check_build_agree_module_global_test.sfn.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Inherit the full parent environment so the nested clang/ld the build
+// spawns find their toolchain (#1410), and SAILFIN_TEST_SCRATCH routes
+// the build cache per-invocation (#1333).
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// The defining module: a struct method that assembles a local `string[]`
+// with `.push` in a loop (pushing both a parameter-array element and a
+// string literal) and returns it. Deliberately contains NO free-function
+// `.push` — that absence is what exposes the lowering gap under the
+// per-module emit. Before the fix, `capsule_resolver` aborted lowering
+// this module with `cannot resolve return type for call to 'args.push'`.
+fn _builder_src() -> string {
+    return "struct Builder {\n"
+        + "    fn make(self, xs: string[]) -> string[] {\n"
+        + "        let mut args: string[] = [\"clang\"];\n"
+        + "        let mut i: int = 0;\n"
+        + "        loop {\n"
+        + "            if i >= xs.length { break; }\n"
+        + "            args.push(xs[i]);\n"
+        + "            i += 1;\n"
+        + "        }\n"
+        + "        args.push(\"-o\");\n"
+        + "        return args;\n"
+        + "    }\n"
+        + "}\n";
+}
+
+fn _main_src() -> string {
+    return "import { Builder } from \"./builder\";\n"
+        + "\n"
+        + "fn main() -> int ![io] {\n"
+        + "    let b = Builder{};\n"
+        + "    let out = b.make([\"a\", \"b\"]);\n"
+        + "    print.info(out[out.length - 1]);\n"
+        + "    return 0;\n"
+        + "}\n";
+}
+
+fn _capsule_toml() -> string {
+    return "[capsule]\n"
+        + "name = \"pushcap1700\"\n"
+        + "version = \"0.1.0\"\n"
+        + "\n"
+        + "[capabilities]\n"
+        + "allow = [\"io\"]\n";
+}
+
+// Stage the two-module capsule under the per-invocation scratch dir. This
+// test owns the directory name, so there is no cross-test collision under
+// the parallel pool.
+fn _stage_capsule() -> string ![io] {
+    let mut root = env.get("SAILFIN_TEST_SCRATCH");
+    if root.length == 0 { root = "/tmp"; }
+    let dir = root + "/sfn-1700-pushcap";
+    fs.createDirectory(dir + "/src", true);
+    fs.writeFile(dir + "/capsule.toml", _capsule_toml());
+    fs.writeFile(dir + "/src/builder.sfn", _builder_src());
+    fs.writeFile(dir + "/src/main.sfn", _main_src());
+    return dir;
+}
+
+test "push in struct method body lowers under per-module emit and runs (#1700)" ![io] {
+    let dir = _stage_capsule();
+    let binpath = dir + "/out";
+
+    // `sfn build -p <capsule>`: per-module codegen + link — each module is
+    // lowered with the others' `.sfn-asm` as import context. This is where
+    // the `cannot resolve return type for call to 'args.push'` abort used
+    // to surface on the `builder` module.
+    let build_exit = process.run_capture([_sfn_bin(), "build", "-p", dir, "-o", binpath], _child_env());
+    let build_out = process.capture_take_stdout();
+    let build_err = process.capture_take_stderr();
+
+    // The defining regression: lowering must NOT abort.
+    assert find(build_out + build_err, "cannot resolve return type") < 0;
+    assert build_exit == 0;
+
+    // ...and the linked program runs, printing the last pushed element
+    // (`-o`), proving the push lowered to correct, runnable IR.
+    let _run_exit = process.run_capture([binpath], _child_env());
+    let run_out = process.capture_take_stdout();
+    let _run_err = process.capture_take_stderr();
+    assert find(run_out, "-o", 0) >= 0;
+}


### PR DESCRIPTION
## Summary

- A struct method that builds a local `string[]` with `.push` failed LLVM lowering with `cannot resolve return type for call to '<arr>.push'` — but **only** under the compiler's per-module (capsule) emit, and **only** when the module had no free-function `.push` to mask it. A single-file `emit`/`build`/`run` of the same code lowered fine.
- **Root cause:** a module whose only callables are struct methods (no free functions) makes `sanitize_functions` take its empty-parse recovery path, where `recover_native_functions_light` re-derives the struct methods *as top-level functions*. That light parser does not recognize `.let`, so the recovered copies carry `Unknown` instructions and never populate locals — so the `.push` receiver's array type can't be resolved and the call hits the `[fatal]` unresolved-callee gate. `flatten_struct_methods` already produces the authoritative copy of every struct method, so there were two `Buildermake` copies in `local_functions`: one correct (`Let,Let,…`) and one buggy (`Unknown,Unknown,…`); the buggy one aborts.
- **Fix:** at the `local_functions` assembly in `lowering_core.sfn`, drop any `safe_functions` entry whose name duplicates a flattened struct method. Genuine free functions (distinct names) are kept; the dedup only fires when *both* copies exist, so a true empty-parse recovery (structs also corrupt → no flattened method) still keeps its recovered functions.

This is the underlying gap that #1687 worked around by hoisting the `LlvmTextBackend` argv builders to free functions. The masking is fully explained: free functions make `parse.functions` non-empty → no recovery → no buggy duplicate.

Closes #1700

## Acceptance Criteria

- [x] A `struct` method body that builds a local `string[]` with `.push` in a loop lowers to LLVM IR and self-hosts (no `cannot resolve return type` abort).
- [x] Regression test under `compiler/tests/` covering a struct method that uses `.push` on a local array.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Map reconciliation

The issue's advisory `## Files Affected` pointed at `compiler/src/llvm/expression_lowering/native/...` (the array-builtin call resolver). The true root was one stage up in the same lowering path — the per-module `local_functions` assembly in `compiler/src/llvm/lowering/lowering_core.sfn`, where the recovery-synthesized duplicate originates. Same semantic unit (the native-IR → LLVM lowering path that resolves an array-builtin method call inside a struct method body); cosmetic map drift, reconciled here.

## Deferred follow-up

`backend.sfn` keeps its free-function workaround in this PR. Inlining the argv builders back into the `LlvmTextBackend` methods (the issue's optional cleanup) needs this fix present in the **pinned seed** first — `make compile` self-hosts against the seed, which still has the bug — so it's a post-seed-cut follow-up, not bundlable here.

## Verification

```bash
make compile   # self-hosts (pass)
make test      # unit 172/172, integration 40/40, e2e 156/156, capsules 37/37 — all pass

# Minimal per-module repro (two-module capsule, struct-method .push, no free-fn .push):
build/native/sailfin build -p <capsule> -o out   # exit 0 (was: failed to lower ... cannot resolve return type)
./out                                            # prints "b"

# New regression test:
build/native/sailfin test compiler/tests/e2e/push_in_struct_method_test.sfn   # PASS
```

## Files Changed

- `compiler/src/llvm/lowering/lowering_core.sfn` — dedup recovered struct-method functions against `flatten_struct_methods` at `local_functions` assembly.
- `compiler/tests/e2e/push_in_struct_method_test.sfn` — new e2e regression (two-module capsule; exercises the per-module emit path a single-file build would miss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013YXQEdi6VxBYnQFNvwUWTr)_