### PR TITLE
chore(codex): sync agent configuration

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,13 +1,13 @@
 # Codex setup for Sailfin
 
-This directory mirrors the high-value parts of the Claude Code setup using Codex-native repository artifacts where available and prompt templates where Codex does not yet provide Claude-style custom slash commands.
+This directory mirrors the high-value, provider-neutral parts of the Claude Code setup using Codex-native repository artifacts where available and prompt templates where Codex does not yet provide Claude-style slash commands.
 
 ## What is configured
 
-- `config.toml` enables repo-local hooks, hierarchical `AGENTS.md` handling, long-running goals, and the two Sailfin skills.
-- `config.toml` wires lifecycle events to small shell scripts under `hooks/`.
-- `skills/` contains reusable Sailfin workflows for safe verification and issue pickup.
-- `prompts/` contains copy/paste prompts for Codex web or CLI sessions.
+- `config.toml` enables repo-local hooks, hierarchical `AGENTS.md` handling, long-running goals, and the Sailfin skills.
+- `hooks/` injects fast session and git context without enforcing obsolete caller-side memory wrappers.
+- `skills/` contains reusable Sailfin workflows for safe verification, issue pickup, compilation debugging, and seed pinning.
+- `prompts/` contains copy/paste prompts for Codex web or CLI sessions, including issue pickup, feature planning, validation, and SFEP management.
 
 ## Local setup
 
@@ -27,24 +27,32 @@ If your Codex build does not auto-load repo-local skills or hooks, paste the rel
 
 ## Web setup
 
-Codex web should be given the same repository context plus one of the prompts in `prompts/`. For the closest equivalent to Claude's `/pickup`, paste `prompts/pickup.md` and optionally append an issue number.
+Codex web should be given the same repository context plus one of the prompts in `prompts/`. For the closest equivalent to Claude's `/pickup`, paste `prompts/pickup.md` and optionally append an issue number. For SFEP lifecycle work, paste `prompts/sfep.md` with the desired mode.
 
 ## Safety behavior
 
 The hooks are intentionally conservative:
 
-- `SessionStart` adds a compact compiler/seed/branch snapshot.
+- `SessionStart` adds a compact compiler/seed/MCP/branch snapshot.
 - `UserPromptSubmit` adds branch, dirty-file count, and unpushed commit count.
-- (Retired) The former `PreToolUse` ulimit guard is gone — the compiler self-applies its 8 GiB memory budget on Linux at startup (#1291).
+- There is no `PreToolUse` ulimit guard: the compiler self-applies its 8 GiB Linux memory budget at startup (`SAILFIN_MEM_LIMIT` overrides; Darwin cannot enforce `RLIMIT_AS`).
 
-The memory cap duplicates the project rule in `AGENTS.md` because uncapped Sailfin compiler runs can exhaust local WSL or IDE hosts.
+The remaining guardrail is time, not caller memory: wrap direct single-file compiler invocations with `timeout 60`; `make` targets handle their own timeouts.
+
+## Current project facts Codex must preserve
+
+- The native compiler is self-hosted from the released seed pinned by `.seed-version`.
+- The runtime is Sailfin-native (`runtime/prelude.sfn` and `runtime/sfn/`); the old C runtime is gone.
+- `sfn check` is the fast parse/type/effect inner loop but does not prove codegen or self-hosting.
+- `make compile` is required before declaring `compiler/src/*.sfn` changes done; `make check` is the full gate.
+- Forward-looking design decisions use the SFEP process in `docs/proposals/0001-sfep-process.md` and the registry in `docs/proposals/README.md`.
 
 ## Issue pickup workflow
 
 Use `prompts/pickup.md` for autonomous issue work. It instructs Codex to:
 
 1. Query `claude-ready` issues and rank them with the same priority order as Claude's `/pickup` command.
-2. Verify pinned-seed freshness before claiming compiler/runtime work.
+2. Verify pinned-seed freshness only when a compiler-source capability must already be present in the pinned seed.
 3. Claim the issue, sync the project board with the existing repository helper, and branch as `codex/<issue>-<slug>`.
 4. Implement, verify, commit, and open a PR with `Closes #<issue>`.
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -26,6 +26,14 @@ enabled = true
 path = ".codex/skills/sailfin-pickup/SKILL.md"
 enabled = true
 
+[[skills.config]]
+path = ".codex/skills/sailfin-debug-compile/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".codex/skills/sailfin-pin-seed/SKILL.md"
+enabled = true
+
 # Lifecycle hooks are intentionally small wrappers around scripts in
 # .codex/hooks/ so the behavior can be reviewed and tested outside Codex.
 [[hooks.SessionStart]]

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Codex SessionStart hook: emit a compact project snapshot that keeps Sailfin's
-# self-hosted compiler constraints visible at the start of every session.
+# self-hosted compiler, Sailfin-native runtime, and proposal process visible at
+# the start of every session.
 
 set -euo pipefail
 
@@ -32,17 +33,29 @@ else
   printf -- '- seedcheck: not built (only needed for `make check`)\n'
 fi
 
+if [[ -f tools/mcp-server/dist/index.js ]]; then
+  printf -- '- mcp-server: tools/mcp-server/dist present\n'
+elif [[ -d tools/mcp-server ]]; then
+  printf -- '- mcp-server: not built — run `make mcp-server` if MCP tools are needed\n'
+fi
+
 branch=$(git branch --show-current 2>/dev/null || printf '(detached)')
 printf -- '- branch: %s\n' "$branch"
 
 version_pin=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/version = \1/p' compiler/capsule.toml 2>/dev/null | head -n1 || true)
 [[ -n "$version_pin" ]] && printf -- '- capsule: %s\n' "$version_pin"
 
+if [[ -f .seed-version ]]; then
+  seed_pin=$(tr -d '[:space:]' < .seed-version)
+  [[ -n "$seed_pin" ]] && printf -- '- pinned seed: v%s\n' "$seed_pin"
+fi
+
 cat <<'MSG'
 
 Reminders:
 - The compiler self-caps memory at 8 GiB on Linux (`SAILFIN_MEM_LIMIT` to override); wrap single-file compiles with `timeout 60`.
+- The runtime is Sailfin-native (`runtime/prelude.sfn`, `runtime/sfn/`); do not add C runtime fixups.
+- Use `sfn check <files>` for the parse/type/effect inner loop, then `make compile` for compiler-source changes.
+- Status source of truth: docs/status.md. SFEP process: docs/proposals/0001-sfep-process.md. Roadmap: site/src/pages/roadmap.astro.
 - Prefer feature branches named `codex/<issue-or-topic>-<slug>`.
-- Status source of truth: docs/status.md. Roadmap: site/src/pages/roadmap.astro.
-- For issue pickup, use .codex/prompts/pickup.md as the web/CLI prompt template.
 MSG

--- a/.codex/prompts/check.md
+++ b/.codex/prompts/check.md
@@ -3,5 +3,5 @@
 ```text
 Verify the current Sailfin working tree.
 
-Follow AGENTS.md and .codex/skills/sailfin-check/SKILL.md. Inspect the diff, identify what changed, choose the smallest sufficient verification ladder, and run the checks. Report exact commands and results. (The compiler self-caps memory; no `ulimit` prefix.)
+Follow AGENTS.md and .codex/skills/sailfin-check/SKILL.md. Inspect the diff, identify what changed, choose the smallest sufficient verification ladder, and run the checks. Prefer `sfn check <touched .sfn files>` as the fast parse/type/effect inner loop, then `make compile` for compiler-source changes and `make check` only for full-gate needs. The compiler self-caps memory; no `ulimit` prefix. Wrap direct single-file compiler invocations with `timeout 60`.
 ```

--- a/.codex/prompts/pickup.md
+++ b/.codex/prompts/pickup.md
@@ -9,12 +9,13 @@ Follow this repository's AGENTS.md and use the Sailfin pickup workflow in .codex
 
 Required workflow:
 1. Query GitHub issues with `gh` and choose/validate the issue.
-2. Run the pinned-seed freshness gate before claiming compiler/runtime work.
-3. Claim the issue, sync the project status, and create a `codex/<issue>-<slug>` branch.
-4. Restate the issue goal, scope, acceptance criteria, files affected, and verification plan.
-5. Implement the smallest focused change that satisfies the issue.
-6. Run the issue's verification commands plus the Sailfin safety checks from .codex/skills/sailfin-check/SKILL.md.
-7. Commit the changes and open a PR with `Closes #<issue>`.
+2. Read any referenced SFEP/design note before planning; do not redesign an accepted SFEP in the issue body.
+3. Apply the seed-dependency policy: bundle a single tightly-coupled compiler-source capability with its consumer by default; verify `## Required in pinned seed` only when the issue explicitly requires a predecessor in the pinned seed.
+4. Claim the issue, sync the project status, and create a `codex/<issue>-<slug>` branch.
+5. Restate the issue goal, scope, acceptance criteria, files affected, design references, and verification plan.
+6. Implement the smallest focused change that satisfies the issue.
+7. Run the issue's verification commands plus the Sailfin safety checks from .codex/skills/sailfin-check/SKILL.md.
+8. Commit the changes and open a PR with `Closes #<issue>`.
 
-The compiler self-caps memory at 8 GiB on Linux; wrap single-file compiles with `timeout 60`.
+The compiler self-caps memory at 8 GiB on Linux; do not use a `ulimit` prefix. Wrap direct single-file compiler invocations with `timeout 60`.
 ```

--- a/.codex/prompts/plan-feature.md
+++ b/.codex/prompts/plan-feature.md
@@ -1,7 +1,7 @@
 # Codex Feature Planning Prompt
 
 ```text
-Plan a Sailfin language/compiler feature before implementation.
+Plan a Sailfin language/compiler/runtime feature before implementation.
 
-Read docs/status.md, the relevant language spec files under site/src/content/docs/docs/reference/, and the compiler pipeline under compiler/src/. Produce an implementation plan in pipeline order (lexer/parser, AST, type checker, effect checker, emitter, LLVM lowering, tests, docs). Identify self-hosting risks, seed dependencies, and verification commands. Do not edit code until I approve the plan.
+Read AGENTS.md, docs/status.md, docs/proposals/0001-sfep-process.md, any relevant SFEPs under docs/proposals/, the relevant language spec files under site/src/content/docs/docs/reference/, and the compiler/runtime source surface under compiler/src/ and runtime/sfn/. Produce an implementation plan in pipeline order (lexer/parser, AST, type checker, effect checker, native emitter, LLVM lowering, runtime/prelude if needed, tests, docs). Identify whether the change requires a new or updated SFEP, self-hosting risks, seed dependencies, and verification commands. Do not edit code until I approve the plan.
 ```

--- a/.codex/prompts/sfep.md
+++ b/.codex/prompts/sfep.md
@@ -1,0 +1,15 @@
+# Codex SFEP Prompt
+
+```text
+Manage a Sailfin Enhancement Proposal (SFEP).
+
+Follow AGENTS.md, docs/proposals/0001-sfep-process.md, docs/proposals/template.md, docs/proposals/README.md, and the SFEP workflow summarized here.
+
+Modes:
+- `new <slug> [type]`: copy docs/proposals/template.md to docs/proposals/draft-<slug>.md, keep `sfep: TBD`, fill all required sections, and report the next likely number from the registry without claiming it.
+- `status <N-or-draft-slug> <Draft|Accepted|Implemented|Withdrawn|Rejected|Superseded>`: locate the proposal, assign/rename a draft only when it leaves draft status, update front matter and `updated:`, move terminal proposals to archive when required, and sync docs/proposals/README.md.
+- `graduate <N>`: only after Stage1 readiness is met end-to-end and self-hosts, set `Implemented`, wire `graduates-to`, update docs/status.md and the relevant spec/preview page, and sync the registry.
+- `list [status]`: print/filter the registry from docs/proposals/README.md.
+
+Never mark a proposal Implemented for parsed-but-unenforced behavior. SFEP Markdown is not subject to `sfn fmt` or the self-host gate unless code changes accompany it.
+```

--- a/.codex/skills/sailfin-check/SKILL.md
+++ b/.codex/skills/sailfin-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sailfin-check
-description: Run Sailfin compiler and test verification safely with the required memory cap.
+description: Run Sailfin compiler and test verification safely with the required self-hosting and formatting gates.
 ---
 
 # Sailfin Check Skill
@@ -9,15 +9,23 @@ Use this skill whenever a task touches Sailfin compiler sources, runtime code, t
 
 ## Safety invariant
 
-- Wrap direct compiler invocations with `timeout 60` for single test files or examples (the compiler self-caps memory on Linux).
-- If `.sfn` files under `compiler/src/` or `runtime/` changed, run the formatter before final verification.
+- The compiler self-caps memory at 8 GiB on Linux (`SAILFIN_MEM_LIMIT` overrides); do not add `ulimit` prefixes or PreToolUse guards for ordinary runs.
+- Wrap direct single-file compiler invocations with `timeout 60`; `make` targets handle their own timeouts.
+- If `.sfn` files under `compiler/src/` or `runtime/` changed, run the formatter before final verification: `sfn fmt --write <files>` followed by `sfn fmt --check <files>` (or `build/native/sailfin ...` when `sfn` is not on `PATH`).
+- If `compiler/src/*.sfn` changed, run `make compile` before test-only validation so tests do not use a stale compiler binary.
 
 ## Verification ladder
 
 1. Documentation/config-only change: run a fast syntax/readability check when available, otherwise `git diff --check`.
-2. Test-only or example change: run the targeted test first, then `make test` when a compiler binary exists.
-3. Compiler/runtime source change: run `make compile` before `make test`; use `make check` when time allows.
-4. Structural compiler change: run `make clean-build` before rebuilding.
+2. Sailfin source edit inner loop: run `sfn check <touched files>` (or `build/native/sailfin check <path>`) to catch parse/type/effect errors quickly.
+3. Test-only or example change: run the targeted test first, then `make test` when a compiler binary exists.
+4. Compiler/runtime source change: run `make compile` before `make test`; use `make check` when declaring a shipped feature, cutting a release, or after higher-risk changes.
+5. Structural compiler change: run `make clean-build` before rebuilding.
+
+## SFEP and docs coupling
+
+- Behavior/status changes update `docs/status.md` first, then the relevant spec/preview page and roadmap if applicable.
+- Forward-looking design work belongs in an SFEP under `docs/proposals/`; do not mark SFEPs `Implemented` before Stage1 readiness and self-hosting are complete.
 
 ## Reporting
 

--- a/.codex/skills/sailfin-debug-compile/SKILL.md
+++ b/.codex/skills/sailfin-debug-compile/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: sailfin-debug-compile
+description: Systematically diagnose Sailfin compilation, self-hosting, or LLVM lowering failures without adding build-driver workarounds.
+---
+
+# Sailfin Debug Compile Skill
+
+Use this skill whenever `sfn check`, `make compile`, a single `.sfn` build, or LLVM/linking fails.
+
+## Phase 1 — Isolate
+
+- For frontend errors, start with `sfn check <file>` or `build/native/sailfin check <file>`.
+- For a direct compile/run reproduction, wrap the compiler invocation with `timeout 60`.
+- For self-hosting failures, capture the failing `make compile` output and preserve the log path.
+
+## Phase 2 — Trace
+
+Map the symptom to the canonical pipeline stage:
+
+1. Lexer/parser: `compiler/src/lexer.sfn`, `compiler/src/parser.sfn`
+2. AST/type/effects: `compiler/src/ast.sfn`, `compiler/src/typecheck.sfn`, `compiler/src/effect_checker.sfn`
+3. Native IR/emitter: `compiler/src/native_ir.sfn`, `compiler/src/emit_native.sfn`
+4. LLVM lowering: `compiler/src/llvm/lowering/`
+5. Runtime/prelude: `runtime/prelude.sfn`, `runtime/sfn/`
+6. Build orchestration: `compiler/src/cli_main.sfn`, `compiler/src/capsule_resolver.sfn` (orchestration only; no fixups)
+
+If a similar construct works elsewhere, compare emitted `.sfn-asm` or `.ll` and look for the first divergence.
+
+## Phase 3 — Fix
+
+- Edit canonical source under `compiler/src/` or `runtime/sfn/`; keep the diff minimal.
+- Never patch the build driver to mask a compiler/runtime bug.
+- Add a focused regression test under `compiler/tests/` when the failure pattern can recur.
+
+## Phase 4 — Verify
+
+- Run `sfn check <touched .sfn files>` for the fast parse/type/effect loop.
+- Run `sfn fmt --write` and `sfn fmt --check` on touched `.sfn` files under `compiler/src/` or `runtime/`.
+- Run `make compile` for compiler-source changes.
+- Run targeted tests, then `make test` or `make check` according to risk.
+
+## Constraints
+
+- The compiler self-caps memory on Linux; no `ulimit` prefix is needed.
+- Timeouts still apply to direct single-file compiler invocations.
+- Structural compiler changes should use `make clean-build` before rebuilding.

--- a/.codex/skills/sailfin-pickup/SKILL.md
+++ b/.codex/skills/sailfin-pickup/SKILL.md
@@ -24,9 +24,15 @@ Use this skill when the user asks Codex to pick up an issue, work the next item,
 
 If the user supplied an issue number, fetch it directly with `gh issue view <N> --json number,title,labels,assignees,body,state` and validate the same pickability rules.
 
-## Seed freshness gate
+## Seed dependency policy
 
-Before claiming compiler or runtime work, read `.seed-version`, fetch the matching `v<seed>` tag, and verify every issue/PR listed in `## Required in pinned seed` has at least one closing or merge commit that is an ancestor of the seed tag. If not, comment on the issue and stop without claiming it.
+`make compile` self-hosts against the binary pinned by `.seed-version`, so a compiler-source capability that a consumer needs in the pinned seed can force a seed cut. Apply the project seed-dependency rule:
+
+- Bundle a capability with its single tightly-coupled consumer by default; this avoids manufacturing a seed cut.
+- Split only when the capability has multiple consumers, is genuinely independent, or has a large blast radius.
+- When split, the predecessor should be labeled `seed-blocker`, the consumer should list it under `## Required in pinned seed`, and the seed bump queues against the normal cadence unless release-critical.
+
+Before claiming compiler/runtime work, read the issue body. If `## Required in pinned seed` lists predecessors, verify at least one closing/merge commit (or an explicit content expectation from the issue body) is present in the pinned seed tag. If not, comment on the issue and stop without claiming it.
 
 ## Claim and branch
 
@@ -40,13 +46,14 @@ The project sync helper remains under `.claude/scripts/` because it is provider-
 
 ## Implementation rules
 
-- Restate the issue goal, scope, acceptance criteria, files affected, and verification plan before editing.
-- For multi-pass compiler changes, implement in pipeline order: lexer, parser, AST, type checker, effect checker, native emitter, LLVM lowering, tests.
+- Restate the issue goal, scope, acceptance criteria, files affected, design/SFEP references, and verification plan before editing.
+- For multi-pass compiler changes, implement in pipeline order: lexer, parser, AST, type checker, effect checker, native emitter, LLVM lowering, runtime/prelude if needed, tests.
 - Keep changes focused and update `docs/status.md` first when behavior changes.
 - Add or update Sailfin-native tests beside related coverage under `compiler/tests/`.
+- Use the Sailfin check skill for formatting and verification.
 
 ## PR handoff
 
 - Run the verification commands from the issue body plus the Sailfin check ladder.
 - Commit atomically with a Conventional Commit style message, for example `fix(compiler): handle ...`.
-- Open a PR whose body includes scope, issue link (`Closes #N`), verification commands, and any residual concerns.
+- Open a PR whose body includes scope, issue link (`Closes #N`), SFEP/design link when applicable, verification commands, and residual concerns.

--- a/.codex/skills/sailfin-pin-seed/SKILL.md
+++ b/.codex/skills/sailfin-pin-seed/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: sailfin-pin-seed
+description: Pin the Sailfin seed compiler to a published release and verify the seed binary.
+---
+
+# Sailfin Pin Seed Skill
+
+Use this skill when asked to update `.seed-version`.
+
+## Workflow
+
+1. Normalize the requested version by stripping a leading `v`/`V`; `.seed-version` stores the bare version.
+2. Show the current pin with `cat .seed-version`.
+3. Update only `.seed-version`.
+4. Run `make fetch-seed` to download the matching release binary.
+5. Run `build/seed/bin/sailfin version` and confirm it reports the expected version.
+6. If requested or needed before merge, run `make compile`.
+7. Commit only `.seed-version` with `chore(seed): pin seed to <VERSION>`.
+
+## Failure handling
+
+- If the release is missing or the binary version mismatches, restore the previous `.seed-version` and report the failure.
+- Do not commit build artifacts.
+- A compile failure after pinning should be investigated as a compiler/seed issue, not papered over in build orchestration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,36 +2,49 @@
 
 ## Project Structure & Module Organization
 
-- `compiler/src/` carries the Sailfin-native compiler sources; the **self-hosted native compiler** (legacy name: stage2) is the primary toolchain.
-- `docs/` has a navigation guide (`docs/README.md`), the canonical status matrix (`docs/status.md`), and engineering references (runtime audit/architecture, build performance). The language specification, grammar, and keyword references live on the docs site under `site/src/content/docs/docs/reference/` and are published at [sailfin.dev/docs/reference/](https://sailfin.dev/docs/reference/). The roadmap lives at [sailfin.dev/roadmap](https://sailfin.dev/roadmap) (source: `site/src/pages/roadmap.astro`). Update the status doc first whenever behaviour changes, then adjust the spec/roadmap accordingly.
-- `docs/proposals/` holds future-facing designs (e.g., package management); leave implementation notes there until the status page marks them shipped.
-- `runtime/native/` hosts the current C runtime implementation; the runtime is planned to move into Sailfin for the 1.0 release.
+- `compiler/src/` carries the Sailfin-native compiler sources; the **self-hosted native compiler** (legacy internal path name: stage2) is the primary toolchain.
+- `runtime/prelude.sfn` and `runtime/sfn/` host the Sailfin-native runtime. The former C runtime under `runtime/native/` has been deleted; do not add C runtime startup/linkage workarounds.
+- `docs/` has a navigation guide (`docs/README.md`), the canonical status matrix (`docs/status.md`), and engineering references. The language specification, grammar, and keyword references live on the docs site under `site/src/content/docs/docs/reference/` and are published at [sailfin.dev/docs/reference/](https://sailfin.dev/docs/reference/). The roadmap lives at [sailfin.dev/roadmap](https://sailfin.dev/roadmap) (source: `site/src/pages/roadmap.astro`). Update the status doc first whenever behaviour changes, then adjust the spec/roadmap accordingly.
+- `docs/proposals/` is the Sailfin Enhancement Proposal (SFEP) registry. Use `docs/proposals/0001-sfep-process.md` and `docs/proposals/template.md` for forward-looking language, runtime/ABI, toolchain, or roadmap-epic design work. Keep single-issue design notes in `docs/proposals/design-notes/`.
 
 ## Build, Test, and Development Commands
 
-- `make test` runs all test cases (using an already compiled build).
-- `make compile` builds the compiler by self-hosting from the latest released seed.
-- `make check` compiles (if needed) and runs the full test suite.
-- `make install` installs the built compiler binary into `PREFIX/bin` (default: `~/.local/bin`).
-- `make clean` removes packaged artifacts (`dist/`).
-- If you need to do some debugging, use the /scratch directory and run/place scripts there.
-- Sailfin files spell effects explicitly (`fn foo() -> Bar ![io, model]`), keep lists ordered by impact, and use `CamelCase` for models or capsules while locals remain `snake_case`.
-- Align terminology with the language spec at `site/src/content/docs/docs/reference/spec/` (capsule, fleet, provenance card) and note currency or latency literals as comments until syntax support arrives.
+- `sfn check <files>` (or `build/native/sailfin check <files>`) is the fast inner loop for parse/type/effect checking; it does not prove codegen, linking, or self-hosting.
+- `make compile` self-hosts the compiler from the released seed pinned by `.seed-version`.
+- `make rebuild` forces a rebuild from the seed.
+- `make check` compiles if needed and runs the full validation gate, including seedcheck self-host validation.
+- `make test`, `make test-unit`, `make test-integration`, and `make test-e2e` run Sailfin-native test suites.
+- `make bench` measures compile time and memory.
+- `make fetch-seed` downloads the pinned seed; `make install` installs the built compiler into `PREFIX/bin` (default: `~/.local/bin`).
+- `make clean` removes packaged artifacts (`dist/`); `make clean-build` removes build artifacts while keeping the seed and is destructive enough to call out before use.
+- If you need scratch scripts or reproductions, place them under `/scratch`.
 
-- Stage tests beside the code in `compiler/tests/` and mirror intent in `docs/status.md` when available.
-- Prefer slim golden inputs in `examples/` plus targeted fixtures; avoid recording generated output.
-- Run `make test` before submitting and capture reproduction steps for regressions.
-- When adding language surface or runtime behaviour, extend coverage in the Sailfin-native tests and reflect the change in `docs/status.md`.
+## Compiler Safety & Self-Hosting Invariants
+
+- The compiler self-applies an 8 GiB Linux `RLIMIT_AS` at startup (`SAILFIN_MEM_LIMIT` overrides; `unlimited`/`off`/`0` disables it). Do **not** add caller-side `ulimit` guards or Codex/Claude pre-tool hooks for ordinary compiler runs.
+- Timeouts still matter: wrap direct single-file compiler invocations with `timeout 60`; `make` targets manage their own timeouts.
+- Before committing changes to `compiler/src/*.sfn`, run `make compile` (or `make check`) before test-only validation so tests do not run against a stale compiler binary.
+- If a change is structural (file splits, module graph changes, renamed exports), run `make clean-build` before rebuilding.
+- Fix compiler failures in `compiler/src/*.sfn`; the build driver (`compiler/src/cli_main.sfn` + `compiler/src/capsule_resolver.sfn`) is pure orchestration and must not grow fixups.
+
+## Style, Tests, and Documentation
+
+- Sailfin files spell effects explicitly (`fn foo() -> Bar ![io, model]`), keep effect lists ordered by impact, and use `CamelCase` for models/capsules while locals remain `snake_case`.
+- Align terminology with the language spec at `site/src/content/docs/docs/reference/spec/` (capsule, fleet, provenance card) and note currency or latency literals as comments until syntax support arrives.
+- Before committing touched `.sfn` files under `compiler/src/` or `runtime/`, run `sfn fmt --write <files>` and then `sfn fmt --check <files>` (or the equivalent `build/native/sailfin` commands).
+- Stage regression tests beside related coverage in `compiler/tests/`; prefer Sailfin-native tests and slim fixtures over recorded generated output.
+- When adding language surface or runtime behavior, extend coverage and update `docs/status.md` first, then the relevant spec/preview page and roadmap if needed.
+- For non-trivial design changes, create or update an SFEP under `docs/proposals/` rather than burying design in issues or PR prose. Do not mark an SFEP `Implemented` until the feature meets the Stage1 readiness bar end-to-end and self-hosts.
 
 ## Commit & Pull Request Guidelines
 
-- History mixes imperative commits and Conventional Commit prefixes; favor `feat(compiler): …`, `fix(bootstrap): …`, etc., for clarity.
-- Keep commits atomic, mention touched capsules, and co-author doc changes in the same PR.
-- Pull requests should summarize scope, link issues, list verification commands, and attach screenshots or trace snippets when behavior shifts.
+- History mixes imperative commits and Conventional Commit prefixes; favor `feat(compiler): …`, `fix(runtime): …`, `docs(sfep): …`, etc., for clarity.
+- Keep commits atomic, mention touched capsules/passes, and co-author docs/status/spec changes in the same PR as behavior changes.
+- Pull requests should summarize scope, link issues/SFEPs, list verification commands, and attach screenshots or trace snippets when behavior shifts.
 
 ## Codex Workflow Notes
 
-- Codex-specific repository setup lives under `.codex/`: `config.toml` enables hooks/skills, `hooks/` mirrors the Claude session safeguards, `skills/` holds reusable Sailfin workflows, and `prompts/` contains web/CLI prompt templates.
+- Codex-specific setup lives under `.codex/`: `config.toml` enables hooks/skills, `hooks/` mirrors the provider-neutral session safeguards, `skills/` holds reusable Sailfin workflows, and `prompts/` contains web/CLI prompt templates.
 - For autonomous issue pickup in Codex web or CLI, use `.codex/prompts/pickup.md`; it mirrors the Claude `/pickup` flow but branches as `codex/<issue>-<slug>`.
-- The compiler self-applies its 8 GiB memory budget on Linux at startup (`SAILFIN_MEM_LIMIT` overrides; see `.claude/rules/compiler-safety.md`) — no `ulimit` prefix is needed. Wrap single-file compiles with `timeout 60` (hang guard).
-- If Codex does not auto-load repo-local skills/hooks in a given environment, explicitly mention the relevant `.codex/skills/*/SKILL.md` file in the prompt and follow `.codex/README.md`.
+- For SFEP work in Codex, use `.codex/prompts/sfep.md` and the proposal process in `docs/proposals/0001-sfep-process.md`.
+- If Codex does not auto-load repo-local skills/hooks in a given environment, explicitly mention the relevant `.codex/skills/*/SKILL.md` file or paste the matching `.codex/prompts/*.md` template.


### PR DESCRIPTION
### Motivation
- The Codex-facing configuration and AGENTS guidance had fallen behind the Claude rules and the repository's current operational facts, causing mismatches in memory handling, runtime expectations, and the SFEP workflow.
- Codex hooks and skills still referenced retired caller-side `ulimit` guards and the removed C runtime, so the repository needs provider-neutral, up-to-date Codex settings that mirror current safety and self-hosting invariants.
- The project now exposes an SFEP process and additional diagnostic workflows that Codex should be able to use directly so autonomous pickup and verification follow the project's delivery rules.

### Description
- Refresh `AGENTS.md` to record that the compiler is self-hosted, the runtime is Sailfin-native, the compiler self-caps memory via `SAILFIN_MEM_LIMIT`, and the SFEP process is authoritative for design work.
- Update `.codex/README.md`, `.codex/config.toml`, and session hooks to remove obsolete pre-tool `ulimit` enforcement, surface pinned-seed and MCP state, and ensure hooks inject fast git/session context.
- Add/update Codex prompts and skills: add `prompts/sfep.md`, improve `prompts/pickup.md`/`check.md`/`plan-feature.md`, extend `skills` with `sailfin-debug-compile` and `sailfin-pin-seed`, and revise `sailfin-check` and `sailfin-pickup` skills to include seed-dependency policy, formatting, and self-hosting ladders.
- Enable the new skills in `.codex/config.toml` and make the hooks/scripts executable so Codex sessions can discover and run the provider-neutral workflows.

### Testing
- Ran `bash -n .codex/hooks/session-start.sh .codex/hooks/inject-git-context.sh` to verify hook scripts parse and returned successfully.
- Ran `git diff --check` to validate no whitespace or diff errors were introduced and it returned successfully.
- Executed `.codex/hooks/session-start.sh && .codex/hooks/inject-git-context.sh` to exercise the session snapshot and git-context injection and observed expected output without errors.
- Verified shell syntax for new hooks with `bash -n` and confirmed all modified `.sh` scripts are syntactically valid and passed checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410124f6908324a9c063245bf18185)