### PR TITLE
Lower primitive `.toString()` so member-access-derived ints resolve (#1706)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1063,6 +1063,71 @@ fn _try_lower_channel_method(member_target: MemberAccessParse, argument_entries:
     };
 }
 
+// #1706: `<expr>.toString()` on a primitive receiver lowers to the
+// `number.to_string` runtime conversion (booleans render "true"/"false";
+// an already-string receiver is identity). The base is lowered as a full
+// expression, so this uniformly covers a plain local, a parameter, a
+// call-bound local, a member-access-bound local (`let idx = s.index;`), an
+// array `.length`-bound local (`let n = xs.length;`), and the
+// no-intermediate-local form (`s.index.toString()`) — every case keys off
+// the lowered operand's LLVM type, not a binding annotation. A non-primitive
+// (struct / array / pointer-aggregate) receiver returns null so a
+// user-defined `toString` still routes through the struct-dispatch path
+// (and an absent one fails closed as before).
+fn _try_lower_tostring_method(member_target: MemberAccessParse, argument_entries: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? ![io] {
+    if member_target.field != "toString" { return null; }
+    // `toString()` takes no arguments; anything else is not this builtin.
+    if argument_entries.length != 0 { return null; }
+    let base = trim_text(member_target.base);
+    if base.length == 0 { return null; }
+
+    // PROBE the receiver type on a throwaway copy of `lines` first. Sailfin
+    // arrays are reference types, so `lower_expression`'s `lines.push`
+    // mutates in place — lowering directly into `lines` and then deferring
+    // (non-primitive / unlowerable receiver) would orphan those instructions
+    // and let the caller re-lower from the unchanged `temp_index`, reusing
+    // SSA temp names and emitting invalid IR (#1706 review). Probing into a
+    // copy keeps the caller's `lines`/`temp_index` pristine on every defer.
+    let probe_lines = extend_string_array([], lines);
+    let probe = lower_expression(base, bindings, locals, temp_index, probe_lines, functions, context, "");
+    if probe.operand == null { return null; }
+    let base_type = trim_text(probe.operand.llvm_type);
+
+    // Only intercept the primitive receivers whose `coerce_operand_to_string`
+    // arm is verified to emit valid IR end-to-end: `int` (i64) — the #1706
+    // target — plus `float` (double) and an already-string receiver
+    // (i8* / the `{i8*, i64}` SfnString aggregate, identity). Everything else
+    // defers to the normal method dispatch (and fails closed if unresolved).
+    // `i1`/`i8`/`i16`/`i32` are deliberately excluded: the boolean (`i1`) arm
+    // of `coerce_operand_to_string` currently feeds a `{i8*, i64}` string
+    // literal into a `select i8*` (invalid IR — a separate, pre-existing
+    // bug); routing them here would manufacture a miscompile rather than the
+    // clean fail-closed diagnostic they get today.
+    let mut _is_primitive: boolean = false;
+    if base_type == "i64" { _is_primitive = true; }
+    if base_type == "double" { _is_primitive = true; }
+    if base_type == "i8*" { _is_primitive = true; }
+    if base_type == "{i8*, i64}" { _is_primitive = true; }
+    if !_is_primitive { return null; }
+
+    // COMMIT: the receiver is primitive, so re-lower the base into the REAL
+    // `lines` (in-place, visible to the caller — the probe's IR is discarded)
+    // and convert. The probe consumed `temp_index..` only in the throwaway
+    // copy, so committing from the same `temp_index` reuses no live names.
+    let base_lowered = lower_expression(base, bindings, locals, temp_index, lines, functions, context, "");
+    if base_lowered.operand == null { return null; }
+    let coerced = coerce_operand_to_string(base_lowered.operand, base_lowered.temp_index, base_lowered.lines);
+    let mut ts_diag: string[] = base_lowered.diagnostics;
+    ts_diag = extend_string_array(ts_diag, coerced.diagnostics);
+    return ExpressionResult {
+        lines: coerced.lines,
+        temp_index: coerced.temp_index,
+        operand: coerced.operand,
+        diagnostics: ts_diag,
+        string_constants: base_lowered.string_constants
+    };
+}
+
 // Typed spawn: `spawn:<kind> <operand>`. Extracted sibling of
 // `lower_expression` (peak-RSS scope split, issue context in CLAUDE.md) —
 // behaviour is identical; each `let` here lives in its own function scope
@@ -2376,6 +2441,15 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             if member_target.success {
                 let channel_lowered = _try_lower_channel_method(member_target, argument_entries, bindings, locals, temp_index, lines, functions, context, expected_type);
                 if channel_lowered != null { return channel_lowered; }
+            }
+            // #1706: `<expr>.toString()` on a primitive receiver lowers to
+            // the `number.to_string` conversion. Runs before the struct /
+            // runtime-helper dispatch (which keys on a binding annotation
+            // a primitive receiver does not carry) so the receiver type is
+            // read straight off the lowered operand.
+            if member_target.success {
+                let tostring_lowered = _try_lower_tostring_method(member_target, argument_entries, bindings, locals, temp_index, lines, functions, context);
+                if tostring_lowered != null { return tostring_lowered; }
             }
             if member_target.success {
                 if member_target.field == "concat" {

--- a/compiler/tests/e2e/fixtures/tostring_member_access_probe.sfn
+++ b/compiler/tests/e2e/fixtures/tostring_member_access_probe.sfn
@@ -1,0 +1,52 @@
+// Fixture for #1706 — `.toString()` on an `int` value derived from a
+// struct field access, an array `.length`, and a direct member access.
+//
+// Before the fix these tripped the lowering fatal
+//   `cannot resolve return type for call to `idx.toString``
+// because the method-dispatch resolver could not establish the receiver's
+// type. The fix intercepts a primitive `.toString()` in `lower_expression`
+// and lowers it through `number.to_string`, reading the receiver type off
+// the lowered operand (so a struct-field / array-length / direct
+// member-access receiver all resolve uniformly).
+struct Shard {
+    valid: boolean,
+    index: int,
+    total: int
+}
+
+fn make_shard(i: int, t: int) -> Shard {
+    return Shard { valid: true, index: i, total: t };
+}
+
+fn select_indices(count: int) -> int[] {
+    let mut out: int[] = [];
+    let mut k = 0;
+    loop {
+        if k >= count { break; }
+        out.push(k);
+        k = k + 1;
+    }
+    return out;
+}
+
+fn main() -> int ![io] {
+    let s = make_shard(2, 3);
+    let idx = s.index;  // initializer is a struct field access -> int
+    print.info("idx=" + idx.toString());
+
+    let xs = select_indices(4);
+    let n = xs.length;  // initializer is array `.length` -> int
+    print.info("len=" + n.toString());
+
+    // Method call directly on the member access, no intermediate local.
+    print.info("direct=" + s.index.toString());
+
+    // Float receiver (double).
+    let ratio = 2.5;
+    print.info("flt=" + ratio.toString());
+
+    // String receiver is identity.
+    let label = "tag";
+    print.info("str=" + label.toString());
+    return 0;
+}

--- a/compiler/tests/e2e/tostring_member_access_test.sfn
+++ b/compiler/tests/e2e/tostring_member_access_test.sfn
@@ -1,0 +1,133 @@
+// End-to-end regression for #1706 — `.toString()` on an `int` value
+// derived from a struct field access, an array `.length`, and a direct
+// member access.
+//
+// Before the fix these tripped the LLVM-lowering fatal
+//   `cannot resolve return type for call to `idx.toString``
+// because the method-dispatch resolver could not establish the receiver's
+// type. The fix (`_try_lower_tostring_method` in
+// `compiler/src/llvm/expression_lowering/native/core.sfn`) intercepts a
+// primitive `.toString()` in `lower_expression` and lowers it through the
+// `number.to_string` conversion, reading the receiver type straight off
+// the lowered base operand — so a struct-field, array-length, and direct
+// member-access receiver all resolve uniformly.
+//
+// This MUST build-and-run (not just `sfn check`): the bug is at stage-6
+// LLVM lowering, which the frontend `check` never reaches — `check` was
+// green on the failing input. The fixture is built in a fresh temp dir and
+// run, asserting the three lines it prints.
+//
+// Build/parallel-runner isolation mirrors `sailfin_main_entry_test.sfn`:
+// the child build inherits the full parent environment (PATH/HOME/TMPDIR
+// for clang+linker, SAILFIN_TEST_SCRATCH so the `program.ll` build cache
+// is per-invocation under `sfn test --jobs N`), and captured stdout is
+// stashed to an out-of-tree marker so it survives the temp-dir teardown.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _fixture_src() -> string ![io] {
+    return fs.readFile("compiler/tests/e2e/fixtures/tostring_member_access_probe.sfn");
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-tostring-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// Build the probe fixture in a temp dir and run it. Stashes the run's
+// captured stdout to `out_marker` and returns the run's exit code, or
+// `-100` if the build itself failed.
+fn _build_and_run(out_marker: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, _fixture_src());
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], []);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+test "tostring: int from struct field / array length / direct member access" ![io] {
+    let marker = _marker("members");
+    let exit = _build_and_run(marker);
+    // Reject the `-100` build-failure sentinel before reading the marker —
+    // on a build failure the marker is never written.
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // `let idx = s.index; idx.toString()` (struct field).
+    assert find(out, "idx=2", 0) >= 0;
+    // `let n = xs.length; n.toString()` (array length).
+    assert find(out, "len=4", 0) >= 0;
+    // `s.index.toString()` (method directly on a member access, no local).
+    assert find(out, "direct=2", 0) >= 0;
+    // Float receiver (double).
+    assert find(out, "flt=2.5", 0) >= 0;
+    // String receiver is identity.
+    assert find(out, "str=tag", 0) >= 0;
+}
+
+// Build an inline source and return the build exit code (the run is never
+// reached on a build failure).
+fn _build_inline_exit(source: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, source);
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        return build_exit;
+    });
+}
+
+test "tostring: struct receiver defers to method dispatch and fails the build cleanly" ![io] {
+    // A struct receiver is NOT a primitive `.toString()`: it must defer to
+    // the struct-method dispatch (no `toString` method exists) and fail the
+    // build, rather than be intercepted. This guards the defer path — the
+    // classification lowering of the base must not be intercepted for
+    // non-primitive receivers, and (post-#1706-review) must not corrupt the
+    // caller's instruction stream. A non-zero build exit confirms the
+    // struct receiver was not silently accepted.
+    let src = "struct Box { value: int }\n" + "fn main() -> int ![io] {\n"
+        + "    let b = Box{ value: 1 };\n"
+        + "    print.info(b.toString());\n"
+        + "    return 0;\n"
+        + "}\n";
+    let build_exit = _build_inline_exit(src);
+    assert build_exit != 0;
+}
+
+test "tostring: boolean receiver is excluded and fails the build (no miscompile)" ![io] {
+    // `i1` is deliberately NOT intercepted (the `coerce_operand_to_string`
+    // boolean arm emits invalid IR — a separate pre-existing bug). A boolean
+    // receiver must therefore DEFER and fail the build closed, NOT be lowered
+    // into a `select i8*` against a `{i8*, i64}` literal. This pins the guard
+    // exclusion so a future widening of the primitive set can't silently
+    // reintroduce the boolean miscompile.
+    let src = "fn main() -> int ![io] {\n" + "    let flag = true;\n"
+        + "    print.info(flag.toString());\n"
+        + "    return 0;\n"
+        + "}\n";
+    let build_exit = _build_inline_exit(src);
+    assert build_exit != 0;
+}


### PR DESCRIPTION
## Summary
- Adds `_try_lower_tostring_method` to the expression-lowering call-site dispatch so `<expr>.toString()` on an `int` (and `float` / already-string) receiver lowers through `number.to_string` instead of tripping the LLVM-lowering fatal `cannot resolve return type for call to ...`.
- The receiver type is read straight off the **lowered base operand**, so every receiver shape resolves uniformly: a plain local, a parameter, a call-bound local, a struct-field-bound local (`let idx = s.index`), an array-`.length`-bound local (`let n = xs.length`), and the no-intermediate-local form (`s.index.toString()`).
- Uses a **probe-then-commit** shape (probe the type on a throwaway copy of `lines`, commit by re-lowering into the real `lines` only when primitive) so a defer leaves the caller's instruction stream / temp counter pristine — Sailfin's `lines` array is a reference type.

Closes #1706

## Diagnosis note (the issue's premise was incomplete)
The issue scoped this as a binding-type-inference gap specific to struct-field / array-`.length` initializers. Investigation showed `.toString()` failed for **every** int receiver — even `let n: int = 5; n.toString()` — because `.toString()` was not an implemented primitive method anywhere (it appears nowhere in compiler/runtime/tests/docs). The fix therefore implements primitive `.toString()` dispatch keyed on the lowered operand's LLVM type, which subsumes the binding-inference concern (the `llvm_type` was already inferred correctly; only the unused `type_annotation` was empty). Scope confirmed with the maintainer before implementing.

## Acceptance Criteria
- [x] `let idx = s.index; idx.toString()` (struct field) compiles and self-hosts.
- [x] `let n = xs.length; n.toString()` (array length) compiles and self-hosts.
- [x] `s.index.toString()` (method directly on member access, no local) resolves.
- [x] Regression test under `compiler/tests/` covering all three.
- [x] `make compile` self-hosts.

## Scope note — boolean deferred
`i1`/`i8`/`i16`/`i32` are deliberately excluded from the intercepted set. The boolean (`i1`) arm of `coerce_operand_to_string` emits invalid IR (`select i8*` fed a `{i8*, i64}` string-literal aggregate) — a **separate, pre-existing bug**. Routing booleans through the new path would manufacture a miscompile, so they instead defer and fail closed with the clean `cannot resolve return type` diagnostic they get today. A regression test pins this exclusion. Fixing `coerce_operand_to_string`'s boolean arm (to enable `bool.toString()`) is a good follow-up.

## Map reconciliation
The advisory `## Files Affected` listed `typecheck*.sfn` (binding inference) and `core_call_resolution.sfn` (dispatch). The real, more general fix lives in one earlier interception point — `compiler/src/llvm/expression_lowering/native/core.sfn` (the `lower_expression` call-site dispatch, alongside the existing `_try_lower_channel_method`) — which handles all receiver shapes off the lowered operand. No `typecheck` change was needed (the `llvm_type` was already inferred); the dispatch fix in `core_call_resolution.sfn` was unnecessary because the interception runs before it.

## Verification
```bash
make compile          # self-hosts (status: pass)
build/native/sailfin test compiler/tests/e2e -k "tostring"   # 3/3 pass
```
Fresh (`--no-cache`) single-file builds:
```
let idx = s.index; idx.toString()     -> 2
let n = xs.length; n.toString()       -> 4
s.index.toString()                    -> 2
2.5.toString()                        -> 2.5
"tag".toString()                      -> tag
bool.toString()                       -> clean `cannot resolve return type` fatal (no invalid IR)
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core.sfn` — new `_try_lower_tostring_method` + dispatch wiring.
- `compiler/tests/e2e/tostring_member_access_test.sfn` — build-and-run regression (lowering bug; `sfn check` wouldn't catch it) + struct/boolean fail-closed guards.
- `compiler/tests/e2e/fixtures/tostring_member_access_probe.sfn` — fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3fybvUTitGt5NjMGnodfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3fybvUTitGt5NjMGnodfx)_