### PR TITLE
fix(typecheck): fail closed on nested Statement.Unknown via E0819

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -618,6 +618,13 @@ fn collect_effects_from_statement(statement: Statement, imports: ImportSymbolTab
         }
         return required;
     }
+    if statement.variant == "Unknown" {
+        // An unparseable statement contributes no analyzable effect. The
+        // E0819 parse diagnostic (typecheck) already fails the build for a
+        // nested `Unknown`, so this arm intentionally returns no requirement
+        // rather than minting a second diagnostic on the same node (#1691).
+        return [];
+    }
     return [];
 }
 

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -62,6 +62,7 @@ import {
     make_try_non_result_fn_diagnostic,
     make_try_non_result_operand_diagnostic,
     make_undefined_function_diagnostic,
+    make_unparseable_statement_diagnostic,
     make_unsupported_statement_keyword_diagnostic,
     register_local_symbol,
     register_symbol,
@@ -347,7 +348,7 @@ fn check_program_scopes(program: Program, interfaces: Statement[], imports: Impo
     let mut diagnostics: Diagnostic[] = [];
 
     for statement in program.statements {
-        let result = check_statement(statement, bindings, interfaces, 0, imports, top_level);
+        let result = check_statement(statement, bindings, interfaces, 0, imports, top_level, true);
         bindings = result.bindings;
         let mut _ci: int = 0;
         loop {
@@ -373,7 +374,7 @@ fn check_program_scopes(program: Program, interfaces: Statement[], imports: Impo
 // callee lookup resolves sibling top-level functions and imports
 // regardless of source order. It is never re-registered, so it does not
 // affect duplicate detection.
-fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: Statement[], scope_start: int, imports: ImportSymbolTable, top_level: SymbolEntry[]) -> ScopeResult {
+fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: Statement[], scope_start: int, imports: ImportSymbolTable, top_level: SymbolEntry[], is_top_level: boolean) -> ScopeResult {
     if statement.variant == "VariableDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
         let walk_diags = walk_expression(statement.initializer, bindings, imports);
@@ -599,7 +600,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 }
             }
             if branch.statement != null {
-                let result = check_statement(branch.statement, bindings, interfaces, scope_start, imports, top_level);
+                let result = check_statement(branch.statement, bindings, interfaces, scope_start, imports, top_level, false);
                 let mut _ci2: int = 0;
                 loop {
                     if _ci2 >= result.diagnostics.length { break; }
@@ -658,6 +659,25 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 diagnostics: [make_unsupported_statement_keyword_diagnostic(unsupported)]
             };
         }
+        // A nested (block-level) unparseable statement must fail closed: the
+        // top-level `Unknown` walk in `tools/check.sfn` (E0500) covers only
+        // `program.statements`, so a `Statement.Unknown` produced inside a
+        // block by `parse_unknown_statement` would otherwise be dropped with
+        // no diagnostic and zero effects (#1691). Gate on `is_top_level` so we
+        // never double-fire with E0500 at top level, and reach here only after
+        // the E0410/E0411 checks above so we never double-fire with those.
+        if !is_top_level {
+            let mut anchor: Token? = null;
+            let mut near: string = "";
+            if statement.tokens.length > 0 {
+                anchor = statement.tokens[0];
+                near = " near `" + statement.tokens[0].lexeme + "`";
+            }
+            return ScopeResult {
+                bindings: bindings,
+                diagnostics: [make_unparseable_statement_diagnostic(anchor, near)]
+            };
+        }
         return ScopeResult { bindings: bindings, diagnostics: [] };
     }
     return ScopeResult { bindings: bindings, diagnostics: [] };
@@ -706,7 +726,7 @@ fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Stateme
     let mut diagnostics: Diagnostic[] = [];
 
     for statement in block.statements {
-        let result = check_statement(statement, bindings, interfaces, scope_start, imports, top_level);
+        let result = check_statement(statement, bindings, interfaces, scope_start, imports, top_level, false);
         bindings = result.bindings;
         let mut _ci: int = 0;
         loop {

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -2027,6 +2027,29 @@ fn make_unsupported_statement_keyword_diagnostic(keyword: string) -> Diagnostic 
     };
 }
 
+// E0819 — a nested (block-level) `Statement.Unknown` that no other pass
+// already diagnosed. Top-level `Unknown` statements surface E0500 from the
+// check driver (`tools/check.sfn`), whose walk covers only
+// `program.statements`; a `Statement.Unknown` produced inside a block by
+// `parse_unknown_statement` (reached via `parse_block`) is invisible to that
+// walk and previously fell through `check_statement`'s `Unknown` arm with no
+// diagnostic — contributing zero effects and being silently dropped at
+// codegen, a fail-open hole in the effects pillar (#1691, epic #1180).
+// Emitted from `check_statement` only for non-top-level statements and only
+// when neither a removed-keyword (E0410) nor an unsupported-keyword (E0411)
+// diagnostic already fired, so it never double-reports. `anchor` is the first
+// token of the unparseable run; `near` quotes its lexeme for the message.
+fn make_unparseable_statement_diagnostic(anchor: Token?, near: string) -> Diagnostic {
+    return Diagnostic {
+        code: "E0819",
+        severity: "error",
+        message: "parse error: unrecognized statement" + near,
+        file_path: "",
+        primary: anchor,
+        suggestion: null
+    };
+}
+
 fn make_missing_interface_member_diagnostic(struct_name: string, interface_name: string, member_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0301",

--- a/compiler/tests/e2e/effect_unknown_block_level_test.sfn
+++ b/compiler/tests/e2e/effect_unknown_block_level_test.sfn
@@ -1,0 +1,120 @@
+// Regression coverage for #1691 (epic #1180, effect-system hardening):
+// a nested (block-level) `Statement.Unknown` must fail closed with a
+// diagnostic (E0819) instead of being silently dropped with zero effects.
+//
+// SCOPE NOTE (verified empirically against the self-hosted compiler):
+// the E0819 arm is a *defense-in-depth* fail-closed for a genuine nested
+// `Statement.Unknown`. In the current parser there is **no reachable
+// source input** that produces a bare nested `Statement.Unknown` outside
+// the reserved-keyword path: `parse_block_statement` absorbs every
+// unrecognized nested statement into an `ExpressionStatement{Raw}` (the
+// silent-drop the issue actually observed for `@@@ junk !!!`), which is
+// the `Expression.Raw` escape owned by #1692's E0818 backstop —
+// explicitly `Out:` of #1691. The only nested construct that reaches
+// `parse_unknown_statement` today is a reserved/unsupported keyword
+// (`while` -> E0411). So these tests pin the load-bearing, reachable
+// invariants of the fix: the gate never double-fires E0819 with the
+// top-level parse diagnostic (E0500) or the reserved-keyword diagnostic
+// (E0411), and pre-existing behavior is preserved. The E0819 emission
+// itself is exercised by review + the self-host build (it must not fire
+// over the compiler/runtime tree); when #1692 structures the Raw escapes
+// such that a bare nested `Unknown` can occur, a direct E0819 trigger
+// test belongs there.
+//
+// Driven through `sfn check --json` (the machine-checkable envelope) and
+// asserted with `sfn/strings` predicates, matching
+// `check_json_schema_test.sfn`. The `sfn/test` `expect_*` matchers are
+// `![pure]` and cannot be called from this `![io]` test.
+import { find, contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Pure-frontend `sfn check` needs no clang, but thread PATH/HOME so a
+// constrained CI shell still resolves anything the frontend touches.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    return e;
+}
+
+struct CheckRun {
+    exit: int,
+    out: string,
+    err: string
+}
+
+// Scratch base for fixtures, keyed by tag so the parallel pool never
+// collides. Materializes a minimal capsule/workspace context plus the
+// per-case fixture under it.
+fn _fixture_dir(tag: string) -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    let root = base + "/sfn-unknown-block-" + tag;
+    fs.createDirectory(root + "/src", true);
+    fs.writeFile(root + "/workspace.toml", "[workspace]\nmembers = []\n");
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"unknown-block-test\"\n"
+        + "version = \"0.1.0\"\n"
+        + "description = \"E2E for nested Unknown fail-closed (#1691)\"\n\n"
+        + "[capabilities]\n"
+        + "required = [\"io\"]\n\n"
+        + "[build]\n"
+        + "entry = \"src/main.sfn\"\n");
+    return root;
+}
+
+fn _write(root: string, name: string, source: string) -> string ![io] {
+    let path = root + "/src/" + name;
+    fs.writeFile(path, source);
+    return path;
+}
+
+fn _check(path: string) -> CheckRun ![io] {
+    let exit = process.run_capture([_sfn_bin(), "check", "--json", path], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return CheckRun { exit: exit, out: out, err: err };
+}
+
+// ---- Test 1: top-level junk still surfaces E0500, never E0819 ----
+// The driver's top-level `Unknown` walk (`tools/check.sfn`) owns E0500;
+// `check_statement` is invoked for the same node with `is_top_level=true`,
+// so the gate must keep E0819 silent — no double-fire.
+test "nested unknown: top-level junk surfaces E0500 only (no E0819 double-fire)" ![io] {
+    let root = _fixture_dir("toplevel");
+    let path = _write(root, "toplevel.sfn", "@@@ junk !!!\n");
+    let r = _check(path);
+    assert r.exit == 1;
+    assert contains(r.out, "\"code\":\"E0500\"");
+    assert find(r.out, "\"code\":\"E0819\"", 0) < 0;
+}
+
+// ---- Test 2: nested reserved `while` surfaces E0411, never E0819 ----
+// `while` is the one construct that reaches `parse_unknown_statement` in a
+// block today. The E0819 arm sits after the E0411 guard, so a nested
+// `while` must still produce E0411 alone — proving the dedup ordering.
+test "nested unknown: nested while surfaces E0411 only (no E0819 dedup)" ![io] {
+    let root = _fixture_dir("while");
+    let path = _write(root, "while.sfn", "fn g() {\n    while(true) { }\n}\n");
+    let r = _check(path);
+    assert r.exit == 1;
+    assert contains(r.out, "\"code\":\"E0411\"");
+    assert find(r.out, "\"code\":\"E0819\"", 0) < 0;
+}
+
+// ---- Test 3: a clean nested block stays clean (no spurious E0819) ----
+// Guards against the gate mis-firing on ordinary block statements.
+test "nested unknown: a valid nested block does not emit E0819" ![io] {
+    let root = _fixture_dir("clean");
+    let path = _write(root, "clean.sfn", "fn ok() {\n    let x = 1;\n    let _ = x + 1;\n}\n");
+    let r = _check(path);
+    assert r.exit == 0;
+    assert find(r.out, "\"code\":\"E0819\"", 0) < 0;
+}


### PR DESCRIPTION
## Summary

- A nested (block-level) `Statement.Unknown` reached the effect checker contributing **zero effects with no diagnostic**, then was silently dropped at codegen — a fail-open hole in the effects pillar. Top-level `Unknown` already errors via E0500 (`tools/check.sfn`), but that walk covers only `program.statements`.
- Adds `make_unparseable_statement_diagnostic` (**E0819**) and emits it from `check_statement`'s `Unknown` arm, gated by a new `is_top_level` flag (never double-fires with E0500) and placed after the E0410/E0411 guards (never double-fires with those).
- Adds a defensive `Unknown` arm to the effect checker's statement walker (`return []`; the parse diagnostic already fails the build).

Closes #1691

## ⚠️ Scope correction (please read)

The issue's headline repro — nested `@@@ junk !!!` — was **misattributed**. Verified empirically against the self-hosted compiler: `parse_block_statement` absorbs every unrecognized nested statement into an `ExpressionStatement{Raw}` (the actual silent-drop), **not** a `Statement.Unknown`. That `Expression.Raw` escape is owned by **#1692**'s E0818 backstop and is explicitly `Out:` of #1691 (`Out: the Expression.Raw effect-escapes`).

The **only** nested construct that reaches `parse_unknown_statement` today is a reserved keyword (`while` → E0411). So acceptance criterion #1 (`@@@ junk !!!` → diagnostic) is not satisfiable within #1691's scope — it needs #1692. (A naive "fail-close on nested Raw" is unsound: valid `a = b;` assignments are also `Raw` until #1692 structures them, which is exactly why #1692 sequences that work first.)

Per maintainer decision, this ships the E0819 arm as **correct fail-closed defense-in-depth** (it must never fire over a valid tree, proven by self-host), with the `@@@` repro redirected to #1692. When #1692 structures the Raw escapes such that a bare nested `Unknown` can occur, a direct E0819-trigger test belongs there.

## Acceptance Criteria

- [x] Top-level `@@@` still surfaces E0500; nested `while(){}` still surfaces E0411 — no E0819 double-fire (tests 1 & 2).
- [x] No E0819 when a removed-keyword (E0410) / E0411 diagnostic already fired (gate placed after those guards).
- [x] `make compile` self-hosts (E0819 arm runs over the whole compiler/runtime tree with no false positives).
- [x] `make test` passes (unit 181/181, integration 41/41, e2e 166/166, capsules 38/38).
- [ ] ~~Nested `@@@ junk !!!` → E0819 + span~~ — premise corrected; redirected to #1692 (see Scope correction).

## Map reconciliation

The advisory `## Files Affected` map listed the parser sites (`parser/statements.sfn`, `parser/declarations.sfn`) as the emission point. Reconciled to the real plumbing: the parser carries no diagnostics channel — diagnostics are minted by AST walkers, so the same nested-only gating is realized in `check_statement` (typecheck) via the `is_top_level` flag rather than at the parser production site. Semantic `In:` unit (the nested-Unknown diagnostic + gating + defensive effect arm) is unchanged.

## Verification

```
make compile          # self-hosts (exit 0)
make test             # unit 181/181, integration 41/41, e2e 166/166, capsules 38/38
build/native/sailfin test compiler/tests/e2e/effect_unknown_block_level_test.sfn   # 3/3 pass
```

## Files Changed

- `compiler/src/typecheck_types.sfn` — `make_unparseable_statement_diagnostic` (E0819)
- `compiler/src/typecheck.sfn` — `is_top_level` param on `check_statement` (3 call sites) + gated `Unknown` arm
- `compiler/src/effect_checker.sfn` — defensive `Unknown` arm (`return []`)
- `compiler/tests/e2e/effect_unknown_block_level_test.sfn` — reachable-invariant regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AThnr4GxHJ9dZRFqomhu3

---
_Generated by [Claude Code](https://claude.ai/code/session_018AThnr4GxHJ9dZRFqomhu3)_