### PR TITLE
perf(http): add parse→policy→forward hot-path benchmark (150ms gate)

### DIFF
--- a/benchmarks/runtime/README.md
+++ b/benchmarks/runtime/README.md
@@ -68,6 +68,28 @@ minutes.
 | `array_map_filter` | collection traversal (`runtime/sfn/array.sfn`) | 8,000,000 | Map (double) → filter (multiples of 3) → reduce (sum) over a large array. |
 | `exception_throw` | exception frames (`runtime/sfn/exception.sfn`) | 600,000 | Per-iteration `try`/`catch`; ~1 in 4 iterations throws and is caught. |
 | `io_throughput` | filesystem adapter (`runtime/sfn/adapters/filesystem.sfn`) | 20,000 | Appends N lines to a temp file (`$TMPDIR`, fallback `/tmp`) via `fs.appendFile`, then reads the file back once. |
+| `http_proxy_hotpath` | MCP-proxy request hot path (parse + `StrMap` + forward) | 12,000 iters × 7 rounds (median) | Per iteration: parse an HTTP/1.1 request (representative inline wire parse) → policy lookup in the real prelude `StrMap` (`runtime/sfn/collections.sfn`) → serialize the forwarded outbound request. CPU-only (no network). Documented **150 ms** budget; the program prints its own PASS/FAIL and the harness gates it with `--budget-time 150`. |
+
+### Hot-path budget gate (`http_proxy_hotpath`, #1712)
+
+`http_proxy_hotpath` establishes the parse→policy→forward baseline for the
+MCP-proxy work (epic #1540, Track C gap C6) with a documented **150 ms**
+per-round wall-clock budget. It is **advisory-only** (no CI gating yet — Track C
+B5/epoll work is out of scope). To check the gate locally:
+
+```bash
+make bench-runtime BENCH_RUNTIME_ARGS="--workload http_proxy_hotpath --budget-time 150"
+```
+
+The benchmark measures the CPU hot path only: a live upstream forward is
+non-deterministic and would break the cross-run comparability requirement, so the
+"forward" step is the outbound-request serialization the proxy performs before
+handing bytes to the socket. The parse is an inline parse mirroring
+`capsules/sfn/http/src/wire.sfn::parse_request` — the `sfn/http` capsule parser
+cannot be reused directly because the harness builds each workload as a bare
+`.sfn` file and a capsule module with its own relative imports does not link into
+a bare-file build. The policy lookup uses the **real** `StrMap` (#1710), which is
+a runtime module and links cleanly.
 
 ### Compiler-version caveats (0.7.0-alpha.47)
 

--- a/benchmarks/runtime/http_proxy_hotpath.sfn
+++ b/benchmarks/runtime/http_proxy_hotpath.sfn
@@ -1,0 +1,258 @@
+// benchmarks/runtime/http_proxy_hotpath.sfn
+//
+// Runtime-execution benchmark: the MCP-proxy request hot path
+//   parse (HTTP/1.1 wire) -> policy decision (StrMap lookup) -> forward
+// (issue #1712, epic #1540 Track C gap C6; folds into the `sfn bench`
+// epic #1503).
+//
+// Purpose: establish a runnable baseline for the parse->policy->forward
+// hot path with a documented 150 ms wall-clock budget, so later perf
+// work (keep-alive reuse, an epoll event loop) has a number to compare
+// against. This benchmark deliberately measures the CPU hot path only,
+// with no network: a real upstream forward is non-deterministic and
+// could not satisfy the "deterministic enough to compare across runs"
+// requirement, and the event-loop/epoll work is explicitly out of scope
+// (Track B B5). The "forward" step is therefore the outbound-request
+// serialization the proxy performs before it would hand bytes to the
+// socket.
+//
+// What is real vs. representative:
+//   * Policy lookup uses the real prelude/stdlib `StrMap` (#1710) from
+//     `runtime/sfn/collections.sfn` — a runtime module that links into a
+//     bare-file build.
+//   * Parsing is a representative inline HTTP/1.1 request parse that
+//     mirrors `capsules/sfn/http/src/wire.sfn::parse_request`. The
+//     `sfn/http` capsule parser cannot be reused directly here because
+//     the `make bench-runtime` harness builds each workload as a bare
+//     `.sfn` file (`sailfin build -o <bin> <src>`), and a capsule module
+//     with its own relative imports does not link into a bare-file
+//     build. The parse therefore lives inline; keep it in sync with the
+//     wire parser's shape if that parser changes materially.
+//
+// Reporting & budget:
+//   * One `RESULT http_proxy_hotpath <median_ms> <iters>` line, where
+//     <median_ms> is the median of `ROUNDS` measured rounds (after
+//     `WARMUP` discarded rounds) and <iters> is the parse->policy->
+//     forward iterations per round. Per-iteration time is <median_ms> /
+//     <iters>, which the harness derives as ops_per_ms.
+//   * The 150 ms budget is enforced two ways: this program prints its
+//     own PASS/FAIL against it, and the harness gates the median when run
+//     with `make bench-runtime BENCH_RUNTIME_ARGS="--budget-time 150"`.
+import {
+    StrMap,
+    str_map_get,
+    str_map_new,
+    str_map_set
+} from "../../runtime/sfn/collections";
+
+struct ParsedReq {
+    method: string;
+    path: string;
+    query: string;
+    headers: string[];
+    body: string;
+}
+
+// Drop a single trailing '\r' (CRLF tolerance), mirroring wire.sfn.
+fn strip_cr(s: string) -> string {
+    let n = s.length;
+    if n == 0 { return s; }
+    let last = substring(s, n - 1, n);
+    if strings_equal(last, "\r") { return substring(s, 0, n - 1); }
+    return s;
+}
+
+fn starts_with(s: string, p: string) -> boolean {
+    if p.length > s.length { return false; }
+    return strings_equal(substring(s, 0, p.length), p);
+}
+
+// Representative HTTP/1.1 request parse — mirrors the structure of
+// capsules/sfn/http/src/wire.sfn::parse_request (request line ->
+// method/target, target -> path/query, header lines until blank, body).
+fn parse_req(raw: string) -> ParsedReq {
+    let total = raw.length;
+
+    let line_nl = find_char(raw, "\n", 0);
+    let mut line_end = total;
+    if line_nl >= 0 { line_end = line_nl; }
+    let request_line = strip_cr(substring(raw, 0, line_end));
+
+    let mut method = "";
+    let mut target = "";
+    let sp1 = find_char(request_line, " ", 0);
+    if sp1 >= 0 {
+        method = substring(request_line, 0, sp1);
+        let sp2 = find_char(request_line, " ", sp1 + 1);
+        if sp2 >= 0 { target = substring(request_line, sp1 + 1, sp2); } else {
+            target = substring(request_line, sp1 + 1, request_line.length);
+        }
+    } else { method = request_line; }
+
+    let mut path = target;
+    let mut query = "";
+    let q = find_char(target, "?", 0);
+    if q >= 0 {
+        path = substring(target, 0, q);
+        query = substring(target, q + 1, target.length);
+    }
+
+    let mut headers: string[] = [];
+    let mut body = "";
+    let mut cursor = total;
+    if line_nl >= 0 { cursor = line_nl + 1; }
+    loop {
+        if cursor >= total { break; }
+        let nl = find_char(raw, "\n", cursor);
+        let mut end = total;
+        if nl >= 0 { end = nl; }
+        let line = strip_cr(substring(raw, cursor, end));
+        let mut next = total;
+        if nl >= 0 { next = nl + 1; }
+        if line.length == 0 {
+            body = substring(raw, next, total);
+            break;
+        }
+        headers.push(line);
+        if nl < 0 { break; }
+        cursor = next;
+    }
+
+    return ParsedReq {
+        method: method,
+        path: path,
+        query: query,
+        headers: headers,
+        body: body
+    };
+}
+
+// Serialize the outbound (forwarded) request: the request line, the
+// header block with the Host header rewritten to the upstream, then the
+// body. This is the CPU work the proxy does before writing to the
+// upstream socket (the socket write itself is out of scope / not
+// deterministic).
+fn build_forward(p: ParsedReq, upstream: string) -> string {
+    let mut target = p.path;
+    if p.query.length > 0 { target = p.path + "?" + p.query; }
+    let mut out = p.method + " " + target + " HTTP/1.1\r\n";
+    let mut i = 0;
+    loop {
+        if i >= p.headers.length { break; }
+        let h = p.headers[i];
+        if starts_with(h, "Host:") { out = out + "Host: " + upstream + "\r\n"; } else {
+            out = out + h + "\r\n";
+        }
+        i = i + 1;
+    }
+    out = out + "\r\n" + p.body;
+    return out;
+}
+
+// Representative proxy policy table: method+path -> decision.
+fn build_policy_table() -> StrMap {
+    let mut m = str_map_new();
+    m = str_map_set(m, "GET /api/orders", "allow");
+    m = str_map_set(m, "POST /api/orders", "allow");
+    m = str_map_set(m, "GET /api/users", "allow");
+    m = str_map_set(m, "POST /api/users", "allow");
+    m = str_map_set(m, "DELETE /api/users", "deny");
+    m = str_map_set(m, "GET /api/products", "allow");
+    m = str_map_set(m, "POST /api/login", "allow");
+    m = str_map_set(m, "GET /health", "allow");
+    m = str_map_set(m, "GET /metrics", "rate-limit");
+    m = str_map_set(m, "GET /admin", "deny");
+    m = str_map_set(m, "GET /api/search", "rate-limit");
+    m = str_map_set(m, "PUT /api/orders", "allow");
+    return m;
+}
+
+// Median of a small int array via insertion sort over a copy.
+fn median(xs: int[]) -> int {
+    let n = xs.length;
+    if n == 0 { return 0; }
+    let mut a: int[] = [];
+    let mut c = 0;
+    loop {
+        if c >= n { break; }
+        a.push(xs[c]);
+        c = c + 1;
+    }
+    let mut x = 1;
+    loop {
+        if x >= n { break; }
+        let key = a[x];
+        let mut j = x - 1;
+        loop {
+            if j < 0 { break; }
+            if a[j] <= key { break; }
+            a[j + 1] = a[j];
+            j = j - 1;
+        }
+        a[j + 1] = key;
+        x = x + 1;
+    }
+    return a[n / 2];
+}
+
+// One measured round: `iters` full parse -> policy -> forward passes
+// over a fixed request. Returns an accumulated sink so the optimizer
+// cannot discard the work.
+fn run_round(table: StrMap, raw: string, upstream: string, iters: int) -> int {
+    let mut sink = 0;
+    let mut i = 0;
+    loop {
+        if i >= iters { break; }
+        let req = parse_req(raw);
+        let key = req.method + " " + req.path;
+        let decision = str_map_get(table, key);
+        if decision == null { sink = sink + req.path.length; } else {
+            let fwd = build_forward(req, upstream);
+            sink = sink + fwd.length + decision.length;
+        }
+        i = i + 1;
+    }
+    return sink;
+}
+
+fn main() ![io, clock] {
+    let iters = 12000;
+    let rounds = 7;
+    let warmup = 2;
+    let budget = 150;
+    let upstream = "upstream.internal:8080";
+    let raw = "GET /api/orders?page=2&limit=50 HTTP/1.1\r\nHost: gateway.local\r\nUser-Agent: sfn-bench/1.0\r\nAccept: application/json\r\nAuthorization: Bearer tok-abc123\r\nX-Request-Id: 7f3a91c2\r\nContent-Length: 0\r\n\r\n";
+
+    let table = build_policy_table();
+
+    // Warm-up rounds (discarded) for steady-state timing.
+    let mut sink = 0;
+    let mut w = 0;
+    loop {
+        if w >= warmup { break; }
+        sink = sink + run_round(table, raw, upstream, iters);
+        w = w + 1;
+    }
+
+    // Measured rounds.
+    let mut times: int[] = [];
+    let mut r = 0;
+    loop {
+        if r >= rounds { break; }
+        let start = monotonic_millis();
+        sink = sink + run_round(table, raw, upstream, iters);
+        let end = monotonic_millis();
+        times.push(end - start);
+        r = r + 1;
+    }
+
+    let med = median(times);
+
+    let mut status = "PASS";
+    if med > budget { status = "FAIL"; }
+
+    print("RESULT http_proxy_hotpath {{med}} {{iters}}");
+    // `sink` is printed (not just branched on) so the parse->policy->forward
+    // work is observable and cannot be eliminated as dead code.
+    print("http_proxy_hotpath: median {{med}}ms over {{iters}} parse->policy->forward iters/round; budget {{budget}}ms; {{status}} (checksum {{sink}})");
+}


### PR DESCRIPTION
## Summary
- Adds `benchmarks/runtime/http_proxy_hotpath.sfn`: a runtime-execution benchmark for the MCP-proxy request hot path — parse an HTTP/1.1 request → policy decision via the real prelude `StrMap` (#1710) → serialize the forwarded outbound request.
- Reports the median of 7 measured rounds (after warm-up) as a single machine-parseable `RESULT` line plus a human PASS/FAIL line against a documented **150 ms** budget; integrates with `make bench-runtime` (gate via `--budget-time 150`).
- Documents the workload and its advisory-only 150 ms threshold in `benchmarks/runtime/README.md`.

Closes #1712

## Acceptance Criteria
- [x] The benchmark runs under `make bench` / `sfn bench` and reports a per-iteration time (`RESULT … <ms> <iters>` → harness derives ops/ms; median 64–65ms, ~5.4µs/iter).
- [x] It exercises real parse + a stand-in policy lookup (the **real** `StrMap`) + a forward — not a micro-loop.
- [x] The 150 ms target is documented; the bench prints pass/fail against it (and the harness gates it with `--budget-time 150`).
- [x] Deterministic enough to compare across runs (2 warm-up rounds + median of 7; stable 64–65ms, stable checksum).
- [x] `make compile` passes.
- [x] `make test` passes (unit 184/184, integration 42/42, e2e 170/170, capsules 38/38).

## Map reconciliation
The advisory `## Files Affected` map said the bench "reuses `capsules/sfn/http/src/wire.sfn`". That literal reuse is **infeasible** under the bench harness: `make bench-runtime` builds each workload as a bare `.sfn` file (`sailfin build -o bin src`), and a **capsule** module with its own relative imports (`wire.sfn` imports `./types`) does **not** link into a bare-file build — confirmed by a spike (`undefined symbol: parse_request` at link). Fixing bare-file capsule linking is a separate compiler concern, out of scope for a perf benchmark. Reconciliation, holding the Goal + In/Out scope:
- **Parse** → inlined `parse_req`, structurally faithful to `wire.sfn::parse_request` (same request-line/target/path-query/header-loop/body logic, same bare-LF + CR tolerance). Documented in the file + README; keep in sync if the wire parser changes materially.
- **Policy lookup** → the **real** `StrMap` from `runtime/sfn/collections.sfn` (a runtime module, which *does* link into bare builds) — genuinely reused, not stubbed.
- **Forward** → deterministic outbound-request serialization (the proxy's pre-socket CPU work); no network, since a live forward can't satisfy the determinism criterion.

This is non-binding-map drift forced by the harness, not semantic scope growth (no new acceptance criterion or public surface). The `blocked` label was stale — the sole blocker #1710 is closed/merged (`StrMap` in the tree, PR #1763).

## Verification
```bash
# self-host + suite
make compile            # pass
make test               # unit 184/184, integration 42/42, e2e 170/170, capsules 38/38

# benchmark, bare build (as the harness does)
sailfin build -o /tmp/hp benchmarks/runtime/http_proxy_hotpath.sfn && /tmp/hp
# RESULT http_proxy_hotpath 64 12000
# http_proxy_hotpath: median 64ms over 12000 parse->policy->forward iters/round; budget 150ms; PASS (checksum 22572000)

# harness integration + gate
make bench-runtime BENCH_RUNTIME_ARGS="--workload http_proxy_hotpath --budget-time 150"
#   http_proxy_hotpath  62ms  193.5 ops/ms  ok   → all workloads within budget
make bench-runtime BENCH_RUNTIME_ARGS="--workload http_proxy_hotpath --budget-time 30"
#   http_proxy_hotpath  64ms  SLOW          → budget violations detected, exit 2  (gate fires)
```

## Files Changed
- `benchmarks/runtime/http_proxy_hotpath.sfn` (new)
- `benchmarks/runtime/README.md` (Workloads row + budget-gate section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPz92k7suYhepCX3nwqVuo

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPz92k7suYhepCX3nwqVuo)_