### PR TITLE
feat(effect-checker): blanket E0818 fail-closed Raw backstop

### DIFF
--- a/capsules/sfn/test/tests/expect_test.sfn
+++ b/capsules/sfn/test/tests/expect_test.sfn
@@ -177,28 +177,28 @@ test "expect: contains_int_array fail" ![pure] {
 
 // -- to_throw --
 test "expect: to_throw pass" ![pure] {
-    assert expect_to_throw(() -> int { return _boom(); }).ok;
+    assert expect_to_throw(fn () -> int { return _boom(); }).ok;
 }
 
 test "expect: to_throw fail (no throw)" ![pure] {
-    let r = expect_to_throw(() -> int { return _no_throw(); });
+    let r = expect_to_throw(fn () -> int { return _no_throw(); });
     assert ! r.ok;
     assert r.message.length > 0;
 }
 
 // -- to_throw_with --
 test "expect: to_throw_with pass" ![pure] {
-    assert expect_to_throw_with(() -> int { return _boom(); }, "overflow").ok;
+    assert expect_to_throw_with(fn () -> int { return _boom(); }, "overflow").ok;
 }
 
 test "expect: to_throw_with fail (wrong message)" ![pure] {
-    let r = expect_to_throw_with(() -> int { return _boom(); }, "disk full");
+    let r = expect_to_throw_with(fn () -> int { return _boom(); }, "disk full");
     assert ! r.ok;
     assert r.message.length > 0;
 }
 
 test "expect: to_throw_with fail (no throw)" ![pure] {
-    let r = expect_to_throw_with(() -> int { return _no_throw(); }, "overflow");
+    let r = expect_to_throw_with(fn () -> int { return _no_throw(); }, "overflow");
     assert ! r.ok;
     assert r.message.length > 0;
 }

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -39,6 +39,7 @@ import {
     check_struct_implements_interfaces,
     check_struct_methods,
     check_type_parameters,
+    check_unanalyzable_raw,
     classify_fn_cast,
     clone_bindings,
     detect_removed_ai_keyword,
@@ -571,7 +572,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
-            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings, imports));
+            diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, bindings, imports));
             diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
             let arm_bindings = register_match_pattern_bindings(case.pattern, bindings);
             let _blk_diags = check_block(case.body, arm_bindings, interfaces, imports, top_level);
@@ -1135,15 +1136,35 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         }
         return [];
     }
-    // #1147: the parser cannot structure `& <fn>` or `<fn> as *T` (the
-    // `as` target only parses a bare identifier; `&` has no prefix form),
-    // so both fall back to `Raw`. Diagnose the unsupported / invalid
-    // function-reference spellings here. Gated on the head resolving to a
-    // function so non-function `<value> as * u8` casts stay clean.
+    // Blanket fail-closed backstop for effect-opaque `Raw` nodes
+    // (#1627 Part F / #1743). `check_fn_reference_raw` first classifies the
+    // residual function-reference spellings (`& <fn>` → E0808, a defensive
+    // `<fn> as <type>` → E0808/E0809); after Part A/B those normally structure
+    // into `Cast`/`Unary`, so this is the last-resort path. Any non-empty Raw
+    // that is NOT a recognized fn-reference is genuinely unanalyzable — every
+    // valid construct has been structured (casts, prefix `*`/`&`, assignment,
+    // typed channels) — so it fails closed with E0818 rather than reaching
+    // codegen effect-blind. Empty Raw is clean; match-arm patterns are exempt
+    // upstream (`walk_match_pattern`) and never reach this arm.
     if expression.variant == "Raw" {
-        return check_fn_reference_raw(expression.text, bindings, expression.span);
+        let fn_diags = check_fn_reference_raw(expression.text, bindings, expression.span);
+        if fn_diags.length > 0 { return fn_diags; }
+        return check_unanalyzable_raw(expression.text, expression.span);
     }
     return [];
+}
+
+// Walk a match-arm pattern for diagnostics, exempting the `Raw` shorthand
+// destructure form from the blanket E0818 fail-closed backstop (#1743).
+// Colon-less shorthand patterns (e.g. `Result.Ok { value }`) legitimately
+// degrade to `Expression.Raw` — they are bindings, not unstructured
+// *expressions*, and carry no effects, so they must not trip E0818. Their
+// bindings are registered separately via `register_match_pattern_bindings`.
+// Structured patterns (Struct/Identifier) are still walked normally.
+fn walk_match_pattern(pattern: Expression?, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
+    if pattern == null { return []; }
+    if pattern.variant == "Raw" { return []; }
+    return walk_expression(pattern, bindings, imports);
 }
 
 // `?` operator (TryOperator) type rules — issue #833, epic #371 (R.3).
@@ -1319,7 +1340,7 @@ fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[], imp
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
-            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings, imports));
+            diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, bindings, imports));
             diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
             diagnostics = diagnostics.concat(walk_block_expressions(case.body, bindings, imports));
             index += 1;

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -2050,6 +2050,38 @@ fn make_unparseable_statement_diagnostic(anchor: Token?, near: string) -> Diagno
     };
 }
 
+// E0818 — the blanket fail-closed backstop for effect-opaque
+// `Expression.Raw` nodes (#1627 Part F / #1743). Once every valid construct
+// has been structured (casts, prefix `*`/`&`, assignment-as-expression, typed
+// `channel:Type`), a non-empty `Raw` reaching the typecheck expression walk is
+// genuinely unanalyzable — the compiler cannot parse it, so it must not slip
+// to codegen effect-blind. This completes #1627's "no valid effectful
+// construct reaches codegen through an effect-opaque node" criterion. The
+// diagnostic fires on node *shape* (`variant == "Raw"`), never on text
+// content: there is no text scan and no effect-keyword anchor.
+fn make_unanalyzable_raw_diagnostic(text: string, span: SourceSpan?) -> Diagnostic {
+    return Diagnostic {
+        code: "E0818",
+        severity: "error",
+        message: "unstructured expression cannot be analyzed; rewrite so the"
+            + " compiler can parse it",
+        file_path: "",
+        primary: token_from_name(trim_text(text), span),
+        suggestion: null
+    };
+}
+
+// The Raw decision invoked by the typecheck `Raw` arm after
+// `check_fn_reference_raw` has had its chance at the residual `& fn` /
+// `<fn> as <type>` spellings. An empty `Raw{text:""}` (the never-escapes
+// placeholder shape, plus whitespace-only text) carries no meaning and is
+// clean; any non-empty Raw fails closed with E0818. Match-arm patterns are
+// exempted upstream — they never reach this arm (see `walk_match_pattern`).
+fn check_unanalyzable_raw(text: string, span: SourceSpan?) -> Diagnostic[] {
+    if trim_text(text).length == 0 { return []; }
+    return [make_unanalyzable_raw_diagnostic(text, span)];
+}
+
 fn make_missing_interface_member_diagnostic(struct_name: string, interface_name: string, member_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0301",

--- a/compiler/tests/e2e/sync_rejects_unimplemented_concurrency_test.sfn
+++ b/compiler/tests/e2e/sync_rejects_unimplemented_concurrency_test.sfn
@@ -143,6 +143,27 @@ fn _emit_rejected(label: string, source: string, mode: string, ext: string, symb
     return true;
 }
 
+// `sfn emit <mode>` must fail closed: rc != 0 and no artifact, without
+// asserting a specific diagnostic. Used where the rejection now happens at
+// typecheck (E0818 fail-closed on the unstructured/unimplemented `spawn`
+// keyword form, #1743) before the resolver's `cannot resolve` path is reached.
+fn _emit_fails_closed(label: string, source: string, mode: string, ext: string) -> bool ![io] {
+    let dir = _scratch_dir();
+    let src = dir + "/" + label + ".sfn";
+    let out = dir + "/" + label + ext;
+    fs.writeFile(src, source);
+    if fs.exists(out) { fs.deleteFile(out); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", out, mode, src], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    let produced = fs.exists(out);
+    if produced { fs.deleteFile(out); }
+    fs.deleteFile(src);
+    if exit == 0 { return false; }
+    if produced { return false; }
+    return true;
+}
+
 // `sfn emit native` must succeed and the `.sfn-asm` must mention `needle`.
 fn _emit_native_succeeds(label: string, source: string, needle: string) -> bool ![io] {
     let dir = _scratch_dir();
@@ -198,7 +219,10 @@ test "sync-rejects: sfn build rejects sfn/sync.parallel import (#617)" ![io] {
 }
 
 test "sync-rejects: sfn build rejects sfn/sync.spawn import (#617)" ![io] {
-    assert _build_rejected("spawn_import_caller", _spawn_import(), "spawn");
+    // The unstructured `spawn(...)` keyword form fails closed at typecheck
+    // (E0818, #1743) before the resolver's `cannot resolve \`spawn\`` path —
+    // still rejected, no binary produced.
+    assert _build_fails_closed("spawn_import_caller", _spawn_import());
 }
 
 test "sync-rejects: sfn build succeeds on channel() now the runtime is wired (#1091)" ![io] {
@@ -206,7 +230,7 @@ test "sync-rejects: sfn build succeeds on channel() now the runtime is wired (#1
 }
 
 test "sync-rejects: sfn build rejects bare prelude spawn() (#617)" ![io] {
-    assert _build_rejected("spawn_prelude_caller", _spawn_prelude(), "spawn");
+    assert _build_fails_closed("spawn_prelude_caller", _spawn_prelude());
 }
 
 test "sync-rejects: sfn build fails closed on unknown void helper (#631)" ![io] {
@@ -214,7 +238,7 @@ test "sync-rejects: sfn build fails closed on unknown void helper (#631)" ![io] 
 }
 
 test "sync-rejects: sfn emit llvm fails closed on void spawn() (#631)" ![io] {
-    assert _emit_rejected("spawn_emit_llvm_caller", _spawn_prelude(), "llvm", ".ll", "spawn");
+    assert _emit_fails_closed("spawn_emit_llvm_caller", _spawn_prelude(), "llvm", ".ll");
 }
 
 test "sync-rejects: sfn emit native succeeds on channel() now lowering exists (#1085)" ![io] {
@@ -222,5 +246,5 @@ test "sync-rejects: sfn emit native succeeds on channel() now lowering exists (#
 }
 
 test "sync-rejects: sfn emit native fails closed on void spawn() (#906)" ![io] {
-    assert _emit_rejected("spawn_emit_native_caller", _spawn_prelude(), "native", ".sfn-asm", "spawn");
+    assert _emit_fails_closed("spawn_emit_native_caller", _spawn_prelude(), "native", ".sfn-asm");
 }

--- a/compiler/tests/unit/effect_raw_failclosed_test.sfn
+++ b/compiler/tests/unit/effect_raw_failclosed_test.sfn
@@ -1,0 +1,125 @@
+// #1627 Part F / #1743 — the blanket fail-closed `Raw` backstop (E0818).
+//
+// After #1186 deleted `collect_effects_from_text`, an `Expression.Raw` node
+// contributes ZERO effects silently. Once every valid construct was structured
+// (casts → `Cast`, prefix `*`/`&` → `Unary`, assignment → `Assignment`, typed
+// `channel:Type` → `Channel`; corpus cleared by #1751), any non-empty `Raw`
+// reaching the typecheck expression walk is genuinely unanalyzable — the
+// compiler cannot parse it, so it must fail closed (E0818) rather than slip to
+// codegen effect-blind. This completes #1627's "no valid effectful construct
+// reaches codegen through an effect-opaque node" criterion.
+//
+// These tests pin: (a) a non-empty `Raw` → E0818; (b) an empty / whitespace
+// `Raw` → clean; (c) the backstop fires on node SHAPE, not text content — a
+// structured node mentioning `print` does not fire, and a `Raw` whose text
+// contains no effect keyword still fires (no text scan, no effect-keyword
+// anchor); (d) match-arm shorthand patterns (which legitimately degrade to
+// `Raw`) are exempt.
+import { Expression } from "../../src/ast";
+import { empty_import_symbols } from "../../src/effect_imports";
+import { parse_program } from "../../src/parser/mod";
+import { typecheck_diagnostics, walk_expression, walk_match_pattern } from "../../src/typecheck";
+import { Diagnostic, SymbolEntry } from "../../src/typecheck_types";
+
+fn _no_bindings() -> SymbolEntry[] {
+    let empty: SymbolEntry[] = [];
+    return empty;
+}
+
+fn _has_code(diags: Diagnostic[], code: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= diags.length { break; }
+        if strings_equal(diags[i].code, code) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _raw_diags(text: string) -> Diagnostic[] ![io] {
+    let raw = Expression.Raw { text: text, span: null };
+    return walk_expression(raw, _no_bindings(), empty_import_symbols());
+}
+
+// ── (a) a non-empty, non-fn-reference Raw fails closed ──
+test "raw: a genuinely unstructured expression fails closed with E0818" ![io] {
+    assert _has_code(_raw_diags("foo bar baz"), "E0818");
+}
+
+test "raw: an unstructured Raw with punctuation fails closed" ![io] {
+    assert _has_code(_raw_diags("@@@ junk @@@"), "E0818");
+}
+
+// ── (b) empty / whitespace-only Raw is clean (the never-escapes shape) ──
+test "raw: an empty Raw is clean (no E0818)" ![io] {
+    let diags = _raw_diags("");
+    assert diags.length == 0;
+}
+
+test "raw: a whitespace-only Raw is clean (trimmed to empty)" ![io] {
+    let diags = _raw_diags("   ");
+    assert diags.length == 0;
+}
+
+// ── (c) node-shape, not text-scan: no effect-keyword anchor ──
+// A structured expression mentioning `print` as a substring must NOT fire
+// E0818 — the backstop keys on `variant == "Raw"`, never on text content.
+test "raw: a structured Identifier mentioning `print` does not fire E0818" ![io] {
+    let ident = Expression.Identifier { name: "printable", span: null };
+    let diags = walk_expression(ident, _no_bindings(), empty_import_symbols());
+    assert ! _has_code(diags, "E0818");
+}
+
+// Conversely a Raw whose text contains no effectful builtin still fails —
+// proving the backstop does not require an effect-keyword anchor in the text.
+test "raw: a Raw with no effect keyword still fails closed (no text scan)" ![io] {
+    assert _has_code(_raw_diags("lorem ipsum dolor"), "E0818");
+}
+
+// And a Raw that merely mentions `print` is treated identically to any other
+// Raw (shape, not content) — it fails closed, not because of the word.
+test "raw: a Raw mentioning `print` as a substring fails closed by shape" ![io] {
+    assert _has_code(_raw_diags("the word print appears here"), "E0818");
+}
+
+// ── (d) match-arm shorthand patterns are exempt ──
+// Colon-less shorthand destructures (e.g. `Result.Ok { value }`) parse to
+// `Expression.Raw` and reach the match-pattern walk; they are bindings, not
+// unstructured expressions, so `walk_match_pattern` exempts them from E0818.
+test "match pattern: a Raw shorthand destructure is exempt from E0818" ![io] {
+    let pattern = Expression.Raw { text: "Result.Ok { value }", span: null };
+    let diags = walk_match_pattern(pattern, _no_bindings(), empty_import_symbols());
+    assert diags.length == 0;
+}
+
+test "match pattern: an empty-text Raw pattern is exempt from E0818" ![io] {
+    let pattern = Expression.Raw { text: "", span: null };
+    let diags = walk_match_pattern(pattern, _no_bindings(), empty_import_symbols());
+    assert diags.length == 0;
+}
+
+// A structured (non-Raw) pattern still walks normally through the exemption
+// helper — the exemption is scoped to the `Raw` shorthand form only.
+test "match pattern: a structured Identifier pattern walks clean" ![io] {
+    let pattern = Expression.Identifier { name: "x", span: null };
+    let diags = walk_match_pattern(pattern, _no_bindings(), empty_import_symbols());
+    assert ! _has_code(diags, "E0818");
+}
+
+// ── end-to-end: a match with a shorthand-destructure arm self-hosts clean ──
+// Pins the wiring (the MatchStatement walker routes patterns through
+// `walk_match_pattern`), so a real match over an enum variant with a
+// brace-destructure arm produces no E0818.
+test "match: a shorthand-destructure arm produces no E0818 end-to-end" ![io] {
+    let source = "enum Box { Full { value: int }, Empty }\n"
+        + "fn unwrap(b: Box) -> int {\n"
+        + "    match b {\n"
+        + "        Box.Full { value } => { return value; }\n"
+        + "        Box.Empty => { return 0; }\n"
+        + "    }\n"
+        + "    return 0;\n"
+        + "}\n";
+    let program = parse_program(source);
+    let diags = typecheck_diagnostics(program);
+    assert ! _has_code(diags, "E0818");
+}

--- a/compiler/tests/unit/string_append_test.sfn
+++ b/compiler/tests/unit/string_append_test.sfn
@@ -3,6 +3,12 @@
 // it emits string_append instead of string_concat for intermediates,
 // reusing the buffer via realloc instead of allocating a new one each time.
 // These tests verify that the optimization produces correct results.
+// Top-level helper for the "function call between concats" case. A
+// statement-position nested `fn` declaration degrades to `Expression.Raw`
+// (no front-end structuring) and now fails closed under E0818 (#1743), so
+// the helper lives at module scope — the shipped form.
+fn make_tag(name: string) -> string { return "<" + name + ">"; }
+
 test "string_append: 3-way chain" {
     let a = "hello";
     let b = " ";
@@ -86,7 +92,6 @@ test "string_append: long chain builds IR-like content" {
 test "string_append: chain with function call between concats" {
     // Ensures the peephole fires correctly when the chain involves a
     // helper function that returns a string between concat operations.
-    fn make_tag(name: string) -> string { return "<" + name + ">"; }
     let result = "prefix:" + make_tag("div") + ":suffix";
     assert result == "prefix:<div>:suffix";
 }

--- a/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
+++ b/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
@@ -4,8 +4,8 @@
 - **Epic:** #1180
 - **Design record extended:** SFEP-0008 (`docs/proposals/0008-effect-validation.md`)
 - **Author:** agent:compiler-architect
-- **Status:** Draft (single-issue design gate; not a new SFEP)
-- **Date:** 2026-06-26; **revised 2026-06-27** (the E0818-flip endgame — parts A–F)
+- **Status:** Draft (single-issue design gate; not a new SFEP) — Parts E (E0819/#1755) and F (E0818/#1743) **implemented**; Parts A–D still pending
+- **Date:** 2026-06-26; **revised 2026-06-27** (the E0818-flip endgame — parts A–F); **annotated 2026-06-29** (Parts E+F shipped)
 - **Decision:** **Structural lift (root fix)** chosen at the design gate. The
   earlier text-anchor "floor" (`_raw_contains_effectful_anchor`) is **superseded**
   and retained below only as the analysis that led to the root-fix decision.
@@ -400,7 +400,11 @@ statement.sfn:196, fed the original operator).
 member/index assignments before vs after) + `effect_assignment_test.sfn`
 (`a = print.info(x)` and `arr[io()] = x` require `![io]`).
 
-### Part E — `E0817` nested `Unknown`
+### Part E — `E0817` nested `Unknown` — **SHIPPED (#1755, E0819)**
+
+> **2026-06-29 note:** Part E shipped as **E0819** (not E0817 — E0817 was
+> reassigned to enum-field conflicts, #1746) in issue **#1755**. The nested
+> `Unknown` fail-closed diagnostic is live.
 
 `Statement.Unknown` is produced by `parse_unknown` (declarations.sfn ~:1793,
 call sites :1320/:1525/:1679/:1691/:1697/:1728) and `parse_unknown_statement`
@@ -436,7 +440,18 @@ second diagnostic on the same node). This is Part E's only effect-checker touch.
 E0817; top-level `@@@` still E0500; `while(){}` still E0411 (dedup proof);
 no E0817 when E0411/removed-keyword already fired.
 
-### Part F — the `E0818` flip + pre-flip enumeration
+### Part F — the `E0818` flip + pre-flip enumeration — **SHIPPED (#1743, E0818)**
+
+> **2026-06-29 note:** Part F shipped in issue **#1743**. The E0818 blanket
+> fail-closed `Raw` backstop landed in **`compiler/src/typecheck.sfn`**
+> (`walk_expression` `Raw` arm) rather than in the effect-checker as the older
+> draft contemplated — the typecheck site is where the `walk_match_pattern`
+> exemption for match-arm shorthand-destructure patterns is natural. Diagnostic
+> factory: `make_unanalyzable_raw_diagnostic` in `typecheck_types.sfn` (named
+> `make_unanalyzable_raw_diagnostic`, not `make_effectful_raw_diagnostic` as the
+> draft had it). The `check_fn_reference_raw` fn-reference path remains on the Raw
+> arm unchanged. Regression test: `compiler/tests/unit/effect_raw_failclosed_test.sfn`.
+> Part E (nested `Unknown`) shipped earlier as E0819 in #1755.
 
 **Enumerate remaining in-source Raw producers BEFORE flipping** (so you
 structure them rather than discover them via a broken build):
@@ -503,8 +518,8 @@ structuring (assignment) lands before the flip, and the flip is last.
 | **B** | Parser: prefix `*`/`&` → `Unary`. typecheck: add `Unary` arm to `walk_expression` (recurse operand → preserves `&fn` E0808). | `make compile` + IR-diff in-source `*ptr`/`&x`. | `effect_prefix_deref_addr_test`. |
 | **C** | Cast-target reader: accept generic/`fn (...)` targets via type-annotation parser. | `make compile`. | `cast_generic_target_test`. |
 | **D** | AST `Assignment` node; parser assignment seam; formatter arm; **7 walker arms**. | `make compile` + IR-diff simple/compound/member/index assignments — **the high-risk gate**. | `assignment_node_ir_identity_test`, `effect_assignment_test`. |
-| **E** | `E0817` at `parse_unknown_statement` site (gated vs E0500/E0411/removed-keyword); defensive `Unknown` effect arm `[]`. | `make compile`. | `effect_unknown_block_level_test`. |
-| **F** | Re-run `SAILFIN_TRACE_RAW=1 make compile` → **must emit zero** Raw for compiler/runtime/capsules. Then flip the E0818 arm. Remove (or gate-off) the probe. | **`make compile` green = the proof no in-source Raw survives**; then `make check`. | `effect_raw_failclosed_test`, `effect_raw_negative_substring_test`. |
+| **E** ✓ | `E0817` at `parse_unknown_statement` site (gated vs E0500/E0411/removed-keyword); defensive `Unknown` effect arm `[]`. **Shipped as E0819 in #1755.** | `make compile`. | `effect_unknown_block_level_test`. |
+| **F** ✓ | Re-run `SAILFIN_TRACE_RAW=1 make compile` → **must emit zero** Raw for compiler/runtime/capsules. Then flip the E0818 arm. Remove (or gate-off) the probe. **Shipped as E0818 in #1743 (typecheck `walk_expression` Raw arm + `walk_match_pattern` exemption).** | **`make compile` green = the proof no in-source Raw survives**; then `make check`. | `effect_raw_failclosed_test`, `effect_raw_negative_substring_test`. |
 
 **Bundling / no seed cut:** every stage is a compiler-source change consumed by
 the same self-host pass. `make compile` builds the new compiler from the pinned

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-06-28. Seed pinned to `0.7.0-alpha.39` (`.seed-version`);
+Updated: 2026-06-29. Seed pinned to `0.7.0-alpha.39` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -127,9 +127,22 @@ here.
   all three children, so `cond ? readFile() : x` can no longer reach codegen
   effect-free (`E0400`). The disambiguation leaves the postfix `?` try operator
   (`a()?`, `a()?.b()?`) untouched — a `?` is ternary only when the token after it
-  can start an expression *and* a top-level `:` follows. The remaining
-  Raw-degraded effect-escapes (prefix `*`/`&`, assignment-as-expression) are
-  tracked under epic #1180 (#1180-c) behind a blanket fail-closed `Raw` backstop.
+  can start an expression *and* a top-level `:` follows. The previously
+  Raw-degraded effect-escapes are now structured into real AST nodes the effect
+  checker walks: casts (#1627/#1737), prefix `*`/`&` (#1737), ternary (#1690),
+  assignment-as-expression (#1745), and typed `channel:Type` (#1750) — so each
+  surfaces its operand's effects instead of silently degrading to `Raw`. With
+  those structured (epic #1180), the blanket fail-closed `Raw` backstop
+  (**E0818**, #1743) is **shipped** as defense-in-depth: any non-empty
+  `Expression.Raw` reaching the typecheck expression walk that is not a recognized
+  fn-reference (`& fn` / `<fn> as T`, still handled by `check_fn_reference_raw`)
+  emits E0818 ("unstructured expression cannot be analyzed; rewrite so the compiler
+  can parse it"); match-arm shorthand-destructure patterns (legitimately Raw) are
+  exempt via `walk_match_pattern`. Diagnostic factory:
+  `make_unanalyzable_raw_diagnostic` (`typecheck_types.sfn`). Regression test:
+  `compiler/tests/unit/effect_raw_failclosed_test.sfn`. E0818 fires on node
+  shape, not text content. E0819 (nested `Unknown` fail-closed) shipped separately
+  in #1755; E0817 was reassigned to enum-field conflicts (#1746).
   The `is` type-guard hole is **closed in #1753**: `<operand> is T` now parses
   to a structured `Is` AST node (not `Expression.Raw`), and the effect checker
   walks the operand — so `readFile() is T` correctly requires `![io]`. Effect

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,7 +35,7 @@ Effect annotations (`![...]`) flag the runtime capabilities you need to declare 
 | Example                  | Effects       | Notes                                                                                                                                      |
 | ------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `basic-enum.sfn`         | `io`          | Enum pattern matching with console logging.                                                                                                |
-| `borrowing.sfn`          | `mut`, `read` | Native compiler borrowing design sample (legacy name: stage2); shows moves, shared borrows, and reborrows without runtime enforcement yet. |
+| `borrowing.sfn`          | `io`          | **Design-stage** user-facing borrowing (`&`/`&mut` borrow expressions, `borrow(...)`, `![read]`/`![mut]`); planned form kept in comments, runnable `main` is a shipped-grammar stub (Phase U, post-1.0).            |
 | `conditionals.sfn`       | `io`          | Branching over values with `print.info`.                                                                                                   |
 | `error-handling.sfn`     | `io`          | Struct-based error propagation matched with logging.                                                                                       |
 | `functions.sfn`          | `io`          | Function defaults and overloading with console output.                                                                                     |
@@ -129,7 +129,7 @@ Effect annotations (`![...]`) flag the runtime capabilities you need to declare 
 - **Effect-sensitive**: `advanced`, `concurrency`, `ai`, `io`, and `web` rely on mocked helpers (`print.*`, `fs.*`, `http.*`, `serve`, `sleep`, `channel`). Declare the exact effects listed above before running them through the bootstrap compiler.
 - **Design-stage examples**: Some examples demonstrate planned features that parse but aren't fully enforced yet. These are marked with **Design-stage** in the notes column. Examples include:
   - `unsafe-extern-interop.sfn` — FFI interop with raw pointers and `unsafe` blocks. Parser accepts the syntax but unsafe semantics are not yet enforced. See [spec §6 Type System](https://sailfin.dev/docs/reference/spec/06-types/).
-  - `borrowing.sfn` — Ownership and borrowing syntax. Parser accepts but the bootstrap compiler does not enforce exclusivity. The native LLVM backend (legacy name: stage2) enforces borrow conflicts.
+  - `borrowing.sfn` — **Design-stage** user-facing ownership/borrowing syntax (`&`/`&mut` borrow expressions, `borrow(...)`, `![read]`/`![mut]`). The planned form is kept in comments and the runnable `main` is a shipped-grammar stub, because a `&mut <value>` borrow expression has no parser arm yet (it would degrade to an unstructured node). The native LLVM backend enforces borrow conflicts on the runtime owned-buffer surface today (Phase R1); the user-facing grammar is previewed until Phase U.
 - **Forward-looking commentary**: Any future syntax remains inside comments—runnable code in this directory sticks to the shipped bootstrap grammar. Update the index whenever you add new examples or adjust their effects.
 
 > Tip: Browse examples alongside the [grammar](https://sailfin.dev/docs/reference/grammar) and [spec](https://sailfin.dev/docs/reference/spec/) to see how planned features map onto the implemented subset.

--- a/examples/basics/borrowing.sfn
+++ b/examples/basics/borrowing.sfn
@@ -1,37 +1,55 @@
 // examples/basics/borrowing.sfn
-
-struct Counter {
-    value: int;
-}
-
-fn read_counter(counter: &Counter) ![read] -> int {
-    return counter.value;
-}
-
-fn increment_counter(counter: &mut Counter) ![mut] {
-    counter.value = counter.value + 1;
-}
-
-fn snapshot(counter: &mut Counter) ![mut, read] -> int {
-    let view: &Counter = borrow(counter);
-    return read_counter(view);
-}
-
+//
+// Design-stage: user-facing ownership/borrowing (`&`/`&mut` borrow
+// expressions, `borrow(...)`, and the `![read]`/`![mut]` borrow effects) is
+// planned future syntax (Phase U, post-1.0 — see CLAUDE.md and
+// reference/preview/ownership.md). Per examples/README.md, future syntax stays
+// inside comments and the runnable body sticks to the shipped bootstrap
+// grammar. A `&mut <value>` borrow expression has no parser arm yet, so it
+// degrades to an unstructured node; this file keeps the planned form in a
+// comment until the feature ships.
+//
+// Planned form (does not yet parse / type-check):
+//
+//     struct Counter {
+//         value: int;
+//     }
+//
+//     fn read_counter(counter: &Counter) ![read] -> int {
+//         return counter.value;
+//     }
+//
+//     fn increment_counter(counter: &mut Counter) ![mut] {
+//         counter.value = counter.value + 1;
+//     }
+//
+//     fn snapshot(counter: &mut Counter) ![mut, read] -> int {
+//         let view: &Counter = borrow(counter);
+//         return read_counter(view);
+//     }
+//
+//     fn main() ![io] {
+//         let mut counter = Counter { value: 0 };
+//
+//         let initial: int = read_counter(&counter);
+//
+//         let mut after_increment: int = initial;
+//         {
+//             let exclusive = &mut counter;       // mutable (exclusive) borrow
+//             increment_counter(exclusive);
+//             after_increment = snapshot(exclusive);
+//         }
+//
+//         let final_view: &Counter = borrow(counter);   // shared reborrow
+//         let delta: int = read_counter(final_view) - initial;
+//
+//         let result: int = after_increment + delta;
+//         print("Borrowing result: {{result}}");
+//     }
+//
+// The native LLVM backend enforces borrow conflicts on the runtime owned-buffer
+// surface today (Phase R1); the user-facing borrow grammar above is previewed
+// until Phase U.
 fn main() ![io] {
-    let mut counter = Counter { value: 0 };
-
-    let initial: int = read_counter(&counter);
-
-    let mut after_increment: int = initial;
-    {
-        let exclusive = &mut counter;
-        increment_counter(exclusive);
-        after_increment = snapshot(exclusive);
-    }
-
-    let final_view: &Counter = borrow(counter);
-    let delta: int = read_counter(final_view) - initial;
-
-    let result: int = after_increment + delta;
-    print("Borrowing result: {{result}}");
+    print("borrowing: `&`/`&mut` borrow expressions are design-stage future syntax — see the comments in this file.");
 }


### PR DESCRIPTION
## Summary
- Flips the blanket fail-closed `Raw` arm **self-host-clean** — the defense-in-depth completing #1627's "no valid effectful construct reaches codegen through an effect-opaque node" criterion. Any non-empty `Expression.Raw` reaching the typecheck expression walk that is not a recognized fn-reference now fails closed with **E0818** instead of slipping to codegen effect-blind.
- E0818 fires on node **shape** (`variant == "Raw"`), never on text content — no text scan, no effect-keyword anchor.
- Match-arm shorthand-destructure `Raw` patterns are exempted via a new `walk_match_pattern` helper (they are bindings, not unstructured expressions).

Closes #1743

## Scope reconciliation (title vs. current tree)
The issue title says "E0818 fail-closed Raw + **E0817** nested Unknown", but the nested-`Unknown` fail-closed (Part E) **already shipped separately under `E0819`** (#1755), and `E0817` was reassigned to enum-field conflicts (#1746). So this PR implements **only the remaining Part F: the E0818 blanket-`Raw` flip**. The defensive effect-checker `Unknown` arm and the `effect_unknown_block_level_test` already exist — no duplicate added.

## Implementation
- `compiler/src/typecheck_types.sfn`: `make_unanalyzable_raw_diagnostic` (E0818) + `check_unanalyzable_raw` (empty/whitespace `Raw` → clean; non-empty → E0818).
- `compiler/src/typecheck.sfn`: the `walk_expression` `Raw` arm runs `check_fn_reference_raw` first (residual `& fn` / `<fn> as T` → E0808/E0809) then falls through to `check_unanalyzable_raw`; new `walk_match_pattern` wired into both `MatchStatement` walkers.
- `compiler/tests/unit/effect_raw_failclosed_test.sfn`: 11 tests (firing path, empty/whitespace-clean, node-shape-not-text-scan negative-substring, match-pattern exemption).

## Acceptance Criteria
- [x] A genuinely unstructured expression → `E0818`; a nested unparseable statement → fails closed (`E0819`, already shipped #1755); valid structured code (typed channels, assignment, match patterns, string-builders) is clean.
- [x] No `E0818`/`E0817` false positives across `compiler/src`+`runtime`+`capsules`+`compiler/tests/`+`examples`.
- [x] `make compile` self-hosts; **`make check` green is the proof** no in-source valid construct degrades to `Raw`.

## Map reconciliation
The advisory `## Files Affected` named `typecheck.sfn`, `typecheck_types.sfn`, `effect_checker.sfn`, `compiler/tests/`. Reconciled to the current tree:
- `effect_checker.sfn` — **not touched**: the issue scoped the arm to "the typecheck `Raw` arm", and `walk_expression` is where the match-pattern exemption is natural (the effect-checker placement hits the 56-pattern false-positive the #1742 census flagged). The defensive `Unknown []` arm there already exists (#1691).
- **Corpus cleanup the #1742/#1751 census missed** (required by acceptance criterion #2 — `compiler/tests/`/capsules/examples must be E0818-clean). Three valid-but-`Raw` construct *classes* (all non-canonical/unsupported front-end forms that only worked via the shadow re-parser; full suite shows exactly 3 affected files) converted to **canonical/shipped forms** — no structuring (`Out:` respected), no feature regression:
  - `compiler/tests/unit/string_append_test.sfn` — statement-position nested `fn make_tag` hoisted to module scope.
  - `capsules/sfn/test/tests/expect_test.sfn` — `() -> int {}` (missing the spec-required `fn` lead-in, §05-expressions) → canonical `fn() -> int {}`.
  - `compiler/tests/e2e/sync_rejects_unimplemented_concurrency_test.sfn` — malformed `spawn(...)` now fails closed via E0818 at typecheck; spawn assertions use `_build_fails_closed`/`_emit_fails_closed` (new). The `parallel` import test still covers the resolver "cannot resolve" path, so that coverage is preserved.
  - `examples/basics/borrowing.sfn` (+ `examples/README.md`) — `&mut` borrow preview (Phase U, post-1.0) moved into future-syntax comments + a shipped-grammar `main` stub, the `raw-pointers.sfn` (#1754) convention. This file already failed `sfn check` (E0420/E0400) before this change.
- `docs/status.md` + design note `1627-fail-closed-raw-unknown-effects.md` — E0818 marked shipped; corrected a stale "not yet structured" claim about prefix `*`/`&`/assignment (both shipped in #1737/#1745).

## Verification
```bash
make compile      # self-hosts (pass)
make check        # PASS — unit 183/183, integration 42/42, e2e 169/169, capsules 38/38
sfn fmt --check   # clean on every touched .sfn
# tests-inclusive census: zero E0818/E0817 across examples + compiler/tests + capsules
build/native/sailfin test compiler/tests/unit/effect_raw_failclosed_test.sfn   # 11/11 pass
```

## Files Changed
- `compiler/src/typecheck.sfn`, `compiler/src/typecheck_types.sfn` — the E0818 flip + match-pattern exemption.
- `compiler/tests/unit/effect_raw_failclosed_test.sfn` (new) — regression coverage.
- `compiler/tests/unit/string_append_test.sfn`, `compiler/tests/e2e/sync_rejects_unimplemented_concurrency_test.sfn`, `capsules/sfn/test/tests/expect_test.sfn`, `examples/basics/borrowing.sfn`, `examples/README.md` — corpus cleanup to canonical forms.
- `docs/status.md`, `docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md` — status sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwnmLDz9ttoXbYWyBin9Xp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwnmLDz9ttoXbYWyBin9Xp)_