### PR TITLE
fix(lowering): resolve `&lt;numeric&gt;.toString()` to the number→string path

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1063,6 +1063,71 @@ fn _try_lower_channel_method(member_target: MemberAccessParse, argument_entries:
     };
 }
 
+// Determine a call receiver's LLVM type WITHOUT emitting any IR, so a
+// `.toString()` interception can decide numeric-ness before committing to
+// lowering an effectful receiver (e.g. `foo().toString()` must lower `foo`
+// exactly once). Handles a simple-identifier receiver (local/parameter
+// binding) and a one-level member-access receiver (`s.index`): a declared
+// struct field's type wins, falling back to `i64` for an array/string
+// `.length`. Returns "" when the type cannot be determined statically.
+fn _infer_receiver_llvm_type(receiver: string, bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> string {
+    if is_simple_identifier(receiver) {
+        let local = find_local_binding(locals, receiver);
+        if local != null { return local.llvm_type; }
+        let param = find_parameter_binding(bindings, receiver);
+        if param != null { return param.llvm_type; }
+        return "";
+    }
+    let parse = parse_member_access(receiver);
+    if !parse.success { return ""; }
+    let struct_info = resolve_struct_info_for_method_target(parse.base, bindings, locals, context);
+    if struct_info != null {
+        let field_info = find_struct_field_info(struct_info, parse.field);
+        if field_info != null { return field_info.llvm_type; }
+    }
+    if parse.field == "length" { return "i64"; }
+    return "";
+}
+
+fn _is_numeric_tostring_type(llvm_type: string) -> boolean {
+    let trimmed = trim_text(llvm_type);
+    if trimmed == "i64" { return true; }
+    if trimmed == "double" { return true; }
+    return false;
+}
+
+// #1706: `<numeric>.toString()` — calling `.toString()` on a value of a
+// numeric scalar type (`int`/`i64` or `float`/`double`). Sailfin has no
+// user-defined methods on primitives, so when the receiver resolves to a
+// numeric type this is unambiguously the number→string conversion; route it
+// through the same `coerce_operand_to_string` descriptor path that string
+// interpolation (`{{x}}`) already uses. Non-numeric receivers return null so
+// struct/string method dispatch is left untouched. The receiver type is
+// resolved before lowering, then the receiver is lowered exactly once, so an
+// effectful receiver is never evaluated twice.
+fn _try_lower_numeric_tostring(member_target: MemberAccessParse, argument_entries: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? ![io] {
+    if member_target.field != "toString" { return null; }
+    if argument_entries.length != 0 { return null; }
+    let receiver = trim_text(member_target.base);
+    if receiver.length == 0 { return null; }
+    let receiver_type = _infer_receiver_llvm_type(receiver, bindings, locals, context);
+    if !_is_numeric_tostring_type(receiver_type) { return null; }
+
+    // Committed: lower the receiver once and convert to a string. Any failure
+    // is returned as a non-null result (operand == null) rather than falling
+    // back to the generic call path, so the receiver is never re-lowered.
+    let lowered = lower_expression(receiver, bindings, locals, temp_index, lines, functions, context, "");
+    if lowered.operand == null { return lowered; }
+    let coerced = coerce_operand_to_string(lowered.operand, lowered.temp_index, lowered.lines);
+    return ExpressionResult {
+        lines: coerced.lines,
+        temp_index: coerced.temp_index,
+        operand: coerced.operand,
+        diagnostics: extend_string_array(lowered.diagnostics, coerced.diagnostics),
+        string_constants: merge_string_constants(lowered.string_constants, coerced.string_constants)
+    };
+}
+
 // Typed spawn: `spawn:<kind> <operand>`. Extracted sibling of
 // `lower_expression` (peak-RSS scope split, issue context in CLAUDE.md) —
 // behaviour is identical; each `let` here lives in its own function scope
@@ -2376,6 +2441,12 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             if member_target.success {
                 let channel_lowered = _try_lower_channel_method(member_target, argument_entries, bindings, locals, temp_index, lines, functions, context, expected_type);
                 if channel_lowered != null { return channel_lowered; }
+            }
+            if member_target.success {
+                // #1706: `<numeric>.toString()` converts a numeric scalar to a
+                // string; route through the shared number→string descriptor.
+                let tostring_lowered = _try_lower_numeric_tostring(member_target, argument_entries, bindings, locals, temp_index, lines, functions, context);
+                if tostring_lowered != null { return tostring_lowered; }
             }
             if member_target.success {
                 if member_target.field == "concat" {

--- a/compiler/tests/e2e/fixtures/numeric_tostring/capsule.toml
+++ b/compiler/tests/e2e/fixtures/numeric_tostring/capsule.toml
@@ -1,0 +1,4 @@
+[capsule]
+name = "fixture/numeric-tostring"
+version = "0.0.0"
+description = "Isolated capsule manifest for the issue #1706 numeric `.toString()` e2e fixture so that `discover_project_root` doesn't walk up into compiler/capsule.toml — that would inherit `sfn/runtime-native` and clobber the fixture's own `fn main()`. Mirrors `fixtures/array_map_closure/capsule.toml`."

--- a/compiler/tests/e2e/fixtures/numeric_tostring/main.sfn
+++ b/compiler/tests/e2e/fixtures/numeric_tostring/main.sfn
@@ -1,0 +1,45 @@
+// Regression fixture for #1706: `.toString()` on a numeric receiver whose
+// value comes from a struct field access (`let idx = s.index;`), an array
+// `.length` (`let n = xs.length;`), or directly off a member access
+// (`s.index.toString()`). Each previously failed closed at LLVM lowering
+// with `cannot resolve return type for call to ... callee signature is not
+// known`; all three must now lower and print the formatted integer.
+struct Shard {
+    valid: boolean;
+    index: int;
+    total: int;
+}
+
+fn make_shard(i: int, t: int) -> Shard {
+    return Shard { valid: true, index: i, total: t };
+}
+
+fn select_indices(count: int) -> int[] {
+    let mut out: int[] = [];
+    let mut k = 0;
+    loop {
+        if k >= count { break; }
+        out.push(k);
+        k = k + 1;
+    }
+    return out;
+}
+
+fn main() -> int ![io] {
+    let s = make_shard(2, 3);
+    let idx = s.index;  // initializer is a struct field access
+    print(idx.toString());  // -> "2"
+
+    let xs = select_indices(4);
+    let n = xs.length;  // initializer is array `.length`
+    print(n.toString());  // -> "4"
+
+    print(s.index.toString());  // method directly on member access -> "2"
+
+    let plain = 9;  // bare int-literal local
+    print(plain.toString());  // -> "9"
+
+    let r = 1.5;  // float (double) local
+    print(r.toString());  // -> "1.5"
+    return 0;
+}

--- a/compiler/tests/e2e/numeric_tostring_test.sfn
+++ b/compiler/tests/e2e/numeric_tostring_test.sfn
@@ -1,0 +1,51 @@
+// End-to-end test for `<numeric>.toString()` (#1706).
+//
+// Calling `.toString()` on a value of a numeric scalar type (`int`/`i64` or
+// `float`/`double`) lowers to the shared number→string descriptor — the same
+// path string interpolation (`{{x}}`) uses. Before the fix, a `.toString()`
+// receiver bound from a struct field access (`let idx = s.index;`), an array
+// `.length` (`let n = xs.length;`), or taken directly off a member access
+// (`s.index.toString()`) failed closed at LLVM lowering with
+// `cannot resolve return type for call to ... callee signature is not known`.
+//
+// Drives the compiler-under-test as a subprocess with the runtime `process.*`
+// builtins and asserts on captured stdout — the canonical e2e pattern (see
+// `.claude/rules/no-bash-e2e.md`, `array_map_closure_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from. Mirrors
+// `sfn/test`'s `_resolve_sfn_bin` so CI can point the test at any compiler.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, plus SAILFIN_TEST_SCRATCH
+// for per-invocation build-cache isolation under the parallel pool, #1333).
+// Inherit the full parent environment — mirrors array_map_closure_test.sfn.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+// Compile+run a fixture and return its exit code plus the trailing-
+// newline-normalized stdout.
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "numeric toString: struct-field, array-length, and direct member access all lower" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/numeric_tostring/main.sfn");
+    assert r.exit == 0;
+    // idx = s.index (2), n = xs.length (4), s.index directly (2),
+    // bare int local (9), float local (1.5).
+    assert r.out == "2\n4\n2\n9\n1.5";
+}


### PR DESCRIPTION
## Summary
- `.toString()` on a numeric value failed closed at LLVM lowering with `cannot resolve return type for call to ... callee signature is not known`. Root cause was broader than the issue described: the receiver's binding type was **not** the problem — `.toString()` was unsupported on **every** numeric receiver (bare int local, struct-field-bound local, array-`.length`-bound local, and direct member access). Sailfin had no numeric `.toString()` method at all; int→string went through `number_to_string` / interpolation.
- Adds `_try_lower_numeric_tostring` to the call-dispatch in `lower_expression` (right after the channel-method check): a no-arg `.toString()` whose receiver statically resolves to a numeric LLVM type (`i64`/`double`) is routed through the existing `coerce_operand_to_string` number→string descriptor — the same path string interpolation (`{{x}}`) uses.
- The receiver type is resolved **without emitting IR** (`_infer_receiver_llvm_type`), so an effectful receiver is lowered exactly once; non-numeric receivers return null and fall through to existing dispatch untouched (no regression to struct/string/user `.toString()`).

Closes #1706

## Acceptance Criteria
- [x] `let idx = s.index; idx.toString()` (struct field) compiles and self-hosts → prints `2`
- [x] `let n = xs.length; n.toString()` (array length) compiles and self-hosts → prints `4`
- [x] `s.index.toString()` (method directly on member access, no local) resolves → prints `2`
- [x] Regression test under `compiler/tests/` covering all three (plus bare-int and `float` arms)
- [x] `make compile` self-hosts

## Map reconciliation
The advisory `## Files Affected` listed `compiler/src/typecheck*.sfn` for "let-binding inference from a member-access initializer." Reconciled: binding inference was already correct (the local carries `i64`), so **no typecheck change was needed**. The real gap was the absence of numeric `.toString()` method dispatch, which lands squarely in the issue's other named `In:` unit — method-dispatch return-type resolution — implemented in `compiler/src/llvm/expression_lowering/native/core.sfn` (the lowering call-dispatch) rather than `core_call_resolution.sfn` specifically, using the idiomatic `_try_lower_*` short-circuit already present for channel methods. Scope (Goal + In/Out) holds; this was discussed with and approved by the maintainer before implementation.

## Verification
```bash
make compile          # self-hosts (status: pass)
make test             # unit 182/182, integration 42/42, e2e 169/169, capsules 38/38 — pass
build/native/sailfin test compiler/tests/e2e/numeric_tostring_test.sfn   # PASS (2\n4\n2\n9\n1.5)
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core.sfn` — `_try_lower_numeric_tostring` + `_infer_receiver_llvm_type` + `_is_numeric_tostring_type`, wired into call dispatch (+71)
- `compiler/tests/e2e/numeric_tostring_test.sfn` — e2e build-and-run regression test
- `compiler/tests/e2e/fixtures/numeric_tostring/{main.sfn,capsule.toml}` — test fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb1aNfqh7FnV1gpMXN3DXm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb1aNfqh7FnV1gpMXN3DXm)_