### PR TITLE
feat(effects): structure assignment-as-expression into an Assignment node

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -115,6 +115,38 @@ enum Expression {
         else_value: Expression,
         span: SourceSpan?
     },
+    // Assignment-as-expression `target <op> rhs` (issue #1627/#1741, epic
+    // #1180, effect-system hardening). Assignment has no AST node before
+    // #1627 — `a = b` parsed as `ExpressionStatement { Raw{"a = b"} }` because
+    // `=` carried precedence -1 and was never climbed, so the leftover `= b`
+    // tokens degraded the whole expression to `Raw`. Since #1186 a `Raw`
+    // contributes zero effects, so an effectful target/rhs (`arr[io()] = x`,
+    // `a = readFile()`) reached codegen effect-free. Structuring it lets the
+    // effect checker, typecheck walker, ownership analysis, and lambda-capture
+    // rewrite all recurse into `target` and `rhs` (the capture walk in
+    // typecheck_captures.sfn DELIBERATELY does not descend — see its #687
+    // note). The
+    // formatter serializes it back to `<target> <operator> <rhs>` — the
+    // exact text the lowering `parse_assignment_expression` already consumes
+    // (string-scan), so no new lowering arm is needed. `operator` is `"="` or
+    // a compound (`"+="`, `"-="`, `"*="`, `"/="`), keeping the node lossless.
+    //
+    // The rvalue is named `rhs`, NOT `value` (#1741): enum field reads slot by
+    // field NAME with a single type per name (the union payload is rendered
+    // per-name and read via a variant-filtered select chain). `value` is
+    // already `string` in `NumberLiteral`/`StringLiteral`/`BooleanLiteral`, so
+    // an `Expression`-typed `value` here collides on that slot and corrupts
+    // reads of the existing string `value` reached through a nested operand
+    // (`Unary{ -, NumberLiteral }.operand.value` came back empty, dropping
+    // negative-int capture type inference — the regression that sank the first
+    // #1741 attempt). `rhs`/`target` are unique names in this enum, so they
+    // take their own slots and the collision is gone. `span` stays last.
+    Assignment {
+        target: Expression,
+        operator: string,
+        rhs: Expression,
+        span: SourceSpan?
+    },
     // Concurrency frontend nodes (M4.0, epic #965, issue #1079). Parse-only
     // targets for the structured-concurrency surface; parsing, type rules,
     // effect-checking, and lowering land in follow-up issues. Runtime

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -906,6 +906,16 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
         required = merge_requirements(required, collect_effects_from_expression(expression.else_value, imports));
         return required;
     }
+    if expression.variant == "Assignment" {
+        // Assignment `target <op> rhs` (#1627 Part D). Both sides can be
+        // effectful — `arr[compute_io()] = x` (effect in the lvalue) and
+        // `a = readFile()` (effect in the rhs) — so the requirement is the
+        // union of the target's and rhs's effects. Before #1627 the whole
+        // assignment degraded to an effect-blind `Raw`, dropping both.
+        let mut required = collect_effects_from_expression(expression.target, imports);
+        required = merge_requirements(required, collect_effects_from_expression(expression.rhs, imports));
+        return required;
+    }
     if expression.variant == "Array" {
         let mut required: EffectRequirement[] = [];
         let mut element_index: int = 0;

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -217,6 +217,22 @@ fn format_expression_into(expression: Expression, out: string[]) -> string[] {
         out.push(")");
         return out;
     }
+    if expression.variant == "Assignment" {
+        // `<target> <operator> <rhs>` (#1627 Part D) — the exact text the
+        // lowering `parse_assignment_expression` string-scan consumes (it
+        // splits on the first top-level `=`, reading the preceding char for a
+        // compound operator). The target is an lvalue (Identifier / Member /
+        // Index / `*`-deref) and never carries a top-level `=`, so the split
+        // is unambiguous; the rhs is parenthesized when it is a Binary/Cast
+        // so embedded operators survive the re-parse. No dedicated lowering
+        // arm is needed; this serialization IS the bridge.
+        format_expression_into(expression.target, out);
+        out.push(" ");
+        out.push(expression.operator);
+        out.push(" ");
+        _format_binary_operand_into(expression.rhs, out);
+        return out;
+    }
     if expression.variant == "TryOperator" {
         // `<operand>?` (#1690). Normally every try operator is desugared by
         // `desugar_try_in_block` before formatting, so this arm does not fire

--- a/compiler/src/emitter_sailfin_expr.sfn
+++ b/compiler/src/emitter_sailfin_expr.sfn
@@ -145,6 +145,14 @@ fn format_expression(expression: Expression) -> string {
         let else_text = format_expression(expression.else_value);
         return condition_text + " ? " + then_text + " : " + else_text;
     }
+    if expression.variant == "Assignment" {
+        // Assignment `target <op> rhs` (#1627 Part D). Human-friendly
+        // Sailfin-to-Sailfin rendering (no operand parens), like the
+        // Conditional/Cast arms above.
+        let target_text = format_expression(expression.target);
+        let rhs_text = format_expression(expression.rhs);
+        return target_text + " " + expression.operator + " " + rhs_text;
+    }
     if expression.variant == "Lambda" {
         return format_lambda_expression(expression);
     }

--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -455,5 +455,17 @@ fn is_two_char_symbol(value: string) -> boolean {
     if value == "<<" { return true; }
     if value == ">>" { return true; }
     if value == ".." { return true; }
+    // Compound assignment operators (#1627 Part D). Tokenizing these as
+    // single symbols lets the expression parser's assignment seam recognize
+    // `x += 1` as `Assignment{operator:"+="}` instead of lexing `+` then `=`
+    // — which made the binary `+` climb fail on the trailing `=` and degrade
+    // the whole statement to an effect-blind `Raw`. The lowering
+    // `parse_assignment_expression` is a string-scan (not token-based), so it
+    // is unaffected by this tokenization change. `%=` is intentionally omitted
+    // (the lowering compound-assignment parser handles only `+= -= *= /=`).
+    if value == "+=" { return true; }
+    if value == "-=" { return true; }
+    if value == "*=" { return true; }
+    if value == "/=" { return true; }
     return false;
 }

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -620,6 +620,23 @@ fn _rewrite_expression(ctx: LiftContext, expression: Expression) -> ExpressionRe
             }
         };
     }
+    if expression.variant == "Assignment" {
+        // Assignment `target <op> rhs` (#1627 Part D). Rewrite both sides so
+        // a captured binding assigned-to or read inside a lambda body
+        // (`fn() { captured = x; }`) is lifted to the captured environment,
+        // threading `ctx` left-to-right.
+        let target = _rewrite_expression(ctx, expression.target);
+        let rhs = _rewrite_expression(target.ctx, expression.rhs);
+        return ExpressionRewriteResult {
+            ctx: rhs.ctx,
+            expression: Expression.Assignment {
+                target: target.expression,
+                operator: expression.operator,
+                rhs: rhs.expression,
+                span: expression.span
+            }
+        };
+    }
     // Lift lambdas nested inside spawn/await operands (#1090). A lambda
     // operand is a spawn target — its captured env crosses the thread
     // boundary and the worker frees it (#1475), so lift it with

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -425,7 +425,24 @@ fn _body_text_allocates_or_stores(text: string) -> boolean {
     loop {
         if i >= n { break; }
         let ch = char_at(text, i);
-        if ch == "(" { return true; }
+        if ch == "(" {
+            // Only a CALL `(` allocates/escapes — a grouping (precedence) `(`
+            // does not. In the native-IR token stream a call `(` immediately
+            // follows its callee (an identifier char, or a `)`/`]` closing the
+            // callee expression), whereas a precedence-grouping paren follows
+            // an operator / `=` / `,` / space or another `(`. A structured
+            // assignment RHS now carries such grouping parens (`acc = (a + b)`,
+            // #1741) where the pre-#1627 `Raw` verbatim source — for the
+            // arena-eligible loops in the self-host set — did not, so this scan
+            // never saw them before. Skipping a grouping `(` is sound: its
+            // inner content is still scanned char-by-char below, so any real
+            // call nested inside is caught at that call's own `(`.
+            let mut prev: string = " ";
+            if i > 0 { prev = char_at(text, i - 1); }
+            if is_identifier_part_char(prev) { return true; }
+            if prev == ")" { return true; }
+            if prev == "]" { return true; }
+        }
         if ch == "[" { return true; }
         if ch == "\"" { return true; }
         if ch == "'" { return true; }

--- a/compiler/src/ownership_checker.sfn
+++ b/compiler/src/ownership_checker.sfn
@@ -944,6 +944,15 @@ fn _scope_after_expression(expression: Expression?, scope: OwnershipScope) -> Ow
         let after_then = _scope_after_expression(expression.then_value, after_condition);
         return _scope_after_expression(expression.else_value, after_then);
     }
+    if expression.variant == "Assignment" {
+        // Assignment `target <op> rhs` (#1627 Part D). Thread the scope
+        // through the rhs then the target so a move inside the rvalue
+        // (`a = consume(buf)`) or an effectful/owning lvalue is recorded and a
+        // later use of a moved binding is still caught. Rhs-before-target
+        // matches evaluation order (the rvalue is computed before the store).
+        let after_rhs = _scope_after_expression(expression.rhs, scope);
+        return _scope_after_expression(expression.target, after_rhs);
+    }
     if expression.variant == "Spawn" {
         // A spawned closure captures owned values as moves (#1220). A
         // bare-fn spawn (`spawn foo(buf)`) is an ordinary call whose

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -409,11 +409,59 @@ fn parse_expression_bp(state: ExpressionTokens, min_precedence: int) -> Expressi
         }
     }
 
+    // Assignment-as-expression `target <op> value` (#1627 Part D). Binds
+    // looser than ternary, right-associative; recognized only at base
+    // precedence (`min_precedence == 0`) so it wraps the fully-climbed (and
+    // possibly ternary-wrapped) `left_expression` as the target. `=` and the
+    // compound operators carry precedence -1 (never climbed), so this is
+    // purely additive — every `a = b` / `x += 1` that previously degraded to
+    // an effect-blind `Raw` now structures into `Assignment`, and the value
+    // recurses at base precedence for right-associativity (`a = b = c`).
+    // `==`/`!=`/`<=`/`>=` lex as distinct two-char tokens, so
+    // `is_assignment_operator` cannot misfire on a comparison.
+    if min_precedence == 0 {
+        if !expression_tokens_is_at_end(current_state) {
+            let assign_token = expression_tokens_peek(current_state);
+            if assign_token.kind.variant == "Symbol" {
+                if is_assignment_operator(assign_token.lexeme) {
+                    let after_op = expression_tokens_advance(current_state);
+                    let value_result = parse_expression_bp(after_op, 0);
+                    if !value_result.success {
+                        return expression_parse_failure(state);
+                    }
+                    return ExpressionParseResult {
+                        state: value_result.state,
+                        expression: Expression.Assignment {
+                            target: left_expression,
+                            operator: assign_token.lexeme,
+                            rhs: value_result.expression,
+                            span: source_span_from_tokens([assign_token])
+                        },
+                        success: true
+                    };
+                }
+            }
+        }
+    }
+
     return ExpressionParseResult {
         state: current_state,
         expression: left_expression,
         success: true
     };
+}
+
+// Recognize an assignment operator (#1627 Part D). Restricted to the set the
+// lowering `parse_assignment_expression` string-scan supports (`= += -= *= /=`);
+// `%=` is intentionally excluded so it stays `Raw` (the lowering compound
+// parser cannot handle it anyway).
+fn is_assignment_operator(op: string) -> boolean {
+    if strings_equal(op, "=") { return true; }
+    if strings_equal(op, "+=") { return true; }
+    if strings_equal(op, "-=") { return true; }
+    if strings_equal(op, "*=") { return true; }
+    if strings_equal(op, "/=") { return true; }
+    return false;
 }
 
 // ============================================================================

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -1028,6 +1028,14 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         diagnostics = diagnostics.concat(walk_expression(expression.else_value, bindings, imports));
         return diagnostics;
     }
+    if expression.variant == "Assignment" {
+        // Assignment `target <op> rhs` (#1627 Part D) — recurse into both
+        // sides so diagnostics (undefined symbols, fn-value misuse, nested
+        // parse-error nodes) in the lvalue and the rvalue still fire.
+        let mut diagnostics = walk_expression(expression.target, bindings, imports);
+        diagnostics = diagnostics.concat(walk_expression(expression.rhs, bindings, imports));
+        return diagnostics;
+    }
     if expression.variant == "Cast" {
         // A bare function identifier cast to a pointer (`<fn> as * u8` /
         // `<fn> as * fn (...)`) is a function-address materialization, not a

--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -329,6 +329,20 @@ fn walk_expression(scope: LocalBinding[], expression: Expression?) -> CaptureWal
         let else_value = walk_expression(scope, expression.else_value);
         return merge_results(merge_results(cond, then_value), else_value);
     }
+    // Assignment `target <op> rhs` (#1627/#1741) is DELIBERATELY not descended
+    // here. The other six structural walkers (effect checker, typecheck,
+    // ownership, both formatters, lambda-lowering) DO carry an Assignment arm —
+    // only the capture walk omits one, on purpose. Capturing a binding through
+    // an assignment (`fn() { g = g + x; }`) where the target/rhs is an enclosing
+    // `let mut` (most acutely a module-level mutable global) makes that binding
+    // a MUTABLE capture, which the lift pass refuses as a fatal (#687,
+    // mutable captures not yet supported). Before #1627 assignment was a `Raw`
+    // node that this walk already dropped (it returns `empty_walk_result()` for
+    // `Raw`), so descending now would NOT be a faithful re-structuring — it
+    // would surface mutable captures that previously self-hosted and ran
+    // (e.g. a parallel worker accumulating into a module global). Falling
+    // through to the empty result below preserves that pre-#1627 behaviour
+    // exactly; assignment-position capture detection waits on #687.
     if expression.variant == "Call" {
         let mut result = walk_expression(scope, expression.callee);
         let mut i: int = 0;

--- a/compiler/tests/unit/effect_assignment_test.sfn
+++ b/compiler/tests/unit/effect_assignment_test.sfn
@@ -1,0 +1,116 @@
+// #1627 Part D — assignment-as-expression must not hide its target's or
+// value's effects.
+//
+// Before #1627 assignment had no AST node: `a = b` / `x += 1` parsed as
+// `ExpressionStatement { Raw{"a = b"} }` because `=` carried precedence -1
+// (never climbed) and the compound operators lexed as two tokens, so the
+// whole statement degraded to an effect-blind `Raw`. After #1186 a `Raw`
+// contributes ZERO effects, so an effectful target or value
+// (`arr[io()] = x`, `a = readFile()`) reached codegen with no declared
+// capability.
+//
+// This pins both halves: (a) the parser now structures `<target> <op>
+// <value>` into `Expression.Assignment` (no `Raw` degradation, for `=` and
+// the compound operators `+= -= *= /=`), and (b)
+// `collect_effects_from_expression` walks BOTH sides so a requirement in the
+// lvalue or the rvalue surfaces. The effect-free canary guards against a
+// false positive on the dominant in-source spelling (`i += 1`,
+// `cursor = cursor + 1`), of which the compiler/runtime source has hundreds;
+// a false positive there would break self-host.
+import { Expression } from "../../src/ast";
+import { EffectRequirement, collect_effects_from_expression } from "../../src/effect_checker";
+import { empty_import_symbols } from "../../src/effect_imports";
+import { parse_program } from "../../src/parser/mod";
+
+fn _probe_expr(snippet: string) -> Expression ![io] {
+    let program = parse_program("fn probe() { " + snippet + "; }");
+    assert program.statements.length >= 1;
+    let fn_stmt = program.statements[0];
+    assert fn_stmt.variant == "FunctionDeclaration";
+    assert fn_stmt.body.statements.length >= 1;
+    let stmt = fn_stmt.body.statements[0];
+    assert stmt.variant == "ExpressionStatement";
+    return stmt.expression;
+}
+
+fn _reqs_contain(reqs: EffectRequirement[], effect: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= reqs.length { break; }
+        if reqs[index].effect == effect { return true; }
+        index += 1;
+    }
+    return false;
+}
+
+fn _assign_reqs(snippet: string) -> EffectRequirement[] ![io] {
+    return collect_effects_from_expression(_probe_expr(snippet), empty_import_symbols());
+}
+
+// -------------------------------------------------------------------
+// Structural lift: simple and compound assignment parse to an
+// `Assignment` node carrying the operator, never a `Raw`.
+// -------------------------------------------------------------------
+test "assign: simple assignment structures into Assignment" ![io] {
+    let expr = _probe_expr("a = b");
+    assert expr.variant == "Assignment";
+    assert strings_equal(expr.operator, "=");
+}
+
+test "assign: compound += structures into Assignment with the operator" ![io] {
+    let expr = _probe_expr("a += 1");
+    assert expr.variant == "Assignment";
+    assert strings_equal(expr.operator, "+=");
+}
+
+test "assign: compound -= *= /= each structure into Assignment" ![io] {
+    assert strings_equal(_probe_expr("a -= 1").operator, "-=");
+    assert strings_equal(_probe_expr("a *= 2").operator, "*=");
+    assert strings_equal(_probe_expr("a /= 2").operator, "/=");
+}
+
+test "assign: index lvalue structures with an Index target" ![io] {
+    let expr = _probe_expr("arr[0] = 5");
+    assert expr.variant == "Assignment";
+    assert expr.target.variant == "Index";
+}
+
+test "assign: member lvalue structures with a Member target" ![io] {
+    let expr = _probe_expr("p.x = 5");
+    assert expr.variant == "Assignment";
+    assert expr.target.variant == "Member";
+}
+
+// -------------------------------------------------------------------
+// Effect attribution: an assignment walks BOTH its target and value.
+// -------------------------------------------------------------------
+test "assign: value-side io surfaces" ![io] {
+    assert _reqs_contain(_assign_reqs("a = print.info(\"x\")"), "io");
+}
+
+test "assign: value-side net surfaces" ![io] {
+    assert _reqs_contain(_assign_reqs("a = http.get(\"u\")"), "net");
+}
+
+test "assign: target-side (index) io surfaces" ![io] {
+    assert _reqs_contain(_assign_reqs("arr[print.info(\"x\")] = 5"), "io");
+}
+
+test "assign: compound value-side io surfaces" ![io] {
+    assert _reqs_contain(_assign_reqs("total += print.info(\"x\")"), "io");
+}
+
+// -------------------------------------------------------------------
+// No false positive: an effect-free assignment requires nothing. These
+// are the dominant in-source spellings (hundreds of sites); a false
+// positive here would break self-host.
+// -------------------------------------------------------------------
+test "assign: effect-free simple assignment requires nothing (self-host canary)" ![io] {
+    let reqs = _assign_reqs("cursor = cursor + 1");
+    assert reqs.length == 0;
+}
+
+test "assign: effect-free compound increment requires nothing (self-host canary)" ![io] {
+    let reqs = _assign_reqs("i += 1");
+    assert reqs.length == 0;
+}


### PR DESCRIPTION
## Summary
- Structures `a = b` / `x += 1` into a real `Expression.Assignment { target, operator, rhs, span }` so the effect checker and structural walkers traverse the target and value — an effectful target/value (`a = readFile()`, `arr[io()] = x`) can no longer reach codegen effect-blind through `Raw`.
- Lexer tokenizes `+= -= *= /=` as single symbols (`%=` stays `Raw`); parser adds an assignment seam in `parse_expression_bp` (base precedence, right-assoc, below ternary); formatter serializes `<target> <op> <rhs>` (the exact text the existing lowering `parse_assignment_expression` consumes — no new lowering arm).
- Re-does the reverted #1737 Part D **with full verification** (now that #1736 unblocks the test runner) and resolves the regression that sank the first attempt.

Closes #1741

## Acceptance Criteria
- [x] `a = print.info(x)` and `arr[print.info(x)] = 5` require `[io]`; `i += 1` is effect-free and compiles (`effect_assignment_test.sfn`, 11 tests).
- [x] **`typecheck_lambda_capture_test` passes** (22 tests) — the negative-int/capture regression is root-caused and fixed (see below), not structured blindly.
- [x] IR-diff: representative simple/compound/member/index assignments lower byte-identically before/after (**LLVM IR byte-identical**; native `.sfn-asm` differs only by a semantics-preserving paren on a nested-binary RHS that lowers to identical LLVM IR).
- [x] `make compile` self-hosts; `make check` suite green (unit 181/181, integration 41/41, capsules 38/38, e2e incl. `arena_loop_rewind` + `concurrency_ownedbuf_asan`).
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Root-cause notes (the three issues the first attempt could not resolve)
1. **The rvalue is named `rhs`, not `value`.** Sailfin's enum field reads slot by field **name** with one type per name; `value` is already `string` in `NumberLiteral`/`StringLiteral`/`BooleanLiteral`, so an `Expression`-typed `value` collided on that slot and corrupted reads of the string `value` reached through a nested operand (`Unary{-, NumberLiteral}.operand.value` returned empty) — the negative-int capture miscompile. Minimal reproduction confirmed it; renaming to the unique `rhs` resolves it. *(The underlying enum-lowering collision — same field name + different type silently corrupts reads instead of erroring — is a separate latent compiler bug worth its own issue.)*
2. **Arena loop-rewind escape scan.** `_body_text_allocates_or_stores` treated any `(` as a call; the structured assignment RHS now carries precedence-grouping parens (`acc = (a + b)`) the old `Raw` verbatim text did not, suppressing a valid mark/rewind optimization. The scan now distinguishes a call `(` (preceded by identifier/`)`/`]`) from a grouping `(`; nested calls are still caught.
3. **Capture walk deliberately omitted** (one of the 7 listed walkers). Descending into Assignment surfaces a lambda's read+write of an enclosing `let mut` (most acutely a module-level global) as a **mutable capture**, which the lift pass refuses as a fatal (#687, unsupported). Before #1627 assignment was a `Raw` node the capture walk already dropped, so a parallel worker accumulating into a module global self-hosted and ran; descending now would regress that. Assignment-position capture detection waits on #687. *(I attempted to confirm this scope call interactively; the prompt could not be delivered, so I proceeded with the lighter, no-new-regression option and documented it in `typecheck_captures.sfn`.)*

## Map reconciliation
Advisory `## Files Affected` drifted from the tree; reconciled:
- `compiler/src/parser/expressions.sfn` (issue listed it) was correct — the seam landed there.
- Added **`compiler/src/llvm/lowering/instructions_helpers.sfn`** (not in the issue map) for the arena-scan fix above — a direct consequence of the in-scope formatter change, required to keep `make check` green.
- Did **not** add the `typecheck_captures.sfn` arm the issue listed (deliberate, per root-cause #3); the file is still touched (documents the omission).

## Design
SFEP-0008; design note `docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md` (Part D). Epic #1180, sub-track #1692. Partially completes #1627's blanket fail-closed criterion (the blanket E0818 flip remains a separate sub-issue, out of scope here).

## Verification
```
make compile            # self-hosts (×3 across iterations)
make check              # unit 181/181, integration 41/41, capsules 38/38, e2e green
sfn test compiler/tests/unit/typecheck_lambda_capture_test.sfn   # 22/22
sfn test compiler/tests/unit/effect_assignment_test.sfn          # 11/11
sfn test compiler/tests/e2e/arena_loop_rewind_test.sfn           # 11/11
sfn test compiler/tests/e2e/concurrency_ownedbuf_asan_interleave_test.sfn  # 2/2
sfn fmt --check <all touched .sfn>   # clean
```

## Files Changed
`ast.sfn`, `lexer.sfn`, `parser/expressions.sfn`, `effect_checker.sfn`, `typecheck.sfn`, `typecheck_captures.sfn`, `ownership_checker.sfn`, `emit_native_format.sfn`, `emitter_sailfin_expr.sfn`, `llvm/expression_lowering/native/lambda_lowering.sfn`, `llvm/lowering/instructions_helpers.sfn`, + new `compiler/tests/unit/effect_assignment_test.sfn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0175b895UCrwtXQ9Lox24AWn)_