### PR TITLE
refactor(cli): split sailfin_cli_main_legacy into per-command dispatch helpers

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -224,6 +224,826 @@ fn _path_strip_ext(name: string) -> string {
     return substring(name, 0, last_dot);
 }
 
+fn _legacy_dispatch_emit(args: string[], binary_dir: string) -> int ![io, clock] {
+    let mut timing = false;
+    let mut out_path = "";
+    // Stage D PR3: explicit module name override. Lets the
+    // resolver's per-module compile (`_cr_compile_one`) shell
+    // out to a fresh subprocess for arena isolation while
+    // preserving the slug-based module name needed for symbol
+    // mangling of cross-capsule deps (where the slug is
+    // `<scope>/<name>/<rest>`, not what `module_name_from_path`
+    // would derive). Empty / not provided → fall back to
+    // `module_name_from_path(path)` so all existing call sites
+    // (humans + tests + build.sh) keep their current shape.
+    let mut module_name_override: string = "";
+    // #957: root of the staged import-context tree
+    // (`build/native/import-context`). When set, the llvm-emit
+    // path reads `<root>/<module-name>.import-deps` to load the
+    // cross-module effect table so callee-effect transitivity
+    // (`E0402`) is enforced on the build path.
+    let mut import_context_root: string = "";
+    // #515: single-shot `sfn emit llvm -o` can route through
+    // `emit_llvm_with_retry` (the same emit+probe+validate+retry
+    // cascade the resolver's multi-source path uses). Validation +
+    // retry are OPT-IN here (default: 1 attempt, no validate) so the
+    // bare CLI stays byte-for-byte behaviour-preserving — a
+    // single-file emit may legitimately reference runtime-provided
+    // externs that don't self-assemble in isolation, and forcing
+    // `llvm-as` on every emit would surface those as spurious
+    // failures (e.g. the exe-path test's Darwin leg). Callers that
+    // KNOW their IR is self-contained opt in: the Makefile
+    // cross-build staging passes `--validate`, and the resolver
+    // validates at its own layer. Flags: `--attempts N` (N >= 1)
+    // sets the count; `--no-retry` == `--attempts 1`;
+    // `--validate` / `--no-validate` toggle the `llvm-as`/`clang`
+    // round-trip.
+    let mut emit_attempts: int = 1;
+    let mut emit_validate: boolean = false;
+    // #906: build-internal per-module native emits set this (via
+    // `--no-resolve-gate`) to skip the lowering dry-run gate, which
+    // would otherwise reject legitimate cross-module calls that the
+    // import-context-free native stage cannot resolve in isolation.
+    let mut skip_resolve_gate: boolean = false;
+    let mut base_index = 1;
+    // Parse optional flags: --timing, --module-name <slug>,
+    // -o <path>, --attempts N, --no-retry, --validate,
+    // --no-validate in any order.
+    let mut consumed_flag: boolean = true;
+    loop {
+        if !consumed_flag { break; }
+        if base_index >= args.length { break; }
+        consumed_flag = false;
+        if strings_equal(args[base_index], "--timing") {
+            timing = true;
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "-o") {
+            base_index += 1;
+            if base_index >= args.length {
+                print(_usage());
+                return 2;
+            }
+            out_path = args[base_index];
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--module-name") {
+            base_index += 1;
+            if base_index >= args.length {
+                print(_usage());
+                return 2;
+            }
+            module_name_override = args[base_index];
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--import-context") {
+            base_index += 1;
+            if base_index >= args.length {
+                print(_usage());
+                return 2;
+            }
+            import_context_root = args[base_index];
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--attempts") {
+            base_index += 1;
+            if base_index >= args.length {
+                print(_usage());
+                return 2;
+            }
+            let parsed = emit_parse_nonneg_int(args[base_index]);
+            if parsed >= 1 { emit_attempts = parsed; }
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--no-retry") {
+            emit_attempts = 1;
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--validate") {
+            emit_validate = true;
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--no-validate") {
+            emit_validate = false;
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+        if strings_equal(args[base_index], "--no-resolve-gate") {
+            skip_resolve_gate = true;
+            base_index += 1;
+            consumed_flag = true;
+            continue;
+        }
+    }
+    let _expected_args = base_index + 2;
+    if args.length != _expected_args {
+        print(_usage());
+
+        return 2;
+    }
+    let mode = args[base_index];
+    let _path_idx = base_index + 1;
+    let path = args[_path_idx];
+    if !fs.exists(path) {
+        print("file not found: " + path);
+
+        return 1;
+    }
+    // #1370: a user-facing `emit llvm` (no `--module-name` /
+    // `--import-context`, i.e. NOT a build-internal worker emit —
+    // every resolver/worker emit threads at least one of those flags)
+    // stages the consumer capsule's dependencies into the
+    // import-context tree first, exactly as `check` / `build` / `run`
+    // already do. Without this, a COLD `emit llvm` of a capsule that
+    // imports e.g. sfn/http `serve` finds no staged
+    // `build/native/import-context/sfn/http/*.sfn-asm`, so the imported
+    // `serve` never enters the lowering `functions` list and the #1323
+    // gate (`expression_lowering/native/core.sfn`) hijacks the call to
+    // the builtin `@sfn_serve`. A loose `.sfn` outside any capsule
+    // resolves to zero sources and is a no-op, preserving bare-emit
+    // behavior; the guard keeps the self-host worker emits unchanged.
+    // Scoped to `llvm`: that is the lowering stage the #1323 gate runs
+    // in; `native` emit is import-context-free by design (#906) and
+    // `sailfin` is a transpile, so neither needs staging.
+    // `stage_capsule_imports_for_emit` no-ops unless the entry's
+    // capsule.toml declares `[dependencies]`, so a bare runtime/prelude
+    // emit (the cross-windows path) is untouched (#1370 regression).
+    if strings_equal(mode, "llvm") && module_name_override.length == 0
+        && import_context_root.length == 0 {
+        let emit_stage_exe = _resolve_self_path(binary_dir);
+        let emit_staged = stage_capsule_imports_for_emit(path, emit_stage_exe, "");
+        if !emit_staged {
+            print.err("sfn emit: warning: capsule import staging incomplete; imported capsule calls may not resolve");
+        }
+    }
+    let source = fs.readFile(path);
+    let mut module_name = module_name_from_path(path);
+    if module_name_override.length > 0 { module_name = module_name_override; }
+    let has_out = out_path.length > 0;
+    if strings_equal(mode, "llvm") {
+        if has_out {
+            if timing {
+                // --timing keeps the single-attempt, no-validate
+                // path: it reports per-phase emit timings, which a
+                // retry loop would distort.
+                let llvm = compile_to_llvm_with_module_timed(source, module_name);
+                _write_llvm_text(out_path, llvm);
+            } else {
+                // #515: route through the shared retry+validator
+                // cascade. Empty `import_asm_paths` degrades to the
+                // legacy in-module-only effect gate (same as the
+                // bare `compile_to_llvm_file_with_module` call this
+                // replaced).
+                let mut import_asm_paths: string[] = [];
+                if import_context_root.length > 0 {
+                    import_asm_paths = _read_import_deps(import_context_root, module_name);
+                }
+                let ok = emit_llvm_with_retry(path, module_name, out_path, import_asm_paths, emit_attempts, emit_validate, false);
+                if !ok { return 1; }
+            }
+        } else {
+            if timing {
+                print(compile_to_llvm_with_module_timed(source, module_name));
+            } else {
+                if !print_llvm_with_module(source, module_name) { return 1; }
+            }
+        }
+        return 0;
+    }
+    if strings_equal(mode, "sailfin") {
+        if has_out {
+            fs.writeFile(out_path, compile_to_sailfin(source));
+        } else { print(compile_to_sailfin(source)); }
+        return 0;
+    }
+    if strings_equal(mode, "native") {
+        // #906: gate the native emit on the same lowering `[fatal]`
+        // that `build` / `emit llvm` reject, so `emit native` fails
+        // closed (rc != 0, no `.sfn-asm`) on unresolved-callee inputs
+        // instead of writing an artifact and exiting 0. The build's
+        // per-module subprocess emit passes `--no-resolve-gate`
+        // (`skip_resolve_gate`) to opt out: that stage emits
+        // intermediate `.sfn-asm` with no cross-module import context,
+        // so it must not gate here — the build stays fail-closed via
+        // its later LLVM lowering stage (#631).
+        let run_gate = !skip_resolve_gate;
+        if has_out {
+            if !write_native_text_file_with_module_gated(source, module_name, out_path, run_gate) {
+                return 1;
+            }
+        } else {
+            if !print_native_text_with_module_gated(source, module_name, run_gate) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    print("unknown emit mode: " + mode);
+
+    return 2;
+}
+
+fn _legacy_dispatch_build(args: string[], runtime_root: string, binary_dir: string) -> int ![io] {
+    // build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json]
+    //       [--work-dir DIR] [--check-determinism] (file | -p <capsule-path>)
+    let mut out_path: string = "";
+    let mut input_path: string = "";
+    let mut capsule_path: string = "";
+    let mut no_cache_flag: boolean = false;
+    let mut clean_flag: boolean = false;
+    let mut cache_trace_flag: boolean = false;
+    let mut json_flag: boolean = false;
+    // `--work-dir DIR` virtualizes the build's intermediate
+    // artifacts (`<DIR>/native/import-context/`, `<DIR>/sailfin/`,
+    // and the default `<DIR>/native/sailfin` output) instead of
+    // the CWD-relative `./build/...` layout. Empty preserves the
+    // legacy paths byte-for-byte. This is the driver-side
+    // equivalent of the prior `scripts/build.sh`'s `WORK_DIR` /
+    // `SEED_CWD` derivation (the script was retired in Stage E
+    // PR7 / #383); `make check`'s stage2/stage3 fixed-point now
+    // routes through this flag.
+    let mut work_dir: string = "";
+    // `--check-determinism` (issue #779) runs the build twice
+    // and compares per-module cache_keys + the linked binary's
+    // sha256, exiting non-zero on mismatch. Pass 2 is driven
+    // by re-executing this same compiler binary as a subprocess
+    // with a sibling `--work-dir` so the two passes don't
+    // stomp each other's artifacts. The sidecar manifest.json
+    // at `build/capsules/<scope>/<name>/manifest.json` is the
+    // ONE artifact that's not virtualized by `--work-dir`;
+    // pass 2 overwrites pass 1's sidecar, so the orchestrator
+    // reads pass 1's sidecar off disk BEFORE invoking pass 2
+    // (see `_do_determinism_check` below). For capsules whose
+    // name isn't in scope/name form, no sidecar is written and
+    // the check degrades to a binary-sha256 comparison.
+    let mut check_determinism_flag: boolean = false;
+
+    // Parse args: support -o OUTPUT and -p PATH in any combination.
+    let mut bi: int = 1;
+    loop {
+        if bi >= args.length { break; }
+        let a = args[bi];
+        if strings_equal(a, "-o") {
+            if bi + 1 >= args.length {
+                print(_usage());
+                return 2;
+            }
+            out_path = args[bi + 1];
+            bi += 2;
+            continue;
+        }
+        if strings_equal(a, "-p") {
+            if bi + 1 >= args.length {
+                print(_usage());
+                return 2;
+            }
+            capsule_path = args[bi + 1];
+            bi += 2;
+            continue;
+        }
+        if strings_equal(a, "--no-cache") {
+            no_cache_flag = true;
+            bi += 1;
+            continue;
+        }
+        if strings_equal(a, "--clean") {
+            clean_flag = true;
+            bi += 1;
+            continue;
+        }
+        if strings_equal(a, "--cache-trace") {
+            cache_trace_flag = true;
+            bi += 1;
+            continue;
+        }
+        if strings_equal(a, "--json") {
+            json_flag = true;
+            bi += 1;
+            continue;
+        }
+        if strings_equal(a, "--work-dir") {
+            if bi + 1 >= args.length {
+                print(_usage());
+                return 2;
+            }
+            work_dir = args[bi + 1];
+            bi += 2;
+            continue;
+        }
+        if strings_equal(a, "--check-determinism") {
+            check_determinism_flag = true;
+            bi += 1;
+            continue;
+        }
+        let mut is_help_flag: boolean = false;
+        if strings_equal(a, "--help") { is_help_flag = true; }
+        if strings_equal(a, "-h") { is_help_flag = true; }
+        if is_help_flag {
+            print(_usage());
+            return 0;
+        }
+        // Positional argument: the source file.
+        if input_path.length > 0 {
+            print(_usage());
+            return 2;
+        }
+        input_path = a;
+        bi += 1;
+    }
+    // Resolved scratch / staging roots for this build. With
+    // `--work-dir` unset both fall back to the legacy in-tree
+    // paths so the default invocation is byte-for-byte identical.
+    let sailfin_cache_dir = _resolve_sailfin_cache_dir_for_work(work_dir);
+    let cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
+
+    // -p resolves the entry path + build kind from the capsule's
+    // manifest. The build then proceeds as for a positional source
+    // file, with the kind controlling whether we link an executable
+    // (binary) or just emit an object (library/runtime).
+    let mut build_kind: string = "binary";
+    // Captured from `-p` resolution so the post-build sidecar
+    // emitter (Stage C2a) has the manifest's name + version
+    // + entry-relative path without re-reading capsule.toml.
+    // Empty when `-p` was not used (positional source only).
+    let mut cap_capsule_name: string = "";
+    let mut cap_version: string = "";
+    let mut cap_entry_relative: string = "";
+    if capsule_path.length > 0 {
+        if input_path.length > 0 {
+            print("sfn build: -p and positional source are mutually exclusive");
+            return 2;
+        }
+        let cap_spec = _resolve_capsule_build_spec(capsule_path);
+        if cap_spec.entry_path.length == 0 { return 1; }
+        input_path = cap_spec.entry_path;
+        build_kind = cap_spec.kind;
+        cap_capsule_name = cap_spec.capsule_name;
+        cap_version = cap_spec.version;
+        cap_entry_relative = cap_spec.entry_relative;
+    }
+    if input_path.length == 0 {
+        print(_usage());
+        return 2;
+    }
+
+    let is_library_build = strings_equal(build_kind, "library");
+    let is_runtime_build = strings_equal(build_kind, "runtime");
+    let no_link = is_library_build;
+    // Stage D PR1: `kind = "runtime"` capsules are now a recognised
+    // schema variant — they ship declarative C / LL / include-dirs
+    // / link-libs source lists rather than `.sfn` modules. The
+    // driver doesn't yet COMPILE them as a top-level `-p` target
+    // (Stage D PR2 wires the link phase up); building one
+    // directly surfaces a hint and exits with the same usage-error
+    // code as other `-p` misuse so scripts/CI don't treat the
+    // unsupported invocation as success and proceed with missing
+    // artifacts.
+    if is_runtime_build {
+        print("sfn build: kind = \"runtime\" capsules are not buildable directly;");
+        print("           declare \"" + cap_capsule_name
+            + "\" as a dependency of a kind=\"binary\" capsule instead.");
+        return 2;
+    }
+
+    // Resolve the consumer's safe scope/name once. Used by:
+    //   (a) the canonical-`out_path` defaulting block below
+    //       (Stage C2b1), and
+    //   (b) the resolver's `ResolverConsumer` so intra-capsule
+    //       relative-import `.ll`s land under the consumer's
+    //       per-capsule tree (Stage C2b2).
+    // Both `out_path` and dep `.ll` routing fall back to the
+    // legacy flat layout when the name isn't scope-form (e.g.
+    // the compiler's own `[capsule].name = "sailfin"`).
+    // Stage D PR3: opt the resolver into walking
+    // `<project_root>/src/**/*.sfn` for any `-p` build of a
+    // `kind = "binary"` capsule. The compiler is the canonical
+    // case — `compiler/src/main.sfn` doesn't transitively
+    // import every `.sfn` under `compiler/src/` (notably
+    // `cli_main.sfn` and the CLI subcommand modules), so the
+    // entry-driven relative-import walker would miss them and
+    // the link would surface 100+ undefined references. Library
+    // builds keep the entry-driven enumeration for now — they
+    // produce a single unlinked `.o` whose multi-file story
+    // shakes out the same way intra-project imports do today.
+    let walk_src = capsule_path.length > 0 && !is_runtime_build && !is_library_build;
+    let mut consumer = ResolverConsumer {
+        scope: "",
+        name: "",
+        walk_project_src: walk_src,
+        include_host_as_dep: false
+    };
+    if cap_capsule_name.length > 0 {
+        let parts0 = parse_scope_name(cap_capsule_name);
+        if is_safe_scope_name(parts0.scope, parts0.name) {
+            consumer = ResolverConsumer {
+                scope: parts0.scope,
+                name: parts0.name,
+                walk_project_src: walk_src,
+                include_host_as_dep: false
+            };
+        }
+    }
+
+    if out_path.length == 0 {
+        // `--work-dir <root>` overrides the canonical
+        // per-capsule layout: when set, the default output is
+        // `<root>/native/sailfin` for binary builds (matching
+        // the prior `scripts/build.sh`'s historical
+        // `OUT="$WORK_DIR/.../native/sailfin"` shape; the
+        // script was retired in Stage E PR7 / #383) or
+        // `<root>/sailfin/program.o` for libraries. The
+        // work-dir form is meant for build orchestration
+        // (now exclusively `make check`'s stage2/stage3
+        // fixed-point comparison; formerly also the prior
+        // build.sh), so it explicitly takes precedence over
+        // the scoped `build/capsules/...` layout.
+        if work_dir.length > 0 {
+            if no_link { out_path = sailfin_cache_dir + "/program.o"; } else {
+                out_path = work_dir + "/native/sailfin";
+            }
+        } else {
+            // Stage C2b: when `-p` is used and `-o` was NOT
+            // given, default to the canonical per-capsule
+            // layout (`build/capsules/<scope>/<name>/{obj/mod.o,
+            // bin/<name>}`) from proposal §4.4. Positional builds
+            // and explicit `-o` paths still use their pre-
+            // existing locations — user override is sacred.
+            // Unsafe / non-scope-form capsule names fall back to
+            // the legacy paths so a malformed `[capsule].name`
+            // can never escape the build root.
+            let mut canonical_set: boolean = false;
+            if consumer.scope.length > 0 {
+                let cap_dir = capsule_artifact_dir(consumer.scope, consumer.name);
+                if no_link {
+                    _ensure_dir(cap_dir + "/obj");
+                    out_path = capsule_artifact_obj_path(consumer.scope, consumer.name);
+                    canonical_set = true;
+                } else {
+                    let bin_name = capsule_default_bin_name(consumer.name);
+                    if bin_name.length > 0 {
+                        _ensure_dir(cap_dir + "/bin");
+                        out_path = capsule_artifact_bin_path(consumer.scope, consumer.name, bin_name);
+                        canonical_set = true;
+                    }
+                }
+            }
+            if !canonical_set {
+                if no_link { out_path = "build/sailfin/program.o"; } else {
+                    out_path = "build/sailfin/program";
+                }
+            }
+        }
+    }
+
+    if !fs.exists(input_path) {
+        print("file not found: " + input_path);
+
+        return 1;
+    }
+
+    if work_dir.length == 0 { _ensure_dir("build"); } else {
+        _ensure_dir(work_dir);
+    }
+    _ensure_dir(sailfin_cache_dir);
+    // Make sure the parent dir of the resolved `out_path` exists
+    // before clang writes the binary / object. With
+    // `--work-dir <DIR>` the default binary lands at
+    // `<DIR>/native/sailfin`, but the only call site that creates
+    // `<DIR>/native/` is `stage_capsule_imports` — which
+    // `prepare_project_capsules` skips when the project has no
+    // capsule deps. Ensure unconditionally so positional builds
+    // (no deps) also succeed.
+    let out_parent = _dirname(out_path);
+    if out_parent.length > 0 { _ensure_dir(out_parent); }
+
+    // Resolve and compile any capsule deps declared in the project's
+    // capsule.toml before compiling the main source. stage_capsule_imports
+    // writes .sfn-asm + .layout-manifest into <work_dir>/native/import-context/
+    // (or build/native/import-context/ when `--work-dir` is unset)
+    // where the main module's lowering will find them.
+    //
+    // Stage D PR3: the `-p` self-host (`walk_src`) explicitly
+    // selects `<binary_dir>/sailfin` here so its 138-module compile
+    // runs each module in a fresh-arena subprocess and fits in 8 GB.
+    // A typical end-user positional build (a handful of capsule deps)
+    // fits in-process and shouldn't pay the subprocess spawn cost —
+    // and shouldn't have its arena state perturbed by `process.run`'s
+    // argv allocations, which has surfaced seed-corruption flakes in
+    // the entry's in-process compile downstream.
+    //
+    // #1405 Bug 2: a positional build of a *large-closure* source
+    // (e.g. a compiler unit test importing the whole compiler) cannot
+    // fit in-process either — it OOMs at ~15.5 GB. So we leave the
+    // empty `sailfin_exe` here and let `prepare_project_capsules`
+    // upgrade it to subprocess isolation *only* when the resolved
+    // closure crosses the size threshold (binary_dir is threaded
+    // below for that decision). Small closures stay in-process.
+    let mut sailfin_exe: string = "";
+    if walk_src {
+        if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sailfin"; }
+    }
+    let capsule_result = prepare_project_capsules(input_path, cache_config, consumer, sailfin_exe, work_dir, binary_dir);
+    // Issue #991: a per-module emit failure (e.g. an effect-gate
+    // `E0402` on an unimported sibling) leaves `ll_paths` empty and
+    // silently drops the offending module from the link. Without
+    // this guard the driver would link the survivors and print
+    // `built:` with exit 0, swallowing the failure. The resolver /
+    // per-module helper has already printed the diagnostic, so
+    // exit non-zero here without re-reporting. A legitimate "no
+    // capsule deps" project returns `success = true` with an empty
+    // `ll_paths`, so dependency-free builds still link and succeed.
+    if !capsule_result.success { return 1; }
+    let capsule_lls = capsule_result.ll_paths;
+
+    let ll_path = sailfin_cache_dir + "/program.ll";
+    let source = fs.readFile(input_path);
+    let module_name = module_name_from_path(input_path);
+    let ok = compile_to_llvm_file_with_module(source, module_name, ll_path, work_dir);
+    if !ok {
+        print("failed to compile LLVM for: " + input_path);
+
+        return 1;
+    }
+
+    // Library builds stop after `clang -c` on the main .ll — no link,
+    // no main symbol required. Capsule deps remain as `.ll` files
+    // under build/sailfin/capsules/ (compiled in `prepare_project_capsules`
+    // but not lowered to `.o` here). Downstream consumers that need
+    // dep object files will compile them on demand once Stage C lands
+    // the in-process driver.
+    if no_link {
+        let backend = LlvmTextBackend { };
+        let no_includes: string[] = [];
+        let rc_obj = backend.assemble(ll_path, out_path, "-O2", no_includes);
+        if rc_obj != 0 {
+            if !json_flag {
+                print("library build failed (clang exit=" + number_to_string(rc_obj)
+                    + ")");
+            }
+            return rc_obj;
+        }
+        if json_flag {
+            // Library builds stop after `clang -c` — no runtime
+            // link, so there's no runtime object-cache activity to
+            // fold; `capsule_result.stats` is the full total.
+            _emit_build_report(input_path, out_path, "library", 0, capsule_result, cache_config, capsule_result.stats);
+        } else {
+            print("built: " + out_path);
+            _print_cache_summary(capsule_result.stats);
+        }
+        // Stage C2a: per-capsule artifact sidecar for `-p` builds.
+        // No-op for positional builds (cap_capsule_name == "").
+        _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "library", cap_entry_relative, out_path, capsule_result);
+        // Epic #513 Phase 0.3 / issue #516: the compiler
+        // self-stamps `build/native/.build-stamp` here so the
+        // Makefile can stop shelling out to git. Gated on
+        // `[capsule].name == "sailfin"` inside the helper,
+        // so foreign capsule builds are a no-op.
+        emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
+        if check_determinism_flag {
+            return _do_determinism_check(out_path, true, cap_capsule_name, work_dir, capsule_path, input_path, binary_dir, cache_trace_flag, json_flag);
+        }
+        return 0;
+    }
+
+    let exe_path = out_path;
+    let mut all_lls: string[] = [ll_path];
+    let mut cli: int = 0;
+    loop {
+        if cli >= capsule_lls.length { break; }
+        all_lls.push(capsule_lls[cli]);
+        cli += 1;
+    }
+    // Issue #940: inject the implicit runtime capsule as a pure
+    // fallback when the resolver surfaced no `[dependencies]`. A
+    // `-p` / declared-dep build (incl. self-host) already carries
+    // `runtime_capsules`, so this is a no-op there; an end-user
+    // `sfn build <file>` with no deps now links via the implicit
+    // `runtime/capsule.toml` instead of the retired probe.
+    let mut build_runtime_caps = capsule_result.runtime_capsules;
+    if build_runtime_caps.length == 0 {
+        build_runtime_caps = runtime_capsule_from_root(runtime_root);
+    }
+    // Shared content-addressed cache root for runtime objects
+    // (#1096), mirroring the `.ll` module cache. Empty under
+    // `--no-cache` so the persistent store is neither read nor
+    // written, matching the summary-fold gate below.
+    let mut build_shared_cache_root: string = "";
+    if cache_config.enabled { build_shared_cache_root = cache_root(); }
+    let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir, build_shared_cache_root);
+    let rc = link_result.rc;
+    if rc != 0 {
+        if !json_flag {
+            print("link failed (clang exit=" + number_to_string(rc) + ")");
+        }
+        return rc;
+    }
+    // Fold the runtime object-cache stats accumulated during the
+    // link into the `.ll` module cache total so the single
+    // `[cache]` summary reflects both layers (#915). Gated on
+    // `cache_config.enabled`: under `--no-cache` the module cache
+    // is never consulted (counters stay zero), and the runtime
+    // object cache — which has no `--no-cache` gate of its own —
+    // must not resurrect a non-zero summary, so its stats are not
+    // folded when caching is disabled.
+    let mut build_cache_stats = capsule_result.stats;
+    if cache_config.enabled {
+        build_cache_stats = merge_cache_stats(capsule_result.stats, link_result.stats);
+    }
+    if json_flag {
+        _emit_build_report(input_path, exe_path, "binary", 0, capsule_result, cache_config, build_cache_stats);
+    } else {
+        print("built: " + exe_path);
+        _print_cache_summary(build_cache_stats);
+    }
+    // Stage C2a: per-capsule artifact sidecar for `-p` builds.
+    // No-op for positional builds (cap_capsule_name == "").
+    _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "binary", cap_entry_relative, exe_path, capsule_result);
+    // Epic #513 Phase 0.3 / issue #516: the compiler self-stamps
+    // `build/native/.build-stamp` here so the Makefile can stop
+    // shelling out to git. Gated on `[capsule].name == "sailfin"`
+    // inside the helper, so foreign capsule builds are a no-op.
+    emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
+    if check_determinism_flag {
+        return _do_determinism_check(exe_path, false, cap_capsule_name, work_dir, capsule_path, input_path, binary_dir, cache_trace_flag, json_flag);
+    }
+    return 0;
+}
+
+fn _legacy_dispatch_run(args: string[], runtime_root: string, binary_dir: string) -> int ![io] {
+    // run [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>
+    let mut input_path: string = "";
+    let mut no_cache_flag: boolean = false;
+    let mut clean_flag: boolean = false;
+    let mut cache_trace_flag: boolean = false;
+
+    let mut ri: int = 1;
+    loop {
+        if ri >= args.length { break; }
+        let a = args[ri];
+        if strings_equal(a, "--no-cache") {
+            no_cache_flag = true;
+            ri += 1;
+            continue;
+        }
+        if strings_equal(a, "--clean") {
+            clean_flag = true;
+            ri += 1;
+            continue;
+        }
+        if strings_equal(a, "--cache-trace") {
+            cache_trace_flag = true;
+            ri += 1;
+            continue;
+        }
+        // Positional argument: the source file (or executable).
+        if input_path.length > 0 {
+            print(_usage());
+            return 2;
+        }
+        input_path = a;
+        ri += 1;
+    }
+    if input_path.length == 0 {
+        print(_usage());
+
+        return 2;
+    }
+
+    // If the argument doesn't look like Sailfin source, treat it as an executable.
+    if !_ends_with(input_path, ".sfn") {
+        return process.run([input_path]);
+    }
+
+    if !fs.exists(input_path) {
+        print("file not found: " + input_path);
+
+        return 1;
+    }
+
+    // #1411: route the top-level `run.ll`/`run` executable under the
+    // per-invocation scratch when one is set (`SAILFIN_TEST_SCRATCH`),
+    // exactly as `sfn build` does (line ~2322). Bare-file dispatch
+    // delegates here (`["run", cmd]`), so it inherits this too. Without
+    // it, two concurrent `sfn run`/bare-dispatch children in the
+    // parallel `sfn test --jobs N` pool both write the fixed
+    // `build/sailfin/run` and clobber each other's executable — a test
+    // asserting on the run's stdout then sees another fixture's output
+    // (non-deterministic, #1411). Empty scratch resolves to
+    // `build/sailfin`, keeping the default invocation byte-for-byte.
+    let run_cache_dir = _resolve_sailfin_cache_dir_for_work("");
+    _ensure_dir(run_cache_dir);
+
+    let ll_path = run_cache_dir + "/run.ll";
+    let exe_path = run_cache_dir + "/run";
+
+    // Resolve and compile capsule deps before lowering the main file.
+    // The unified resolver covers relative imports, manifest-declared
+    // capsule deps, and workspace-implicit imports in one pass —
+    // text-level fallback retired with Stage B. CLI overrides
+    // (`--no-cache` / `--clean` / `--cache-trace`) layer on top of
+    // env-var defaults (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`).
+    let run_cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
+    // `sfn run` has no `-p` plumbing yet, so the consumer is
+    // always empty: relative-import `.ll`s take the legacy
+    // flat layout (Stage C2b2). When `sfn run -p` lands, this
+    // becomes a one-line update mirroring `sfn build`.
+    // Stage D PR3 / #1405 Bug 2: `sfn run` keeps the in-process
+    // compile path for small fixtures (its typical use case). It
+    // doesn't take `-p` yet, so `sailfin_exe`/`work_dir` stay empty;
+    // threading `binary_dir` lets `prepare_project_capsules` upgrade
+    // to subprocess isolation only when the resolved closure is large
+    // enough to otherwise OOM (a whole-compiler-importing `sfn run`).
+    let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), "", "", binary_dir);
+    let capsule_lls = run_capsule_result.ll_paths;
+
+    let source = fs.readFile(input_path);
+    let module_name = module_name_from_path(input_path);
+    let ok = compile_to_llvm_file_with_module(source, module_name, ll_path, "");
+    if !ok {
+        print("failed to compile LLVM for: " + input_path);
+
+        return 1;
+    }
+
+    let mut all_lls: string[] = [ll_path];
+    let mut rli: int = 0;
+    loop {
+        if rli >= capsule_lls.length { break; }
+        all_lls.push(capsule_lls[rli]);
+        rli += 1;
+    }
+    // Issue #940: same implicit-capsule fallback as `sfn build`
+    // (no-op for `-p` / declared-dep, load-bearing for a no-dep
+    // `sfn run <file>`).
+    let mut run_runtime_caps = run_capsule_result.runtime_capsules;
+    if run_runtime_caps.length == 0 {
+        run_runtime_caps = runtime_capsule_from_root(runtime_root);
+    }
+    // Shared runtime-object cache root (#1096); empty under
+    // `--no-cache` to leave the persistent store untouched.
+    let mut run_shared_cache_root: string = "";
+    if run_cache_config.enabled { run_shared_cache_root = cache_root(); }
+    let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "", run_shared_cache_root);
+    let link_rc = link_result.rc;
+    if link_rc != 0 {
+        // A native link failure is a real compiler/runtime bug to
+        // fix at the source — never paper over it. The prior
+        // `process.run(["sfn", "run", input_path])` "seed fallback"
+        // re-invoked `sfn run`, so on any persistent link failure
+        // it recursed into itself forever (#969). Fail closed with
+        // the clang exit code instead.
+        print("link failed (clang exit=" + number_to_string(link_rc) + ")");
+        return link_rc;
+    }
+
+    // Cache summary mirrors `sfn build`: quiet for builds with no
+    // cache activity (no manifest deps, or `--no-cache`), and the
+    // human-readable counterpart of the eventual `--json` build
+    // report's `cache` field. Runtime object-cache stats fold in
+    // alongside the `.ll` module cache total (#915), gated on
+    // `run_cache_config.enabled` so `--no-cache` stays quiet (see
+    // the `sfn build` fold site for the rationale).
+    let mut run_cache_stats = run_capsule_result.stats;
+    if run_cache_config.enabled {
+        run_cache_stats = merge_cache_stats(run_capsule_result.stats, link_result.stats);
+    }
+    _print_cache_summary(run_cache_stats);
+    let run_rc = process.run([exe_path]);
+    return run_rc;
+}
+
+fn _legacy_dispatch_package(args: string[]) -> int ![io] {
+    return handle_package_command(args);
+}
+
+fn _legacy_dispatch_lock(args: string[]) -> int ![io] {
+    return handle_lock_command(args);
+}
+
+fn _legacy_dispatch_config(args: string[]) -> int ![io] {
+    return handle_config_command(args);
+}
+
+fn _legacy_dispatch_check(args: string[], binary_dir: string) -> int ![io] {
+    return handle_check_command(args, binary_dir);
+}
+
 // Historical C ABI boundary — the now-retired C driver called
 // `sailfin_cli_main__cli_main` with an `int64_t` return type.
 // After M5.5 (#473) the only callers are `sailfin_cli_main_v2`
@@ -322,810 +1142,14 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
         if is_emit { print.err("cli: cmd_is_emit=true"); }
     }
 
-    if is_emit {
-        let mut timing = false;
-        let mut out_path = "";
-        // Stage D PR3: explicit module name override. Lets the
-        // resolver's per-module compile (`_cr_compile_one`) shell
-        // out to a fresh subprocess for arena isolation while
-        // preserving the slug-based module name needed for symbol
-        // mangling of cross-capsule deps (where the slug is
-        // `<scope>/<name>/<rest>`, not what `module_name_from_path`
-        // would derive). Empty / not provided → fall back to
-        // `module_name_from_path(path)` so all existing call sites
-        // (humans + tests + build.sh) keep their current shape.
-        let mut module_name_override: string = "";
-        // #957: root of the staged import-context tree
-        // (`build/native/import-context`). When set, the llvm-emit
-        // path reads `<root>/<module-name>.import-deps` to load the
-        // cross-module effect table so callee-effect transitivity
-        // (`E0402`) is enforced on the build path.
-        let mut import_context_root: string = "";
-        // #515: single-shot `sfn emit llvm -o` can route through
-        // `emit_llvm_with_retry` (the same emit+probe+validate+retry
-        // cascade the resolver's multi-source path uses). Validation +
-        // retry are OPT-IN here (default: 1 attempt, no validate) so the
-        // bare CLI stays byte-for-byte behaviour-preserving — a
-        // single-file emit may legitimately reference runtime-provided
-        // externs that don't self-assemble in isolation, and forcing
-        // `llvm-as` on every emit would surface those as spurious
-        // failures (e.g. the exe-path test's Darwin leg). Callers that
-        // KNOW their IR is self-contained opt in: the Makefile
-        // cross-build staging passes `--validate`, and the resolver
-        // validates at its own layer. Flags: `--attempts N` (N >= 1)
-        // sets the count; `--no-retry` == `--attempts 1`;
-        // `--validate` / `--no-validate` toggle the `llvm-as`/`clang`
-        // round-trip.
-        let mut emit_attempts: int = 1;
-        let mut emit_validate: boolean = false;
-        // #906: build-internal per-module native emits set this (via
-        // `--no-resolve-gate`) to skip the lowering dry-run gate, which
-        // would otherwise reject legitimate cross-module calls that the
-        // import-context-free native stage cannot resolve in isolation.
-        let mut skip_resolve_gate: boolean = false;
-        let mut base_index = 1;
-        // Parse optional flags: --timing, --module-name <slug>,
-        // -o <path>, --attempts N, --no-retry, --validate,
-        // --no-validate in any order.
-        let mut consumed_flag: boolean = true;
-        loop {
-            if !consumed_flag { break; }
-            if base_index >= args.length { break; }
-            consumed_flag = false;
-            if strings_equal(args[base_index], "--timing") {
-                timing = true;
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "-o") {
-                base_index += 1;
-                if base_index >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                out_path = args[base_index];
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--module-name") {
-                base_index += 1;
-                if base_index >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                module_name_override = args[base_index];
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--import-context") {
-                base_index += 1;
-                if base_index >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                import_context_root = args[base_index];
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--attempts") {
-                base_index += 1;
-                if base_index >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                let parsed = emit_parse_nonneg_int(args[base_index]);
-                if parsed >= 1 { emit_attempts = parsed; }
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--no-retry") {
-                emit_attempts = 1;
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--validate") {
-                emit_validate = true;
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--no-validate") {
-                emit_validate = false;
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-            if strings_equal(args[base_index], "--no-resolve-gate") {
-                skip_resolve_gate = true;
-                base_index += 1;
-                consumed_flag = true;
-                continue;
-            }
-        }
-        let _expected_args = base_index + 2;
-        if args.length != _expected_args {
-            print(_usage());
-
-            return 2;
-        }
-        let mode = args[base_index];
-        let _path_idx = base_index + 1;
-        let path = args[_path_idx];
-        if !fs.exists(path) {
-            print("file not found: " + path);
-
-            return 1;
-        }
-        // #1370: a user-facing `emit llvm` (no `--module-name` /
-        // `--import-context`, i.e. NOT a build-internal worker emit —
-        // every resolver/worker emit threads at least one of those flags)
-        // stages the consumer capsule's dependencies into the
-        // import-context tree first, exactly as `check` / `build` / `run`
-        // already do. Without this, a COLD `emit llvm` of a capsule that
-        // imports e.g. sfn/http `serve` finds no staged
-        // `build/native/import-context/sfn/http/*.sfn-asm`, so the imported
-        // `serve` never enters the lowering `functions` list and the #1323
-        // gate (`expression_lowering/native/core.sfn`) hijacks the call to
-        // the builtin `@sfn_serve`. A loose `.sfn` outside any capsule
-        // resolves to zero sources and is a no-op, preserving bare-emit
-        // behavior; the guard keeps the self-host worker emits unchanged.
-        // Scoped to `llvm`: that is the lowering stage the #1323 gate runs
-        // in; `native` emit is import-context-free by design (#906) and
-        // `sailfin` is a transpile, so neither needs staging.
-        // `stage_capsule_imports_for_emit` no-ops unless the entry's
-        // capsule.toml declares `[dependencies]`, so a bare runtime/prelude
-        // emit (the cross-windows path) is untouched (#1370 regression).
-        if strings_equal(mode, "llvm") && module_name_override.length == 0
-            && import_context_root.length == 0 {
-            let emit_stage_exe = _resolve_self_path(binary_dir);
-            let emit_staged = stage_capsule_imports_for_emit(path, emit_stage_exe, "");
-            if !emit_staged {
-                print.err("sfn emit: warning: capsule import staging incomplete; imported capsule calls may not resolve");
-            }
-        }
-        let source = fs.readFile(path);
-        let mut module_name = module_name_from_path(path);
-        if module_name_override.length > 0 {
-            module_name = module_name_override;
-        }
-        let has_out = out_path.length > 0;
-        if strings_equal(mode, "llvm") {
-            if has_out {
-                if timing {
-                    // --timing keeps the single-attempt, no-validate
-                    // path: it reports per-phase emit timings, which a
-                    // retry loop would distort.
-                    let llvm = compile_to_llvm_with_module_timed(source, module_name);
-                    _write_llvm_text(out_path, llvm);
-                } else {
-                    // #515: route through the shared retry+validator
-                    // cascade. Empty `import_asm_paths` degrades to the
-                    // legacy in-module-only effect gate (same as the
-                    // bare `compile_to_llvm_file_with_module` call this
-                    // replaced).
-                    let mut import_asm_paths: string[] = [];
-                    if import_context_root.length > 0 {
-                        import_asm_paths = _read_import_deps(import_context_root, module_name);
-                    }
-                    let ok = emit_llvm_with_retry(path, module_name, out_path, import_asm_paths, emit_attempts, emit_validate, false);
-                    if !ok { return 1; }
-                }
-            } else {
-                if timing {
-                    print(compile_to_llvm_with_module_timed(source, module_name));
-                } else {
-                    if !print_llvm_with_module(source, module_name) { return 1; }
-                }
-            }
-            return 0;
-        }
-        if strings_equal(mode, "sailfin") {
-            if has_out {
-                fs.writeFile(out_path, compile_to_sailfin(source));
-            } else { print(compile_to_sailfin(source)); }
-            return 0;
-        }
-        if strings_equal(mode, "native") {
-            // #906: gate the native emit on the same lowering `[fatal]`
-            // that `build` / `emit llvm` reject, so `emit native` fails
-            // closed (rc != 0, no `.sfn-asm`) on unresolved-callee inputs
-            // instead of writing an artifact and exiting 0. The build's
-            // per-module subprocess emit passes `--no-resolve-gate`
-            // (`skip_resolve_gate`) to opt out: that stage emits
-            // intermediate `.sfn-asm` with no cross-module import context,
-            // so it must not gate here — the build stays fail-closed via
-            // its later LLVM lowering stage (#631).
-            let run_gate = !skip_resolve_gate;
-            if has_out {
-                if !write_native_text_file_with_module_gated(source, module_name, out_path, run_gate) {
-                    return 1;
-                }
-            } else {
-                if !print_native_text_with_module_gated(source, module_name, run_gate) {
-                    return 1;
-                }
-            }
-            return 0;
-        }
-        print("unknown emit mode: " + mode);
-
-        return 2;
-    }
+    if is_emit { return _legacy_dispatch_emit(args, binary_dir); }
 
     if is_build {
-        // build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json]
-        //       [--work-dir DIR] [--check-determinism] (file | -p <capsule-path>)
-        let mut out_path: string = "";
-        let mut input_path: string = "";
-        let mut capsule_path: string = "";
-        let mut no_cache_flag: boolean = false;
-        let mut clean_flag: boolean = false;
-        let mut cache_trace_flag: boolean = false;
-        let mut json_flag: boolean = false;
-        // `--work-dir DIR` virtualizes the build's intermediate
-        // artifacts (`<DIR>/native/import-context/`, `<DIR>/sailfin/`,
-        // and the default `<DIR>/native/sailfin` output) instead of
-        // the CWD-relative `./build/...` layout. Empty preserves the
-        // legacy paths byte-for-byte. This is the driver-side
-        // equivalent of the prior `scripts/build.sh`'s `WORK_DIR` /
-        // `SEED_CWD` derivation (the script was retired in Stage E
-        // PR7 / #383); `make check`'s stage2/stage3 fixed-point now
-        // routes through this flag.
-        let mut work_dir: string = "";
-        // `--check-determinism` (issue #779) runs the build twice
-        // and compares per-module cache_keys + the linked binary's
-        // sha256, exiting non-zero on mismatch. Pass 2 is driven
-        // by re-executing this same compiler binary as a subprocess
-        // with a sibling `--work-dir` so the two passes don't
-        // stomp each other's artifacts. The sidecar manifest.json
-        // at `build/capsules/<scope>/<name>/manifest.json` is the
-        // ONE artifact that's not virtualized by `--work-dir`;
-        // pass 2 overwrites pass 1's sidecar, so the orchestrator
-        // reads pass 1's sidecar off disk BEFORE invoking pass 2
-        // (see `_do_determinism_check` below). For capsules whose
-        // name isn't in scope/name form, no sidecar is written and
-        // the check degrades to a binary-sha256 comparison.
-        let mut check_determinism_flag: boolean = false;
-
-        // Parse args: support -o OUTPUT and -p PATH in any combination.
-        let mut bi: int = 1;
-        loop {
-            if bi >= args.length { break; }
-            let a = args[bi];
-            if strings_equal(a, "-o") {
-                if bi + 1 >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                out_path = args[bi + 1];
-                bi += 2;
-                continue;
-            }
-            if strings_equal(a, "-p") {
-                if bi + 1 >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                capsule_path = args[bi + 1];
-                bi += 2;
-                continue;
-            }
-            if strings_equal(a, "--no-cache") {
-                no_cache_flag = true;
-                bi += 1;
-                continue;
-            }
-            if strings_equal(a, "--clean") {
-                clean_flag = true;
-                bi += 1;
-                continue;
-            }
-            if strings_equal(a, "--cache-trace") {
-                cache_trace_flag = true;
-                bi += 1;
-                continue;
-            }
-            if strings_equal(a, "--json") {
-                json_flag = true;
-                bi += 1;
-                continue;
-            }
-            if strings_equal(a, "--work-dir") {
-                if bi + 1 >= args.length {
-                    print(_usage());
-                    return 2;
-                }
-                work_dir = args[bi + 1];
-                bi += 2;
-                continue;
-            }
-            if strings_equal(a, "--check-determinism") {
-                check_determinism_flag = true;
-                bi += 1;
-                continue;
-            }
-            let mut is_help_flag: boolean = false;
-            if strings_equal(a, "--help") { is_help_flag = true; }
-            if strings_equal(a, "-h") { is_help_flag = true; }
-            if is_help_flag {
-                print(_usage());
-                return 0;
-            }
-            // Positional argument: the source file.
-            if input_path.length > 0 {
-                print(_usage());
-                return 2;
-            }
-            input_path = a;
-            bi += 1;
-        }
-        // Resolved scratch / staging roots for this build. With
-        // `--work-dir` unset both fall back to the legacy in-tree
-        // paths so the default invocation is byte-for-byte identical.
-        let sailfin_cache_dir = _resolve_sailfin_cache_dir_for_work(work_dir);
-        let cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
-
-        // -p resolves the entry path + build kind from the capsule's
-        // manifest. The build then proceeds as for a positional source
-        // file, with the kind controlling whether we link an executable
-        // (binary) or just emit an object (library/runtime).
-        let mut build_kind: string = "binary";
-        // Captured from `-p` resolution so the post-build sidecar
-        // emitter (Stage C2a) has the manifest's name + version
-        // + entry-relative path without re-reading capsule.toml.
-        // Empty when `-p` was not used (positional source only).
-        let mut cap_capsule_name: string = "";
-        let mut cap_version: string = "";
-        let mut cap_entry_relative: string = "";
-        if capsule_path.length > 0 {
-            if input_path.length > 0 {
-                print("sfn build: -p and positional source are mutually exclusive");
-                return 2;
-            }
-            let cap_spec = _resolve_capsule_build_spec(capsule_path);
-            if cap_spec.entry_path.length == 0 { return 1; }
-            input_path = cap_spec.entry_path;
-            build_kind = cap_spec.kind;
-            cap_capsule_name = cap_spec.capsule_name;
-            cap_version = cap_spec.version;
-            cap_entry_relative = cap_spec.entry_relative;
-        }
-        if input_path.length == 0 {
-            print(_usage());
-            return 2;
-        }
-
-        let is_library_build = strings_equal(build_kind, "library");
-        let is_runtime_build = strings_equal(build_kind, "runtime");
-        let no_link = is_library_build;
-        // Stage D PR1: `kind = "runtime"` capsules are now a recognised
-        // schema variant — they ship declarative C / LL / include-dirs
-        // / link-libs source lists rather than `.sfn` modules. The
-        // driver doesn't yet COMPILE them as a top-level `-p` target
-        // (Stage D PR2 wires the link phase up); building one
-        // directly surfaces a hint and exits with the same usage-error
-        // code as other `-p` misuse so scripts/CI don't treat the
-        // unsupported invocation as success and proceed with missing
-        // artifacts.
-        if is_runtime_build {
-            print("sfn build: kind = \"runtime\" capsules are not buildable directly;");
-            print("           declare \"" + cap_capsule_name
-                + "\" as a dependency of a kind=\"binary\" capsule instead.");
-            return 2;
-        }
-
-        // Resolve the consumer's safe scope/name once. Used by:
-        //   (a) the canonical-`out_path` defaulting block below
-        //       (Stage C2b1), and
-        //   (b) the resolver's `ResolverConsumer` so intra-capsule
-        //       relative-import `.ll`s land under the consumer's
-        //       per-capsule tree (Stage C2b2).
-        // Both `out_path` and dep `.ll` routing fall back to the
-        // legacy flat layout when the name isn't scope-form (e.g.
-        // the compiler's own `[capsule].name = "sailfin"`).
-        // Stage D PR3: opt the resolver into walking
-        // `<project_root>/src/**/*.sfn` for any `-p` build of a
-        // `kind = "binary"` capsule. The compiler is the canonical
-        // case — `compiler/src/main.sfn` doesn't transitively
-        // import every `.sfn` under `compiler/src/` (notably
-        // `cli_main.sfn` and the CLI subcommand modules), so the
-        // entry-driven relative-import walker would miss them and
-        // the link would surface 100+ undefined references. Library
-        // builds keep the entry-driven enumeration for now — they
-        // produce a single unlinked `.o` whose multi-file story
-        // shakes out the same way intra-project imports do today.
-        let walk_src = capsule_path.length > 0 && !is_runtime_build && !is_library_build;
-        let mut consumer = ResolverConsumer {
-            scope: "",
-            name: "",
-            walk_project_src: walk_src,
-            include_host_as_dep: false
-        };
-        if cap_capsule_name.length > 0 {
-            let parts0 = parse_scope_name(cap_capsule_name);
-            if is_safe_scope_name(parts0.scope, parts0.name) {
-                consumer = ResolverConsumer {
-                    scope: parts0.scope,
-                    name: parts0.name,
-                    walk_project_src: walk_src,
-                    include_host_as_dep: false
-                };
-            }
-        }
-
-        if out_path.length == 0 {
-            // `--work-dir <root>` overrides the canonical
-            // per-capsule layout: when set, the default output is
-            // `<root>/native/sailfin` for binary builds (matching
-            // the prior `scripts/build.sh`'s historical
-            // `OUT="$WORK_DIR/.../native/sailfin"` shape; the
-            // script was retired in Stage E PR7 / #383) or
-            // `<root>/sailfin/program.o` for libraries. The
-            // work-dir form is meant for build orchestration
-            // (now exclusively `make check`'s stage2/stage3
-            // fixed-point comparison; formerly also the prior
-            // build.sh), so it explicitly takes precedence over
-            // the scoped `build/capsules/...` layout.
-            if work_dir.length > 0 {
-                if no_link { out_path = sailfin_cache_dir + "/program.o"; } else {
-                    out_path = work_dir + "/native/sailfin";
-                }
-            } else {
-                // Stage C2b: when `-p` is used and `-o` was NOT
-                // given, default to the canonical per-capsule
-                // layout (`build/capsules/<scope>/<name>/{obj/mod.o,
-                // bin/<name>}`) from proposal §4.4. Positional builds
-                // and explicit `-o` paths still use their pre-
-                // existing locations — user override is sacred.
-                // Unsafe / non-scope-form capsule names fall back to
-                // the legacy paths so a malformed `[capsule].name`
-                // can never escape the build root.
-                let mut canonical_set: boolean = false;
-                if consumer.scope.length > 0 {
-                    let cap_dir = capsule_artifact_dir(consumer.scope, consumer.name);
-                    if no_link {
-                        _ensure_dir(cap_dir + "/obj");
-                        out_path = capsule_artifact_obj_path(consumer.scope, consumer.name);
-                        canonical_set = true;
-                    } else {
-                        let bin_name = capsule_default_bin_name(consumer.name);
-                        if bin_name.length > 0 {
-                            _ensure_dir(cap_dir + "/bin");
-                            out_path = capsule_artifact_bin_path(consumer.scope, consumer.name, bin_name);
-                            canonical_set = true;
-                        }
-                    }
-                }
-                if !canonical_set {
-                    if no_link { out_path = "build/sailfin/program.o"; } else {
-                        out_path = "build/sailfin/program";
-                    }
-                }
-            }
-        }
-
-        if !fs.exists(input_path) {
-            print("file not found: " + input_path);
-
-            return 1;
-        }
-
-        if work_dir.length == 0 { _ensure_dir("build"); } else {
-            _ensure_dir(work_dir);
-        }
-        _ensure_dir(sailfin_cache_dir);
-        // Make sure the parent dir of the resolved `out_path` exists
-        // before clang writes the binary / object. With
-        // `--work-dir <DIR>` the default binary lands at
-        // `<DIR>/native/sailfin`, but the only call site that creates
-        // `<DIR>/native/` is `stage_capsule_imports` — which
-        // `prepare_project_capsules` skips when the project has no
-        // capsule deps. Ensure unconditionally so positional builds
-        // (no deps) also succeed.
-        let out_parent = _dirname(out_path);
-        if out_parent.length > 0 { _ensure_dir(out_parent); }
-
-        // Resolve and compile any capsule deps declared in the project's
-        // capsule.toml before compiling the main source. stage_capsule_imports
-        // writes .sfn-asm + .layout-manifest into <work_dir>/native/import-context/
-        // (or build/native/import-context/ when `--work-dir` is unset)
-        // where the main module's lowering will find them.
-        //
-        // Stage D PR3: the `-p` self-host (`walk_src`) explicitly
-        // selects `<binary_dir>/sailfin` here so its 138-module compile
-        // runs each module in a fresh-arena subprocess and fits in 8 GB.
-        // A typical end-user positional build (a handful of capsule deps)
-        // fits in-process and shouldn't pay the subprocess spawn cost —
-        // and shouldn't have its arena state perturbed by `process.run`'s
-        // argv allocations, which has surfaced seed-corruption flakes in
-        // the entry's in-process compile downstream.
-        //
-        // #1405 Bug 2: a positional build of a *large-closure* source
-        // (e.g. a compiler unit test importing the whole compiler) cannot
-        // fit in-process either — it OOMs at ~15.5 GB. So we leave the
-        // empty `sailfin_exe` here and let `prepare_project_capsules`
-        // upgrade it to subprocess isolation *only* when the resolved
-        // closure crosses the size threshold (binary_dir is threaded
-        // below for that decision). Small closures stay in-process.
-        let mut sailfin_exe: string = "";
-        if walk_src {
-            if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sailfin"; }
-        }
-        let capsule_result = prepare_project_capsules(input_path, cache_config, consumer, sailfin_exe, work_dir, binary_dir);
-        // Issue #991: a per-module emit failure (e.g. an effect-gate
-        // `E0402` on an unimported sibling) leaves `ll_paths` empty and
-        // silently drops the offending module from the link. Without
-        // this guard the driver would link the survivors and print
-        // `built:` with exit 0, swallowing the failure. The resolver /
-        // per-module helper has already printed the diagnostic, so
-        // exit non-zero here without re-reporting. A legitimate "no
-        // capsule deps" project returns `success = true` with an empty
-        // `ll_paths`, so dependency-free builds still link and succeed.
-        if !capsule_result.success { return 1; }
-        let capsule_lls = capsule_result.ll_paths;
-
-        let ll_path = sailfin_cache_dir + "/program.ll";
-        let source = fs.readFile(input_path);
-        let module_name = module_name_from_path(input_path);
-        let ok = compile_to_llvm_file_with_module(source, module_name, ll_path, work_dir);
-        if !ok {
-            print("failed to compile LLVM for: " + input_path);
-
-            return 1;
-        }
-
-        // Library builds stop after `clang -c` on the main .ll — no link,
-        // no main symbol required. Capsule deps remain as `.ll` files
-        // under build/sailfin/capsules/ (compiled in `prepare_project_capsules`
-        // but not lowered to `.o` here). Downstream consumers that need
-        // dep object files will compile them on demand once Stage C lands
-        // the in-process driver.
-        if no_link {
-            let backend = LlvmTextBackend { };
-            let no_includes: string[] = [];
-            let rc_obj = backend.assemble(ll_path, out_path, "-O2", no_includes);
-            if rc_obj != 0 {
-                if !json_flag {
-                    print("library build failed (clang exit=" + number_to_string(rc_obj)
-                        + ")");
-                }
-                return rc_obj;
-            }
-            if json_flag {
-                // Library builds stop after `clang -c` — no runtime
-                // link, so there's no runtime object-cache activity to
-                // fold; `capsule_result.stats` is the full total.
-                _emit_build_report(input_path, out_path, "library", 0, capsule_result, cache_config, capsule_result.stats);
-            } else {
-                print("built: " + out_path);
-                _print_cache_summary(capsule_result.stats);
-            }
-            // Stage C2a: per-capsule artifact sidecar for `-p` builds.
-            // No-op for positional builds (cap_capsule_name == "").
-            _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "library", cap_entry_relative, out_path, capsule_result);
-            // Epic #513 Phase 0.3 / issue #516: the compiler
-            // self-stamps `build/native/.build-stamp` here so the
-            // Makefile can stop shelling out to git. Gated on
-            // `[capsule].name == "sailfin"` inside the helper,
-            // so foreign capsule builds are a no-op.
-            emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
-            if check_determinism_flag {
-                return _do_determinism_check(out_path, true, cap_capsule_name, work_dir, capsule_path, input_path, binary_dir, cache_trace_flag, json_flag);
-            }
-            return 0;
-        }
-
-        let exe_path = out_path;
-        let mut all_lls: string[] = [ll_path];
-        let mut cli: int = 0;
-        loop {
-            if cli >= capsule_lls.length { break; }
-            all_lls.push(capsule_lls[cli]);
-            cli += 1;
-        }
-        // Issue #940: inject the implicit runtime capsule as a pure
-        // fallback when the resolver surfaced no `[dependencies]`. A
-        // `-p` / declared-dep build (incl. self-host) already carries
-        // `runtime_capsules`, so this is a no-op there; an end-user
-        // `sfn build <file>` with no deps now links via the implicit
-        // `runtime/capsule.toml` instead of the retired probe.
-        let mut build_runtime_caps = capsule_result.runtime_capsules;
-        if build_runtime_caps.length == 0 {
-            build_runtime_caps = runtime_capsule_from_root(runtime_root);
-        }
-        // Shared content-addressed cache root for runtime objects
-        // (#1096), mirroring the `.ll` module cache. Empty under
-        // `--no-cache` so the persistent store is neither read nor
-        // written, matching the summary-fold gate below.
-        let mut build_shared_cache_root: string = "";
-        if cache_config.enabled { build_shared_cache_root = cache_root(); }
-        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir, build_shared_cache_root);
-        let rc = link_result.rc;
-        if rc != 0 {
-            if !json_flag {
-                print("link failed (clang exit=" + number_to_string(rc) + ")");
-            }
-            return rc;
-        }
-        // Fold the runtime object-cache stats accumulated during the
-        // link into the `.ll` module cache total so the single
-        // `[cache]` summary reflects both layers (#915). Gated on
-        // `cache_config.enabled`: under `--no-cache` the module cache
-        // is never consulted (counters stay zero), and the runtime
-        // object cache — which has no `--no-cache` gate of its own —
-        // must not resurrect a non-zero summary, so its stats are not
-        // folded when caching is disabled.
-        let mut build_cache_stats = capsule_result.stats;
-        if cache_config.enabled {
-            build_cache_stats = merge_cache_stats(capsule_result.stats, link_result.stats);
-        }
-        if json_flag {
-            _emit_build_report(input_path, exe_path, "binary", 0, capsule_result, cache_config, build_cache_stats);
-        } else {
-            print("built: " + exe_path);
-            _print_cache_summary(build_cache_stats);
-        }
-        // Stage C2a: per-capsule artifact sidecar for `-p` builds.
-        // No-op for positional builds (cap_capsule_name == "").
-        _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "binary", cap_entry_relative, exe_path, capsule_result);
-        // Epic #513 Phase 0.3 / issue #516: the compiler self-stamps
-        // `build/native/.build-stamp` here so the Makefile can stop
-        // shelling out to git. Gated on `[capsule].name == "sailfin"`
-        // inside the helper, so foreign capsule builds are a no-op.
-        emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
-        if check_determinism_flag {
-            return _do_determinism_check(exe_path, false, cap_capsule_name, work_dir, capsule_path, input_path, binary_dir, cache_trace_flag, json_flag);
-        }
-        return 0;
+        return _legacy_dispatch_build(args, runtime_root, binary_dir);
     }
 
     if is_run {
-        // run [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>
-        let mut input_path: string = "";
-        let mut no_cache_flag: boolean = false;
-        let mut clean_flag: boolean = false;
-        let mut cache_trace_flag: boolean = false;
-
-        let mut ri: int = 1;
-        loop {
-            if ri >= args.length { break; }
-            let a = args[ri];
-            if strings_equal(a, "--no-cache") {
-                no_cache_flag = true;
-                ri += 1;
-                continue;
-            }
-            if strings_equal(a, "--clean") {
-                clean_flag = true;
-                ri += 1;
-                continue;
-            }
-            if strings_equal(a, "--cache-trace") {
-                cache_trace_flag = true;
-                ri += 1;
-                continue;
-            }
-            // Positional argument: the source file (or executable).
-            if input_path.length > 0 {
-                print(_usage());
-                return 2;
-            }
-            input_path = a;
-            ri += 1;
-        }
-        if input_path.length == 0 {
-            print(_usage());
-
-            return 2;
-        }
-
-        // If the argument doesn't look like Sailfin source, treat it as an executable.
-        if !_ends_with(input_path, ".sfn") {
-            return process.run([input_path]);
-        }
-
-        if !fs.exists(input_path) {
-            print("file not found: " + input_path);
-
-            return 1;
-        }
-
-        // #1411: route the top-level `run.ll`/`run` executable under the
-        // per-invocation scratch when one is set (`SAILFIN_TEST_SCRATCH`),
-        // exactly as `sfn build` does (line ~2322). Bare-file dispatch
-        // delegates here (`["run", cmd]`), so it inherits this too. Without
-        // it, two concurrent `sfn run`/bare-dispatch children in the
-        // parallel `sfn test --jobs N` pool both write the fixed
-        // `build/sailfin/run` and clobber each other's executable — a test
-        // asserting on the run's stdout then sees another fixture's output
-        // (non-deterministic, #1411). Empty scratch resolves to
-        // `build/sailfin`, keeping the default invocation byte-for-byte.
-        let run_cache_dir = _resolve_sailfin_cache_dir_for_work("");
-        _ensure_dir(run_cache_dir);
-
-        let ll_path = run_cache_dir + "/run.ll";
-        let exe_path = run_cache_dir + "/run";
-
-        // Resolve and compile capsule deps before lowering the main file.
-        // The unified resolver covers relative imports, manifest-declared
-        // capsule deps, and workspace-implicit imports in one pass —
-        // text-level fallback retired with Stage B. CLI overrides
-        // (`--no-cache` / `--clean` / `--cache-trace`) layer on top of
-        // env-var defaults (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`).
-        let run_cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
-        // `sfn run` has no `-p` plumbing yet, so the consumer is
-        // always empty: relative-import `.ll`s take the legacy
-        // flat layout (Stage C2b2). When `sfn run -p` lands, this
-        // becomes a one-line update mirroring `sfn build`.
-        // Stage D PR3 / #1405 Bug 2: `sfn run` keeps the in-process
-        // compile path for small fixtures (its typical use case). It
-        // doesn't take `-p` yet, so `sailfin_exe`/`work_dir` stay empty;
-        // threading `binary_dir` lets `prepare_project_capsules` upgrade
-        // to subprocess isolation only when the resolved closure is large
-        // enough to otherwise OOM (a whole-compiler-importing `sfn run`).
-        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), "", "", binary_dir);
-        let capsule_lls = run_capsule_result.ll_paths;
-
-        let source = fs.readFile(input_path);
-        let module_name = module_name_from_path(input_path);
-        let ok = compile_to_llvm_file_with_module(source, module_name, ll_path, "");
-        if !ok {
-            print("failed to compile LLVM for: " + input_path);
-
-            return 1;
-        }
-
-        let mut all_lls: string[] = [ll_path];
-        let mut rli: int = 0;
-        loop {
-            if rli >= capsule_lls.length { break; }
-            all_lls.push(capsule_lls[rli]);
-            rli += 1;
-        }
-        // Issue #940: same implicit-capsule fallback as `sfn build`
-        // (no-op for `-p` / declared-dep, load-bearing for a no-dep
-        // `sfn run <file>`).
-        let mut run_runtime_caps = run_capsule_result.runtime_capsules;
-        if run_runtime_caps.length == 0 {
-            run_runtime_caps = runtime_capsule_from_root(runtime_root);
-        }
-        // Shared runtime-object cache root (#1096); empty under
-        // `--no-cache` to leave the persistent store untouched.
-        let mut run_shared_cache_root: string = "";
-        if run_cache_config.enabled { run_shared_cache_root = cache_root(); }
-        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "", run_shared_cache_root);
-        let link_rc = link_result.rc;
-        if link_rc != 0 {
-            // A native link failure is a real compiler/runtime bug to
-            // fix at the source — never paper over it. The prior
-            // `process.run(["sfn", "run", input_path])` "seed fallback"
-            // re-invoked `sfn run`, so on any persistent link failure
-            // it recursed into itself forever (#969). Fail closed with
-            // the clang exit code instead.
-            print("link failed (clang exit=" + number_to_string(link_rc) + ")");
-            return link_rc;
-        }
-
-        // Cache summary mirrors `sfn build`: quiet for builds with no
-        // cache activity (no manifest deps, or `--no-cache`), and the
-        // human-readable counterpart of the eventual `--json` build
-        // report's `cache` field. Runtime object-cache stats fold in
-        // alongside the `.ll` module cache total (#915), gated on
-        // `run_cache_config.enabled` so `--no-cache` stays quiet (see
-        // the `sfn build` fold site for the rationale).
-        let mut run_cache_stats = run_capsule_result.stats;
-        if run_cache_config.enabled {
-            run_cache_stats = merge_cache_stats(run_capsule_result.stats, link_result.stats);
-        }
-        _print_cache_summary(run_cache_stats);
-        let run_rc = process.run([exe_path]);
-        return run_rc;
+        return _legacy_dispatch_run(args, runtime_root, binary_dir);
     }
 
     // `sfn test` migrated to `sfn/cli` (epic #351, Issue 3.8) — handled
@@ -1140,17 +1164,17 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn publish` migrated to `sfn/cli` (epic #351, Issue 3.9) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    if is_package { return handle_package_command(args); }
+    if is_package { return _legacy_dispatch_package(args); }
 
-    if is_lock { return handle_lock_command(args); }
+    if is_lock { return _legacy_dispatch_lock(args); }
 
     // `sfn login` migrated to `sfn/cli` (epic #351, Issue 3.2) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    if is_config { return handle_config_command(args); }
+    if is_config { return _legacy_dispatch_config(args); }
 
     // `sfn fmt` migrated to `sfn/cli` (epic #351, Issue 3.4) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    if is_check { return handle_check_command(args, binary_dir); }
+    if is_check { return _legacy_dispatch_check(args, binary_dir); }
 
     // #1502: internal self-host fixed-point validator (undocumented).
     if is_selfhost { return handle_selfhost_command(args, binary_dir); }


### PR DESCRIPTION
## Summary
- Extract each command dispatch arm (`emit`, `build`, `run`, `package`, `lock`, `config`, `check`) out of the 937-line `sailfin_cli_main_legacy` into its own `_legacy_dispatch_<cmd>` helper in `cli_main.sfn`; the legacy body now only computes the command flags and delegates.
- Pure behavior-preserving move — each arm relocated verbatim, no semantic change (SFEP-0027 §3.3, Phase A). `sailfin_cli_main_legacy` drops from ~937 to ~150 lines, shrinking the single function the lowering pass holds in working set at once (the `cli_main` per-module peak-RSS lever that caps parallel CI `--jobs`).

Closes #1734

## Acceptance Criteria
- [x] Each command arm lives in a `_legacy_dispatch_` helper; `sailfin_cli_main_legacy` only computes the command flags and dispatches.
- [x] Effect rows preserved — `_legacy_dispatch_emit` is `[io, clock]` (its `compile_to_llvm_with_module_timed` call is the sole `clock` source); `build`/`run`/`package`/`lock`/`config`/`check` are `[io]`; the dispatch entry stays `[io, clock]`. `sfn check compiler/src/cli_main.sfn` clean.
- [x] `sfn fmt --check` clean on the touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes (per-command e2e tests are the parity oracle).

## Map reconciliation
The advisory map drifted from the tree but the semantic `In:` scope held — reconciled, no scope growth:
- `sailfin_cli_main_legacy` had already moved from `cli_main.sfn:1918` (grooming, 2026-06-26) to ~239 (sibling Phase A build-driver carves landed first), and was ~933 lines, not 937. Same function, same module — followed it.
- The arm set in scope (`emit`, `build`, `run`) carried large inline bodies; `package`/`lock`/`config`/`check` were already thin `handle_*_command` delegations, so their `_legacy_dispatch_*` helpers are exact passthroughs (uniform Phase B migration seeds). `selfhost`/`is_help`/bare-file/unknown-command were out of the command list and left inline.

## Verification
```bash
make compile   # status: pass — build/native/sailfin rebuilt (self-host holds)
make test      # status: pass — unit 184/184, integration 42/42, e2e 169/169, capsules 38/38
build/native/sailfin fmt --check compiler/src/cli_main.sfn   # clean
build/native/sailfin check compiler/src/cli_main.sfn         # checked 1 files: ok
```

## Files Changed
- `compiler/src/cli_main.sfn` — 7 `_legacy_dispatch_<cmd>` helpers added before `sailfin_cli_main_legacy`; the 7 dispatch arms now delegate to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfhS9cz71ddvQsp6epzUTC)_