### PR TITLE
fix(corpus): clear the residual valid-but-Raw tail in tests and examples

### DIFF
--- a/compiler/tests/unit/intrinsic_declarations_test.sfn
+++ b/compiler/tests/unit/intrinsic_declarations_test.sfn
@@ -54,7 +54,14 @@ fn _trim(value: string) -> string {
         end -= 1;
     }
     if start == 0 && end == value.length { return value; }
-    return value[start: end];
+    let mut out: string = "";
+    let mut k: int = start;
+    loop {
+        if k >= end { break; }
+        out = out + value[k];
+        k += 1;
+    }
+    return out;
 }
 
 fn ensure_intrinsic_declarations(lines: string[]) -> string[] {

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,7 +96,7 @@ Effect annotations (`![...]`) flag the runtime capabilities you need to declare 
 | `type-guards.sfn`                 | `io`                 | Runtime type refinement and guarded matches within `main`.         |
 | `unions.sfn`                      | `io`                 | Union + intersection typing with runtime checks.                   |
 | `pointer-arithmetic.sfn`          | `io`, `unsafe`       | **Design-stage** pointer arithmetic with malloc/free.              |
-| `raw-pointers.sfn`                | `io`, `unsafe`       | **Design-stage** raw pointer creation and dereference with `&raw`. |
+| `raw-pointers.sfn`                | `io`                 | **Design-stage** raw pointer creation/dereference with `&raw`; planned form kept in comments, runnable `main` is a shipped-grammar stub. |
 | `unsafe-extern-interop.sfn`       | `io`, `unsafe`       | **Design-stage** extern function declarations and unsafe blocks.   |
 | `web-server-with-concurrency.sfn` | `clock`, `io`, `net` | HTTP handler spawning routines and throttled background work.      |
 

--- a/examples/advanced/raw-pointers.sfn
+++ b/examples/advanced/raw-pointers.sfn
@@ -1,20 +1,35 @@
 // examples/advanced/raw-pointers.sfn
-
-fn main() ![unsafe, io] {
-    let mut value: i32 = 42;
-
-    // Take a raw pointer to the value
-    let ptr: *i32 = &raw value;
-
-    unsafe {
-        // Read through the pointer
-        let read_value = *ptr;
-        print("Read value: {{ read_value }}");
-
-        // Write through the pointer
-        *ptr = 100;
-    }
-
-    // Value was modified through the pointer
-    print("Modified value: {{ value }}");
+//
+// Design-stage: taking a raw pointer to a local with `&raw` is planned future
+// syntax. Per examples/README.md, future syntax stays inside comments and the
+// runnable body sticks to the shipped bootstrap grammar. The `&raw` operator
+// has no parser arm yet, so it degrades to an unstructured node; this file
+// keeps the planned form in a comment until the feature ships.
+//
+// Planned form (does not yet parse):
+//
+//     fn main() ![unsafe, io] {
+//         let mut value: i32 = 42;
+//
+//         // Take a raw pointer to the value
+//         let ptr: *i32 = &raw value;
+//
+//         unsafe {
+//             // Read through the pointer
+//             let read_value = *ptr;
+//             print("Read value: {{ read_value }}");
+//
+//             // Write through the pointer
+//             *ptr = 100;
+//         }
+//
+//         // Value was modified through the pointer
+//         print("Modified value: {{ value }}");
+//     }
+//
+// For shipped pointer usage today (malloc-backed pointers, `as` casts, `unsafe`
+// blocks, and `*` dereference), see `pointer-arithmetic.sfn` and
+// `unsafe-extern-interop.sfn`.
+fn main() ![io] {
+    print("raw-pointers: `&raw` is design-stage future syntax — see the comments in this file.");
 }

--- a/examples/advanced/type-guards.sfn
+++ b/examples/advanced/type-guards.sfn
@@ -1,27 +1,47 @@
 // examples/advanced/type-guards.sfn
-
 struct User {
     name: string;
     age: int;
 }
 
-fn process(input: string | int) ![io] {
-    if input is string {
-        print("It's a string: {{input}}");
-    } else {
-        print("It's a number: {{input}}");
+struct StringInput {
+    value: string;
+}
+
+struct IntInput {
+    value: int;
+}
+
+// Runtime type refinement on a tagged union: matching on named struct variants
+// is the shipped discriminator (mirrors examples/basics/error-handling.sfn). The
+// `i32` union tag drives the arm selection.
+fn process(input: StringInput | IntInput) ![io] {
+    match input {
+        StringInput { value } => print("It's a string: {{value}}"),
+        IntInput { value } => print("It's a number: {{value}}")
     }
 }
 
+// Planned future syntax — the `x is T` type-guard operator (not yet shipped; it
+// has no parser arm and degrades to an unstructured node). Tracked by #1753:
+//
+//     fn process(input: string | int) ![io] {
+//         if input is string {
+//             print("It's a string: {{input}}");
+//         } else {
+//             print("It's a number: {{input}}");
+//         }
+//     }
 fn main() ![io] {
-    process("Sail");
-    process(42);
+    process(StringInput { value: "Sail" });
+    process(IntInput { value: 42 });
 
     let user = User { name: "Robin", age: 22 };
 
     match user {
-        User { name, age } if age >= 18 => print("Adult user: {{name}}"),
+        User { name, age }
+        if age >= 18 => print("Adult user: {{name}}"),
         User { name, age } => print("Minor user: {{name}}"),
-        _ => print("Unknown entity"),
+        _ => print("Unknown entity")
     }
 }

--- a/examples/advanced/unions.sfn
+++ b/examples/advanced/unions.sfn
@@ -1,13 +1,31 @@
 // examples/advanced/unions.sfn
+struct StringValue {
+    value: string;
+}
 
-fn printValue(value: string | int) ![io] {
-    if value is string {
-        print("It's a string: {{value}}");
-    } else {
-        print("It's a number: {{value}}");
+struct IntValue {
+    value: int;
+}
+
+// Discriminate a tagged union by matching named struct variants — the shipped
+// runtime type-refinement surface (the `i32` union tag selects the arm).
+fn printValue(value: StringValue | IntValue) ![io] {
+    match value {
+        StringValue { value } => print("It's a string: {{value}}"),
+        IntValue { value } => print("It's a number: {{value}}")
     }
 }
 
+// Planned future syntax — the `x is T` type-guard operator (not yet shipped; it
+// has no parser arm and degrades to an unstructured node). Tracked by #1753:
+//
+//     fn printValue(value: string | int) ![io] {
+//         if value is string {
+//             print("It's a string: {{value}}");
+//         } else {
+//             print("It's a number: {{value}}");
+//         }
+//     }
 interface Admin {
     isAdmin: boolean;
 }
@@ -19,9 +37,12 @@ interface User {
 type AdminUser = Admin & User;
 
 fn main() ![io] {
-    printValue("Sailfin");
-    printValue(42);
+    printValue(StringValue { value: "Sailfin" });
+    printValue(IntValue { value: 42 });
 
-    let admin: AdminUser = { name: "Alice", isAdmin: true };
+    let admin: AdminUser = {
+        name: "Alice",
+        isAdmin: true
+    };
     print("Admin: {{admin.name}}");
 }

--- a/examples/concurrency/routines.sfn
+++ b/examples/concurrency/routines.sfn
@@ -1,11 +1,12 @@
 // examples/concurrency/routines.sfn
-
 fn main() ![io] {
-    routine "named" {
-        print("This is routine 1");
-    }
-
-    routine {
-        print("This is an unnamed routine");
-    }
+    // Design-stage: named routines (`routine "name" { ... }`) are deferred
+    // concurrency syntax. Per examples/README.md, future syntax stays inside
+    // comments until the feature ships:
+    //
+    //     routine "named" {
+    //         print("This is routine 1");
+    //     }
+    // The unnamed `routine { ... }` form is structured today (RoutineStatement).
+    routine { print("This is an unnamed routine"); }
 }


### PR DESCRIPTION
## Summary
- Gives a disposition to every construct that still degraded to `Expression.Raw` and reached `collect_effects_from_expression` across `compiler/tests/` + `examples/`, so the blanket `E0818` fail-closed flip (#1743) can land false-positive-free.
- **Corpus-only** — no compiler source changed (a temporary census sentinel in `emit_native_format.sfn` was added then fully reverted; `git diff -- compiler/src/ runtime/` is empty).
- `is` type-guards are corpus-fixed now (deferred to the real type-narrowing feature #1753); slice / `&raw` / named `routine` are moved behind the shipped form or a future-syntax comment.

Closes #1751

## Dispositions
| Construct | File | Disposition |
|---|---|---|
| slice `value[start: end]` | `intrinsic_declarations_test.sfn` (`_trim`) | Rewritten as a char-by-char `[start, end)` accumulation loop — **behavior-identical**. |
| `x is T` guard | `type-guards.sfn`, `unions.sfn` | Replaced with a shipped tagged-union match on named struct variants; planned `is` form kept in a comment (→ #1753). |
| `&raw value` | `raw-pointers.sfn` | Design-stage future syntax moved into a comment; runnable `main` is a shipped-grammar stub (effects `io`). |
| named `routine "x" {}` | `routines.sfn` | Deferred concurrency syntax moved into a comment; structured unnamed `routine {}` kept. |

> Note: `unions.sfn` has a **pre-existing** intersection-type field-access build failure (`@.runtime.field.name` on `admin.name`), verified against the original and unrelated to this change — a separate codegen bug, out of scope here. `sfn check` passes; the suite does not build this example.

## Acceptance Criteria
- [x] Each construct has a landed disposition (structured-to-shipped or corpus-fixed + commented).
- [x] Tests-inclusive Raw census over `compiler/tests/` + `examples/` shows **0 unexpected** effect-checker-visible `Raw` (only 42 closure directives + 60 #1743-exempt match-arm patterns remain).
- [x] `intrinsic_declarations_test.sfn` passes (the `_trim` rewrite is behavior-preserving).
- [x] `sfn check` passes on every touched `.sfn` file; `sfn fmt --check` clean.
- [x] `make compile` self-hosts.
- [x] `make check` green.

## Map reconciliation
- `unions.sfn` was **not** in the groomed `## Files Affected` map but holds the same `is` type-guard **semantic unit** (the #1742 census's "2 hits" — one here, one in `type-guards.sfn`). Surfaced by re-running the census; fixed as an in-unit sibling (reconcile-and-proceed, not scope growth).
- `examples/README.md` `raw-pointers.sfn` row updated (effects `io, unsafe` → `io`) to match the now comment-only design-stage surface.

## Verification
```bash
make compile        # self-hosts (also passed WITH the census sentinel → compiler/src+runtime Raw-free)
make check          # status: pass
build/native/sailfin check examples/advanced/{type-guards,unions,raw-pointers}.sfn \
  examples/concurrency/routines.sfn compiler/tests/unit/intrinsic_declarations_test.sfn   # checked 5 files: ok
# Raw census (the #1742 sentinel method), examples + compiler/tests:
#   total Raw hits: 102  |  closure directives: 42  |  match-arm patterns (exempt): 60  |  OTHER: 0
```

## Files Changed
- `compiler/tests/unit/intrinsic_declarations_test.sfn`
- `examples/advanced/type-guards.sfn`
- `examples/advanced/unions.sfn`
- `examples/advanced/raw-pointers.sfn`
- `examples/concurrency/routines.sfn`
- `examples/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GuJqgRuSEUBC4HzFPNnPG

---
_Generated by [Claude Code](https://claude.ai/code/session_013GuJqgRuSEUBC4HzFPNnPG)_