### PR TITLE
fix(lowering): reject enum same-name/different-type field reads with E0817

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -183,6 +183,45 @@ fn lower_runtime_global_reference(temp_index: int, lines: string[]) -> Expressio
     };
 }
 
+// Build the `[fatal] [E0817]` message for a same-name field reused at
+// base-incompatible types across variants (#1746). Names the enum, the
+// field, and a per-variant "variant `X` declares it `T`" census (preferring
+// the source annotation, falling back to the lowered LLVM type), plus a
+// narrowing fix-it hint. Called only on the failure paths so the common
+// (consistent-base) access pays nothing.
+fn _enum_field_conflict_diag(enum_name: string, field: string, variants: EnumVariantInfo[], fields: StructFieldInfo[]) -> string {
+    let mut conflict_desc: string = "";
+    let mut conflict_index: int = 0;
+    loop {
+        if conflict_index >= fields.length { break; }
+        if conflict_index > 0 { conflict_desc = conflict_desc + ", "; }
+        let mut conflict_type_name = fields[conflict_index].type_annotation;
+        if conflict_type_name.length == 0 {
+            conflict_type_name = fields[conflict_index].llvm_type;
+        }
+        conflict_desc = conflict_desc + "variant `" + variants[conflict_index].name
+            + "` declares it `"
+            + conflict_type_name
+            + "`";
+        conflict_index += 1;
+    }
+    let mut narrow_hint: string = "the variant";
+    if variants.length > 0 {
+        narrow_hint = "the variant (e.g. `if <receiver>.variant == \""
+            + variants[0].name
+            + "\"`)";
+    }
+    return "llvm lowering [fatal] [E0817]: enum `" + enum_name + "` field `"
+        + field
+        + "` is read at conflicting types across variants ("
+        + conflict_desc
+        + "); narrow "
+        + narrow_hint
+        + " before reading `."
+        + field
+        + "`, or rename the field in one variant";
+}
+
 fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, base_operand: LLVMOperand, pointer_available: boolean, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[], expected_type: string, narrowed_variant: string) -> ExpressionResult ![io] {
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
@@ -506,10 +545,21 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     }
 
     if !consistent_base {
-        messages.push("llvm lowering: enum member access for `" + enum_info.name
-            + "."
-            + parse.field
-            + "` uses incompatible field types across variants");
+        // #1746: a same-name field read at base-incompatible types across
+        // variants has no single static result type. Without narrowing this
+        // access is unrepresentable, so reject it with a located `[fatal]`
+        // error instead of returning a null operand the caller silently
+        // degrades to `double` (the original silent miscompile).
+        //
+        // Reachability note: a string LHS threads an aggregate `expected_type`
+        // (`{i8*, i64}`) that matches neither variant's scalar field type, so
+        // the expected-type filter preserves both variants (its keep-on-empty-
+        // match guard) and the base mismatch (i8 vs i64) lands here. A future
+        // string-storage ABI flip could shift that filter outcome — the
+        // negative e2e test (enum_same_name_field_conflict_test.sfn) guards it.
+        let diag = _enum_field_conflict_diag(enum_info.name, parse.field, selected_variants, selected_fields);
+        print.err(diag);
+        messages.push(diag);
         return make_expression_result(current_lines, current_temp, null, messages, enum_string_constants);
     }
 
@@ -538,10 +588,11 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             pointer_coercion = true;
             field_type = base_type + "*";
         } else {
-            messages.push("llvm lowering: enum member access for `" + enum_info.name
-                + "."
-                + parse.field
-                + "` uses incompatible field types across variants");
+            // #1746: pointer-depth mismatch beyond the single-level coercion
+            // the chain can repair — also unrepresentable as one result type.
+            let diag = _enum_field_conflict_diag(enum_info.name, parse.field, selected_variants, selected_fields);
+            print.err(diag);
+            messages.push(diag);
             return make_expression_result(current_lines, current_temp, null, messages, enum_string_constants);
         }
     }

--- a/compiler/tests/e2e/enum_same_name_field_conflict_test.sfn
+++ b/compiler/tests/e2e/enum_same_name_field_conflict_test.sfn
@@ -1,0 +1,151 @@
+// End-to-end regression for #1746: an enum field whose name is reused at a
+// DIFFERENT (base-incompatible) type across variants must never silently
+// miscompile a read.
+//
+// Two behaviors are pinned here, both via a full `sfn build` (the hazard
+// lives in LLVM lowering — `lower_enum_member_access` in
+// `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` —
+// so it is NOT visible to `sfn check` / `assert_does_not_compile`, which run
+// the frontend only):
+//
+//   1. POSITIVE — a read under variant narrowing (`if e.variant == "Lit"`)
+//      resolves to a single, unambiguous field type and reads CORRECTLY for
+//      both the `string` and the `int` variant. This is the path the
+//      compiler's own AST relies on (`enum Expression` reuses `value` /
+//      `arguments` / `fields` at incompatible types, read only under
+//      narrowing), so it must stay correct.
+//
+//   2. NEGATIVE — an UN-narrowed read of the same collided field has no
+//      single static result type and is unrepresentable. Before the fix it
+//      returned a null operand the caller silently degraded to `double`
+//      (the reported corruption: the repro printed nothing). It must now be
+//      rejected with a located `[fatal] [E0817]` build error naming the
+//      enum, the field, and the conflicting per-variant types.
+//
+// Build hygiene mirrors `sailfin_main_entry_test.sfn`: write the fixture
+// into a fresh `with_tmp_dir` (so `sfn build` does not auto-discover the
+// repo's capsules) and thread the full parent environment to the nested
+// build (PATH for clang/linker, SAILFIN_TEST_SCRATCH for parallel-pool
+// build-cache isolation per #1333).
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-enum-collision-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// A program that reads the collided `value` field (string in `Lit`, int in
+// `Op`) only under `if e.variant == "..."` narrowing. The `int` read is
+// returned as the exit code (42) so a correct read is observable without an
+// int->string conversion; the `string` read is printed.
+fn _positive_src() -> string {
+    return "enum E {\n" + "    Lit { value: string },\n"
+        + "    Op { operator: string, value: int }\n"
+        + "}\n"
+        + "\n"
+        + "fn read_lit_value(e: E) -> string ![io] {\n"
+        + "    if e.variant == \"Lit\" {\n"
+        + "        return e.value;\n"
+        + "    }\n"
+        + "    return \"?\";\n"
+        + "}\n"
+        + "\n"
+        + "fn read_op_value(e: E) -> int ![io] {\n"
+        + "    if e.variant == \"Op\" {\n"
+        + "        return e.value;\n"
+        + "    }\n"
+        + "    return -1;\n"
+        + "}\n"
+        + "\n"
+        + "fn main() -> int ![io] {\n"
+        + "    let a = E.Lit { value: \"hello\" };\n"
+        + "    let b = E.Op { operator: \"+\", value: 42 };\n"
+        + "    print.info(\"Lit.value=[\" + read_lit_value(a) + \"]\");\n"
+        + "    return read_op_value(b);\n"
+        + "}\n";
+}
+
+// The reported repro: an un-narrowed read of the collided `value` field.
+fn _negative_src() -> string {
+    return "enum E {\n" + "    Lit { value: string },\n"
+        + "    Op { operator: string, value: int }\n"
+        + "}\n"
+        + "\n"
+        + "fn main() -> int ![io] {\n"
+        + "    let a = E.Lit { value: \"hello\" };\n"
+        + "    print.info(\"Lit.value=[\" + a.value + \"]\");\n"
+        + "    return 0;\n"
+        + "}\n";
+}
+
+// Build `src` and run the binary. Stashes the run's stdout to `out_marker`
+// and returns the run exit code, or -100 if the build itself failed.
+fn _build_and_run(out_marker: string, src: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, src);
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], []);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+// Build `src` expecting FAILURE; stash the build's stderr to `err_marker`
+// and return the build exit code (0 means it unexpectedly succeeded).
+fn _build_expect_fail(err_marker: string, src: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, src);
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let err = process.capture_take_stderr();
+        fs.writeFile(err_marker, err);
+        return build_exit;
+    });
+}
+
+test "enum-collision: narrowed reads of a same-name/different-type field are correct" ![io] {
+    let marker = _marker("positive");
+    let exit = _build_and_run(marker, _positive_src());
+    // -100 == build failure; the narrowed reads must build AND run, with the
+    // `int` variant's value (42) landing on the exit status.
+    assert exit == 42;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // The `string` variant's value must read back intact (not empty/garbage).
+    assert find(out, "Lit.value=[hello]", 0) >= 0;
+}
+
+test "enum-collision: un-narrowed read is rejected with E0817" ![io] {
+    let marker = _marker("negative");
+    let build_exit = _build_expect_fail(marker, _negative_src());
+    let err = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // The build must FAIL (not silently miscompile)...
+    assert build_exit != 0;
+    // ...with the located E0817 diagnostic naming the field and the conflict.
+    assert find(err, "E0817", 0) >= 0;
+    assert find(err, "value", 0) >= 0;
+    assert find(err, "conflicting types across variants", 0) >= 0;
+}


### PR DESCRIPTION
## Summary

- An enum field reused at **base-incompatible** types across variants (e.g. `value: string` in one variant, `value: int` in another) silently miscompiled when read **un-narrowed**: `lower_enum_member_access` pushed a non-`[fatal]` diagnostic and returned a null operand the caller degraded to `double`, so the read produced empty/garbage with **no** build error (the reported repro printed nothing).
- Such an un-narrowed read has no single static result type, so it is unrepresentable. The two genuinely-ambiguous paths (the `!consistent_base` branch and the pointer-depth-mismatch `else`) now emit a located **`[fatal] [E0817]`** that names the enum, the field, and the per-variant conflicting types, with a narrowing fix-it hint. Reachable correct paths (reads under variant narrowing, or filtered to one base by `expected_type`) are unchanged and still lower correctly.

Design fork resolution (approved at the design gate): **Option B** (correct the read lowering — representable reads stay correct) **+** a use-site `E0817` guard for the unrepresentable case. Pure declaration-site Option A was ruled out: the compiler's own `enum Expression` reuses `value`/`arguments`/`fields`, so a declaration-site rejection would reject the compiler's AST and break self-host. (A frontend `sfn check`-time variant of the guard is a sensible fast-follow — see "Notes" — but is intentionally out of this PR.)

Closes #1746

## Acceptance Criteria

- [x] The minimal repro is rejected at compile time with a diagnostic naming the enum (`E`), the colliding field (`value`), and the conflicting types (`string` vs `int`). *(Satisfies criterion 1's "option A" branch; fires at build/emit — the hazard lives in LLVM lowering, invisible to the frontend `sfn check`. See Notes.)*
- [x] A regression test pinning the chosen behavior — positive (narrowed reads correct) **and** negative (un-narrowed read → `E0817`).
- [x] No same-name/different-type collision remains undetected: the three in-tree `enum Expression` collisions are **same-base** and read only under narrowing (census-clean), so they never reach the fatal paths.
- [x] `make compile` self-hosts; `make check` green.

## Map reconciliation

The advisory `## Files Affected` pointed at `compiler/src/llvm/rendering.sfn` (payload layout) and `typecheck.sfn`/`effect_checker.sfn` (if option A). Reconciled to the actual surface: the payload layout (`rendering.sfn`) is already correct (flat byte-blob with per-variant offsets); the defect and fix are entirely in the **read** lowering — `lower_enum_member_access` in `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn`. No `rendering.sfn`/`typecheck.sfn` change is needed for the approved Option B + use-site guard. Same `In:` semantic unit (enum field-access read lowering), different file than the non-binding map named.

## Verification

```bash
# Repro now rejected (was: prints nothing, exit 0):
build/native/sailfin run repro.sfn
#  llvm lowering [fatal] [E0817]: enum `E` field `value` is read at conflicting
#  types across variants (variant `Lit` declares it `string`, variant `Op`
#  declares it `int`); narrow the variant (e.g. `if <receiver>.variant == "Lit"`)
#  before reading `.value`, or rename the field in one variant

make compile     # self-hosts (the 3 in-tree Expression collisions still lower under narrowing)
build/native/sailfin test compiler/tests/e2e/enum_same_name_field_conflict_test.sfn   # PASS (2/2)
build/native/sailfin test compiler/tests/unit/enum_mixed_field_types_test.sfn         # PASS (4/4) — Cell/Cell? path not regressed
make check       # PASS — unit 181/181, integration 41/41, e2e 165/165, capsules 38/38
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` — fatal `E0817` on the two base-incompatible read paths; `_enum_field_conflict_diag` helper (called only on failure paths).
- `compiler/tests/e2e/enum_same_name_field_conflict_test.sfn` — new positive/negative e2e pair.

## Notes

- **Why build-time, not `sfn check`-time:** the miscompile is in LLVM lowering, which `sfn check` (parse + typecheck + effect-check only) does not run, so the guard is a lowering `[fatal]` surfaced by the existing IR-write gate. Issue criterion 1 phrased the option-A rejection as "at `sfn check` time"; this PR delivers the equivalent at build/emit per the approved plan. A frontend `sfn check`-time **use-site** guard (so the error surfaces in the fast inner loop) is a reasonable fast-follow, but it requires the typecheck walker to model enum narrowing — without that it would reject the compiler's own narrowed AST reads and break self-host, so it is deliberately deferred.
- The issue's stated premise that #1741 cleared the one in-tree instance is **incomplete** — three same-name reuses remain in `enum Expression`, but all are same-base and narrowing-only, so they are correct (not a hazard) under this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MjisEc5oCWEaULW384DNw

---
_Generated by [Claude Code](https://claude.ai/code/session_011MjisEc5oCWEaULW384DNw)_