### PR TITLE
test(build): record cli_main/cli_commands peak-RSS deltas + line-budget sentinel

### DIFF
--- a/compiler/tests/unit/cli_main_line_budget_test.sfn
+++ b/compiler/tests/unit/cli_main_line_budget_test.sfn
@@ -1,0 +1,50 @@
+// Line-budget sentinel for `compiler/src/cli_main.sfn` — the cheap
+// regression guard for SFEP-0027 Phase A's per-worker RSS lever.
+//
+// Phase A carved the build-driver orchestration out of `cli_main.sfn`
+// into `compiler/src/build/{runtime_objs,link,determinism,cache}.sfn`
+// (#1730–#1733) and shattered the 937-line `sailfin_cli_main_legacy`
+// into per-command `_legacy_dispatch_<cmd>` helpers (#1734). That took
+// `cli_main.sfn` from 3,067 lines to ~1,409 and dropped its isolated
+// per-module emit peak RSS from ~2,415 MB to ~1,065 MB
+// (docs/proposals/0006-build-architecture.md, "post-Phase-A CLI deltas").
+//
+// Because per-module working set is what bounds parallel `--jobs`
+// (SFEP-0027 §2.1), `cli_main.sfn` must not silently re-balloon back
+// toward the pre-Phase-A monolith. This sentinel fails the build if the
+// module regrows past a budget with modest headroom over the current
+// Phase-A size.
+//
+// Budget rationale: SFEP-0027 §8 names `< 1,200` as the *Phase-B-era*
+// target (reached once the 7 remaining commands migrate out into
+// `cli/commands/`). The current Phase-A floor is ~1,409 lines (the
+// `_legacy_dispatch_<cmd>` helpers still live here until Phase B), so the
+// Phase-A budget is 1,500 — enough headroom for routine maintenance,
+// tight enough to flag build-driver code creeping back. Tighten to 1,200
+// when Phase B empties the legacy dispatch arms.
+import { find_char_local } from "../../src/string_utils";
+
+let CLI_MAIN_LINE_BUDGET: int = 1500;
+
+// Count newlines, matching `wc -l` semantics (a trailing newline is not
+// double-counted). Cheap single linear scan via `find_char_local`.
+fn _count_newlines(source: string) -> int {
+    let mut count: int = 0;
+    let mut pos: int = 0;
+    loop {
+        let idx = find_char_local(source, "\n", pos);
+        if idx < 0 { break; }
+        count += 1;
+        pos = idx + 1;
+    }
+    return count;
+}
+
+test "cli_main.sfn stays under the SFEP-0027 Phase A line budget" ![io] {
+    let source = fs.readFile("compiler/src/cli_main.sfn");
+    let lines = _count_newlines(source);
+    // A non-empty read is a precondition — guards against a path typo
+    // silently passing the budget check on an empty string.
+    assert lines > 0;
+    assert lines < CLI_MAIN_LINE_BUDGET;
+}

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -1647,6 +1647,35 @@ Runtime execution performance (the dimension most affected by C-runtime deletion
 tracked separately in `docs/perf/runtime-performance.md` with its own `make bench-runtime`
 harness and 0.7.0 baseline.
 
+### post-Phase-A CLI deltas (2026-06-29, SFEP-0027 Phase A)
+
+SFEP-0027 Phase A carved the build-driver orchestration out of `cli_main.sfn`
+into `compiler/src/build/{runtime_objs,link,determinism,cache}.sfn` (#1730–#1733)
+and shattered the 937-line `sailfin_cli_main_legacy` into per-command
+`_legacy_dispatch_<cmd>` helpers (#1734). The falsifiable Phase A success gate
+(#1735) is the per-module emit RSS drop. Measured with `make bench
+--module cli_main --module cli_commands` (Darwin arm64, compiler
+`sfn 0.7.0-alpha.50+dev.e4eac88c`); the "before" column is the 0.7.0 baseline CSV
+row above.
+
+| Module | emit time (before → after) | peak RSS (before → after) | IR lines (before → after) |
+| --- | --- | --- | --- |
+| `cli_main` | 19.76 s → **10.24 s** (−48%) | 2,473,616 KB (2,415 MB) → **1,090,560 KB (1,065 MB)** (−56%) | 20,543 → 9,977 |
+| `cli_commands` | 22.30 s → **10.77 s** (−52%) | 3,520,976 KB (3,438 MB) → **1,162,240 KB (1,135 MB)** (−67%) | 29,258 → 10,335 |
+
+Both CLI modules drop out of the "two heaviest CLI emitters" callout above: their
+post-Phase-A peak RSS (~1.0–1.1 GB) is well under the 4,389 MB
+`llvm__expression_lowering__native__core` peak and roughly in line with the median
+emitter. `cli_commands` is unchanged in source by Phase A (it is emptied in Phase C),
+but its isolated emit shrank because the build-driver functions it imports moved out
+of the monolithic `cli_main` closure into small `build/` modules — its emit import
+closure (and thus IR-line expansion and working set) shrank with the carve. Per
+SFEP-0027 §8, no Phase A step raised peak RSS; both levers measurably lowered it, so
+neither is reverted. A line-budget sentinel
+(`compiler/tests/unit/cli_main_line_budget_test.sfn`, budget 1,500) guards
+`cli_main.sfn` against silently re-ballooning toward the pre-Phase-A 3,067-line
+monolith.
+
 ---
 
 ## Cross-references

--- a/docs/proposals/0027-cli-rss-modularization.md
+++ b/docs/proposals/0027-cli-rss-modularization.md
@@ -346,8 +346,10 @@ This is a structural refactor, not a language feature; the checklist maps to
   module name in mangling).
 - [x] Lowers to LLVM IR — unchanged lowering; the *goal* is lower per-module
   RSS during lowering.
-- [ ] Regression coverage — existing CLI/e2e tests must stay green; add a
-  per-module RSS guard (§8).
+- [x] Regression coverage — existing CLI/e2e tests stay green; per-module RSS
+  lever guarded by the line-budget sentinel
+  `compiler/tests/unit/cli_main_line_budget_test.sfn` (§8, #1735). (Phase B/C
+  command-migration coverage still pending.)
 - [ ] Self-hosts — `make compile` per step; `make check` per structural step.
 - [ ] `sfn fmt --check` clean — every touched `.sfn`.
 - [ ] Documented — update `docs/status.md` (CLI module map) and cross-ref
@@ -381,6 +383,23 @@ This is a structural refactor, not a language feature; the checklist maps to
 - Optional: a `compiler/tests/` guard asserting `cli_main.sfn` stays under a
   line budget (e.g. < 1,200 lines) so the module cannot silently re-balloon —
   a cheap regression sentinel for the RSS lever.
+
+**Phase A result (2026-06-29, #1735).** The threshold is met for both CLI
+modules — full before/after table in
+`docs/proposals/0006-build-architecture.md` ("post-Phase-A CLI deltas"):
+
+| Module | peak RSS (before → after) | emit time (before → after) |
+| --- | --- | --- |
+| `cli_main` | 2,415 MB → **1,065 MB** (−56%) | 19.76 s → 10.24 s (−48%) |
+| `cli_commands` | 3,438 MB → **1,135 MB** (−67%) | 22.30 s → 10.77 s (−52%) |
+
+Both modules drop out of the "two heaviest CLI emitters" callout, landing near
+the median emitter and well under the 4,389 MB lowering-core peak. No step raised
+RSS, so nothing is reverted. The line-budget sentinel shipped as
+`compiler/tests/unit/cli_main_line_budget_test.sfn` (budget **1,500** — the SFEP's
+`< 1,200` is the Phase-B target, reached once the 7 remaining commands migrate out
+of `cli_main.sfn`; the Phase-A floor is ~1,409 lines while the
+`_legacy_dispatch_<cmd>` helpers still live there).
 
 **Migration coverage (Phase B/C).**
 - Each migrated command gains/keeps a `cli/commands/<name>.sfn` test peer


### PR DESCRIPTION
## Summary
- SFEP-0027 Phase A falsifiable success gate: records the per-module emit before/after for `cli_main`/`cli_commands` and adds a line-budget sentinel so `cli_main.sfn` cannot silently re-balloon.
- Measured per-module peak RSS drop (the lever that bounds parallel `--jobs`): `cli_main` **2415 → 1065 MB (−56%)**, `cli_commands` **3438 → 1135 MB (−67%)**. Both drop out of the "two heaviest CLI emitters" callout.
- Test + docs only — no `compiler/src` capability change, no seed dependency.

Closes #1735

## Acceptance Criteria
- [x] Before/after `cli_main`/`cli_commands` peak-RSS + emit-time deltas recorded (SFEP-0027 §8 + 0006); `cli_main` peak RSS measurably lower than the pre-Phase-A baseline (2415 → 1065 MB, −56%).
- [x] A line-budget sentinel test for `cli_main.sfn` lives in `compiler/tests/` and passes (`cli_main_line_budget_test.sfn`, budget 1,500).
- [x] `sfn fmt --check` clean on every touched `.sfn` (the new test; docs are Markdown).
- [x] `make compile` passes (no compiler source changed; self-host invariant holds).
- [x] `make test` passes (159 test files, 0 failures).

## Measurements
`make bench --module cli_main --module cli_commands` (Darwin arm64, `sfn 0.7.0-alpha.50+dev.e4eac88c`); "before" = 0.7.0 baseline CSV (`docs/baselines/compile-0.7.0-darwin-arm64.csv`).

| Module | emit time (before → after) | peak RSS (before → after) | IR lines |
| --- | --- | --- | --- |
| `cli_main` | 19.76s → 10.24s (−48%) | 2,415 MB → 1,065 MB (−56%) | 20,543 → 9,977 |
| `cli_commands` | 22.30s → 10.77s (−52%) | 3,438 MB → 1,135 MB (−67%) | 29,258 → 10,335 |

`cli_commands` is unchanged in source by Phase A (emptied in Phase C) but its isolated emit shrank because the build-driver functions it imports moved out of the monolithic `cli_main` closure into small `build/` modules.

## Map reconciliation
Advisory `## Files Affected` named `compiler/tests/unit/` (new sentinel) and "0006 or 0027" for the deltas. Recorded the deltas in **both** `0006-build-architecture.md` (canonical perf baseline, "post-Phase-A CLI deltas") and `0027-cli-rss-modularization.md` §8/§7. No path drift.

## Budget note
SFEP-0027 §8 names `< 1,200` as the line budget — that is the **Phase-B** target, reached once the 7 remaining commands migrate out of the legacy dispatch. The current Phase-A floor is ~1,409 lines (the `_legacy_dispatch_<cmd>` helpers still live in `cli_main.sfn`), so the sentinel budget is **1,500**; tighten to 1,200 when Phase B empties the legacy dispatch arms.

## Verification
\`\`\`bash
make bench --module cli_main --module cli_commands   # deltas above
make compile   # PASS (self-host holds; no compiler source changed)
make test      # PASS — 159 files, 0 failures; new sentinel PASS
\`\`\`

## Files Changed
- `compiler/tests/unit/cli_main_line_budget_test.sfn` (new)
- `docs/proposals/0006-build-architecture.md`
- `docs/proposals/0027-cli-rss-modularization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)