### PR TITLE
fix(llvm): dedupe runtime-helper declares so the prelude links again (#1736)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -6,25 +6,26 @@
 // and libc declarations.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-import { NativeFunction } from "../../native_ir";
+import { TypeContext, TraitMetadata } from "../types";
+import { starts_with, number_to_string } from "../utils";
+import { sfn_abi_hash_decimal } from "./abi_hash";
 import {
     render_enum_type_definitions,
-    render_imported_function_declarations,
-    render_runtime_helper_declarations,
+    extract_declared_symbol_names,
     render_struct_type_definitions,
-    render_trait_metadata_comments
+    render_trait_metadata_comments,
+    render_runtime_helper_declarations,
+    render_imported_function_declarations
 } from "../rendering";
+import { extend_string_lines, module_source_filename } from "./lowering_io";
+import { NativeFunction } from "../../native_ir";
+import { async_runtime_declare_lines } from "../runtime_helpers";
 import {
     find_function_by_name,
-    render_interface_type_definitions,
     render_vtable_constants,
-    render_vtable_type_definitions
+    render_vtable_type_definitions,
+    render_interface_type_definitions
 } from "../rendering_helpers";
-import { async_runtime_declare_lines } from "../runtime_helpers";
-import { TraitMetadata, TypeContext } from "../types";
-import { number_to_string, starts_with } from "../utils";
-import { sfn_abi_hash_decimal } from "./abi_hash";
-import { extend_string_lines, module_source_filename } from "./lowering_io";
 
 // Render the LLVM IR preamble: source filename, trait metadata,
 // struct/enum/interface type definitions, async runtime types,
@@ -153,7 +154,12 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
 
     // Imported function declarations
     if debug_lowering { print.err("emit-llvm: phase=render_imports"); }
-    let imported_declarations = render_imported_function_declarations(imported_functions, local_functions, type_context, runtime_helpers);
+    // #1736: hand the imported-declare pass the symbols the typed
+    // runtime-helper pass already declared, so it does not re-declare a
+    // shared helper (e.g. `sfn_print` / `sfn_array_concat`) with the erased
+    // import-closure signature and produce a conflicting redefinition.
+    let helper_declared_symbols = extract_declared_symbol_names(helper_declarations);
+    let imported_declarations = render_imported_function_declarations(imported_functions, local_functions, type_context, runtime_helpers, helper_declared_symbols);
     if imported_declarations != null {
         if imported_declarations.length > 0 {
             lines = extend_string_lines(lines, imported_declarations);

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -6,26 +6,26 @@
 // and libc declarations.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-import { TypeContext, TraitMetadata } from "../types";
-import { starts_with, number_to_string } from "../utils";
-import { sfn_abi_hash_decimal } from "./abi_hash";
-import {
-    render_enum_type_definitions,
-    extract_declared_symbol_names,
-    render_struct_type_definitions,
-    render_trait_metadata_comments,
-    render_runtime_helper_declarations,
-    render_imported_function_declarations
-} from "../rendering";
-import { extend_string_lines, module_source_filename } from "./lowering_io";
 import { NativeFunction } from "../../native_ir";
-import { async_runtime_declare_lines } from "../runtime_helpers";
+import {
+    extract_declared_symbol_names,
+    render_enum_type_definitions,
+    render_imported_function_declarations,
+    render_runtime_helper_declarations,
+    render_struct_type_definitions,
+    render_trait_metadata_comments
+} from "../rendering";
 import {
     find_function_by_name,
+    render_interface_type_definitions,
     render_vtable_constants,
-    render_vtable_type_definitions,
-    render_interface_type_definitions
+    render_vtable_type_definitions
 } from "../rendering_helpers";
+import { async_runtime_declare_lines } from "../runtime_helpers";
+import { TraitMetadata, TypeContext } from "../types";
+import { number_to_string, starts_with } from "../utils";
+import { sfn_abi_hash_decimal } from "./abi_hash";
+import { extend_string_lines, module_source_filename } from "./lowering_io";
 
 // Render the LLVM IR preamble: source filename, trait metadata,
 // struct/enum/interface type definitions, async runtime types,

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -2,29 +2,29 @@
 //
 // LLVM IR rendering functions for declarations and metadata comments.
 // Handles trait metadata comments, runtime helper declarations, and function declarations.
+import { TypeContext, TraitMetadata, RuntimeHelperDescriptor } from "./types";
+import {
+    index_of,
+    trim_text,
+    append_string,
+    sanitize_symbol,
+    number_to_string,
+    join_with_separator,
+    string_array_contains
+} from "./utils";
 import { NativeFunction, NativeParameter } from "../native_ir";
+import { map_return_type, map_parameter_type } from "./type_mapping";
 import { substring } from "../string_utils";
 import {
-    collect_parameter_types,
-    extract_struct_type_from_llvm,
-    render_interface_signature
-} from "./rendering_helpers";
-import {
-    effective_helper_declare_return_type,
     is_async_runtime_target,
-    runtime_helper_descriptors
+    runtime_helper_descriptors,
+    effective_helper_declare_return_type
 } from "./runtime_helpers";
-import { map_parameter_type, map_return_type } from "./type_mapping";
-import { RuntimeHelperDescriptor, TraitMetadata, TypeContext } from "./types";
 import {
-    append_string,
-    index_of,
-    join_with_separator,
-    number_to_string,
-    sanitize_symbol,
-    string_array_contains,
-    trim_text
-} from "./utils";
+    collect_parameter_types,
+    render_interface_signature,
+    extract_struct_type_from_llvm
+} from "./rendering_helpers";
 
 fn clamp_collection_length(value: int, max: int) -> int {
     if value < 0 { return 0; }
@@ -380,7 +380,43 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
 // =============================================================================
 // Imported Function Declarations
 // =============================================================================
-fn render_imported_function_declarations(imported_functions: NativeFunction[], local_functions: NativeFunction[], context: TypeContext, runtime_helpers: string[]) -> string[] {
+// #1736: extract the `@<symbol>` names from rendered `declare ... @sym(...)`
+// lines. Used to share the typed-descriptor pass's declared-symbol set with
+// the imported-function pass below, so a helper that both passes resolve to
+// the same symbol (e.g. `print` → `sfn_print`, `concat` → `sfn_array_concat`,
+// where `target != symbol` so the #633 import-shadow skip does not fire) is
+// declared exactly once — with the typed shape the prelude's own call sites
+// use, not the erased import-closure shape.
+fn extract_declared_symbol_names(lines: string[]) -> string[] {
+    let mut symbols: string[] = [];
+    if lines.length == 0 { return symbols; }
+    let mut index: int = 0;
+    loop {
+        if index >= lines.length { break; }
+        let line = lines[index];
+        // Only parse `declare`-prefixed lines. Capability-metadata comment
+        // lines (`; intrinsic <sym> requires ...`) carry no `@` today, but
+        // keying on the `declare ` prefix makes the extractor robust if a
+        // future comment shape ever embeds an `@symbol` token.
+        if index_of(line, "declare ") == 0 {
+            let at_pos = index_of(line, "@");
+            if at_pos >= 0 {
+                let after_at = substring(line, at_pos + 1, line.length);
+                let paren_pos = index_of(after_at, "(");
+                if paren_pos > 0 {
+                    let symbol = substring(after_at, 0, paren_pos);
+                    if !string_array_contains(symbols, symbol) {
+                        symbols.push(symbol);
+                    }
+                }
+            }
+        }
+        index += 1;
+    }
+    return symbols;
+}
+
+fn render_imported_function_declarations(imported_functions: NativeFunction[], local_functions: NativeFunction[], context: TypeContext, runtime_helpers: string[], already_declared_symbols: string[]) -> string[] {
     if imported_functions.length == 0 { return []; }
     // Issue #633: previously this pass collected the runtime-helper
     // symbol set and skipped imported declares that collided with any
@@ -420,6 +456,20 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
         }
         // Skip if we've already emitted a declaration for this function
         if string_array_contains(emitted_declarations, sanitized_name) {
+            index += 1;
+            continue;
+        }
+        // Issue #1736: skip when the typed runtime-helper declare pass
+        // (`render_runtime_helper_declarations`, run just before this one)
+        // already declared this symbol. For helpers whose `target != symbol`
+        // (e.g. `print` → `sfn_print`, `concat` → `sfn_array_concat`) the
+        // #633 import-shadow skip in that pass does not fire, so it emits the
+        // typed descriptor shape (`{i8*, i64}` / `{i8**,i64,i64}*`). The
+        // prelude's own call sites use that typed shape, so emitting the
+        // erased import-closure declare here would produce a conflicting
+        // redefinition that clang's per-module verifier rejects. The typed
+        // declare must win, so defer to it.
+        if string_array_contains(already_declared_symbols, sanitized_name) {
             index += 1;
             continue;
         }

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -2,29 +2,29 @@
 //
 // LLVM IR rendering functions for declarations and metadata comments.
 // Handles trait metadata comments, runtime helper declarations, and function declarations.
-import { TypeContext, TraitMetadata, RuntimeHelperDescriptor } from "./types";
-import {
-    index_of,
-    trim_text,
-    append_string,
-    sanitize_symbol,
-    number_to_string,
-    join_with_separator,
-    string_array_contains
-} from "./utils";
 import { NativeFunction, NativeParameter } from "../native_ir";
-import { map_return_type, map_parameter_type } from "./type_mapping";
 import { substring } from "../string_utils";
 import {
-    is_async_runtime_target,
-    runtime_helper_descriptors,
-    effective_helper_declare_return_type
-} from "./runtime_helpers";
-import {
     collect_parameter_types,
-    render_interface_signature,
-    extract_struct_type_from_llvm
+    extract_struct_type_from_llvm,
+    render_interface_signature
 } from "./rendering_helpers";
+import {
+    effective_helper_declare_return_type,
+    is_async_runtime_target,
+    runtime_helper_descriptors
+} from "./runtime_helpers";
+import { map_parameter_type, map_return_type } from "./type_mapping";
+import { RuntimeHelperDescriptor, TraitMetadata, TypeContext } from "./types";
+import {
+    append_string,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    string_array_contains,
+    trim_text
+} from "./utils";
 
 fn clamp_collection_length(value: int, max: int) -> int {
     if value < 0 { return 0; }

--- a/compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
+++ b/compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
@@ -24,13 +24,13 @@
 // dedup at unit speed instead of as a slow link failure.
 import { find } from "sfn/strings";
 
-import { NativeFunction, NativeParameter } from "../../src/native_ir";
-import { TypeContext } from "../../src/llvm/types";
 import {
     extract_declared_symbol_names,
-    render_runtime_helper_declarations,
-    render_imported_function_declarations
+    render_imported_function_declarations,
+    render_runtime_helper_declarations
 } from "../../src/llvm/rendering";
+import { TypeContext } from "../../src/llvm/types";
+import { NativeFunction, NativeParameter } from "../../src/native_ir";
 
 fn _empty_context() -> TypeContext {
     return TypeContext {

--- a/compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
+++ b/compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
@@ -1,0 +1,147 @@
+// compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
+//
+// Regression coverage for #1736: the regenerated runtime prelude emitted a
+// runtime helper's `declare` TWICE with conflicting signatures, breaking the
+// per-module clang verifier (`invalid redefinition of function`) and so
+// `sfn test` / `sfn build` / `sfn run` and `make check`'s test phase.
+//
+// Two declare-emission passes run into the same module preamble
+// (`lowering_phase_render.sfn`):
+//   1. `render_runtime_helper_declarations` — the typed descriptor shape from
+//      the runtime-helper registry (`print` → `{i8*, i64}`, `concat` →
+//      `{i8**,i64,i64}*`).
+//   2. `render_imported_function_declarations` — the source-level erased shape
+//      from the prelude's transitive import closure (`sfn_print(* u8, i64)`,
+//      `sfn_array_concat(* u8, * u8) -> * u8`).
+//
+// For `print`/`concat` the registry rows carry `target != symbol`
+// (`target` "print"/"concat", `symbol` "sfn_print"/"sfn_array_concat"), so the
+// #633 import-shadow skip in pass 1 does NOT fire and it emits the typed
+// declare. Pre-fix, pass 2 then emitted a second erased declare for the same
+// symbol — the conflicting pair. The fix shares pass 1's declared-symbol set
+// with pass 2 (via `extract_declared_symbol_names`), so pass 2 defers to the
+// typed declare the prelude's own call sites actually use. This locks the
+// dedup at unit speed instead of as a slow link failure.
+import { find } from "sfn/strings";
+
+import { NativeFunction, NativeParameter } from "../../src/native_ir";
+import { TypeContext } from "../../src/llvm/types";
+import {
+    extract_declared_symbol_names,
+    render_runtime_helper_declarations,
+    render_imported_function_declarations
+} from "../../src/llvm/rendering";
+
+fn _empty_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
+}
+
+fn _param(name: string, type_annotation: string) -> NativeParameter {
+    return NativeParameter {
+        name: name,
+        type_annotation: type_annotation,
+        mutable: false,
+        default_value: null,
+        span: null
+    };
+}
+
+fn _fn(name: string, return_type: string, parameters: NativeParameter[]) -> NativeFunction {
+    return NativeFunction {
+        name: name,
+        is_async: false,
+        parameters: parameters,
+        return_type: return_type,
+        effects: [],
+        decorators: [],
+        is_extern: true,
+        instructions: []
+    };
+}
+
+// The two prelude-transitive imports whose source-level (erased) declare
+// collided with the registry's typed declare in #1736.
+fn _colliding_imports() -> NativeFunction[] {
+    return [_fn("sfn_print", "void", [_param("text", "* u8"), _param("len", "i64")]), _fn("sfn_array_concat", "* u8", [_param("a", "* u8"), _param("b", "* u8")])];
+}
+
+// Count emitted lines that declare `@<symbol>(` across a line set.
+fn _declare_count(lines: string[], symbol: string) -> int {
+    let needle = "@" + symbol + "(";
+    let mut count = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= lines.length { break; }
+        if find(lines[i], "declare ", 0) == 0 {
+            if find(lines[i], needle, 0) >= 0 { count += 1; }
+        }
+        i += 1;
+    }
+    return count;
+}
+
+// ── extract_declared_symbol_names parses `@sym(` out of declare lines ──
+test "declare-dedup (#1736): extract_declared_symbol_names reads symbols from declare lines" {
+    let lines: string[] = ["declare void @sfn_print({i8*, i64})", "; intrinsic sfn_array_concat requires capabilities: ![]", "declare { i8**, i64, i64 }* @sfn_array_concat({ i8**, i64, i64 }*, { i8**, i64, i64 }*)", "declare noalias i8* @calloc(i64, i64)"];
+    let syms = extract_declared_symbol_names(lines);
+    // The comment line carries no `@`, so it contributes nothing.
+    assert syms.length == 3;
+    assert find(syms[0], "sfn_print", 0) == 0;
+    assert find(syms[1], "sfn_array_concat", 0) == 0;
+    assert find(syms[2], "calloc", 0) == 0;
+}
+
+// ── Pass 1 emits the typed declare for the target != symbol rows ──
+test "declare-dedup (#1736): helper pass emits the typed print/concat declares" {
+    let no_locals: NativeFunction[] = [];
+    let helper_lines = render_runtime_helper_declarations(["print", "concat"], no_locals, _colliding_imports());
+    assert _declare_count(helper_lines, "sfn_print") == 1;
+    assert _declare_count(helper_lines, "sfn_array_concat") == 1;
+}
+
+// ── Pass 2 skips a symbol the helper pass already declared (typed wins) ──
+test "declare-dedup (#1736): imported pass defers to the typed helper declare" {
+    let no_locals: NativeFunction[] = [];
+    let imports = _colliding_imports();
+    let helper_lines = render_runtime_helper_declarations(["print", "concat"], no_locals, imports);
+    let already = extract_declared_symbol_names(helper_lines);
+
+    // With the helper-declared set threaded in, pass 2 emits NO second declare.
+    let imported_lines = render_imported_function_declarations(imports, no_locals, _empty_context(), [], already);
+    assert _declare_count(imported_lines, "sfn_print") == 0;
+    assert _declare_count(imported_lines, "sfn_array_concat") == 0;
+
+    // Net across BOTH passes: exactly one declare per helper symbol.
+    let mut combined: string[] = [];
+    let mut h: int = 0;
+    loop {
+        if h >= helper_lines.length { break; }
+        combined.push(helper_lines[h]);
+        h += 1;
+    }
+    let mut k: int = 0;
+    loop {
+        if k >= imported_lines.length { break; }
+        combined.push(imported_lines[k]);
+        k += 1;
+    }
+    assert _declare_count(combined, "sfn_print") == 1;
+    assert _declare_count(combined, "sfn_array_concat") == 1;
+}
+
+// ── Negative control: the skip is load-bearing ──
+// Without the shared set (empty `already_declared`), pass 2 still emits the
+// erased declare — proving the dedup, not some unrelated filter, suppresses
+// the duplicate above.
+test "declare-dedup (#1736): empty already-declared set still emits the import declare" {
+    let no_locals: NativeFunction[] = [];
+    let imports = _colliding_imports();
+    let imported_lines = render_imported_function_declarations(imports, no_locals, _empty_context(), [], []);
+    assert _declare_count(imported_lines, "sfn_print") == 1;
+    assert _declare_count(imported_lines, "sfn_array_concat") == 1;
+}


### PR DESCRIPTION
## Summary
- The regenerated runtime prelude emitted two conflicting `declare`s for the same runtime-helper symbol (`sfn_print`, `sfn_array_concat`), so clang's per-module verifier rejected it and `sfn test` / `sfn build` / `sfn run` and `make check`'s test phase failed at link (`invalid redefinition of function`).
- Two declare-emission passes write into the same module preamble without a shared dedup set: `render_runtime_helper_declarations` emits the **typed** descriptor shape (`{i8*, i64}` / `{i8**,i64,i64}*`); `render_imported_function_declarations` independently emits the source-level **erased** shape from the import closure. For `print`/`concat` the registry rows carry `target != symbol`, so the #633 import-shadow skip (gated on `target == symbol`) does not fire and both passes emit.
- Fix: share pass 1's declared-symbol set with pass 2. `extract_declared_symbol_names` reads the `@sym(` tokens from pass 1's emitted declare lines; the caller threads them into `render_imported_function_declarations`, which now skips a symbol pass 1 already declared. The **typed** declare wins (pass 1 runs first) — exactly the shape the prelude's own call sites use. #633 `target == symbol` mirror rows are unaffected: pass 1 skips them, so they never enter the shared set and pass 2 still emits their imported declare.

Closes #1736

## Acceptance Criteria
- [x] A regenerated `build/sailfin/sfn__runtime-native__prelude.sfn-O0.ll` declares each runtime helper exactly once with a signature consistent with its call sites (verified: `sfn_print` → `declare void @sfn_print({i8*, i64})`, `sfn_array_concat` → `declare { i8**, i64, i64 }* @sfn_array_concat(...)`; whole-module duplicate-declare scan empty).
- [x] `sfn test` / `make test-unit` link and run (`test "t" [pure] { assert true; }` passes; new regression test passes 4/4).
- [x] `make compile` still self-hosts; suite green. (`make compile` exit 0; full `make test` green — see Verification. `make check` runs the same passes in CI.)

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree. `compiler/src/llvm/rendering.sfn` (declare emitters) and `compiler/src/llvm/lowering/lowering_phase_render.sfn` (caller) were changed exactly as listed; `runtime_helpers.sfn` and the `runtime/sfn/*` files were read-only references and needed no edit.

## Verification
```bash
make compile          # self-hosts, exit 0
make test             # unit 179/179, integration 41/41, e2e 163/163, capsules 38/38 — status: pass

# AC1 — each helper declared exactly once, typed shape, no dupes:
grep "declare.*@sfn_print(\|declare.*@sfn_array_concat(" \
  build/sailfin/sfn__runtime-native__prelude.sfn-O0.ll
#   declare void @sfn_print({i8*, i64})
#   declare { i8**, i64, i64 }* @sfn_array_concat({ i8**, i64, i64 }*, { i8**, i64, i64 }*)

# AC2 — trivial pure test + new regression test:
build/native/sailfin test compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
#   PASS (all 4 tests passed)
```

## Files Changed
- `compiler/src/llvm/rendering.sfn` — new `extract_declared_symbol_names`; `render_imported_function_declarations` gains an `already_declared_symbols` param and skips symbols pass 1 already declared.
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — caller extracts pass 1's declared symbols and threads them into pass 2.
- `compiler/tests/unit/prelude_helper_declare_dedup_test.sfn` — new regression test (extractor, typed-wins dedup, net-once-per-symbol, load-bearing negative control).

https://claude.ai/code/session_01NyaR82P936FUrDEgq4Gezm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyaR82P936FUrDEgq4Gezm)_