### PR TITLE
feat(parser): structure typed channel:Type(N) into Channel + Raw census

### DIFF
--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -274,8 +274,8 @@ fn format_expression_into(expression: Expression, out: string[]) -> string[] {
     }
     if expression.variant == "Channel" {
         // `channel[:<kind>](capacity?)` (§2.6.4). Capacity optional
-        // (unbuffered default); `kind` is "" today (element-type form
-        // deferred in the parser). Fails closed downstream until #1085.
+        // (unbuffered default); `kind` is non-empty for the typed colon
+        // form `channel:<Type>(...)` (#1742), "" for the bare `channel(...)`.
         if expression.kind.length > 0 {
             out.push("channel:");
             out.push(expression.kind);

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -696,6 +696,24 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
             if !expression_tokens_is_at_end(after_channel) {
                 if symbol_matches(expression_tokens_peek(after_channel), "(") {
                     channel_followed_by_paren = true;
+                } else if symbol_matches(expression_tokens_peek(after_channel), ":") {
+                    // Typed form `channel:<Type>(...)`. Commit only when a
+                    // type identifier and an opening paren follow, so a bare
+                    // `channel` used as an identifier in a labelled position
+                    // (`channel: foo`) is not misread as a constructor. The
+                    // kind is the bare type name the native lowering slices
+                    // between `channel:` and `(` (core.sfn).
+                    let after_typed_colon = expression_tokens_advance(after_channel);
+                    if !expression_tokens_is_at_end(after_typed_colon) {
+                        if expression_tokens_peek(after_typed_colon).kind.variant == "Identifier" {
+                            let after_typed_name = expression_tokens_advance(after_typed_colon);
+                            if !expression_tokens_is_at_end(after_typed_name) {
+                                if symbol_matches(expression_tokens_peek(after_typed_name), "(") {
+                                    channel_followed_by_paren = true;
+                                }
+                            }
+                        }
+                    }
                 }
             }
             if channel_followed_by_paren {
@@ -1245,32 +1263,57 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
 // form fails the parse hard rather than backtracking to an identifier
 // call. `capacity` is bound only for the canonical single-argument form;
 // zero or extra arguments leave it `null` and are a typecheck-layer arity
-// concern (deferred — issue #1080 is parse-only). The element type
-// (`channel<T>(...)`) is not parsed yet — `element_type` stays `null`.
+// concern (deferred — issue #1080 is parse-only). The typed colon form
+// `channel:<Type>(...)` is parsed (#1742): the bare type name is captured
+// into `element_type` and `kind`. The generic `channel<T>(...)` angle-bracket
+// form is still deferred.
 fn parse_channel_expression(state: ExpressionTokens) -> ExpressionParseResult {
     let channel_token = expression_tokens_peek(state);
     let after_channel = expression_tokens_advance(state);
     if expression_tokens_is_at_end(after_channel) {
         return expression_parse_failure(state);
     }
-    let next = expression_tokens_peek(after_channel);
+    // Optional typed form `channel:<Type>(...)`. The element kind is the bare
+    // type name the native lowering slices between `channel:` and `(`
+    // (`lower_channel_typed_expression` in core.sfn), so capture the type
+    // identifier verbatim — the formatter round-trips it back to that exact
+    // text and no new lowering arm is needed. Structuring it here moves the
+    // construct off the `Raw` shadow-reparser path so the effect checker and
+    // typechecker walk the capacity argument (issue #1742).
+    let mut cursor = after_channel;
+    let mut element_type: TypeAnnotation? = null;
+    let mut channel_kind: string = "";
+    if symbol_matches(expression_tokens_peek(cursor), ":") {
+        let after_colon = expression_tokens_advance(cursor);
+        if expression_tokens_is_at_end(after_colon) {
+            return expression_parse_failure(state);
+        }
+        let type_token = expression_tokens_peek(after_colon);
+        if type_token.kind.variant != "Identifier" {
+            return expression_parse_failure(state);
+        }
+        channel_kind = identifier_text(type_token);
+        element_type = TypeAnnotation { text: channel_kind };
+        cursor = expression_tokens_advance(after_colon);
+    }
+    if expression_tokens_is_at_end(cursor) {
+        return expression_parse_failure(state);
+    }
+    let next = expression_tokens_peek(cursor);
     if !symbol_matches(next, "(") { return expression_parse_failure(state); }
-    let args_result = parse_call_arguments(after_channel);
+    let args_result = parse_call_arguments(cursor);
     if !args_result.success { return expression_parse_failure(state); }
     let mut capacity: Expression? = null;
     if args_result.arguments.length == 1 {
         capacity = args_result.arguments[0];
     }
-    // `element_type` is `null` until `channel<T>(...)` parsing lands (a
-    // follow-up), so `kind` stays "" today; #1082's `spawn_future_kind` is
-    // ready to derive it from the annotation once the generic form is parsed.
     return ExpressionParseResult {
         state: args_result.state,
         expression: Expression.Channel {
-            element_type: null,
+            element_type: element_type,
             capacity: capacity,
             span: source_span_from_tokens([channel_token]),
-            kind: ""
+            kind: channel_kind
         },
         success: true
     };

--- a/compiler/tests/unit/parser_concurrency_test.sfn
+++ b/compiler/tests/unit/parser_concurrency_test.sfn
@@ -13,8 +13,8 @@
 // convention in `parser_iife_postfix_test.sfn` (the block-scoped `let`
 // initializer path is opaque, tracked separately).
 import { Block, Expression } from "../../src/ast";
-import { typecheck_diagnostics } from "../../src/typecheck";
 import { parse_program } from "../../src/parser/mod";
+import { typecheck_diagnostics } from "../../src/typecheck";
 
 // True if typechecking `source` produces a diagnostic with `code`.
 fn _produces_diagnostic(source: string, code: string) -> boolean ![io] {
@@ -197,6 +197,50 @@ test "concurrency: channel commits to construct even with extra args" ![io] {
     let expr = first_let_initializer("let c = channel(1, 2);");
     assert expr.variant == "Channel";
     assert expr.capacity == null;
+}
+
+// -------------------------------------------------------------------
+// Typed `channel:<Type>(capacity?)` (issue #1742) parses to a structured
+// `Channel` node carrying the bare element-type name in `kind` (and a
+// `TypeAnnotation` in `element_type`) — NOT a `Raw` node riding the shadow
+// re-parser. This is what lets the effect checker / typechecker walk the
+// capacity argument. The `kind` text is captured verbatim because the
+// native lowering slices it between `channel:` and `(`.
+// -------------------------------------------------------------------
+test "concurrency: typed channel:OwnedBuf(2) parses to Channel with kind" ![io] {
+    let expr = first_let_initializer("let c = channel:OwnedBuf(2);");
+    assert expr.variant == "Channel";
+    assert strings_equal(expr.kind, "OwnedBuf");
+    assert expr.element_type != null;
+    assert strings_equal(expr.element_type.text, "OwnedBuf");
+    assert expr.capacity != null;
+    assert expr.capacity.variant == "NumberLiteral";
+}
+
+// A scalar typed channel with no capacity still structures: `kind` carries
+// the type name and `capacity` is the unbuffered-default null.
+test "concurrency: typed channel:int() parses to Channel with kind int" ![io] {
+    let expr = first_let_initializer("let c = channel:int();");
+    assert expr.variant == "Channel";
+    assert strings_equal(expr.kind, "int");
+    assert expr.capacity == null;
+}
+
+// Regression guard: the typed dispatch commits ONLY on the full
+// `channel:<Ident>(` form. `channel:Foo` without a trailing `(` must not be
+// misread as a typed channel — it falls through the constructor path.
+test "concurrency: channel:Type without parens is not a Channel node" ![io] {
+    let expr = first_let_initializer("let c = channel:Foo;");
+    assert expr.variant != "Channel";
+}
+
+// Regression guard: the bare untyped `channel(...)` form keeps an empty
+// `kind` — the typed path must not leak a kind onto it.
+test "concurrency: untyped channel(4) keeps empty kind" ![io] {
+    let expr = first_let_initializer("let c = channel(4);");
+    assert expr.variant == "Channel";
+    assert strings_equal(expr.kind, "");
+    assert expr.element_type == null;
 }
 
 // `await` parses at unary precedence, so a `Binary` operand only arises

--- a/docs/proposals/design-notes/1742-typed-channel-raw-census.md
+++ b/docs/proposals/design-notes/1742-typed-channel-raw-census.md
@@ -1,0 +1,110 @@
+# Design note — #1742: typed `channel:Type` structuring + tests-inclusive `Raw` census
+
+- **Issue:** #1742 (structure typed `channel:Type` / `spawn:Type`; tests-inclusive `Raw` census)
+- **Epic:** #1692 (sub-track of #1180); prerequisite for the blanket `E0818` flip
+- **Design record extended:** SFEP-0008 (`docs/proposals/0008-effect-validation.md`)
+  and the companion note `1627-fail-closed-raw-unknown-effects.md` (the E0818 endgame)
+- **Author:** agent:Sailbot (orchestrator)
+- **Status:** Draft (single-issue design gate; not a new SFEP)
+- **Date:** 2026-06-28
+
+---
+
+## 1. What shipped in this PR
+
+`channel:Type(N)` (the typed-channel constructor, e.g. `channel:OwnedBuf(2)`) now
+parses into a **structured `Expression.Channel`** node instead of degrading to
+`Expression.Raw`. The parser populates the long-reserved `element_type:
+TypeAnnotation?` and `kind: string` fields on `Channel` from the `:Type`
+annotation; the bare-type name is captured **verbatim** (e.g. `"OwnedBuf"`)
+because the native lowering (`lower_channel_typed_expression` in
+`compiler/src/llvm/expression_lowering/native/core.sfn`) slices the element kind
+out of the serialized `channel:<kind>(` text to drive the `owned` flag and ring
+stride.
+
+Because the `emit_native_format.sfn` `Channel` arm already serializes a node with
+`kind.length > 0` as exactly `channel:<kind>(<cap>)` — byte-identical to the text
+the shadow re-parser already lowers — **no new lowering arm, AST field, effect-checker
+arm, typecheck arm, or formatter arm was required.** The single change is in the
+parser (`compiler/src/parser/expressions.sfn`): the `channel` dispatch now commits
+on the `channel:<Ident>(` form, and `parse_channel_expression` consumes the optional
+`:Type` before the argument list.
+
+**Effect:** the structured `Channel` node is now walked by the effect checker
+(`collect_effects_from_expression`'s `Channel` arm recurses into `capacity`) and
+the typechecker, closing the soundness gap where an effectful capacity argument
+(`channel:OwnedBuf(io_call())`) inside a typed channel silently contributed zero
+effects via the `Raw` fall-through.
+
+`spawn:Type` is **not** a `Raw` producer: `spawn` followed by `:` is an explicit
+hard `ParseError` (issue #1531 — `spawn:<type>` is internal native-IR notation,
+not user syntax). The concurrency test exercises the structured `Spawn` via the
+bare `spawn fn() -> int { ... }` form, whose `kind` is derived from the lambda
+return type. No change was needed for `spawn`.
+
+### Verification
+
+- `concurrency_lowering_ir_test` — 7/7 pass, incl. `channel:OwnedBuf(2)` →
+  `elem_size 32, owned 1`.
+- `concurrency_ownedbuf_asan_interleave_test` — 2/2 pass.
+- `string_append_test` — 12/12 pass (a cited #1737 over-fire offender).
+- `make compile` self-hosts.
+
+---
+
+## 2. Tests-inclusive `Raw` census
+
+**Method.** A throwaway sentinel was wrapped around the `emit_native_format.sfn`
+`Raw` arm (`out.push("RAWCENSUS<<" + text + ">>")`), the compiler was rebuilt, and
+`sfn emit native` was run over every `.sfn` in `compiler/tests/`, `examples/`, and
+`capsules/` (578 files); the self-host build of `compiler/src` + `runtime` was its
+own census leg (a non-empty `Raw` would lower the sentinel text and break the
+build — it did not). The sentinel was then reverted; **only the parser change ships.**
+
+The emitter sentinel surfaces `Raw` at the *serialization* layer, which is a
+**superset** of the effect-checker-visible `Raw`. Two emit-layer-only categories
+were filtered out as non-concerns and cross-checked against the parser/effect-checker
+by direct tracing (`compiler-explorer`):
+
+- **Emitter-synthesized closure directives** (`<closure_pair …>`,
+  `<closure_env_load_prologue …>`) — created during lambda *lowering*, after
+  effect-check; never reach `collect_effects_from_expression`.
+- (Re-classified — see below) match-arm patterns.
+
+### Census results
+
+| Set | Valid-but-`Raw` reaching the effect checker |
+|---|---|
+| `compiler/src` + `runtime` (self-host set) | **Zero** — clean self-host under the sentinel proves it |
+| `compiler/tests` + `examples` + `capsules` | The residual classes in the table below |
+
+| Construct | Hits | Reaches `collect_effects_from_expression`? | Shipped status | Disposition |
+|---|---|---|---|---|
+| **`channel:Type(N)`** | — | was `Raw`, now `Channel` | shipped | **Structured (this PR).** |
+| `spawn:Type` | — | hard `ParseError` (not `Raw`) | n/a (#1531) | Not a `Raw` producer. |
+| Match-arm patterns `Result.Ok { value }`, `Shape.Circle { radius }`, … | 56 | **Yes** (`collect_effects_from_match_case` → `collect_effects_from_expression(case.pattern)`) | **shipped, core** | **Deferred to the E0818 flip.** Patterns are a *binding* position, not an effectful expression; the flip must structure patterns into a dedicated `Pattern` node (or skip the pattern position in `collect_effects_from_match_case`). Out of #1742's named `In:` scope. |
+| `value is string` type-guards | 2 | Yes (if-condition) | parsed, **not enforced** | Incomplete feature — `is` has no parser arm; degrades to `Raw`. Follow-up: structure the `is` operator (or gate it). |
+| slice `value[start: end]` | 1 | Yes | **unsupported** (`:` unparsed in `[]`) | Slice syntax is not shipped; degrades to `Raw`. Follow-up if/when slices ship. |
+| `&raw value` | 1 | Yes | **design-stage** (examples/README) | Future syntax → genuine residual. |
+| named `routine "x" { … }` | 1 | Yes (expression-statement) | **deferred concurrency** | Not-shipped syntax → genuine residual. (Unnamed `routine { … }` is structured as `RoutineStatement` and is fine.) |
+
+### Implication for the blanket E0818 flip
+
+The census's purpose (per #1742) is to ensure the blanket `E0818` backstop can flip
+without false positives. It cannot yet: **match-arm patterns** are a shipped,
+ubiquitous construct that degrades to `Raw` and is walked by the effect checker via
+the match-case path. Flipping `E0818` today would over-fire on every
+`Result.Ok { value }` arm. The remaining residuals are either incomplete (`is`,
+slice) or genuinely future/deferred (`&raw`, named `routine`).
+
+**Recommended sequencing before the E0818 flip (separate sub-issue(s)):**
+
+1. Structure match-arm patterns into a dedicated `Pattern` AST node (or exclude the
+   pattern position from effect collection) — the dominant blocker.
+2. Decide `is` type-guards: structure or gate behind a diagnostic.
+3. `&raw` / named `routine` / slice: these are not-yet-shipped syntax; the E0818
+   arm should treat them as the intended fail-closed targets (they are exactly the
+   "unstructured construct — rewrite so the compiler can parse it" case), or they
+   stay junk until their features ship.
+
+`channel:Type` is removed from this list by this PR.


### PR DESCRIPTION
## Summary
- Parser now recognizes the typed channel constructor `channel:Type(N)` (e.g. `channel:OwnedBuf(2)`) and populates the long-reserved `element_type`/`kind` fields on `Expression.Channel` instead of degrading to `Expression.Raw`. The bare type name is captured **verbatim**, so the native lowering's `channel:<kind>(` slice (owned-flag + ring stride) round-trips byte-identically — **no new lowering, AST, effect-checker, typecheck, or formatter arm needed**. The construct now leaves the `Raw` shadow-reparser path, so the effect checker and typechecker walk the capacity argument.
- `spawn:Type` needs no change — it is already a hard `ParseError` (#1531), not `Raw`.
- Runs the tests-inclusive `Raw` census the issue asks for and records it as a design-note.

Closes #1742

## Acceptance Criteria
- [x] `channel:OwnedBuf(2)` / `spawn:int` parse into structured nodes (not `Raw`); `concurrency_lowering_ir_test` (7/7, incl. `channel:OwnedBuf(2)` → elem_size 32 / owned 1) + `concurrency_ownedbuf_asan_interleave_test` (2/2) build and pass.
- [x] A documented census of valid-but-`Raw` constructs across `compiler/src`+`runtime`+`capsules`+`compiler/tests/`+examples — see `docs/proposals/design-notes/1742-typed-channel-raw-census.md`. **Self-host set (`compiler/src`+`runtime`): zero valid-but-`Raw`.** `channel:Type` structured here. ⚠️ The census surfaced that the residual is **larger than this issue's `In:` scope**: match-arm patterns (shipped, ~56 sites) plus `is`-guards / slices degrade to `Raw` and reach the effect checker; `&raw` / named `routine` are genuine future/deferred junk. Structuring patterns/`is`/slices is a separate, larger parser/AST effort triaged for the E0818 flip (sub-issue) in the design-note — so this criterion is delivered as **census documented + residual triaged**, not literal zero. Flagged for reviewer judgment (see Notes).
- [x] `make compile` self-hosts; `make check` green (full suite RUNS: unit 181/181, integration 41/41, e2e 164/164, capsules 38/38).

## Map reconciliation
None — `## Files Affected` matched the tree. The change landed entirely in `compiler/src/parser/expressions.sfn` (the issue's first-named file); the effect-checker/typecheck/formatter files it listed needed **no** edit because the existing `Channel` arms already handle a node with non-empty `kind` / non-null `element_type` (confirmed by code-reviewer).

## Verification
```bash
make check            # pass — triple-pass self-host + unit 181 / integration 41 / e2e 164 / capsules 38
build/native/sailfin test compiler/tests/unit/parser_concurrency_test.sfn          # 28/28 (4 new typed-channel cases)
build/native/sailfin test compiler/tests/e2e/concurrency_lowering_ir_test.sfn      # 7/7
build/native/sailfin test compiler/tests/e2e/concurrency_ownedbuf_asan_interleave_test.sfn  # 2/2
build/native/sailfin test compiler/tests/unit/string_append_test.sfn               # 12/12 (cited #1737 offender)
```

## Files Changed
- `compiler/src/parser/expressions.sfn` — typed `channel:<Type>(` dispatch + `parse_channel_expression` captures `element_type`/`kind`; two stale comments refreshed.
- `compiler/src/emit_native_format.sfn` — stale `kind is "" today` comment refreshed (no behavior change).
- `compiler/tests/unit/parser_concurrency_test.sfn` — 4 new regression tests (typed positive, scalar typed, no-paren fall-through, untyped keeps empty kind).
- `docs/proposals/design-notes/1742-typed-channel-raw-census.md` — the documented census.

## Notes for reviewer
The census (the issue's second deliverable) revealed the `Raw` soundness surface is broader than the `channel:Type`/`spawn:Type` the issue scoped for structuring — **match-arm patterns are the dominant residual** and are shipped/core, so the literal "zero valid-but-Raw" acceptance line cannot be met in this M-sized, channel/spawn-scoped PR. Per the issue's "structure each **or document why**" clause, the residual is enumerated with dispositions and sequencing for the separate E0818-flip sub-issue. If you'd prefer the residual structuring bundled or re-groomed into sub-issues instead, say so and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEwEC4jx61mWMjPcqnEgeJ)_