### PR TITLE
fix(lowering): declare vtable-only interface methods in consumer modules (#1739)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -681,6 +681,119 @@ fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? 
     return find_declare_signature_t(pretrim_lines(lines), symbol);
 }
 
+// #1739: recover a method's signature from a per-module interface vtable
+// constant that references it. The vtable constant
+// (`@vtable.<Struct>.<Interface>.const = internal constant ...`) references
+// EVERY interface method symbol via a bitcast of its function-pointer type
+// (`<fptype> bitcast (<fptype> @<sym> to <fptype>)`), but a consumer module
+// only emits a direct call site for the methods it actually calls. So a
+// method referenced *only* by the vtable has no call site for
+// `find_declare_signature` to recover from, and the mangling pass would
+// leave its `@<sym>` reference unmangled and undeclared → an undefined value
+// in the vtable initializer (invalid IR). This recovers the signature from
+// the vtable's bitcast function-pointer type so the reference can be
+// rewritten to the provider symbol and an external declare injected.
+// Intentionally scans raw `lines` (not `pretrim_lines`d / indexed like the
+// #1512 hot-shim paths): this runs only in block 2b's cold fallback branch
+// (a vtable-only-referenced imported method), not the per-symbol shim loop,
+// so the index machinery would not pay for itself here.
+fn find_vtable_method_signature(lines: string[], symbol: string) -> DeclareSignature? {
+    if symbol.length == 0 { return null; }
+    let needle = "@" + symbol + " to ";
+    let bitcast_kw = "bitcast (";
+    let mut index: int = 0;
+    loop {
+        if index >= lines.length { break; }
+        let line = lines[index];
+        index += 1;
+        // Only interface vtable constants reference methods via bitcast.
+        if index_of(line, "= internal constant %vtable.") < 0 { continue; }
+        let at_pos = index_of(line, needle);
+        if at_pos < 0 { continue; }
+        // The function-pointer type sits between the enclosing `bitcast (`
+        // and the `@<symbol>` token. The last `bitcast (` before `at_pos` is
+        // the cast for this entry (each entry is one bitcast).
+        let prefix = substring(line, 0, at_pos);
+        let mut bc: int = -1;
+        let mut search_from: int = 0;
+        loop {
+            let rel = index_of(substring(prefix, search_from, prefix.length), bitcast_kw);
+            if rel < 0 { break; }
+            bc = search_from + rel;
+            search_from = bc + 1;
+        }
+        if bc < 0 { continue; }
+        let type_start = bc + bitcast_kw.length;
+        let fptype = trim_text(substring(line, type_start, at_pos));
+        if fptype.length == 0 { continue; }
+        let sig = _parse_fn_pointer_type(fptype);
+        if sig != null { return sig; }
+    }
+    return null;
+}
+
+// Parse an LLVM function-pointer type (`<ret> (<params>)*`) into a
+// DeclareSignature. Depth-aware so nested function-pointer parameter types
+// (themselves containing parens) split correctly.
+fn _parse_fn_pointer_type(fptype: string) -> DeclareSignature? {
+    let paren_open = index_of(fptype, "(");
+    if paren_open < 0 { return null; }
+    let return_type = trim_text(substring(fptype, 0, paren_open));
+    if return_type.length == 0 { return null; }
+    // Find the matching close paren for the parameter list.
+    let mut depth: int = 0;
+    let mut i: int = paren_open;
+    let mut close: int = -1;
+    loop {
+        if i >= fptype.length { break; }
+        let ch = fptype[i];
+        if ch == "(" { depth += 1; }
+        if ch == ")" {
+            depth -= 1;
+            if depth == 0 {
+                close = i;
+                break;
+            }
+        }
+        i += 1;
+    }
+    if close < 0 { return null; }
+    let params_text = substring(fptype, paren_open + 1, close);
+    let mut param_types: string[] = [];
+    let mut ps: int = 0;
+    let mut sc: int = 0;
+    let mut pd: int = 0;
+    let mut cd: int = 0;
+    loop {
+        if sc >= params_text.length { break; }
+        let pch = params_text[sc];
+        if pch == "(" { pd += 1; }
+        if pch == ")" {
+            if pd > 0 { pd -= 1; }
+        }
+        if pch == "{" { cd += 1; }
+        if pch == "}" {
+            if cd > 0 { cd -= 1; }
+        }
+        if pch == "," {
+            if pd == 0 {
+                if cd == 0 {
+                    let part = trim_text(substring(params_text, ps, sc));
+                    if part.length > 0 { param_types.push(part); }
+                    ps = sc + 1;
+                }
+            }
+        }
+        sc += 1;
+    }
+    let last = trim_text(substring(params_text, ps, params_text.length));
+    if last.length > 0 { param_types.push(last); }
+    return DeclareSignature {
+        return_type: return_type,
+        param_types: param_types
+    };
+}
+
 // Symbol → header-line index over pre-trimmed module lines (#1512). The
 // mangling shim loop probes hundreds of symbols against the module; doing
 // that with `find_declare_signature` / `_has_declare_or_define` re-scans

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -39,6 +39,7 @@ import {
     extract_module_name_from_native_text,
     find_declare_signature,
     find_signature_in_index,
+    find_vtable_method_signature,
     has_declare_or_define_in_index,
     insert_before_llvm_footer,
     pretrim_lines,
@@ -347,10 +348,20 @@ fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], curren
             if index_of(bare, "__") >= 0 { continue; }
             if string_array_contains(defined, bare) { continue; }
             if string_array_contains(import_olds, bare) { continue; }
-            // Only act when this module actually references the method (the
+            // Only act when this module actually references the method. The
             // signature is recovered from the bare call site, which still
-            // exists in `rewritten` at this point — before substitution).
-            let signature = find_declare_signature(rewritten, bare);
+            // exists in `rewritten` at this point — before substitution.
+            let mut signature = find_declare_signature(rewritten, bare);
+            // #1739: a method referenced only by a per-module interface
+            // vtable constant (not a direct call site) is missed by the
+            // call-site scan above. Recover its signature from the vtable's
+            // bitcast function-pointer type so the reference is rewritten to
+            // the provider symbol and an external declare is injected —
+            // otherwise the vtable initializer references an undefined value
+            // (invalid IR; #1739).
+            if signature == null {
+                signature = find_vtable_method_signature(rewritten, bare);
+            }
             if signature == null { continue; }
             let target = bare + "__" + provider_suffix;
             import_olds.push(bare);

--- a/compiler/tests/e2e/interface_vtable_consumer_declares_test.sfn
+++ b/compiler/tests/e2e/interface_vtable_consumer_declares_test.sfn
@@ -1,0 +1,93 @@
+// End-to-end regression for #1739: a consumer module that imports an
+// interface-implementing struct must lower to VALID IR regardless of which
+// interface methods it calls.
+//
+// Symptom (#1739): the compiler emits a per-module interface vtable constant
+// (`@vtable.<Struct>.<Interface>.const = internal constant ...`) that
+// references EVERY interface method symbol, but only the methods the consumer
+// directly CALLS were rewritten to the provider's module-qualified symbol and
+// declared. A consumer that imports the struct and calls only SOME interface
+// methods left the rest undefined in the vtable initializer:
+//   error: use of undefined value '@<Struct><Method>'
+// (emit retries 3x, IR validation rejected output → capsule-resolver: failed
+// to lower).
+//
+// This is a build-only failure of the #1389 class: `sfn check` models no
+// codegen/link and passes, so the bug surfaces only at `sfn build` / IR
+// validation. The fix recovers the uncalled method's signature from the
+// vtable's bitcast function-pointer type so it is rewritten to the provider
+// symbol and declared exactly like a called method.
+//
+// The fixture is the LlvmTextBackend/Backend shape from
+// `compiler/src/backend.sfn` (a two-method interface, structurally
+// implemented) that the SFEP-0027 §3.1 build-driver split exposes: an
+// assemble-only consumer (#1730) and the mirror link-only consumer.
+//
+// Build/parallel-runner hygiene (temp-dir build, full inherited env via
+// `process.environ()` for the nested clang/ld toolchain + per-invocation
+// SAILFIN_TEST_SCRATCH cache routing) mirrors
+// check_build_agree_module_global_test.sfn — see `.claude/rules/no-bash-e2e.md`.
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Inherit the full parent environment so the nested clang/ld the build
+// spawns find their toolchain, and SAILFIN_TEST_SCRATCH routes the build
+// cache per-invocation (#1333).
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// Provider: a two-method interface, structurally implemented by a struct.
+fn _provider_src() -> string {
+    return "interface Shape {\n" + "    fn area(self) -> int;\n"
+        + "    fn describe(self) -> int;\n"
+        + "}\n"
+        + "\n"
+        + "struct Circle {\n"
+        + "    r: int;\n"
+        + "    fn area(self) -> int { return self.r; }\n"
+        + "    fn describe(self) -> int { return self.r + 1; }\n"
+        + "}\n";
+}
+
+// Consumer that imports Circle and calls exactly one interface method
+// (`method_call` is "area" or "describe"). The uncalled method is the one
+// the vtable left undefined before the fix.
+fn _consumer_src(method_call: string) -> string {
+    return "import { Circle } from \"./shapes\";\n" + "fn main() ![io] {\n"
+        + "    let c = Circle { r: 5 };\n"
+        + "    print(number.to_string(c."
+        + method_call
+        + "()));\n"
+        + "}\n";
+}
+
+// Write provider + consumer into `dir`, build the consumer, and return the
+// build exit code (0 = valid IR + successful link).
+fn _build_consumer(dir: string, consumer_name: string, method_call: string) -> int ![io] {
+    fs.writeFile(dir + "/shapes.sfn", _provider_src());
+    let consumer_path = dir + "/" + consumer_name + ".sfn";
+    fs.writeFile(consumer_path, _consumer_src(method_call));
+    let binpath = dir + "/" + consumer_name + ".out";
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, consumer_path], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    return exit;
+}
+
+test "lowering: assemble-only consumer of an interface struct lowers to valid IR (#1739)" ![io] {
+    let exit = with_tmp_dir(fn (dir: string) -> int {
+        return _build_consumer(dir, "consumer_area", "area");
+    });
+    assert exit == 0;
+}
+
+test "lowering: link-only consumer of an interface struct lowers to valid IR (#1739)" ![io] {
+    let exit = with_tmp_dir(fn (dir: string) -> int {
+        return _build_consumer(dir, "consumer_describe", "describe");
+    });
+    assert exit == 0;
+}

--- a/compiler/tests/unit/vtable_method_signature_test.sfn
+++ b/compiler/tests/unit/vtable_method_signature_test.sfn
@@ -1,0 +1,96 @@
+// Unit coverage for `find_vtable_method_signature` / `_parse_fn_pointer_type`
+// (compiler/src/llvm/lowering/lowering_helpers.sfn), the #1739 fix that
+// recovers an interface method's signature from a per-module vtable constant
+// when the method is referenced ONLY by the vtable (no direct call site).
+//
+// The e2e regression (interface_vtable_consumer_declares_test.sfn) proves the
+// end-to-end build path on the `i64 (i8*)` shape the fixture happens to emit.
+// This pins the parser's edge cases directly — void return, zero params,
+// nested function-pointer params, multi-entry lines, and no-match — so the
+// recovery logic is protected independent of whichever fptypes a future
+// fixture produces. Tests exercise the parser through the public
+// `find_vtable_method_signature` (the private `_parse_fn_pointer_type` is not
+// exported).
+import { find_vtable_method_signature } from "../../src/llvm/lowering/lowering_helpers";
+
+// Build a single vtable constant line in the exact format
+// `render_vtable_constants` emits: comma-joined `<fptype> bitcast (<fptype>
+// @<sym> to <fptype>)` entries wrapped in `= internal constant %vtable...`.
+fn _entry(fptype: string, sym: string) -> string {
+    return fptype + " bitcast (" + fptype + " @" + sym + " to " + fptype + ")";
+}
+
+fn _vtable_line(entries: string) -> string {
+    return "@vtable.X.Y.const = internal constant %vtable.X.Y { " + entries
+        + " }";
+}
+
+// Recover the return type for `sym`, or a sentinel when no signature is found.
+fn _ret(lines: string[], sym: string) -> string {
+    let sig = find_vtable_method_signature(lines, sym);
+    if sig == null { return "<null>"; }
+    return sig.return_type;
+}
+
+fn _nparams(lines: string[], sym: string) -> int {
+    let sig = find_vtable_method_signature(lines, sym);
+    if sig == null { return -1; }
+    return sig.param_types.length;
+}
+
+fn _param(lines: string[], sym: string, i: int) -> string {
+    let sig = find_vtable_method_signature(lines, sym);
+    if sig == null { return "<null>"; }
+    if i >= sig.param_types.length { return "<oob>"; }
+    return sig.param_types[i];
+}
+
+test "vtable sig: standard self-only method (i64 (i8*))" {
+    let lines = [_vtable_line(_entry("i64 (i8*)*", "Circlearea"))];
+    assert _ret(lines, "Circlearea") == "i64";
+    assert _nparams(lines, "Circlearea") == 1;
+    assert _param(lines, "Circlearea", 0) == "i8*";
+}
+
+test "vtable sig: void return type is preserved" {
+    let lines = [_vtable_line(_entry("void (i8*)*", "Sinkconsume"))];
+    assert _ret(lines, "Sinkconsume") == "void";
+    assert _nparams(lines, "Sinkconsume") == 1;
+    assert _param(lines, "Sinkconsume", 0) == "i8*";
+}
+
+test "vtable sig: zero-parameter signature" {
+    let lines = [_vtable_line(_entry("i64 ()*", "Counttick"))];
+    assert _ret(lines, "Counttick") == "i64";
+    assert _nparams(lines, "Counttick") == 0;
+}
+
+test "vtable sig: nested function-pointer parameter does not mis-split" {
+    let lines = [_vtable_line(_entry("i64 (i8*, void (i8*)*)*", "Hookrun"))];
+    assert _ret(lines, "Hookrun") == "i64";
+    assert _nparams(lines, "Hookrun") == 2;
+    assert _param(lines, "Hookrun", 0) == "i8*";
+    assert _param(lines, "Hookrun", 1) == "void (i8*)*";
+}
+
+test "vtable sig: second entry on a multi-entry line is recovered" {
+    let entries = _entry("i64 (i8*)*", "Shapearea") + ", " + _entry("i64 (i8*)*", "Shapedescribe");
+    let lines = [_vtable_line(entries)];
+    // The uncalled `describe` is the one the producer left undefined; ensure
+    // its type is recovered from its own (second) bitcast, not the first.
+    assert _ret(lines, "Shapedescribe") == "i64";
+    assert _nparams(lines, "Shapedescribe") == 1;
+    assert _param(lines, "Shapedescribe", 0) == "i8*";
+}
+
+test "vtable sig: a prefix symbol does not match a longer one" {
+    let lines = [_vtable_line(_entry("i64 (i8*)*", "Circlearea"))];
+    // `Circle` is a prefix of `Circlearea`; the trailing ` to ` anchor must
+    // prevent a false match.
+    assert _ret(lines, "Circle") == "<null>";
+}
+
+test "vtable sig: non-vtable lines yield no signature" {
+    let lines = ["declare i64 @foo(i8*)", "  %t = call i64 @foo(i8* %x)"];
+    assert _ret(lines, "foo") == "<null>";
+}


### PR DESCRIPTION
## Summary
- A consumer module that imports an interface-implementing struct emits a per-module `internal constant` interface vtable referencing **every** interface method symbol, but the mangling pass (block 2b, #960) only rewrote `@<Struct><Method>` → the provider-qualified symbol and injected an external `declare` for methods it found a **call site** for. A method referenced **only** by the vtable (never called) was left unmangled and undeclared → the vtable initializer referenced an undefined value and IR validation rejected the module.
- This is a **build-only failure** (#1389 class): `sfn check` passes (it models no codegen/link); the bug only surfaces at `make compile` / `sfn build`. It blocked the SFEP-0027 §3.1 build-driver split, where assemble-only and link-only `backend` consumers each call just one `Backend` method.
- Fix: recover the uncalled method's signature from the vtable's `bitcast` function-pointer type (`find_vtable_method_signature` / `_parse_fn_pointer_type` in `lowering_helpers.sfn`) and feed it into block 2b's existing rewrite + declare-injection path when call-site recovery returns `null`. **Called methods take the unchanged path and are byte-identical**; the fallback only fires for a vtable-only-referenced imported method, so self-host is unperturbed.

Closes #1739

## Design decision
The issue listed three candidate directions. "Emit a declare for every vtable-referenced method" (Option A) is correct in spirit, but a bare declare alone won't link: the vtable references the **bare fused name** `@<Struct><Method>` while the provider defines the **module-qualified** `@<Struct><Method>__<provider>`. The called-method path already does the right thing (rewrite to provider symbol **and** declare) — it's just call-site-driven. So the minimal, architecturally-consistent fix extends that path's signature recovery with a vtable-bitcast fallback. This preserves the intentional per-module `internal` vtables and dynamic-dispatch semantics, and reuses existing machinery. Option B (external cross-module vtable) has no existing infrastructure; Option C (emit only on polymorphic use) risks regressing cross-module dynamic dispatch for user programs.

## Acceptance Criteria
- [x] An assemble-only (calls one method) consumer of an interface struct lowers to valid IR — regression fixture added.
- [x] A link-only (calls the other method) consumer lowers to valid IR — mirror fixture added.
- [x] `make compile` self-hosts.
- [x] `sfn fmt --check` clean on all touched `.sfn` files.

## Verification
```text
# Manual 2-module repro (assemble-only / link-only / calls-neither):
#   before: build/sailfin/program.ll: error: use of undefined value '@Circledescribe'
#   after:  built + ran (prints 5 / 8 / 9)
# Emitted IR after fix:
#   @vtable.Circle.Shape.const = ... @Circlearea__...shapes ..., @Circledescribe__...shapes ...
#   declare i64 @Circledescribe__tmp__repro1739__shapes(i8*)   <- now declared + provider-mangled

make compile                                              # pass (self-host)
sfn test compiler/tests/unit/vtable_method_signature_test.sfn       # PASS (7 tests)
sfn test compiler/tests/e2e/interface_vtable_consumer_declares_test.sfn  # PASS (2 tests)
```
The full suite (`sfn test compiler/tests/{unit,integration,e2e} capsules`) is running to completion post-push as the final regression gate; CI runs it authoritatively.

## Map reconciliation
The advisory `## Files likely involved` named `compiler/src/llvm/...` interface-vtable lowering. The actual fix lands in the **mangling pass** (`compiler/src/llvm/lowering/lowering_helpers.sfn` + `lowering_helpers_mangling.sfn`) rather than the vtable *renderer* — the root cause is the call-site-driven symbol rewrite/declare in block 2b (#960), not the vtable emission itself (which correctly references all methods). Same `In:` semantic unit (LLVM lowering of the consumer vtable); reconciled to the precise sites.

## Files Changed
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — new `find_vtable_method_signature` + `_parse_fn_pointer_type`.
- `compiler/src/llvm/lowering/lowering_helpers_mangling.sfn` — block 2b fallback to the vtable signature recovery.
- `compiler/tests/e2e/interface_vtable_consumer_declares_test.sfn` — assemble-only + link-only build regression.
- `compiler/tests/unit/vtable_method_signature_test.sfn` — parser edge cases (void return, zero/nested params, multi-entry, prefix/no-match).

## Notes
- This is a `seed-blocker`: the lowering fix must reach the **pinned seed** before the SFEP-0027 §3.1 splits (`build/link.sfn`, etc.) can self-host with `backend` imports. Recommend queuing the seed advance against the next cadence bump (per `.claude/rules/seed-dependency.md`); not a reactive cut.

https://claude.ai/code/session_01WiRvtmwDwecSrpbHy6TDq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiRvtmwDwecSrpbHy6TDq7)_