### PR TITLE
fix(serve): reject truncated requests on the EOF path, freeing the buffer

### DIFF
--- a/compiler/tests/e2e/serve_loopback_test.sfn
+++ b/compiler/tests/e2e/serve_loopback_test.sfn
@@ -64,6 +64,11 @@ extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
 
 extern fn close(fd: i32) -> i32;
 
+// `shutdown(fd, SHUT_WR=1)` — half-close the write side so the server's
+// recv sees EOF (a truncated request, #1709) while the read side stays
+// open to drain the server's 500 reply. Identical C ABI on both targets.
+extern fn shutdown(sockfd: i32, how: i32) -> i32;
+
 // The listening port for the loopback server. Fixed (this is the sole
 // server-loopback test in the native e2e pool, so it does not collide
 // under `--jobs N`); high + uncommon to avoid clashing with a developer's
@@ -210,6 +215,46 @@ fn _lb_request(port: i64, request: string) -> string {
         close(fd);
         return "";
     }
+    let resp = _lb_recv_all(fd);
+    close(fd);
+    return resp;
+}
+
+// `_lb_fire_and_close(port, request)` — connect, send `request` (which may
+// be empty), then close WITHOUT reading the response. The fire-and-forget
+// shape for driving the server's error paths (empty / truncated
+// connections, #1709) without blocking on a 500 the peer may never read:
+// an empty send closes immediately (the server's first recv returns 0 —
+// EOF — with no bytes), and a partial head is delivered then followed by
+// FIN (the server reads the partial, then EOF before the `\r\n\r\n`
+// terminator). Both take the worker's free-and-500 early-return path
+// rather than a 10s recv-timeout wait. Returns true if the connection
+// was established.
+fn _lb_fire_and_close(port: i64, request: string) -> bool {
+    let fd: i32 = _lb_connect(port);
+    if fd < 0 { return false; }
+    let n: i64 = strlen(request as * u8) as i64;
+    if n > 0 { let _ = _lb_send_all(fd, request as * u8, n); }
+    close(fd);
+    return true;
+}
+
+// `_lb_request_halfclose(port, request)` — send a deliberately truncated
+// head, half-close the write side (SHUT_WR) so the server sees EOF before
+// the `\r\n\r\n` terminator, then drain the reply. Unlike
+// `_lb_fire_and_close`, this keeps the read side open to OBSERVE the
+// server's response (a 500 for the truncated request, #1709). Returns the
+// response text, or "" on a connect/send failure.
+fn _lb_request_halfclose(port: i64, request: string) -> string {
+    let fd: i32 = _lb_connect(port);
+    if fd < 0 { return ""; }
+    if !_lb_send_all(fd, request as * u8, strlen(request as * u8) as i64) {
+        close(fd);
+        return "";
+    }
+    // SHUT_WR = 1: signal EOF to the server's recv while keeping the read
+    // side open to drain its 500 response.
+    shutdown(fd, 1);
     let resp = _lb_recv_all(fd);
     close(fd);
     return resp;
@@ -433,6 +478,40 @@ test "serve loopback: macOS request delivery + framed behavioral round-trips" ![
     let oversize_resp = _lb_request(port, oversize_req);
     print.info("[serve-loopback] oversize: " + oversize_resp);
     assert contains(oversize_resp, "HTTP/1.1 500");
+
+    // #1709: a truncated request (EOF before the `\r\n\r\n` terminator) is
+    // rejected with a 500 — NOT moved into the handler as a malformed
+    // request. Before the fix the partial buffer was handed to the handler
+    // (which saw an unparseable head and 404'd); after it, the worker's
+    // EOF early-return path frees the request buffer and sends a direct
+    // 500. Asserting the 500 distinguishes the fixed behavior from the old
+    // dispatch-the-garbage path.
+    let trunc_resp = _lb_request_halfclose(port, "GET /probe HTTP/1.1\r\nHost: x");
+    print.info("[serve-loopback] truncated: " + trunc_resp);
+    assert contains(trunc_resp, "HTTP/1.1 500");
+
+    // #1709: hammer the error paths — interleave empty (immediate-close)
+    // and truncated (partial head + EOF) connections so each repeatedly
+    // takes the worker's free-and-500 early-return path. A per-connection
+    // request-buffer leak, a double-free, or a crash/hang on these paths
+    // would destabilize the long-lived server; the post-storm valid
+    // round-trip below proves it survived every error-path connection
+    // intact. This is the achievable proxy for the RSS-stability criterion
+    // — there is no in-process RSS probe, and the blocking server never
+    // exits cleanly for an atexit LeakSanitizer pass (the focused, clean-
+    // exit ASAN leak gate over `_serve_recv_request` lives in
+    // `serve_request_leak_test.sfn`).
+    let mut storm: i64 = 0;
+    loop {
+        if storm >= 40 { break; }
+        let _e = _lb_fire_and_close(port, "");
+        let _t = _lb_fire_and_close(port, "GET /probe HTTP/1.1\r\nHost: x");
+        storm = storm + 1;
+    }
+    let post_storm = _lb_request(port, "GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    print.info("[serve-loopback] post-storm: " + post_storm);
+    assert contains(post_storm, "HTTP/1.1 200");
+    assert contains(post_storm, "ROOT-OK");
 
     // Typed `fetch` client round-trips status + headers from the live
     // server (the #1323 framed path, proven end-to-end through the

--- a/compiler/tests/e2e/serve_request_leak_test.sfn
+++ b/compiler/tests/e2e/serve_request_leak_test.sfn
@@ -1,0 +1,235 @@
+// Focused leak gate for the serve request-recv early-return paths
+// (#1709, gap B8 of epic #1540). The blocking `serve()` accept loop never
+// returns cleanly, so an atexit LeakSanitizer pass over the whole server
+// is impossible (the loopback storm in `serve_loopback_test.sfn` is the
+// live-server stability proxy). This test instead drives the leak-prone
+// helper — `runtime/sfn/concurrency/serve.sfn::_serve_recv_request` — in
+// isolation over a `socketpair`, through a C harness that exits cleanly so
+// LeakSanitizer's atexit pass can run.
+//
+// `_serve_recv_request` has external linkage (the `_serve_` prefix exists
+// precisely so the native backend's file-local-but-external runtime
+// helpers do not collide — see serve.sfn's header), so the harness binds
+// it directly. Three legs, each on a fresh socketpair:
+//
+//   A. truncated — write a partial head (no `\r\n\r\n`) then close the
+//      write end; recv sees EOF before the terminator. Post-#1709 the
+//      helper FREES the growing buffer and returns NULL (no dispatch, no
+//      leak). Pre-fix it returned the partial buffer — caught here both as
+//      a non-NULL return (exit 1) AND, since the harness drops it, as a
+//      LeakSanitizer report.
+//   B. over-cap — declare `Content-Length: 2000000` (over the 1 MiB cap)
+//      with a complete head; the helper rejects it: free + NULL.
+//   C. valid — a complete head + `\r\n\r\n`; the helper returns a non-NULL
+//      buffer the harness frees (so a clean leg leaves nothing for LSan).
+//
+// Build with `-fsanitize=address` and run with SAILFIN_MEM_LIMIT=unlimited
+// (the instrumented binary's own self-cap would otherwise abort the ~16 TB
+// shadow reservation at startup) — only an actual `ERROR: AddressSanitizer:`
+// / leak report FAILS; a startup abort or a missing ASAN runtime SKIPS, per
+// `.claude/rules/compiler-safety.md`. A plain (uninstrumented) build+run
+// leg always exercises the three legs for behavioral coverage when clang is
+// present.
+//
+// NOTE on matchers: `sfn/test`'s `expect_*` are `![pure]` and cannot be
+// called from an `![io]` test; assert on captured output with `sfn/strings`.
+import { find, contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `run_capture`'s empty array is the *empty* environment, not "inherit".
+// Thread the toolchain variables: the legs spawn clang + its linker (PATH),
+// and SAILFIN_TEST_SCRATCH routes the build-cache per invocation so the
+// parallel pool does not collide.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// The ASAN run's child env, with SAILFIN_MEM_LIMIT=unlimited so the
+// instrumented binary's own self-cap does not abort the ~16 TB shadow
+// reservation at startup. detect_leaks=1 forces the atexit leak pass even
+// where the platform default leaves it off.
+fn _asan_env() -> string[] ![io] {
+    let mut e = _child_env();
+    e.push("SAILFIN_MEM_LIMIT=unlimited");
+    e.push("ASAN_OPTIONS=detect_leaks=1");
+    return e;
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    base = base + "/sfn-serve-request-leak";
+    fs.createDirectory(base, true);
+    return base;
+}
+
+fn _repo_root() -> string ![io] {
+    let configured = env.get("SAILFIN_REPO_ROOT");
+    if configured.length > 0 { return configured; }
+    return ".";
+}
+
+fn _serve_path() -> string ![io] {
+    return _repo_root() + "/runtime/sfn/concurrency/serve.sfn";
+}
+
+// Emit serve.ll into the scratch dir (re-emit only if absent).
+fn _emit_serve_ll() -> string ![io] {
+    let dir = _scratch_dir();
+    let ll = dir + "/serve.ll";
+    if !fs.exists(ll) {
+        let exit = process.run_capture([_sfn_bin(), "emit", "-o", ll, "llvm", _serve_path()], _child_env());
+        let _o = process.capture_take_stdout();
+        let _e = process.capture_take_stderr();
+        assert exit == 0;
+    }
+    return ll;
+}
+
+// The socketpair leak harness. Stubs the scheduler externs that serve.sfn's
+// DEFINED accept-loop functions reference (the leak legs never drive the
+// accept loop, but the linker still needs the symbols resolved). Each leg
+// uses a fresh AF_UNIX SOCK_STREAM pair: bytes written to `sv[1]` and the
+// `close(sv[1])` FIN are read by `_serve_recv_request(sv[0])`.
+fn _leak_harness_c() -> string {
+    return "#include <stddef.h>\n" + "#include <stdlib.h>\n"
+        + "#include <stdio.h>\n"
+        + "#include <string.h>\n"
+        + "#include <unistd.h>\n"
+        + "#include <sys/socket.h>\n"
+        + "\n"
+        + "/* serve.sfn scheduler externs — referenced by the accept-loop\n"
+        + " * functions in the linked IR; never called on the recv legs. */\n"
+        + "void *sfn_taskqueue_create(long capacity) { (void)capacity; return NULL; }\n"
+        + "void sfn_taskqueue_destroy(void *q) { (void)q; }\n"
+        + "void sfn_taskqueue_enqueue(void *q, void *t) { (void)q; (void)t; }\n"
+        + "void *sfn_task_create_detached(long fn, long ctx) { (void)fn; (void)ctx; return NULL; }\n"
+        + "void *sfn_scheduler_create(void *q) { (void)q; return NULL; }\n"
+        + "\n"
+        + "/* Module-init / runtime trio the emitted IR's global ctor + struct\n"
+        + " * helpers reference (same stubs as runtime_memory_arena_test). */\n"
+        + "void sailfin_runtime_mark_persistent(void *p) { (void)p; }\n"
+        + "void *sfn_alloc_struct(long n) { return calloc(1, (size_t)n); }\n"
+        + "void sfn_type_register(void *d) { (void)d; }\n"
+        + "\n"
+        + "extern char *_serve_recv_request(int fd);\n"
+        + "\n"
+        + "/* Drive one leg: write `req` (len bytes) to the peer, close it so\n"
+        + " * the recv side sees EOF, then call the helper. Returns the helper's\n"
+        + " * pointer (NULL on the reject paths). */\n"
+        + "static char *drive(const char *req, size_t len) {\n"
+        + "    int sv[2];\n"
+        + "    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) return (char *)-1;\n"
+        + "    if (len > 0) { ssize_t _w = write(sv[1], req, len); (void)_w; }\n"
+        + "    close(sv[1]);\n"
+        + "    char *r = _serve_recv_request(sv[0]);\n"
+        + "    close(sv[0]);\n"
+        + "    return r;\n"
+        + "}\n"
+        + "\n"
+        + "int main(void) {\n"
+        + "    /* Leg A — truncated head, EOF before the terminator: NULL, freed. */\n"
+        + "    const char *trunc = \"GET / HTTP/1.1\\r\\nHost: x\";\n"
+        + "    char *a = drive(trunc, strlen(trunc));\n"
+        + "    if (a == (char *)-1) { fprintf(stderr, \"socketpair A failed\\n\"); return 2; }\n"
+        + "    if (a != NULL) { fprintf(stderr, \"truncated: expected NULL, got non-NULL\\n\"); return 1; }\n"
+        + "\n"
+        + "    /* Leg B — over-cap Content-Length, complete head: NULL, freed. */\n"
+        + "    const char *over = \"POST / HTTP/1.1\\r\\nContent-Length: 2000000\\r\\n\\r\\nx\";\n"
+        + "    char *b = drive(over, strlen(over));\n"
+        + "    if (b == (char *)-1) { fprintf(stderr, \"socketpair B failed\\n\"); return 4; }\n"
+        + "    if (b != NULL) { fprintf(stderr, \"over-cap: expected NULL, got non-NULL\\n\"); return 3; }\n"
+        + "\n"
+        + "    /* Leg C — complete head, no body: non-NULL buffer the caller owns. */\n"
+        + "    const char *valid = \"GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n\";\n"
+        + "    char *c = drive(valid, strlen(valid));\n"
+        + "    if (c == (char *)-1) { fprintf(stderr, \"socketpair C failed\\n\"); return 6; }\n"
+        + "    if (c == NULL) { fprintf(stderr, \"valid: expected non-NULL, got NULL\\n\"); return 5; }\n"
+        + "    free(c);\n"
+        + "    return 0;\n"
+        + "}\n";
+}
+
+// ---- Phase 1: emit sanity — _serve_recv_request is defined ----
+test "serve emit: _serve_recv_request is a defined external symbol" ![io] {
+    let ll = _emit_serve_ll();
+    let ir = fs.readFile(ll);
+    assert contains(ir, "@_serve_recv_request(");
+}
+
+// ---- Phase 2: plain leak-leg roundtrip (clang) ----
+test "serve recv: EOF / over-cap / valid legs behave (C harness via clang) (#1709)" ![io] {
+    let dir = _scratch_dir();
+    let ll = _emit_serve_ll();
+
+    let harness = dir + "/leak_harness.c";
+    fs.writeFile(harness, _leak_harness_c());
+
+    let bin = dir + "/serve_recv_legs";
+    let link_exit = process.run_capture(["clang", "-Wno-override-module", harness, ll, "-o", bin, "-lm"], _child_env());
+    let _lo = process.capture_take_stdout();
+    let _le = process.capture_take_stderr();
+    if link_exit != 0 {
+        // clang unavailable or link failed — skip (the emit assertion above
+        // still pins the symbol contract).
+        assert true;
+        return;
+    }
+    let run_exit = process.run_capture([bin], _child_env());
+    let _ro = process.capture_take_stdout();
+    let _re = process.capture_take_stderr();
+    assert run_exit == 0;
+}
+
+// ---- Phase 3: ASAN leak leg (best effort, skip-on-no-ASAN) ----
+test "serve recv: error-path buffers are freed — no leaks (ASAN, best effort) (#1709)" ![io] {
+    let dir = _scratch_dir();
+    let ll = _emit_serve_ll();
+
+    let harness = dir + "/leak_harness.c";
+    fs.writeFile(harness, _leak_harness_c());
+
+    let bin_asan = dir + "/serve_recv_legs_asan";
+    let asan_link = process.run_capture(["clang", "-fsanitize=address", "-Wno-override-module", harness, ll, "-o", bin_asan, "-lm"], _child_env());
+    let _alo = process.capture_take_stdout();
+    let _ale = process.capture_take_stderr();
+    if asan_link != 0 {
+        // ASAN runtime not available on this host — the plain leg covered
+        // behavior.
+        assert true;
+        return;
+    }
+
+    let asan_exit = process.run_capture([bin_asan], _asan_env());
+    let asan_out = process.capture_take_stdout();
+    let asan_err = process.capture_take_stderr();
+    if asan_exit == 0 {
+        // Clean: no leaks, all legs behaved.
+        assert true;
+    } else if find(asan_out + asan_err, "ERROR: AddressSanitizer:", 0) >= 0 {
+        // A genuine sanitizer report — a request buffer leaked (or a
+        // double-free / UAF) on an error path. The #1709 regression signal.
+        assert false;
+    } else if find(asan_out + asan_err, "detected memory leaks", 0) >= 0 {
+        // LeakSanitizer's standalone leak summary line — also a real leak.
+        assert false;
+    } else {
+        // Startup/environment failure (shadow mapping under a vmem cap,
+        // missing runtime) — not a verdict on the free discipline. Skip.
+        assert true;
+    }
+}

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -297,8 +297,11 @@ fn _serve_content_length(buf: * u8, header_end: i64) -> i64 {
 // `_serve_recv_request(fd)` — read a full request (head + body) into a
 // growing libc buffer (doubling like `http.sfn`'s `_recv_all`).
 // Returns a NUL-terminated, caller-owned buffer (null on OOM / error /
-// over-cap body, which the worker turns into a `500` + connection
-// close).
+// over-cap body / a truncated request — EOF before the `\r\n\r\n` header
+// terminator — which the worker turns into a `500` + connection close).
+// Every null-returning path frees the growing buffer before returning, so
+// the worker's direct-500 path never has a request buffer to reclaim
+// (#1709): the request is freed here, never moved into the handler.
 //
 // Phase 1 reads until the `\r\n\r\n` header terminator, on EOF, or on
 // a `recv` error. A client that never sends the terminator must not be
@@ -364,10 +367,15 @@ fn _serve_recv_request(fd: i32) -> * u8 {
         }
     }
 
-    // EOF before the headers completed: return what we have.
+    // EOF (or a client that closed the write side) before the `\r\n\r\n`
+    // terminator: the request is truncated/empty and must NOT be moved into
+    // the handler. Free the partial buffer and signal the error to the
+    // worker (null -> direct 500, no dispatch) so the request buffer is
+    // reclaimed on this early-return path rather than handed to user code as
+    // a malformed request (#1709).
     if header_end < 0 {
-        memset(_serve_ptr_off(buf, len), 0, 1 as usize);
-        return buf;
+        free(buf);
+        return null;
     }
 
     // Phase 2 — drain the Content-Length body, if any.
@@ -565,11 +573,14 @@ fn sfn_serve_handler_dispatch(handler: * u8, request: OwnedBuf) -> OwnedBuf {
 // effect-free externs + the effect-erased dispatch, so it carries no
 // effect annotation (matching `future.sfn`'s trampolines).
 //
-// A null request (recv error, OOM, or the header cap exceeded) is
-// NOT handed to user code — the handler reads the request `OwnedBuf`'s
-// bytes, so a null backing would risk a crash inside the handler.
-// Instead the worker skips dispatch and sends a `500` directly
-// (`_serve_send_response(fd, null)`).
+// A null request (recv error, OOM, the header cap exceeded, or a
+// truncated request — EOF before the header terminator) is NOT handed to
+// user code — the handler reads the request `OwnedBuf`'s bytes, so a null
+// backing would risk a crash inside the handler, and a truncated request
+// is malformed. `_serve_recv_request` has already freed the buffer on
+// every such path, so there is nothing to reclaim here; the worker simply
+// skips dispatch and sends a `500` directly (`_serve_send_response(fd,
+// null)`).
 fn _serve_conn_worker(ctx: * u8) -> * u8 {
     if ctx as i64 == 0 { return null; }
     let base: i64 = ctx as i64;


### PR DESCRIPTION
## Summary
- `_serve_recv_request` returned the partial buffer non-null on EOF before the `\r\n\r\n` header terminator, so `_serve_conn_worker` **moved a truncated/empty request into the user handler** instead of rejecting it. Now it `free(buf); return null;` on that path, routing to the worker's existing direct-500 path — the request buffer is reclaimed on **every** early-return (500 / EOF) path and never handed to user code as a malformed request.
- The recv-error, OOM, header-cap, and over-cap-body null paths already freed the buffer (audited, confirmed). The task-handle (#1203) and response-buffer (#1476) leaks remain fixed — confirm-only, untouched.

Closes #1709

## Acceptance Criteria
- [x] After N sequential connections (mix of valid + malformed/empty), RSS is stable (no per-connection growth) — exercised by an 80-connection error-path storm; the server still round-trips a valid request afterward (the achievable proxy — there is no in-process RSS probe, and the blocking `serve()` never exits cleanly for an atexit pass).
- [x] The valid round-trip path is unchanged (existing loopback assertions + post-storm `200`/`ROOT-OK`).
- [x] A leak-checker / ASAN leg over the serve loop reports no leaks on the error paths — new `serve_request_leak_test.sfn` drives `_serve_recv_request` in isolation over a `socketpair` through a clean-exit C harness so LeakSanitizer's atexit pass runs; skip-on-no-ASAN per `.claude/rules/compiler-safety.md`.
- [x] No double-free: the handler-echo alias guard still holds (code review traced single-free on every path: error, truncated, valid, echo-alias, null-handler).
- [x] `make compile` passes (self-host).
- [x] `make test` passes.

## Map reconciliation
None — both advisory-map paths matched the tree: the fix landed in `runtime/sfn/concurrency/serve.sfn` (connection worker error/early-return paths) and `compiler/tests/e2e/` (extended the serve loopback test + added a focused leak test).

## Verification
```bash
sfn check runtime/sfn/concurrency/serve.sfn          # ok
make compile                                          # pass (self-host)
sailfin test compiler/tests/e2e/serve_request_leak_test.sfn   # PASS (3/3)
sailfin test compiler/tests/e2e/serve_loopback_test.sfn       # PASS (truncated->500, storm survived)
make test                                             # unit 177/177, integration 41/41, e2e 161/161, capsules 38/38
```

## Files Changed
- `runtime/sfn/concurrency/serve.sfn` — EOF-before-terminator path frees the partial buffer and returns null; doc comments updated to document the freeing contract the worker relies on.
- `compiler/tests/e2e/serve_loopback_test.sfn` — half-close truncated-request `500` assertion + an 80-connection error-path storm with a post-storm valid round-trip; adds a `shutdown` extern and `_lb_fire_and_close` / `_lb_request_halfclose` client helpers.
- `compiler/tests/e2e/serve_request_leak_test.sfn` (new) — socketpair + clean-exit C harness leak gate over `_serve_recv_request` (truncated / over-cap / valid legs); best-effort ASAN leg + a plain behavioral leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDMuHixDp84PqJvuA6Sy38

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDMuHixDp84PqJvuA6Sy38)_