### PR TITLE
docs(sfep): graduate SFEP-0031 to Implemented

### DIFF
--- a/docs/proposals/0031-inline-export-decl.md
+++ b/docs/proposals/0031-inline-export-decl.md
@@ -1,15 +1,15 @@
 ---
 sfep: 0031
 title: Inline `export <declaration>` syntax
-status: Accepted
+status: Implemented
 type: language
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-06-27
 author: "agent:compiler-architect; human review"
 tracking: "#1681, #1680"
 supersedes:
 superseded-by:
-graduates-to:
+graduates-to: reference/spec/02-modules.md
 ---
 
 # SFEP-0031 — Inline `export <declaration>` syntax

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -53,7 +53,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0028](./0028-typed-array-higher-order-fns.md) | Typed / Generic-Element Array Higher-Order Functions (map / filter / reduce) | Draft | language |
 | [0029](./0029-lambda-syntax.md) | Lambda expression syntax for 1.0 — keep, reform, or defer | Accepted | language |
 | [0030](./0030-first-class-function-values.md) | First-Class Function Values | Accepted | language |
-| [0031](./0031-inline-export-decl.md) | Inline `export <declaration>` syntax | Accepted | language |
+| [0031](./0031-inline-export-decl.md) | Inline `export <declaration>` syntax | Implemented | language |
 
 ## Subdirectories
 


### PR DESCRIPTION
## Summary

- Graduates **SFEP-0031** (Inline `export <declaration>` syntax) from `Accepted` → `Implemented`, now that the feature shipped in #1713 (closed #1681).
- Sets `graduates-to: reference/spec/02-modules.md` and updates the registry row in `docs/proposals/README.md`.

Docs-only follow-up to #1713; no code change.

## Why now

The feature clears the Stage1 readiness bar end-to-end: it parses, type/effect-checks, emits the `.export` manifest (parity with the block form), lowers to LLVM, has unit + integration + e2e regression coverage (the e2e is the direct #1681 regression), and self-hosts. Per `.claude/rules/proposals.md`, that warrants `Implemented`.

## Files Changed

- `docs/proposals/0031-inline-export-decl.md` — `status: Implemented`, `updated: 2026-06-27`, `graduates-to: reference/spec/02-modules.md`.
- `docs/proposals/README.md` — registry row `Accepted` → `Implemented`.

Refs #1681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01SAdssM6XtJCAKJBX2s8oWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAdssM6XtJCAKJBX2s8oWS)_