### PR TITLE
fix(lowering): cross-dir method-bearing struct import lowers under --import-context (#1701)

### DIFF
--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -47,6 +47,7 @@ import {
 
 import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } from "../../assert_failure";
 import { Program, Statement } from "../../ast";
+import { LinkPlan, LlvmTextBackend } from "../../backend";
 import { assemble_runtime_capsule_link_inputs } from "../../build/runtime_objs";
 import {
     CacheKey,
@@ -87,7 +88,6 @@ import {
     _suite_name_from_path,
     _write_text_cmd
 } from "../../cli_commands_utils";
-import { link_test_objects } from "../../cli_main";
 import { ImportSymbolTable, empty_import_symbols } from "../../effect_imports";
 import { compile_tests_to_llvm_file_with_module_imports, module_name_from_path } from "../../main";
 import { LayoutManifest } from "../../native_ir";
@@ -1326,10 +1326,27 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     // them (keeps the link complete without double-adding).
     if !has_lm { libs.push("-lm"); }
     if !has_pthread { libs.push("-pthread"); }
-    // Dispatch through the `Backend` seam via the cli_main entry point
-    // (kept there to avoid a cross-dir `../../backend` import; see
-    // `link_test_objects`). Reproduces the prior test-link argv exactly.
-    return link_test_objects(rt.object_paths, ir_inputs, out_path, libs);
+    // Dispatch the test-binary link directly through the `Backend` seam.
+    // This is a cross-directory `../../backend` import of the method-bearing
+    // `LlvmTextBackend`; the #1687 workaround that routed it through
+    // `cli_main::link_test_objects` was removed once #1701 (cross-dir
+    // method-bearing struct lowering under `--import-context`) was fixed. The
+    // `backend.link` *called*-method path here was the one repaired by #1701's
+    // `find_declare_signature_t` correction (#1739/#1740 had already fixed the
+    // uncalled/vtable-only method path). Reproduces the prior test-link argv
+    // exactly (test_mode).
+    let backend = LlvmTextBackend { };
+    let no_link_flags: string[] = [];
+    let plan = LinkPlan {
+        objects: rt.object_paths,
+        ir_inputs: ir_inputs,
+        out_path: out_path,
+        opt_flag: "-O0",
+        link_flags: no_link_flags,
+        libs: libs,
+        test_mode: true
+    };
+    return backend.link(plan);
 }
 
 // Resolve the per-test scratch root used for the test runner's

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -857,30 +857,16 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
     return LinkResult { rc: rc, stats: inputs.stats };
 }
 
-// Test-binary link entry point for the `sfn test` command. Lives here
-// (sibling to `backend.sfn`) rather than in `cli/commands/test.sfn`
-// because lowering a cross-directory `../../backend` import of the
-// method-bearing `LlvmTextBackend` under the build's import-context fails
-// (a separate compiler limitation; standalone emit and same-dir
-// `./backend` imports both lower fine). The test command threads the
-// already-ordered pieces (runtime objects, IR inputs, deduped libs) and
-// this helper builds the test-layout `LinkPlan` and dispatches through the
-// `Backend` seam.
-fn link_test_objects(objects: string[], ir_inputs: string[], out_path: string, libs: string[]) -> int ![io] {
-    let backend = LlvmTextBackend { };
-    let no_link_flags: string[] = [];
-    let plan = LinkPlan {
-        objects: objects,
-        ir_inputs: ir_inputs,
-        out_path: out_path,
-        opt_flag: "-O0",
-        link_flags: no_link_flags,
-        libs: libs,
-        test_mode: true
-    };
-    return backend.link(plan);
-}
-
+// (#1701) The `link_test_objects` indirection that previously lived here —
+// the #1687 workaround for the cross-directory `../../backend` import of the
+// method-bearing `LlvmTextBackend` failing to lower under the build's
+// import-context — was removed once that lowering path was fixed. The
+// uncalled/vtable-only method sub-case was fixed by #1739/#1740
+// (`find_vtable_method_signature`); the *called*-method sub-case (the
+// cross-dir invalid-`declare` failure this `backend.link` call hit) was fixed
+// by #1701's `find_declare_signature_t` correction. `cli/commands/test.sfn`
+// now constructs the test-layout `LinkPlan` and dispatches through the
+// `Backend` seam directly via a `../../backend` import.
 fn _clang_link(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> LinkResult ![io] {
     // Default link used by `build` and `run` for single-module programs.
     let resolved_cache_dir = _resolve_sailfin_cache_dir(cache_dir);

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1051,7 +1051,16 @@ fn find_declare_signature_t(trimmed: string[], symbol: string) -> DeclareSignatu
                 let params_start = call_pos + call_needle.length;
                 let close_paren = index_of(substring(line, params_start, line.length), ")");
                 if close_paren >= 0 {
-                    let params_text = substring(trimmed, params_start, params_start
+                    // #1701: read the parameter list from `line` (the current
+                    // line string), NOT `trimmed` (the whole line array). The
+                    // typo made the call-site signature fallback parse garbage
+                    // params — an empty `()` (clang-tolerated) for the
+                    // compiler's own `cli/commands/test` → `backend.link`, but
+                    // an unparseable `(s)` for a generic cross-dir
+                    // method-bearing-struct consumer under `--import-context`,
+                    // so its injected `declare` was invalid IR and the module
+                    // failed to lower.
+                    let params_text = substring(line, params_start, params_start
                         + close_paren);
                     if ret_type.length > 0 {
                         // Strip parameter values, keeping only types.

--- a/compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn
+++ b/compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn
@@ -1,0 +1,153 @@
+// End-to-end regression for #1701: a module in a NESTED directory that
+// imports a method-bearing struct from another directory via a
+// cross-directory relative import (`../../backend`), constructs it, and
+// calls a method, must lower to VALID IR under the build's per-module
+// `--import-context` staging path — the path `sfn build -p <dir>` drives.
+//
+// Symptom (#1701): the cross-dir consumer's per-module emit ran with
+// `--import-context`, but the imported struct's interface vtable referenced
+// method symbols that were never rewritten to the provider's
+// module-qualified symbol nor declared, so IR validation rejected the
+// output and the resolver reported `capsule-resolver: failed to lower
+// <module> to LLVM IR`. Crucially the bug needed BOTH conditions: the
+// cross-directory import AND the build's import-context staging — standalone
+// emit (no import-context) and same-directory imports both lowered fine.
+//
+// This is a build-only failure of the #1389 class: `sfn check` models no
+// codegen/link and passes; the bug surfaces only at `sfn build` / IR
+// validation. The failure had two sub-cases in the mangling pass's imported
+// struct-method handling: an *uncalled* method referenced only by the
+// interface vtable (fixed by #1739/#1740's `find_vtable_method_signature`),
+// and a *called* method whose injected external `declare` got a garbage
+// parameter list from a `substring(trimmed, ...)` typo in
+// `find_declare_signature_t`'s call-site recovery — empty `()` for the
+// compiler's own `cli/commands/test` → `backend.link` (clang-tolerated) but
+// unparseable `(s)` here, so the module failed to lower. #1701 fixed the
+// called-method path (`trimmed` → `line`). This fixture exercises BOTH: it
+// calls `run` (the called-method path) and leaves `describe` vtable-only.
+// #1740's e2e test (`interface_vtable_consumer_declares_test.sfn`) covers the
+// SAME-DIR single-file shape; this test pins the distinct CROSS-DIR + `-p`
+// import-context shape from #1701 so it cannot regress as #347 / #1640 grow
+// the backend surface across modules.
+//
+// The fixture mirrors the LlvmTextBackend/Backend shape from
+// `compiler/src/backend.sfn`: a fieldless struct that structurally
+// implements a two-method interface, whose methods carry `![io]` and take a
+// struct parameter. The nested consumer calls exactly ONE interface method,
+// leaving the other vtable-only (the #1739 trigger), and reaches the
+// provider through a cross-directory `../../backend` import.
+//
+// NOTE: assert on captured stdout+stderr with `sfn/strings` predicates
+// (the `sfn/test` `expect_*` matchers are `![pure]` and cannot be called
+// from an `![io]` test). (#842.)
+import { find, contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// The build spawns a nested `clang` + linker, so the child needs `PATH`
+// (an empty `run_capture` env is the *empty* environment, not "inherit").
+// `SAILFIN_TEST_SCRATCH` routes the `program.ll` build-cache dir per
+// invocation so the parallel pool does not collide on `build/sailfin`.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// A fresh capsule root under the runner's scratch dir (or /tmp), keyed by
+// `tag` so concurrent tests in the parallel pool never collide.
+fn _make_capsule(tag: string) -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    let root = base + "/sfn-xdir-method-" + tag;
+    fs.createDirectory(root + "/src/a/b", true);
+
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"xdir-method-test\"\n"
+        + "version = \"0.1.0\"\n\n"
+        + "[capabilities]\n"
+        + "required = [\"io\"]\n\n"
+        + "[build]\n"
+        + "kind = \"binary\"\n"
+        + "entry = \"src/main.sfn\"\n");
+
+    // Provider (sibling of the entry): a two-method interface structurally
+    // implemented by a fieldless struct whose methods carry `![io]` and take
+    // a struct parameter — the LlvmTextBackend/Backend shape.
+    fs.writeFile(root + "/src/backend.sfn", "struct Job {\n"
+        + "    value: int;\n"
+        + "}\n\n"
+        + "interface Worker {\n"
+        + "    fn run(self, job: Job) -> int ![io];\n"
+        + "    fn describe(self) -> int;\n"
+        + "}\n\n"
+        + "struct LocalWorker {\n"
+        + "    fn run(self, job: Job) -> int ![io] {\n"
+        + "        print.info(\"worker ran\");\n"
+        + "        return job.value * 2;\n"
+        + "    }\n\n"
+        + "    fn describe(self) -> int {\n"
+        + "        return 7;\n"
+        + "    }\n"
+        + "}\n");
+
+    // Nested consumer: reaches the provider through a CROSS-DIRECTORY
+    // `../../backend` import, constructs the method-bearing struct, and
+    // calls exactly ONE interface method (`run`) — `describe` stays
+    // vtable-only.
+    fs.writeFile(root + "/src/a/b/consumer.sfn", "import { LocalWorker, Job } from \"../../backend\";\n\n"
+        + "fn run_consumer() -> int ![io] {\n"
+        + "    let w = LocalWorker { };\n"
+        + "    let j = Job { value: 21 };\n"
+        + "    return w.run(j);\n"
+        + "}\n\n"
+        + "export { run_consumer };\n");
+
+    // Entry: calls the nested consumer so it is linked and the produced
+    // binary is runnable.
+    fs.writeFile(root + "/src/main.sfn", "import { run_consumer } from \"./a/b/consumer\";\n\n"
+        + "fn main() ![io] {\n"
+        + "    let r = run_consumer();\n"
+        + "    print.info(\"backend-result=\" + number_to_string(r));\n"
+        + "}\n");
+
+    return root;
+}
+
+// Build the capsule through the real resolver (`-p` ⇒ per-module emit with
+// `--import-context`), assert it lowered cleanly, then run the linked binary
+// and assert the cross-dir method call produced the right value.
+test "cross-dir method-bearing struct import lowers under import-context, links, runs (#1701)" ![io] {
+    let root = _make_capsule("link");
+    let out_bin = root + "/prog";
+    let exit = process.run_capture([_sfn_bin(), "build", "-p", root, "-o", out_bin], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    let log = out + err;
+
+    // The authoritative #1701 signal: the resolver must not report a
+    // lowering failure for the cross-dir consumer.
+    assert ! contains(log, "failed to lower");
+    assert ! contains(log, "use of undefined value");
+    assert exit == 0;
+
+    // The linked binary runs and prints the resolved value. `print.info`
+    // prefixes with `[info] `, so the fixed prefix rules out an incidental
+    // substring match. run(Job{21}) == 42.
+    let run_exit = process.run_capture([out_bin], _child_env());
+    let run_out = process.capture_take_stdout();
+    let run_err = process.capture_take_stderr();
+    assert run_exit == 0;
+    assert find(run_out + run_err, "[info] backend-result=42", 0) >= 0;
+}


### PR DESCRIPTION
## Summary

- **Fix:** A cross-directory import of a method-bearing struct (e.g. `import { LlvmTextBackend } from "../../backend"`) that constructs it and **calls a method** failed to lower under the build's per-module `--import-context` path (`capsule-resolver: failed to lower <module> to LLVM IR`), while standalone emit and same-dir imports both worked. Root cause: in `find_declare_signature_t`'s call-site signature-recovery fallback, the parameter list was read with `substring(trimmed, ...)` — `trimmed` is the `string[]` line array, not the current `line` string. The garbage param list went into the injected external `declare` for the called imported method: a harmless empty `()` for the compiler's own `cli/commands/test` → `backend.link` (clang-tolerated), but an unparseable `(s)` for a generic cross-dir consumer → invalid IR → failed to lower. The vtable-only (uncalled) method path was already correct via #1739/#1740; this fixes the **called**-method path with a one-token correction (`trimmed` → `line`).
- **Revert the #1687 workaround:** `cli/commands/test.sfn` now imports `LlvmTextBackend`/`LinkPlan` directly from `../../backend` and builds the test-layout `LinkPlan` inline; the now-dead `cli_main::link_test_objects` helper is removed.
- **Regression test:** new e2e that builds a nested-dir consumer of a method-bearing interface struct via `sfn build -p` (the import-context path), exercising both the called-method and vtable-only paths, then runs the binary.

Closes #1701

## Acceptance Criteria

- [x] A module under a nested directory that does `import { S } from "../../s"` where `S` is a struct **with methods**, constructs `S {}`, and calls a method, lowers under the build's import-context path and self-hosts.
- [x] Regression coverage that exercises the cross-dir + import-context path (an e2e fixture with a nested-dir consumer of a method-bearing struct, **built** — not just `sfn check`-ed): `compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn`.
- [x] `make compile` passes (compiler self-hosts) — including the previously-failing shape, with the #1687 workaround reverted to a direct `../../backend` import.
- [ ] `make test` passes (no regressions) — **deferred to CI**: the local serial test run wedged; deferring the full suite to CI per maintainer direction. `make compile` (self-host), the new regression test, and the directly-relevant unit tests ran clean locally.

## Map reconciliation

The advisory `## Files Affected` map pointed at `capsule_resolver.sfn` / `capsule_emit_parallel.sfn` / `llvm/imports.sfn` for the import-context staging + slug resolution. The actual root cause was one layer further in — the same semantic `In:` unit ("the per-module LLVM lowering path under `--import-context`") but located in `compiler/src/llvm/lowering/lowering_helpers.sfn` (`find_declare_signature_t`). Slug resolution and import-context staging were verified correct (the consumer's `.import-deps` and staged `.sfn-asm` resolve fine); the failure was the malformed injected `declare`. In-scope drift, reconciled — no semantic scope growth.

## Verification

```bash
make compile            # status: pass (self-hosts with the workaround reverted)
# Minimal repro fixture (nested src/a/b/consumer.sfn importing ../../backend, method-bearing struct):
#   before fix: capsule-resolver: failed to lower .../src/a/b/consumer to LLVM IR  (declare ...run(s) — invalid IR)
#   after  fix: built + ran -> "[info] backend-result=42"
build/native/sailfin test compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn   # PASS
build/native/sailfin fmt --check <touched .sfn>   # clean
```

Full `make test` is left for CI to run.

## Files Changed

- `compiler/src/llvm/lowering/lowering_helpers.sfn` — the fix (`substring(trimmed, …)` → `substring(line, …)` in `find_declare_signature_t`).
- `compiler/src/cli/commands/test.sfn` — revert #1687 workaround to a direct `../../backend` import + inline test-layout `LinkPlan`.
- `compiler/src/cli_main.sfn` — remove the now-dead `link_test_objects` helper.
- `compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn` — new regression test.

## Follow-up

Code review flagged a latent type-checker gap: `substring` accepted a `string[]` where a `string` was expected (which is how this typo went undetected). Out of scope for #1701; worth a separate issue.

https://claude.ai/code/session_015ZsFkVUZ64GHoZAyhKaotT

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZsFkVUZ64GHoZAyhKaotT)_