### PR TITLE
feat(typecheck): structured, enforced `x is T` type-guard operator

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -93,6 +93,21 @@ enum Expression {
     },
     Range { start: Expression, end: Expression },
     Cast { operand: Expression, target_type: TypeAnnotation },
+    // Type-guard operator `x is T` (issue #1753, epic #1180, effect-system
+    // hardening). Before #1753 a guard degraded to `Expression.Raw` because
+    // the postfix parser had no `is` arm — and since #1186 a `Raw` node
+    // contributes zero effects, so an effectful operand (`readFile() is T`)
+    // reached codegen effect-blind, and the branch bodies saw the operand at
+    // its un-narrowed type. Structuring it here lets the effect checker and
+    // typecheck walker recurse into `operand` (the target is a static type,
+    // effect-free). The formatter serializes it back to `(operand) is <type>`
+    // — the exact text the lowering shadow re-parser `parse_is_expression`
+    // consumes — and the if-lowering narrows the guarded operand in the
+    // then-branch via the same `narrowed_variant` machinery `if
+    // <base>.variant == "<V>"` already uses. Fields `operand`/`target_type`
+    // match `Cast`, so they share the enum's per-name field slots (no GEP
+    // collision — see the `Assignment` note below).
+    Is { operand: Expression, target_type: TypeAnnotation },
     // Postfix `?` error-propagation operator (R.1, epic #371). Distinct
     // from the statement-level `TryStatement`. Type rules and emission
     // land in R.3 / R.4 — today this is parse-only.

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -889,6 +889,13 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
         // effect of its own.
         return collect_effects_from_expression(expression.operand, imports);
     }
+    if expression.variant == "Is" {
+        // A type-guard's operand is the effectful surface: `readFile() is T`
+        // performs the io of `readFile` before the (effect-free) type test.
+        // Before #1753 the guard degraded to `Raw` (effect-blind) — walk the
+        // operand so the requirement surfaces; the target type carries none.
+        return collect_effects_from_expression(expression.operand, imports);
+    }
     if expression.variant == "Binary" {
         let mut required = collect_effects_from_expression(expression.left, imports);
         required = merge_requirements(required, collect_effects_from_expression(expression.right, imports));

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -71,6 +71,17 @@ fn _format_binary_operand_into(operand: Expression, out: string[]) -> string[] {
         out.push(")");
         return out;
     }
+    if operand.variant == "Is" {
+        // `!(x is T)` parses as `Unary{!, Is}` — wrap the `Is` so the negation
+        // survives the round-trip. Without the parens the Unary formatter emits
+        // `!(x) is T`, and the lowering shadow re-parser (`parse_is_expression`)
+        // matches the top-level ` is ` and absorbs `!(x)` as the operand,
+        // dropping the negation (#1753).
+        out.push("(");
+        format_expression_into(operand, out);
+        out.push(")");
+        return out;
+    }
     format_expression_into(operand, out);
     return out;
 }
@@ -197,6 +208,18 @@ fn format_expression_into(expression: Expression, out: string[]) -> string[] {
         out.push("(");
         format_expression_into(expression.operand, out);
         out.push(") as ");
+        out.push(expression.target_type.text);
+        return out;
+    }
+    if expression.variant == "Is" {
+        // `(operand) is <type>` (#1753) — the exact text the lowering shadow
+        // re-parser `parse_is_expression` consumes (it scans for a top-level
+        // ` is `). The operand parens are load-bearing: they let
+        // `strip_enclosing_parentheses` recover an operand that may contain
+        // embedded operators, exactly as the `Cast` formatter does.
+        out.push("(");
+        format_expression_into(expression.operand, out);
+        out.push(") is ");
         out.push(expression.target_type.text);
         return out;
     }

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -332,6 +332,7 @@ import {
     parse_ternary_expression,
     parse_raw_address_expression,
     parse_cast_expression,
+    parse_is_expression,
     parse_array_literal_metadata,
     map_metadata_annotation
 } from "./core_parsing";
@@ -392,6 +393,7 @@ import {
     lower_struct_literal,
     lower_enum_literal,
     lower_cast_expression,
+    lower_is_expression,
     try_lower_interpolated_string_literal
 } from "./core_literals_lowering";
 
@@ -2209,6 +2211,17 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         if logical.symbol == "||" {
             return lower_logical_or(stripped, logical, bindings, locals, temp_index, lines, functions, context);
         }
+    }
+
+    // `is` type-guard (#1753). Placed AFTER the logical split so
+    // `x is T && y` peels `&&` first, but BEFORE the comparison/bitwise
+    // finders so a generic target's angle brackets (`x is Foo<X>`) are not
+    // mis-split at `<`. `parse_is_expression` declines when the target
+    // carries a top-level operator, so a clean `(operand) is Type` only
+    // reaches here once the surrounding operators are already peeled.
+    let is_parse = parse_is_expression(stripped);
+    if is_parse.recognized {
+        return lower_is_expression(is_parse, bindings, locals, temp_index, lines, functions, context);
     }
 
     // Slice B (2026-05-02): bitwise + shift operator dispatch.

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -49,6 +49,7 @@ import { lower_expression } from "./core";
 import {
     coerce_operand_to_type,
     dominant_type,
+    emit_comparison_instruction,
     integer_llvm_width,
     is_float_llvm_type,
     is_integer_llvm_type
@@ -1425,6 +1426,143 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
         operand: boxed.operand,
         diagnostics: diagnostics,
         string_constants: collected_string_constants
+    };
+}
+
+// Lower an `is` type-guard (#1753) to a boolean `i1`. v1 supports a named
+// `enum` operand: extract the operand's discriminant tag and `icmp eq` it
+// against the target variant's tag — the same discriminant test `match`
+// emits (instructions_match_condition.sfn) and that `if <base>.variant ==
+// "<V>"` lowers to. The then-branch narrowing of the guarded operand is
+// applied separately by `lower_if_instruction` via the `narrowed_variant`
+// machinery. A non-enum operand (inline union, primitive, struct) gets a
+// clear v1 diagnostic: in-branch narrowing of those surfaces is not yet
+// wired (the `narrowed_variant` flow is enum-only), so shipping a boolean
+// without the narrowed use would be a half-feature. They are documented
+// fast-follows (SFEP-0034 §3.6).
+fn lower_is_expression(parse: CastParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
+    let mut diagnostics = parse.diagnostics;
+    let empty_constants = empty_string_constant_set();
+    if !parse.success {
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+
+    let lowered = lower_expression(parse.value, bindings, locals, temp_index, lines, functions, context, "");
+    let mut _ci_is: int = 0;
+    loop {
+        if _ci_is >= lowered.diagnostics.length { break; }
+        diagnostics.push(lowered.diagnostics[_ci_is]);
+        _ci_is += 1;
+    }
+    if lowered.operand == null {
+        return ExpressionResult {
+            lines: lowered.lines,
+            temp_index: lowered.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: lowered.string_constants
+        };
+    }
+    let subject = lowered.operand;
+    let mut current_lines = lowered.lines;
+    let mut current_temp = lowered.temp_index;
+
+    // Resolve the operand's enum type from its LLVM type (strip a pointer
+    // suffix for the boxed-struct ABI), mirroring core_member_lowering.
+    let mut candidate = subject.llvm_type;
+    if ends_with_pointer_suffix(candidate) {
+        let stripped = trim_text(strip_pointer_suffix(candidate));
+        if stripped.length > 0 { candidate = stripped; }
+    }
+    let enum_info = find_enum_info_by_llvm_type(context, candidate);
+    if enum_info == null {
+        diagnostics.push("llvm lowering: `is` on a non-enum value `" + subject.llvm_type
+            + "` is not yet supported; the operand must be a named `enum` type");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: lowered.string_constants
+        };
+    }
+    let variant_info = resolve_enum_variant_info(enum_info, parse.type_annotation);
+    if variant_info == null {
+        diagnostics.push("llvm lowering: enum `" + enum_info.name
+            + "` has no variant `"
+            + parse.type_annotation
+            + "` for `is`");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: lowered.string_constants
+        };
+    }
+
+    // Map the tag type and extract/load the discriminant tag (field 0).
+    let mut tag_llvm_type: string = "i32";
+    if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
+    if enum_info.tag_type == "i16" { tag_llvm_type = "i16"; }
+    if enum_info.tag_type == "i32" { tag_llvm_type = "i32"; }
+    if enum_info.tag_type == "i64" { tag_llvm_type = "i64"; }
+
+    let mut tag_temp: string = "";
+    if ends_with_pointer_suffix(subject.llvm_type) {
+        let tag_ptr_temp = format_temp_name(current_temp);
+        current_temp += 1;
+        current_lines.push("  " + tag_ptr_temp + " = getelementptr inbounds "
+            + enum_info.llvm_name
+            + ", "
+            + subject.llvm_type
+            + " "
+            + subject.value
+            + ", i32 0, i32 0");
+        let load_temp = format_temp_name(current_temp);
+        current_temp += 1;
+        current_lines.push("  " + load_temp + " = load " + tag_llvm_type + ", "
+            + tag_llvm_type
+            + "* "
+            + tag_ptr_temp);
+        tag_temp = load_temp;
+    } else {
+        let extract_temp = format_temp_name(current_temp);
+        current_temp += 1;
+        current_lines.push("  " + extract_temp + " = extractvalue " + subject.llvm_type
+            + " "
+            + subject.value
+            + ", 0");
+        tag_temp = extract_temp;
+    }
+
+    let tag_operand = LLVMOperand {
+        llvm_type: tag_llvm_type,
+        value: tag_temp
+    };
+    let variant_tag_operand = LLVMOperand {
+        llvm_type: tag_llvm_type,
+        value: number_to_string(variant_info.tag)
+    };
+    let comparison = emit_comparison_instruction("==", tag_operand, variant_tag_operand, current_temp, current_lines);
+    let mut _cc_is: int = 0;
+    loop {
+        if _cc_is >= comparison.diagnostics.length { break; }
+        diagnostics.push(comparison.diagnostics[_cc_is]);
+        _cc_is += 1;
+    }
+    return ExpressionResult {
+        lines: comparison.lines,
+        temp_index: comparison.temp_index,
+        operand: comparison.operand,
+        diagnostics: diagnostics,
+        string_constants: lowered.string_constants
     };
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
@@ -790,6 +790,215 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     };
 }
 
+// `is` type-guard re-parser (#1753) — the lowering mirror of the `Is`
+// formatter (`emit_native_format.sfn`), which serializes a guard as
+// `(operand) is <type>`. Reuses `CastParseResult` (same shape): `value`
+// is the operand text, `type_annotation` is the guard's target type.
+// Scans for a top-level ` is ` outside of brackets/strings, identical to
+// `parse_cast_expression`'s ` as ` scan. Declines (`recognized = false`)
+// when the text after `is` carries a top-level (angle-depth-0) binary
+// operator char — that means `is` is not the outermost operator (`x is T == z`
+// is `(x is T) == z`), so the dispatcher must split the comparison / bitwise
+// operator first and re-parse the now clean `x is T`. (`&&`/`||` are peeled
+// before is-dispatch.) Generic targets are accepted whole: `<`/`>` are tracked
+// as angle depth, so a `Foo < int >` target — which the formatter renders with
+// a depth-0 space before `<` — is NOT mistaken for a trailing operator.
+fn parse_is_expression(text: string) -> CastParseResult {
+    let trimmed = trim_text(text);
+    let mut diagnostics: string[] = [];
+    if trimmed.length == 0 {
+        return CastParseResult {
+            recognized: false,
+            success: false,
+            value: "",
+            type_annotation: "",
+            diagnostics: diagnostics
+        };
+    }
+
+    let mut paren_depth: int = 0;
+    let mut bracket_depth: int = 0;
+    let mut brace_depth: int = 0;
+    let mut angle_depth: int = 0;
+    let mut in_single: boolean = false;
+    let mut in_double: boolean = false;
+    let mut escape_next: boolean = false;
+    let mut index: int = 0;
+    let mut match_index: int = -1;
+    loop {
+        if index >= trimmed.length { break; }
+        let ch = char_at(trimmed, index);
+        if in_double {
+            if escape_next {
+                escape_next = false;
+                index += 1;
+                continue;
+            }
+            if ch == "\\" {
+                escape_next = true;
+                index += 1;
+                continue;
+            }
+            if ch == "\"" { in_double = false; }
+            index += 1;
+            continue;
+        }
+        if in_single {
+            if escape_next {
+                escape_next = false;
+                index += 1;
+                continue;
+            }
+            if ch == "\\" {
+                escape_next = true;
+                index += 1;
+                continue;
+            }
+            if ch == "'" { in_single = false; }
+            index += 1;
+            continue;
+        }
+        if ch == "\"" {
+            in_double = true;
+            index += 1;
+            continue;
+        }
+        if ch == "'" {
+            in_single = true;
+            index += 1;
+            continue;
+        }
+        if ch == "(" {
+            paren_depth += 1;
+            index += 1;
+            continue;
+        }
+        if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+            index += 1;
+            continue;
+        }
+        if ch == "[" {
+            bracket_depth += 1;
+            index += 1;
+            continue;
+        }
+        if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+            index += 1;
+            continue;
+        }
+        if ch == "{" {
+            brace_depth += 1;
+            index += 1;
+            continue;
+        }
+        if ch == "}" {
+            if brace_depth > 0 { brace_depth -= 1; }
+            index += 1;
+            continue;
+        }
+        if ch == "<" {
+            angle_depth += 1;
+            index += 1;
+            continue;
+        }
+        if ch == ">" {
+            if angle_depth > 0 { angle_depth -= 1; }
+            index += 1;
+            continue;
+        }
+
+        if paren_depth == 0 {
+            if bracket_depth == 0 {
+                if brace_depth == 0 {
+                    if angle_depth == 0 {
+                        let _is_end = index + 4;
+                        if _is_end <= trimmed.length {
+                            let window = substring(trimmed, index, _is_end);
+                            if window == " is " { match_index = index; }
+                        }
+                    }
+                }
+            }
+        }
+        index += 1;
+    }
+
+    if match_index < 0 {
+        return CastParseResult {
+            recognized: false,
+            success: false,
+            value: "",
+            type_annotation: "",
+            diagnostics: diagnostics
+        };
+    }
+    let value = trim_text(substring(trimmed, 0, match_index));
+    let annotation = trim_text(substring(trimmed, match_index + 4, trimmed.length));
+    let mut _is_malformed: boolean = false;
+    if value.length == 0 { _is_malformed = true; }
+    if annotation.length == 0 { _is_malformed = true; }
+    if _is_malformed {
+        diagnostics.push("llvm lowering: malformed `is` expression `" + text
+            + "`");
+        return CastParseResult {
+            recognized: true,
+            success: false,
+            value: value,
+            type_annotation: annotation,
+            diagnostics: diagnostics
+        };
+    }
+    // Precedence guard: a top-level (angle-depth-0) binary OPERATOR character in
+    // the target means `is` is not the outermost operator (`x is T == z` is
+    // `(x is T) == z`), so decline and let the comparison/bitwise split run
+    // first; the inner `x is T` is then re-parsed here. (`&&`/`||` are already
+    // peeled before the is-dispatch.) We must NOT key on whitespace: the formatter
+    // renders a generic target as `Foo < int >` with a depth-0 space before `<`,
+    // so a whitespace check would wrongly decline every generic target and defeat
+    // the dispatch ordering. `<`/`>` are tracked as angle depth (generics), so a
+    // type's own brackets never trigger the guard; only a true operator char does.
+    let mut a_index: int = 0;
+    let mut a_angle: int = 0;
+    loop {
+        if a_index >= annotation.length { break; }
+        let a_ch = char_at(annotation, a_index);
+        if a_ch == "<" { a_angle += 1; } else if a_ch == ">" {
+            if a_angle > 0 { a_angle -= 1; }
+        } else if a_angle == 0 {
+            let mut _is_op: boolean = false;
+            if a_ch == "=" { _is_op = true; }
+            if a_ch == "!" { _is_op = true; }
+            if a_ch == "+" { _is_op = true; }
+            if a_ch == "-" { _is_op = true; }
+            if a_ch == "*" { _is_op = true; }
+            if a_ch == "/" { _is_op = true; }
+            if a_ch == "%" { _is_op = true; }
+            if a_ch == "|" { _is_op = true; }
+            if a_ch == "^" { _is_op = true; }
+            if a_ch == "&" { _is_op = true; }
+            if _is_op {
+                return CastParseResult {
+                    recognized: false,
+                    success: false,
+                    value: "",
+                    type_annotation: "",
+                    diagnostics: diagnostics
+                };
+            }
+        }
+        a_index += 1;
+    }
+    return CastParseResult {
+        recognized: true,
+        success: true,
+        value: value,
+        type_annotation: annotation,
+        diagnostics: diagnostics
+    };
+}
+
 fn parse_array_literal_metadata(entries: string[], context: TypeContext) -> ArrayLiteralMetadata {
     if entries.length == 0 {
         return ArrayLiteralMetadata { element_type: "", start_index: 0 };

--- a/compiler/src/llvm/lowering/instructions_if.sfn
+++ b/compiler/src/llvm/lowering/instructions_if.sfn
@@ -175,6 +175,37 @@ fn _parse_variant_guard(condition: string) -> _VariantGuard {
     return _VariantGuard { matched: true, base: base, variant: variant };
 }
 
+// Parse an `is` type-guard of the shape `(<base>) is <Variant>` (#1753) —
+// the text the `Is` formatter emits for `if <base> is <Variant>`. Maps onto
+// the SAME `_VariantGuard` the `.variant ==` form produces, so the existing
+// then-branch narrowing applies unchanged. `<base>` must be a simple
+// identifier (after stripping the formatter's enclosing parens) and
+// `<Variant>` a simple variant name; a compound operand or a generic /
+// qualified target yields no narrowing (the boolean still lowers — only the
+// narrowing is conservatively skipped).
+fn _parse_is_guard(condition: string) -> _VariantGuard {
+    let none = _VariantGuard { matched: false, base: "", variant: "" };
+    let trimmed = trim_text(condition);
+    let marker = " is ";
+    let mi = index_of(trimmed, marker);
+    if mi <= 0 { return none; }
+    let mut base = trim_text(substring(trimmed, 0, mi));
+    let variant = trim_text(substring(trimmed, mi + marker.length, trimmed.length));
+    // Strip the single enclosing paren pair the `Is` formatter wraps the
+    // operand in (`(operand) is <type>`).
+    if base.length >= 2 {
+        if base[0] == "(" {
+            if base[base.length - 1] == ")" {
+                base = trim_text(substring(base, 1, base.length - 1));
+            }
+        }
+    }
+    if !is_simple_identifier(base) { return none; }
+    if variant.length == 0 { return none; }
+    if !is_simple_identifier(variant) { return none; }
+    return _VariantGuard { matched: true, base: base, variant: variant };
+}
+
 // Return a copy of `locals` with the binding named `base_name` carrying
 // `narrowed_variant = variant` (all other fields preserved).
 fn _narrow_locals_for_variant(locals: LocalBinding[], base_name: string, variant: string) -> LocalBinding[] {
@@ -372,7 +403,12 @@ fn lower_if_instruction(function: NativeFunction, start_index: int, llvm_return:
 
     // Flow-sensitive variant narrowing: an `if <base>.variant == "<V>"`
     // guard narrows `<base>` to variant V inside the then-branch only.
-    let _guard = _parse_variant_guard(sanitized_condition_source);
+    let mut _guard = _parse_variant_guard(sanitized_condition_source);
+    if !_guard.matched {
+        // `if <base> is <Variant>` narrows identically to `<base>.variant ==
+        // "<Variant>"` (#1753) — reuse the same then-branch narrowing.
+        _guard = _parse_is_guard(sanitized_condition_source);
+    }
     let mut then_locals: LocalBinding[] = base_locals;
     let mut then_param_bindings: ParameterBinding[] = bindings;
     let mut _guard_local_active: boolean = false;

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -1083,6 +1083,94 @@ fn read_cast_target(state: ExpressionTokens) -> CastTargetParseResult {
     };
 }
 
+// Read an `is` type-guard target (issue #1753). A narrower sibling of
+// `read_cast_target`: `is` is a runtime type predicate, not a reinterpret
+// cast, so it accepts ONLY a named type with an optional generic argument
+// list (`Foo`, `Foo<X, Y>`) — no pointer prefix (`* T`) and no fn-pointer
+// (`fn (A) -> B`) forms, which are meaningless as a guard target. This is
+// exactly Step 2b of `read_cast_target`. Returns `success:false` on a
+// non-identifier head or unbalanced generic brackets so the enclosing
+// expression falls through to `expression_parse_failure` → `Raw`.
+fn read_is_target(state: ExpressionTokens) -> CastTargetParseResult {
+    let mut cursor = state;
+    let mut text: string = "";
+
+    if expression_tokens_is_at_end(cursor) {
+        return CastTargetParseResult {
+            state: state,
+            text: "",
+            success: false
+        };
+    }
+    let head_tok = expression_tokens_peek(cursor);
+    if head_tok.kind.variant != "Identifier" {
+        return CastTargetParseResult {
+            state: state,
+            text: "",
+            success: false
+        };
+    }
+    text = _cast_target_append(text, identifier_text(head_tok));
+    cursor = expression_tokens_advance(cursor);
+
+    // Optional generic args: consume `< ... >` balancing angle brackets,
+    // identical to `read_cast_target` Step 2b.
+    if !expression_tokens_is_at_end(cursor) {
+        let maybe_lt = expression_tokens_peek(cursor);
+        if maybe_lt.kind.variant == "Symbol" {
+            if strings_equal(maybe_lt.lexeme, "<") {
+                text = _cast_target_append(text, "<");
+                cursor = expression_tokens_advance(cursor);
+                let mut angle_depth: int = 1;
+                loop {
+                    if expression_tokens_is_at_end(cursor) {
+                        return CastTargetParseResult {
+                            state: state,
+                            text: "",
+                            success: false
+                        };
+                    }
+                    let g_tok = expression_tokens_peek(cursor);
+                    if strings_equal(g_tok.lexeme, "<") {
+                        angle_depth += 1;
+                        text = _cast_target_append(text, g_tok.lexeme);
+                        cursor = expression_tokens_advance(cursor);
+                    } else if strings_equal(g_tok.lexeme, ">>") {
+                        if angle_depth >= 2 { angle_depth -= 2; } else {
+                            angle_depth = 0;
+                        }
+                        if angle_depth == 0 {
+                            text = _cast_target_append(text, ">");
+                            cursor = expression_tokens_advance(cursor);
+                            break;
+                        }
+                        text = _cast_target_append(text, ">>");
+                        cursor = expression_tokens_advance(cursor);
+                    } else if strings_equal(g_tok.lexeme, ">") {
+                        angle_depth -= 1;
+                        if angle_depth == 0 {
+                            text = _cast_target_append(text, ">");
+                            cursor = expression_tokens_advance(cursor);
+                            break;
+                        }
+                        text = _cast_target_append(text, ">");
+                        cursor = expression_tokens_advance(cursor);
+                    } else {
+                        text = _cast_target_append(text, g_tok.lexeme);
+                        cursor = expression_tokens_advance(cursor);
+                    }
+                }
+            }
+        }
+    }
+
+    return CastTargetParseResult {
+        state: cursor,
+        text: text,
+        success: true
+    };
+}
+
 // ============================================================================
 // Postfix Operators (calls, member access, indexing, struct literals)
 // ============================================================================
@@ -1137,6 +1225,29 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             current_expression = Expression.Cast {
                 operand: current_expression,
                 target_type: TypeAnnotation { text: cast_result.text }
+            };
+            continue;
+        }
+
+        // `is` type-guards (issue #1753, epic #1180). `is` is a soft keyword
+        // (lexes as Identifier; same convention as `as`). Postfix-binding so
+        // `x is string && y` parses as `(x is string) && y` (`&&` is a Symbol
+        // handled by the lower binding-power climb, which breaks the postfix
+        // chain first). The target is a named type with optional generics
+        // (`read_is_target`); a non-identifier target falls through to a parse
+        // failure → `Raw` (correct: it is junk). The narrowing + boolean
+        // lowering land in typecheck / llvm lowering on the structured `Is`.
+        if identifier_matches(token, "is") {
+            let after_is = expression_tokens_advance(current_state);
+            if expression_tokens_is_at_end(after_is) {
+                return expression_parse_failure(state);
+            }
+            let is_result = read_is_target(after_is);
+            if !is_result.success { return expression_parse_failure(state); }
+            current_state = is_result.state;
+            current_expression = Expression.Is {
+                operand: current_expression,
+                target_type: TypeAnnotation { text: is_result.text }
             };
             continue;
         }

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -1057,6 +1057,15 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         }
         return walk_expression(expression.operand, bindings, imports);
     }
+    if expression.variant == "Is" {
+        // Type-guard `x is T` (#1753) — recurse into the operand so inner
+        // diagnostics (undefined symbols, fn-value misuse, nested parse-error
+        // nodes) still fire. The target type is a static type name, not an
+        // expression, so there is nothing to walk there. Flow-sensitive
+        // narrowing is applied at lowering via the `narrowed_variant`
+        // machinery (the typecheck pass tracks names only — no type field).
+        return walk_expression(expression.operand, bindings, imports);
+    }
     if expression.variant == "TryOperator" {
         return walk_expression(expression.operand, bindings, imports);
     }

--- a/compiler/tests/e2e/is_type_guard_test.sfn
+++ b/compiler/tests/e2e/is_type_guard_test.sfn
@@ -1,0 +1,133 @@
+// End-to-end test for the `x is T` type-guard operator lowering (issue #1753).
+//
+// Proves the full pipeline end-to-end: the discriminant tag test (`x is T`
+// lowers to `icmp eq` on the enum tag) AND the then-branch narrowing that lets
+// member access (`v.content`) resolve to the correct variant field. Mirrors the
+// build-and-run pattern from `sailfin_main_entry_test.sfn` and
+// `enum_same_name_field_conflict_test.sfn`.
+//
+// The fixture defines an enum with two variants, a function that uses `is` to
+// branch, and a `main` that calls it with both variants. The test builds the
+// fixture binary, runs it, and asserts on the stdout.
+//
+// Parallel-runner isolation: `_child_env()` returns `process.environ()` so
+// PATH (clang/linker) and SAILFIN_TEST_SCRATCH (per-invocation build-cache
+// isolation, #1333) are both forwarded to the nested `sfn build`.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-is-guard-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// The fixture exercises:
+//   1. `if v is Text { return "T:" + v.content; }` — discriminant test AND
+//      then-branch narrowing so `v.content` resolves to the Text variant field.
+//   2. The fall-through for the Number variant returns "N".
+//   3. `main` calls `describe` with both variants and prints the results.
+//      Each line is printed separately so the test can assert on each one.
+fn _fixture_src() -> string {
+    return "enum Value { Text { content: string }, Number { amount: int } }\n"
+        + "\n"
+        + "fn describe(v: Value) -> string ![io] {\n"
+        + "    if v is Text { return \"T:\" + v.content; }\n"
+        + "    return \"N\";\n"
+        + "}\n"
+        + "\n"
+        + "fn main() ![io] {\n"
+        + "    print(describe(Value.Text { content: \"hi\" }));\n"
+        + "    print(describe(Value.Number { amount: 9 }));\n"
+        + "}\n";
+}
+
+// A negated guard `!(v is Text)` must preserve the negation through the
+// formatter ↔ lowering round-trip (#1753 review fix): the `Is` operand is
+// parenthesized in `_format_binary_operand_into` so `!` is not absorbed into
+// the guard operand. Text → "T:hi" (negation false, fall through); Number →
+// "not-text" (negation true).
+fn _negated_fixture_src() -> string {
+    return "enum Value { Text { content: string }, Number { amount: int } }\n"
+        + "\n"
+        + "fn describe(v: Value) -> string ![io] {\n"
+        + "    if !(v is Text) { return \"not-text\"; }\n"
+        + "    return \"T:\" + v.content;\n"
+        + "}\n"
+        + "\n"
+        + "fn main() ![io] {\n"
+        + "    print(describe(Value.Text { content: \"hi\" }));\n"
+        + "    print(describe(Value.Number { amount: 9 }));\n"
+        + "}\n";
+}
+
+// Build `src` in a fresh temp dir and run the resulting binary.
+// Stashes the combined stdout to `out_marker` and returns the run exit code,
+// or -100 if the build failed.
+fn _build_and_run(out_marker: string, src: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, src);
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], []);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+// -------------------------------------------------------------------
+// The discriminant test and narrowing must produce the right output for
+// the Text variant (prefix "T:" followed by the field value "hi").
+// -------------------------------------------------------------------
+test "is type-guard e2e: Text variant discriminant and field narrowing" ![io] {
+    let marker = _marker("text");
+    let exit = _build_and_run(marker, _fixture_src());
+    // -100 == build failure; the fixture must compile and run.
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert find(out, "T:hi", 0) >= 0;
+}
+
+// -------------------------------------------------------------------
+// The fall-through branch for the non-matching variant must produce "N".
+// -------------------------------------------------------------------
+test "is type-guard e2e: non-matching variant falls through to else branch" ![io] {
+    let marker = _marker("number");
+    let exit = _build_and_run(marker, _fixture_src());
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert find(out, "N", 0) >= 0;
+}
+
+// -------------------------------------------------------------------
+// A negated guard `!(v is Text)` must keep the negation: Text → "T:hi"
+// (guard true, negation false, fall through), Number → "not-text".
+// -------------------------------------------------------------------
+test "is type-guard e2e: negated guard preserves negation" ![io] {
+    let marker = _marker("negated");
+    let exit = _build_and_run(marker, _negated_fixture_src());
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert find(out, "T:hi", 0) >= 0;
+    assert find(out, "not-text", 0) >= 0;
+}

--- a/compiler/tests/integration/is_effect_walk_test.sfn
+++ b/compiler/tests/integration/is_effect_walk_test.sfn
@@ -1,0 +1,93 @@
+// Integration test for the effect-walker coverage of `Expression.Is`
+// (issue #1753).
+//
+// Before #1753, `x is T` degraded to `Expression.Raw`, and since #1186 a `Raw`
+// node contributes zero effects — so `reads() is Variant` in a pure function
+// silently passed `sfn check`. The fix structures the node as `Expression.Is`
+// and the effect checker recurses into its operand, surfacing the operand's
+// `![io]` requirement via E0400.
+//
+// Two cases are pinned: the missing-effect path MUST exit non-zero with E0400,
+// and the correctly-annotated version MUST check clean. The test drives `sfn
+// check` as a subprocess (matching the style of
+// `compiler/tests/integration/undefined_function_check_test.sfn`) so it
+// exercises the full parse → typecheck → effect-check → render pipeline.
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if needle.length > haystack.length { return false; }
+    let mut i: int = 0;
+    let limit = haystack.length - needle.length;
+    loop {
+        if i > limit { break; }
+        if substring(haystack, i, i + needle.length) == needle { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _mint_fixture(name: string, source: string) -> string ![io] {
+    let dir = fs.mkdtemp("sfn-is-effect-");
+    assert dir.length > 0;
+    let path = dir + "/" + name;
+    fs.writeFile(path, source);
+    return path;
+}
+
+fn _check_output(path: string) -> string ![io] {
+    let _rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return out + err;
+}
+
+fn _check_exit(path: string) -> i64 ![io] {
+    let rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    return rc;
+}
+
+// A function that calls an `![io]` helper and applies `is T` to the result,
+// WITHOUT declaring `![io]` on the caller. The operand's effect must surface.
+fn _missing_effect_source() -> string {
+    return "enum Thing { Text { content: string }, Other }\n"
+        + "fn reads() -> Thing ![io] { print.info(\"x\"); return Thing.Other; }\n"
+        + "fn check_it() -> bool { return reads() is Text; }\n";
+}
+
+// The same program with `![io]` properly declared on the caller — must pass.
+fn _declared_effect_source() -> string {
+    return "enum Thing { Text { content: string }, Other }\n"
+        + "fn reads() -> Thing ![io] { print.info(\"x\"); return Thing.Other; }\n"
+        + "fn check_it() -> bool ![io] { return reads() is Text; }\n";
+}
+
+// -------------------------------------------------------------------
+// Missing `![io]`: the operand's effect must surface as E0400.
+// -------------------------------------------------------------------
+test "is effect-walk: effectful operand in pure caller is rejected with E0400" ![io] {
+    let fixture = _mint_fixture("missing.sfn", _missing_effect_source());
+
+    let rc = _check_exit(fixture);
+    assert rc != 0;
+
+    let combined = _check_output(fixture);
+    assert _contains(combined, "E0400");
+
+    fs.deleteFile(fixture);
+}
+
+// -------------------------------------------------------------------
+// Declared `![io]`: the same body with the correct annotation checks clean.
+// -------------------------------------------------------------------
+test "is effect-walk: effectful operand in io-annotated caller checks clean" ![io] {
+    let fixture = _mint_fixture("declared.sfn", _declared_effect_source());
+
+    let rc = _check_exit(fixture);
+    assert rc == 0;
+
+    let combined = _check_output(fixture);
+    assert ! _contains(combined, "E0400");
+
+    fs.deleteFile(fixture);
+}

--- a/compiler/tests/unit/parser_is_type_guard_test.sfn
+++ b/compiler/tests/unit/parser_is_type_guard_test.sfn
@@ -1,0 +1,88 @@
+// Unit tests for the `x is T` type-guard operator (issue #1753).
+//
+// Pins the parser-level structure of `Expression.Is` nodes: the variant
+// name, operand shape, target_type text, precedence relative to `&&`, and
+// generic targets. Mirrors the style of `effect_cast_operand_test.sfn` and
+// `parser_iife_postfix_test.sfn` — parse a short snippet, walk to the
+// relevant expression, and assert on fields.
+import { Expression } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+// Return the expression of the first return statement in the first top-level
+// function declaration of `source`.
+fn _return_expr(source: string) -> Expression ![io] {
+    let program = parse_program(source);
+    let fn_stmt = program.statements[0];
+    assert fn_stmt.variant == "FunctionDeclaration";
+    let ret = fn_stmt.body.statements[0];
+    assert ret.variant == "ReturnStatement";
+    let expr = ret.expression;
+    assert expr != null;
+    return expr;
+}
+
+// Return the condition expression of the first `if` statement inside the
+// first top-level function declaration of `source`.
+fn _if_condition(source: string) -> Expression ![io] {
+    let program = parse_program(source);
+    let fn_stmt = program.statements[0];
+    assert fn_stmt.variant == "FunctionDeclaration";
+    let if_stmt = fn_stmt.body.statements[0];
+    assert if_stmt.variant == "IfStatement";
+    return if_stmt.condition;
+}
+
+// -------------------------------------------------------------------
+// Basic parse: `v is Text` structures into Expression.Is with the right
+// operand variant and target_type text.
+// -------------------------------------------------------------------
+test "is type-guard: basic guard condition parses to Is node" ![io] {
+    let expr = _if_condition("fn f(v: Value) -> bool { if v is Text { } }");
+    assert expr.variant == "Is";
+    assert expr.operand.variant == "Identifier";
+    assert expr.target_type.text == "Text";
+}
+
+// -------------------------------------------------------------------
+// Return position: `return v is Text` also structures into Is.
+// -------------------------------------------------------------------
+test "is type-guard: guard in return position structures into Is" ![io] {
+    let expr = _return_expr("fn f(v: Value) -> bool { return v is Text; }");
+    assert expr.variant == "Is";
+    assert expr.operand.variant == "Identifier";
+    assert expr.target_type.text == "Text";
+}
+
+// -------------------------------------------------------------------
+// Generic target: `x is Foo<int>` carries the full generic text.
+// -------------------------------------------------------------------
+test "is type-guard: generic target carries full type text" ![io] {
+    let expr = _return_expr("fn f(x: Box) -> bool { return x is Foo<int>; }");
+    assert expr.variant == "Is";
+    assert expr.target_type.text == "Foo < int >";
+}
+
+// -------------------------------------------------------------------
+// Precedence: `x is Text && y` must parse as `(x is Text) && y`, i.e.
+// a Binary whose left is the Is node — `is` binds tighter than `&&`.
+// -------------------------------------------------------------------
+test "is type-guard: is binds tighter than &&" ![io] {
+    let expr = _return_expr("fn f(x: Value, y: bool) -> bool { return x is Text && y; }");
+    assert expr.variant == "Binary";
+    assert expr.operator == "&&";
+    assert expr.left.variant == "Is";
+    assert expr.left.operand.variant == "Identifier";
+    assert expr.left.target_type.text == "Text";
+    assert expr.right.variant == "Identifier";
+}
+
+// -------------------------------------------------------------------
+// Operand is not limited to identifiers: a member expression
+// (`obj.value is Text`) also structures into Is.
+// -------------------------------------------------------------------
+test "is type-guard: member-expression operand structures into Is" ![io] {
+    let expr = _return_expr("fn f(obj: Wrapper) -> bool { return obj.value is Text; }");
+    assert expr.variant == "Is";
+    assert expr.operand.variant == "Member";
+    assert expr.target_type.text == "Text";
+}

--- a/docs/proposals/0034-is-type-guard.md
+++ b/docs/proposals/0034-is-type-guard.md
@@ -1,0 +1,333 @@
+---
+sfep: 0034
+title: Structured, Enforced `x is T` Type-Guard Operator
+status: Accepted
+type: language
+created: 2026-06-28
+updated: 2026-06-28
+author: "agent:compiler-architect; agent:Sailbot (as-built revision); human review"
+tracking: "#1753"
+supersedes:
+superseded-by:
+graduates-to:
+---
+
+# SFEP-0034 — Structured, Enforced `x is T` Type-Guard Operator
+
+> Design record for issue #1753 (epic #1180, effect-system hardening). Related:
+> SFEP-0008 (effect validation as build gate). The v1 slice (named-enum
+> type-guards) is implemented end-to-end and self-hosts; the broader surface
+> (inline unions, primitives, else-complement narrowing) is deferred to the
+> fast-follows listed in §3.9 — hence `Accepted`, not `Implemented`.
+
+## 1. Summary
+
+Promote `x is T` from a parsed-but-unenforced construct — it degraded to
+`Expression.Raw`, contributed zero effects, and performed zero narrowing — into
+a **structured, enforced** type-guard operator. We add an `Is` expression node
+(modelled on the existing `as`→`Cast` path), make the effect checker walk its
+operand, make the formatter round-trip it, and lower `x is T` on a named `enum`
+operand to the enum's discriminant tag test. Crucially, the then-branch
+**narrows** the guarded operand to the tested variant — reusing the LLVM
+lowering's existing `narrowed_variant` machinery (the same flow-sensitive
+refinement that powers `if x.variant == "V"`), so member access inside the
+branch resolves against the narrowed variant. `if input is Text { input.value }`
+now works, reached through an ordinary `if`/`else`.
+
+## 2. Motivation
+
+`x is T` is the conventional, boring type-guard form (TypeScript `x is T`
+predicates, Python `isinstance`, Rust `matches!`). In Sailfin it was a trap:
+
+- `is` was **not a keyword or soft keyword** — it lexed as an `Identifier`.
+- There was **no `is` arm** in `parse_postfix_chain` — the postfix loop broke on
+  the non-`Symbol` `is` token, leaving `is T` unconsumed, and the leftover-token
+  guard forced the whole expression into the `Expression.Raw` fallthrough.
+- A `Raw` condition contributes **zero effects** (since #1186) and **zero
+  narrowing** — so an effectful operand (`readFile() is T`) reached codegen
+  effect-blind (the exact headline-integrity gap epic #1180 is closing), and the
+  branch bodies saw the operand at its un-narrowed type.
+
+Per the project principle "don't ship unfinished safety claims," we either remove
+the construct or finish it. This SFEP finishes it for the canonical sum type
+(named enums), the case where a type guard earns its keep.
+
+## 3. Design
+
+### 3.1 Lexing
+
+No lexer change. `is` is recognized at parse time via
+`identifier_matches(token, "is")`, exactly as `as` is and import-aliases are.
+Keeping it a soft keyword (not reserved) preserves identifiers named `is` and
+keeps the old seed — which lexes `is` as an identifier — compatible (see §5).
+
+### 3.2 Parsing
+
+An `is` arm in `parse_postfix_chain` (`parser/expressions.sfn`), placed right
+after the `as` arm, builds `Expression.Is { operand, target_type }`. The target
+is read by `read_is_target` — a narrower sibling of `read_cast_target` that
+accepts **only** a named type with an optional generic argument list (`Foo`,
+`Foo<X, Y>`): no pointer prefix (`* T`) and no fn-pointer (`fn (A) -> B`) forms,
+which are meaningless as a runtime type predicate. A non-identifier target falls
+through to a parse failure → `Raw`.
+
+**Precedence.** Placing `is` in the postfix loop makes it postfix-tight, like
+`as`. `x is T && y` parses as `(x is T) && y` because `&&` is a `Symbol` handled
+by the lower binding-power climb, which terminates the postfix chain first.
+`!(x is T)` and `x is T == z` likewise parse with the guard innermost. We do not
+introduce a bespoke infix precedence tier (it would diverge from `as` for no
+realistic gain).
+
+### 3.3 AST
+
+One variant added to `Expression` (`ast.sfn`), beside `Cast`:
+
+```sfn
+Is { operand: Expression, target_type: TypeAnnotation },
+```
+
+Field names `operand` / `target_type` match `Cast`, so they share the enum's
+per-name field slots (no GEP collision — see the `Assignment` field-name note).
+`TypeAnnotation { text: string }` carries the target type verbatim.
+
+### 3.4 Effect checking
+
+An `Is` arm in `collect_effects_from_expression` (`effect_checker.sfn`),
+identical to the `Cast`/`Unary` arms, recurses into `operand` only:
+
+```sfn
+if expression.variant == "Is" {
+    return collect_effects_from_expression(expression.operand, imports);
+}
+```
+
+The target type carries no effect; the operand is the effectful surface. This
+closes the effect-blind hole: `readFile() is T` now surfaces `![io]`. The
+typecheck `walk_expression` gains a matching `Is` arm that recurses into the
+operand so inner diagnostics (undefined symbols, fn-value misuse, parse-error
+nodes) still fire.
+
+### 3.5 Narrowing model (as built — reuse the existing machinery)
+
+The drafted design proposed adding a `narrowed_type`/`declared_type` field to the
+typecheck `SymbolEntry`. **Implementation discovery superseded that plan:** the
+typecheck pass tracks names only (`SymbolEntry` has no type field) and performs no
+expression-type inference (#829), so a typecheck-level narrowing slot would have
+**no consumer** — nothing in `sfn check` reads a refined type. Meanwhile the LLVM
+lowering **already implements flow-sensitive narrowing**: a `ParameterBinding` /
+`LocalBinding` carries a `narrowed_variant` field, and `lower_if_instruction`
+already narrows a guarded operand in the then-branch for a condition of the exact
+shape `<base>.variant == "<V>"` (parsed by `_parse_variant_guard`), which
+`lower_enum_member_access` then consumes to resolve `<base>.field` against variant
+`V`.
+
+So `is` narrowing **reuses that machinery** rather than building a redundant
+parallel substrate in typecheck:
+
+1. `_parse_is_guard` (in `instructions_if.sfn`) recognizes the formatted guard
+   `(base) is Variant` — stripping the operand's enclosing parens, requiring a
+   simple-identifier base and a simple-identifier variant — and returns the same
+   `_VariantGuard { base, variant }` the `.variant ==` form produces.
+2. `lower_if_instruction` tries `_parse_variant_guard` first, then falls back to
+   `_parse_is_guard`. Either way the existing then-branch overlay
+   (`_narrow_locals_for_variant` / `_narrow_bindings_for_variant`) sets
+   `narrowed_variant` for the guarded operand, and `_restore_narrowing` clears it
+   after the branch so it does not leak.
+
+The result: `if input is Text { input.value }` narrows `input` to `Text` in the
+then-branch with **zero new narrowing infrastructure** — it is exactly the
+`if input.variant == "Text"` path with an `is` front door.
+
+**Then-branch only.** The existing machinery narrows the then-branch; there is no
+else-branch complement narrowing (deferred — §3.9). **Simple-identifier operand
+only** (the existing restriction); a member/call operand lowers and effect-walks
+but does not narrow.
+
+### 3.6 Lowering model (named enums in v1)
+
+The condition reaches LLVM lowering as rendered `.sfn-asm` text: the native-IR
+formatter (§3.7) serializes `Is` to `(operand) is <type>`, and
+`lower_condition_to_i1` lowers it via `lower_expression`. The new pieces:
+
+1. **`parse_is_expression`** (`core_parsing.sfn`) — the lowering shadow re-parser,
+   mirroring `parse_cast_expression`: scan for a top-level ` is ` outside
+   brackets/strings; split into operand + target type. It **declines** when the
+   target carries a top-level (angle-depth-0) whitespace — that means `is` is not
+   the outermost operator (`x is T && y`, `x is T == z`), so the dispatcher peels
+   the logical/comparison operator first. Generic targets keep their inner spaces
+   at angle-depth ≥ 1 and are accepted whole.
+2. **Dispatch** in `lower_expression` (`core.sfn`), placed **after** the logical
+   (`&&`/`||`) split (so chained guards peel first) but **before** the
+   comparison/bitwise finders (so a generic target's `<>` is not mis-split).
+3. **`lower_is_expression`** (`core_literals_lowering.sfn`) — lowers the operand,
+   resolves its enum from the LLVM type via `find_enum_info_by_llvm_type` (strip a
+   pointer suffix for the boxed-struct ABI), resolves the target variant via
+   `resolve_enum_variant_info`, extracts/loads the discriminant tag (field 0;
+   `getelementptr`+`load` for a pointer operand, `extractvalue` for a by-value
+   aggregate), and emits `icmp eq` against the variant's tag — the **same**
+   discriminant test `match` emits (`instructions_match_condition.sfn`).
+
+**v1 scope — enum operands.** A **named `enum`** operand is fully supported
+(boolean + then-branch narrowing). A **non-enum** operand (inline `string | int`
+union, primitive, plain struct) is **not** supported: `lower_is_expression`
+returns no value with a `llvm lowering: is on a non-enum value ...` diagnostic.
+Because in-branch narrowing of those surfaces (extracting a union payload for an
+identifier use) is not wired — the `narrowed_variant` flow is enum-based —
+shipping a boolean without the narrowed use would be a half-feature. They are
+fast-follows (§3.9). Note: lowering diagnostics are non-fatal in `build`/`run`
+(consistent with `cast`/`match` unsupported-case handling), and `sfn check` is
+frontend-only, so a non-enum `is` is not statically rejected today — it is a
+documented limitation pending expression-type inference (#829).
+
+### 3.7 Formatter
+
+A source-level `sfn fmt` round-trips `x is T` (verified `fmt --check`-stable). The
+native-IR formatter (`emit_native_format.sfn`) serializes `Is` to
+`(operand) is <type>` — the exact text `parse_is_expression` consumes; the
+operand parens are load-bearing so `strip_enclosing_parentheses` recovers an
+operand with embedded operators, exactly as the `Cast` formatter does.
+
+### 3.8 Worked example (`examples/advanced/type-guards.sfn`)
+
+```sfn
+enum Input {
+    Text { value: string },
+    Number { amount: int },
+}
+
+fn process(input: Input) ![io] {
+    if input is Text {
+        print("It's a string: {{input.value}}");   // input: Text in this branch
+    } else {
+        print("It's a number: {{input.amount}}");
+    }
+}
+```
+
+`input is Text` lowers to a tag `extractvalue`/`icmp eq`; the then-branch narrows
+`input` to `Text` so `input.value` resolves. Verified output:
+`It's a string: Sail` / `It's a number: 42`.
+
+### 3.9 Scope & slicing — ONE PR, deferred fast-follows
+
+v1 (this PR) ships, for **named enum operands**: the structured `Is` node, the
+parser arm, effect-walk, formatter round-trip, the enum-discriminant boolean
+lowering, and then-branch narrowing via the reused `narrowed_variant` machinery.
+
+**Deferred fast-follows** (file as sub-issues of #1180):
+- `is` on **inline unions** (`string | int`) and **primitives** — needs
+  union-payload narrowing for in-branch identifier use.
+- **Else-branch complement** narrowing.
+- **Member/index/call operand** narrowing.
+- **`&&`-chained guard** narrowing.
+- A **static (frontend) diagnostic** for a non-enum operand — blocked on
+  expression-type inference (#829).
+
+**Seed dependency — BUNDLE, no seed cut.** All v1 pieces are compiler-source with
+a single consumer (the compiler + the converted example). The old pinned seed
+lexes `is` as an identifier and the compiler source contains no `x is T`, so
+`make compile` builds the new compiler from the old seed, which then compiles the
+converted example in the same self-host pass. No `/pin-seed`.
+(`.claude/rules/seed-dependency.md`.)
+
+## 4. Effect & capability impact
+
+`is` is effect-transparent: it requires the union of its operand's effects and
+adds none. The change is a **net tightening** — `readFile() is T` previously
+parsed to `Raw` and dropped the operand's `![io]`; now the structured `Is` node
+forces the operand to be walked and the requirement surfaces. This advances
+SFEP-0008 and epic #1180's headline-integrity goal by removing one more
+`Raw`-degradation effect hole. No new effects, no capability-manifest change.
+
+## 5. Self-hosting impact
+
+Passes touched, in pipeline order:
+
+- **Lexer** — no change (`is` stays a soft keyword).
+- **Parser** (`parser/expressions.sfn`) — `is` postfix arm + `read_is_target`.
+- **AST** (`ast.sfn`) — `Is { operand, target_type }` beside `Cast`.
+- **Typecheck** (`typecheck.sfn`) — a `walk_expression` `Is` arm (operand
+  recursion). **No `SymbolEntry` change** (the drafted field was dropped — see
+  §3.5).
+- **Effect checker** (`effect_checker.sfn`) — the one-line `Is` operand-passthrough.
+- **Formatter** (`emit_native_format.sfn`) — the `Is` serialization arm.
+- **LLVM lowering** — `parse_is_expression` (`core_parsing.sfn`), dispatch
+  (`core.sfn`), `lower_is_expression` (`core_literals_lowering.sfn`), and
+  `_parse_is_guard` + guard-fallback wiring (`instructions_if.sfn`).
+
+**Self-hosting invariant preserved.** The change is **additive** and the old seed
+is unaffected: it lexes `is` as an identifier and the compiler source uses no
+`x is T`, so `make compile` builds the new compiler from the old seed; that
+compiler then compiles the converted example in the same pass. No seed cut.
+Verified: `make compile` (exit 0) after the change.
+
+## 6. Alternatives considered
+
+- **Narrowing via a new `SymbolEntry` type field (the drafted model (a)).**
+  Rejected on implementation: typecheck has no expression-type inference (#829),
+  so a typecheck refinement slot has no consumer; the LLVM lowering already owns
+  flow narrowing (`narrowed_variant`). Reusing it is smaller and is the layer
+  that actually drives codegen.
+- **A side-table narrowing environment.** Rejected — duplicates the binding
+  plumbing the lowering already threads.
+- **Shipping inline-union / primitive `is` in v1.** Deferred — in-branch payload
+  narrowing for unions is not wired and would be a half-feature; the enum case is
+  the canonical, fully-working surface.
+- **`is` as a reserved keyword.** Rejected per "keywords are expensive"; the soft
+  keyword (the `as` precedent) keeps the old seed compatible.
+- **A custom infix precedence tier for `is`.** Rejected — diverges from `as` for
+  no realistic gain.
+- **Multi-type RHS (`x is (A | B)`).** Rejected for v1 — a guard tests one
+  variant; multi-type is sugar for an `||` of guards (a follow-up).
+
+## 7. Stage1 readiness mapping
+
+- [x] **Parses** — `is` postfix arm + `read_is_target` produce a structured `Is`
+  node (no `Raw` fallthrough).
+- [x] **Type-checks / effect-checks** — `walk_expression` `Is` arm + effect-walk
+  `Is` arm; effectful operand surfaces its effect (`E0400`).
+- [x] **Emits valid `.sfn-asm`** — native formatter serializes `(operand) is
+  <type>`; round-trips through `parse_is_expression`.
+- [x] **Lowers to LLVM IR** — `lower_is_expression` emits the tag
+  `extractvalue`/`getelementptr`+`load` + `icmp eq` for enum-variant targets.
+- [x] **Regression coverage** — parser unit, effect-walk integration, and
+  build-and-run e2e tests (§8).
+- [x] **Self-hosts** — `make compile` (exit 0); old seed compiles the new
+  compiler, which compiles the converted example.
+- [x] **`sfn fmt --check` clean** — every touched `.sfn` under `compiler/src/`
+  and `examples/`.
+- [x] **Documented** — `docs/status.md` flips `is` to shipped (enum scope noted);
+  spec chapter added; `examples/advanced/type-guards.sfn` rewritten to real `is`.
+
+(Checked for the **v1 enum slice**. The SFEP stays `Accepted` rather than
+`Implemented` because the §3.9 fast-follows — unions/primitives, else-complement —
+are out of this slice.)
+
+## 8. Test plan
+
+- **`compiler/tests/unit/parser_is_type_guard_test.sfn`** — `x is T` parses to a
+  structured `Is` node (operand Identifier, `target_type.text`); generic target
+  captured; `x is T && y` parses as `(x is T) && y` (Binary with `Is` left).
+- **`compiler/tests/integration/is_effect_walk_test.sfn`** — a pure caller with
+  `<effectful call> is <Variant>` is rejected for the missing effect; the same
+  body with `![io]` compiles.
+- **`compiler/tests/e2e/is_type_guard_test.sfn`** — build and run an enum `is`
+  program; assert the then-branch narrowing + member access output (`T:hi` / `N`),
+  threading `PATH` / `SAILFIN_TEST_SCRATCH` per `.claude/rules/no-bash-e2e.md`.
+- **Self-host** — `make compile` + the full suite; the converted example
+  participates in the seedcheck corpus.
+
+## 9. References
+
+- Issue #1753 (this feature); epic #1180 (effect-system hardening).
+- SFEP-0008 (`docs/proposals/0008-effect-validation.md`) — effect validation as
+  build gate; this SFEP closes one `Raw`-degradation effect hole.
+- `.claude/rules/seed-dependency.md` — the bundle decision (no seed cut).
+- Key source: `parser/expressions.sfn` (`is` arm, `read_is_target`); `ast.sfn`
+  (`Is`); `effect_checker.sfn` / `typecheck.sfn` (operand walk);
+  `emit_native_format.sfn` (formatter); `core_parsing.sfn`
+  (`parse_is_expression`); `core_literals_lowering.sfn` (`lower_is_expression`);
+  `core.sfn` (dispatch); `instructions_if.sfn` (`_parse_is_guard`, narrowing
+  reuse via `narrowed_variant`); `instructions_match_condition.sfn` (the
+  discriminant-test prior art).
+- TypeScript `x is T` type predicates; Rust `matches!` — prior art.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -56,6 +56,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0031](./0031-inline-export-decl.md) | Inline `export <declaration>` syntax | Implemented | language |
 | [0032](./0032-untyped-lambda-param-inference.md) | Infer Untyped Lambda Parameter/Return Types from the Call Site | Implemented | language |
 | [0033](./0033-string-runtime-length-aware-abi.md) | Length-aware ({i8*, i64}) ABI for query-side string runtime helpers | Accepted | runtime |
+| [0034](./0034-is-type-guard.md) | Structured, Enforced `x is T` Type-Guard Operator | Accepted | language |
 
 ## Subdirectories
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-06-24. Seed pinned to `0.7.0-alpha.39` (`.seed-version`);
+Updated: 2026-06-28. Seed pinned to `0.7.0-alpha.39` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -130,7 +130,10 @@ here.
   can start an expression *and* a top-level `:` follows. The remaining
   Raw-degraded effect-escapes (prefix `*`/`&`, assignment-as-expression) are
   tracked under epic #1180 (#1180-c) behind a blanket fail-closed `Raw` backstop.
-  Effect polymorphism (`!E` variables, polymorphic HOFs) remains post-1.0.
+  The `is` type-guard hole is **closed in #1753**: `<operand> is T` now parses
+  to a structured `Is` AST node (not `Expression.Raw`), and the effect checker
+  walks the operand — so `readFile() is T` correctly requires `![io]`. Effect
+  polymorphism (`!E` variables, polymorphic HOFs) remains post-1.0.
 - **Undefined free-function rejection** (`E0420`, #616/#812): unresolvable
   bare-identifier callees fail typecheck.
 - **Function references**: a bare fn name in value position lowers to the
@@ -155,6 +158,7 @@ here.
 | `if`/`else`, `for` | Shipped | |
 | `loop` / `break` / `continue` | Shipped | `while` is intentionally not a keyword (`E0411` with a `loop` fix-it) |
 | `match` | Shipped | Literals, `_`, guards, enum-variant destructuring |
+| `x is T` type-guard operator | **Shipped** (enum operands; #1753) | Parses to a structured `Is` AST node; effect checker walks the operand (closes the `Raw`-degradation effect-blind hole in epic #1180). Lowers to the enum's discriminant tag test and narrows the operand to the matched variant in the then-branch — same flow-sensitive narrowing as `match`. v1 scope: **named `enum` operands only**; non-enum unions, primitives, and plain structs are deferred. Else-branch complement narrowing is also deferred. See `examples/advanced/type-guards.sfn` |
 | `try`/`catch`/`finally` | Shipped | Maps to runtime exceptions |
 | String interpolation (`{{ }}`) | Shipped | `${ }` migration planned pre-1.0 (see Known Design Issues) |
 | Pattern-match exhaustiveness | Partial | Runtime backstop (`match_exhaustive_failed`) |

--- a/examples/advanced/type-guards.sfn
+++ b/examples/advanced/type-guards.sfn
@@ -1,47 +1,22 @@
 // examples/advanced/type-guards.sfn
-struct User {
-    name: string;
-    age: int;
+// A tagged enum is the canonical sum type the `x is T` type-guard refines.
+enum Input {
+    Text { value: string },
+    Number { amount: int }
 }
 
-struct StringInput {
-    value: string;
-}
-
-struct IntInput {
-    value: int;
-}
-
-// Runtime type refinement on a tagged union: matching on named struct variants
-// is the shipped discriminator (mirrors examples/basics/error-handling.sfn). The
-// `i32` union tag drives the arm selection.
-fn process(input: StringInput | IntInput) ![io] {
-    match input {
-        StringInput { value } => print("It's a string: {{value}}"),
-        IntInput { value } => print("It's a number: {{value}}")
+// The `x is T` type-guard operator (#1753): `input is Text` is a structured,
+// enforced predicate. It lowers to the enum's discriminant test, and the
+// then-branch narrows `input` to the `Text` variant so `input.value` resolves
+// against it — the same flow-sensitive narrowing `match` uses, reached through
+// an ordinary `if`/`else`.
+fn process(input: Input) ![io] {
+    if input is Text { print("It's a string: {{input.value}}"); } else {
+        print("It's a number: {{input.amount}}");
     }
 }
 
-// Planned future syntax — the `x is T` type-guard operator (not yet shipped; it
-// has no parser arm and degrades to an unstructured node). Tracked by #1753:
-//
-//     fn process(input: string | int) ![io] {
-//         if input is string {
-//             print("It's a string: {{input}}");
-//         } else {
-//             print("It's a number: {{input}}");
-//         }
-//     }
 fn main() ![io] {
-    process(StringInput { value: "Sail" });
-    process(IntInput { value: 42 });
-
-    let user = User { name: "Robin", age: 22 };
-
-    match user {
-        User { name, age }
-        if age >= 18 => print("Adult user: {{name}}"),
-        User { name, age } => print("Minor user: {{name}}"),
-        _ => print("Unknown entity")
-    }
+    process(Input.Text { value: "Sail" });
+    process(Input.Number { amount: 42 });
 }

--- a/site/src/content/docs/docs/reference/spec/05-expressions.md
+++ b/site/src/content/docs/docs/reference/spec/05-expressions.md
@@ -12,11 +12,11 @@ sidebar:
 | Comparison | `==` `!=` `<` `>` `<=` `>=` |
 | Logical | `&&` `\|\|` `!` |
 | Compound assignment | `+=` `-=` `*=` `/=` |
-| Type check | `is` |
+| Type-guard | `is` |
 | Borrow | `&expr` `&mut expr` |
 | Cast | `expr as Type` |
 
-`&&` and `||` short-circuit. `is` performs a runtime type check and returns `boolean`.
+`&&` and `||` short-circuit. `is` tests whether an enum value is a specific variant (see §5 "Type-guard operator") and returns `bool`.
 
 Operator precedence: unary > multiplicative > additive > comparison > equality > `&&` > `||` > assignment.
 
@@ -96,3 +96,40 @@ A lambda's parameter and return types may be **omitted** when it is passed direc
 
 - **Source-level signedness is not tracked through casts.** Sailfin's `i8`/`u8`/`i16`/`u16`/`i32`/`u32` annotations all collapse to LLVM `i8`/`i16`/`i32`, so `255_u8 as u64` lowers as `sext` and produces `-1` instead of `255`. Tracked in [issue #295](https://github.com/SailfinIO/sailfin/issues/295)/[#296](https://github.com/SailfinIO/sailfin/issues/296) follow-ups.
 - **Mixed `int` + `float` in a binary op (without an explicit cast) still silently widens to `double`** — the architect-planned `dominant_type` tightening that would reject this rides on Slice E (`number` retirement). Workaround today: spell the cast (`x as float + y` or `x + y as int`). Tracked in [issue #296](https://github.com/SailfinIO/sailfin/issues/296).
+
+## Type-guard operator (`is`)
+
+`expr is Variant` tests whether a named `enum` value is a specific variant. It is an infix binary operator with the same precedence as comparison operators, and it returns `bool`.
+
+```sfn
+enum Input {
+    Text { value: string },
+    Number { amount: int }
+}
+
+fn process(input: Input) ![io] {
+    if input is Text {
+        print("It's a string: {{input.value}}");
+    } else {
+        print("It's a number: {{input.amount}}");
+    }
+}
+```
+
+### Semantics
+
+- **Discriminant test.** `x is Variant` lowers to the enum's discriminant tag comparison — the same check `match` uses for an enum-variant arm.
+- **Flow-sensitive narrowing (then-branch).** Inside the `if`-`is` then-branch the compiler narrows the operand's type to the tested variant. Member accesses against the narrowed binding (`input.value` above) resolve against that variant's payload fields — the same narrowing `match` applies to a destructured arm.
+- **Effect transparency.** The effect checker walks the operand of `is`. If the operand expression itself requires effects (e.g. `readFile() is T`), those effects must be declared on the enclosing function. The operator adds no effects of its own.
+- **Returns `bool`.** The result is an ordinary boolean expression usable in any boolean context — `if`, `&&`/`||`, `let b = x is Variant`, etc.
+
+### v1 scope and limitations
+
+The current implementation supports `is` on **named `enum` operands only**. The following are not yet supported and are deferred:
+
+- Non-enum operands: inline union types (`string | int`), primitives, and plain structs.
+- Else-branch complement narrowing: the else-branch does not narrow the operand to the complement set of variants.
+
+These limitations exist because the typecheck pass does not yet perform general expression-type inference ([#829](https://github.com/SailfinIO/sailfin/issues/829)), and the lowering's narrowing machinery is enum-discriminant-based. Non-enum narrowing will be addressed when expression-type inference lands.
+
+The worked example is `examples/advanced/type-guards.sfn`.

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -173,7 +173,7 @@ const postV1Platform: RoadmapCategory = {
 const exploration: RoadmapItem[] = [
   { label: "Perf-parity native backend — the post-1.0 long tail beyond the seal-sufficient backend (#1640): full optimization and codegen maturity after the 1.0 capability seal lands", status: "planned" },
   { label: "Structured concurrency (v0 shipped) — routine, channel, spawn/await, parallel, scheduler work today; atomics beyond channel-send and richer sync primitives are post-1.0", status: "in-progress" },
-  { label: "Effect system hardening — wire validate_effects() into compilation gate, hierarchical effects, polymorphism", status: "planned" },
+  { label: "Effect system hardening — validate_effects() is a build gate (shipped); Raw-degradation holes closed for cast (#1627), ternary (#1690), and is type-guard (#1753); remaining: prefix */& and assignment-as-expression (#1180-c); hierarchical effects and polymorphism post-1.0", status: "in-progress" },
   { label: "Phase 2 containers — closures with capture, generic constraints, drop emission", status: "planned" },
   { label: "Documentation expansion — production-quality site coverage, remove legacy stage references", status: "planned" },
   { label: "LLM adoption levers — llms.txt, sfn check --json, MCP server, Rosetta Code corpus", status: "planned" },


### PR DESCRIPTION
## Summary
- Promotes `x is T` from a parsed-but-unenforced construct (it degraded to `Expression.Raw` — zero effects, zero narrowing) into a **structured, enforced** type-guard operator: a structured `Is` AST node that the effect checker and typecheck walker recurse into, the formatter round-trips, and the LLVM lowering turns into the enum discriminant test.
- For a named `enum` operand, `x is T` lowers to the tag test (`extractvalue`/`load` + `icmp eq`) and **narrows the operand in the then-branch** to the tested variant — reusing the existing `narrowed_variant` machinery (the `if x.variant == "V"` path) — so `if input is Text { input.value }` works through an ordinary `if`/`else`.
- Closes one Raw-degradation effect-blind hole for epic #1180: `readFile() is T` now correctly requires `[io]`.

Closes #1753

## Design (SFEP-0034)
Design record: `docs/proposals/0034-is-type-guard.md` (this PR creates it; status `Accepted`, registry row added). The user approved the design gate, then asked to implement immediately.

**⚠️ Deviations from the drafted design — please review (all documented in SFEP-0034 §3.5/§3.6/§3.9):**
1. **Narrowing reuses the existing LLVM `narrowed_variant` machinery** instead of the drafted typecheck `SymbolEntry` substrate (model a). Discovery during implementation: typecheck tracks names only and has no expression-type inference (#829), so a typecheck refinement slot would have had **no consumer**, while the lowering already implements flow narrowing. This is smaller and lands the narrowing at the layer that drives codegen.
2. **v1 scope is named `enum` operands** (not the inline `string | int` union from the original issue example). The `narrowed_variant` flow is enum-based; the example was rewritten to a named enum.
3. **Then-branch narrowing only** (no else-branch complement) — the existing machinery narrows the then-branch.
4. **Non-enum operands** produce a non-fatal lowering diagnostic, not a clean static error (frontend has no types, #829).

Items 2–4 are deferred fast-follows (SFEP-0034 §3.9), to be filed as #1180 sub-issues.

## Acceptance criteria (as-built v1)
- [x] `x is T` parses to a structured `Is` node (no `Raw` fallthrough)
- [x] effect checker walks the operand (effectful operand surfaces its effect — `E0400`)
- [x] formatter round-trips (`(operand) is <type>`; `!(x is T)` keeps its negation)
- [x] enum operand lowers to a correct boolean discriminant + then-branch variant narrowing (member access resolves)
- [x] regression coverage (parser unit, effect-walk integration, build-and-run e2e incl. negated guard)
- [x] self-hosts (`make compile`)
- [x] `sfn fmt --check` clean on every touched `.sfn`
- [x] `examples/advanced/type-guards.sfn` rewritten to real `is`; `docs/status.md` + spec §5 + roadmap updated

## Map reconciliation
The issue had no `## Files Affected` map (it was design-gated/ungroomed). The implemented surface matches SFEP-0034 §5, with the narrowing landing in `llvm/lowering/instructions_if.sfn` (reusing existing machinery) rather than a new `typecheck_types.sfn` `SymbolEntry` field — see deviation #1 above.

## Verification
```
make compile                     # self-hosts, exit 0
make test                        # unit 182/182, integration 42/42, e2e 166/166, capsules 38/38 — status: pass
sfn fmt --check <all touched>    # clean
build/native/sailfin run examples/advanced/type-guards.sfn
  → It's a string: Sail
  → It's a number: 42
```
Code-reviewer (Opus) gate run on the diff: 2 should-fix findings (`!(x is T)` formatter gap; generic-target precedence guard) — both **fixed and re-verified**, with a negated-guard regression test added.

## Files changed
- Compiler: `ast.sfn`, `parser/expressions.sfn`, `effect_checker.sfn`, `typecheck.sfn`, `emit_native_format.sfn`, `llvm/.../core_parsing.sfn`, `core_literals_lowering.sfn`, `core.sfn`, `llvm/lowering/instructions_if.sfn`
- Tests: `tests/unit/parser_is_type_guard_test.sfn`, `tests/integration/is_effect_walk_test.sfn`, `tests/e2e/is_type_guard_test.sfn`
- Docs/example: `docs/proposals/0034-is-type-guard.md`, `docs/proposals/README.md`, `docs/status.md`, `spec/05-expressions.md`, `roadmap.astro`, `examples/advanced/type-guards.sfn`

https://claude.ai/code/session_01AJVWriJr5ms212f9KqWJQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJVWriJr5ms212f9KqWJQG)_