### PR TITLE
test(e2e): surface child output on build-and-run failure for macOS nightly diagnosis

### DIFF
--- a/compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn
+++ b/compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn
@@ -74,9 +74,20 @@ fn _race_round(base: string, round: int, n: int) -> boolean ![io] {
     script = script + "wait\n";
 
     let exit = process.run_capture(["bash", "-c", script], process.environ());
-    let _o = process.capture_take_stdout();
-    let _e = process.capture_take_stderr();
-    if exit != 0 { return false; }
+    let o = process.capture_take_stdout();
+    let e = process.capture_take_stderr();
+    if exit != 0 {
+        // Surface the child output so a re-fire in the macOS nightly is
+        // diagnosable (OOM/SIGABRT vs. a genuine cache-key race) — these
+        // background `sfn run`s otherwise swallow their stderr (#1462).
+        print.err("[objkey-race] round " + number_to_string(round)
+            + " bash exit="
+            + number_to_string(exit)
+            + " output:\n"
+            + o
+            + e);
+        return false;
+    }
 
     // Verify every child produced exactly its own marker.
     let mut ok = true;
@@ -86,10 +97,18 @@ fn _race_round(base: string, round: int, n: int) -> boolean ![io] {
         let tag = number_to_string(round) + "_" + number_to_string(j);
         let marker = "OBJKEY_MARK_" + tag;
         let outp = base + "/o_" + tag + ".txt";
-        if !fs.exists(outp) { ok = false; } else {
+        if !fs.exists(outp) {
+            print.err("[objkey-race] missing child output " + outp);
+            ok = false;
+        } else {
             let got = fs.readFile(outp);
             // Own marker present...
-            if !contains(got, marker) { ok = false; }
+            if !contains(got, marker) {
+                print.err("[objkey-race] child " + tag
+                    + " missing own marker; got:\n"
+                    + got);
+                ok = false;
+            }
             // ...and no sibling's marker leaked in (cross-contamination).
             let mut s = 0;
             loop {

--- a/compiler/tests/e2e/struct_field_separator_test.sfn
+++ b/compiler/tests/e2e/struct_field_separator_test.sfn
@@ -54,10 +54,19 @@ fn _emit(source: string, tag: string, kind: string, ext: string) -> string ![io]
     fs.writeFile(src, source);
     if fs.exists(out) { fs.deleteFile(out); }
     let exit = process.run_capture([_sfn_bin(), "emit", "-o", out, kind, src], _child_env());
-    let _o = process.capture_take_stdout();
-    let _e = process.capture_take_stderr();
+    let o = process.capture_take_stdout();
+    let e = process.capture_take_stderr();
     fs.deleteFile(src);
-    if exit != 0 { return ""; }
+    if exit != 0 {
+        // Surface child output so a macOS-nightly re-fire is diagnosable
+        // (OOM/SIGABRT vs. an emit bug) — otherwise swallowed (#1462).
+        print.err("[struct-sep] emit failed tag=" + tag + " exit="
+            + number_to_string(exit)
+            + " output:\n"
+            + o
+            + e);
+        return "";
+    }
     if !fs.exists(out) { return ""; }
     let text = fs.readFile(out);
     fs.deleteFile(out);
@@ -74,7 +83,16 @@ fn _run(source: string, tag: string) -> string ![io] {
     let out = process.capture_take_stdout();
     let err = process.capture_take_stderr();
     fs.deleteFile(src);
-    if exit != 0 { return ""; }
+    if exit != 0 {
+        // Surface child output so a macOS-nightly re-fire is diagnosable
+        // (OOM/SIGABRT vs. a run-pipeline bug) — otherwise swallowed (#1462).
+        print.err("[struct-sep] run failed tag=" + tag + " exit="
+            + number_to_string(exit)
+            + " output:\n"
+            + out
+            + err);
+        return "";
+    }
     return out + err;
 }
 


### PR DESCRIPTION
## Summary

The macOS-arm64 nightly self-host check keeps re-firing as **exit 134 (SIGABRT)** in concurrent build-and-run e2e tests, **roaming** across test files:

- nightly **#74** (2026-06-27): `concurrent_runtime_objkey_race_test.sfn:116:5` (first-pass-tests phase)
- nightly **#72** (2026-06-25): `struct_field_separator_test.sfn:112:5` (seedcheck-tests phase)

This is the same failure class the **v0.7.0 release tracker (#1462)** documents under its "Self-host stability gate" — root-caused as macOS-specific bugs + **peak-RSS pressure (margin-dependent OOM)** under concurrent cold compiles. Linux x86_64 has stayed green throughout. The fix declared "fixed 2026-06-25/26" narrowed the margin (nightly #73 went green) but **did not hold** — #74 re-fired, breaking the green-streak soak.

The blocker to actually root-causing each re-fire: these nested `sfn run`/`sfn emit` children **swallow their stdout/stderr** (`let _o = ...; let _e = ...; return ""`), so the nightly logs never show *why* the build failed.

## Change

Print the captured child output on **every failure path** in the two tests that have fired, so the next re-fire distinguishes an OOM/SIGABRT abort from a genuine cache-key race or an emit/run bug:

- `concurrent_runtime_objkey_race_test.sfn` — emit the round's `bash -c` exit + combined output on non-zero exit; emit a child's captured file on a missing/wrong marker.
- `struct_field_separator_test.sfn` — emit the child exit + combined output on `_emit`/`_run` failure.

**Diagnostic-only.** Output is added solely on the failure branch; passing behavior is unchanged.

## Verification

- `make compile` — green (compiler self-hosts)
- `sfn fmt --check` — clean on both files
- `sfn check` — ok (pre-existing W0210 bare-assert lints only)
- `sailfin test` on both files — `concurrent_runtime_objkey_race_test` 1/1, `struct_field_separator` 6/6

## Scope / follow-ups

This PR makes the flake **diagnosable**; it does not claim to fix the underlying margin-dependent OOM. The actual margin reduction (lowering the objkey test's 6× concurrent fan-out / capping macOS build-jobs concurrency in the e2e pool) is filed separately, since cutting the fan-out trades regression-guard strength and is an architect-level call. The re-fire is recorded on #1462 (soak counter reset).

Refs #1462

https://claude.ai/code/session_01WwjDfRqcGNxkotdFzV8cXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwjDfRqcGNxkotdFzV8cXW)_