### PR TITLE
fix(lowering): lift lambdas nested inside another lambda body; add sfn/test::with_cwd (#1168)

### DIFF
--- a/.claude/rules/no-bash-e2e.md
+++ b/.claude/rules/no-bash-e2e.md
@@ -71,10 +71,13 @@ The supported building blocks (all already shipped):
   captured output with `sfn/strings::find` or `==`. (Making the matchers
   callable from `![io]` contexts is tracked against #842.)
 - **Temp dirs:** `with_tmp_dir(fn(dir) { ... })` from `sfn/test`.
-- **Per-child env:** pass `["KEY=value", ...]` as the `run_capture` env
-  argument. There is **no** `with_env`/`with_cwd` fixture (process-global
-  `setenv`/`chdir` is unsound under the future parallel runner — see
-  `fixtures.sfn`); always scope env to the child you spawn.
+- **Per-child env / cwd:** pass `["KEY=value", ...]` as the `run_capture`
+  env argument, and a cwd path as its third argument (`""` inherits). The
+  `with_env(args, env, body)` (#1166) and `with_cwd(args, env, cwd, body)`
+  (#1168) fixtures in `sfn/test` wrap this per-child shape. There is **no**
+  process-global `setenv`/`chdir` fixture (process-global mutation is unsound
+  under the future parallel runner — see `fixtures.sfn`); always scope env
+  and cwd to the child you spawn.
 - **Build a binary to run it:** when a test must compile a fixture to an
   executable (not just frontend-check it), thread `SAILFIN_TEST_SCRATCH`
   through to the spawned compiler so its staging stays per-invocation —

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -5,26 +5,23 @@
 // is an ordinary closure that may capture the enclosing test's locals
 // (M1.5 closures-with-capture, #687 emission + #689 dispatch).
 //
-// Only `with_tmp_dir` ships here. The originally-proposed `with_env` and
-// `with_cwd` fixtures are intentionally NOT provided:
+// Three scoped fixtures ship here, all built on per-child control so they
+// are safe under the (future) parallel test runner:
 //
-//   * They require mutating *process-global* state (`setenv` / `chdir`)
-//     and restoring it. The runtime exposes no such primitive — only
-//     `env.get` / `env.home` exist — and adding C for it cuts against the
-//     in-flight C→Sailfin runtime port (the C surface is frozen after the
-//     test-infra epic's Phase 0).
-//   * Even with the primitives, both are unsound under structured
-//     concurrency: `chdir(2)` sets a per-*process* working directory and
-//     `setenv(3)` mutates a shared, non-thread-safe `environ`, so a
-//     process-global fixture corrupts sibling tasks the moment the test
-//     runner goes parallel. The right shape is per-child control, which
-//     already ships as the typed `Env` + `os::run_capture` API. A
-//     concurrency-aware redesign is tracked in #1107.
+//   * `with_tmp_dir` — create a temp dir, run the body, remove the tree on
+//     scope exit (including the throwing path).
+//   * `with_env` (#1166) — run a subprocess under a scoped `os::Env`.
+//   * `with_cwd` (#1168) — run a subprocess in a scoped working directory.
 //
-// That concurrency-aware redesign ships here as `with_env` (#1166): a
-// per-child scoped-environment runner over the typed `os::Env` +
-// `os::run_capture` API, with the parent `environ` never mutated. See
-// its doc comment below.
+// The originally-proposed `with_env` / `with_cwd` fixtures were going to
+// mutate *process-global* state (`setenv(3)` / `chdir(2)`) and restore it.
+// Both are unsound under structured concurrency: `chdir(2)` sets a
+// per-*process* cwd and `setenv(3)` mutates a shared, non-thread-safe
+// `environ`, so a process-global fixture corrupts sibling tasks the moment
+// the runner goes parallel. The shipped shape is per-child instead: the
+// scoped environment / cwd is applied to a *single* spawned child via
+// `os::run_capture(args, env, cwd)` (#1167), and the parent process is never
+// read or written. See each helper's doc comment below.
 //
 // Teardown delegates to `sfn/fs::remove_all` (#976) — a pure-Sailfin
 // `rm -rf` composed from the `fs.*` runtime intrinsics
@@ -105,5 +102,34 @@ fn with_env(args: string[], env: Env, body: fn (ProcessOutput) -> int) -> int ![
     // cwd-aware `with_env`/`with_cwd` ergonomic wrapper is the
     // companion follow-up, not this change.
     let out = run_capture(args, env, "");
+    return body(out);
+}
+
+// Run `args` as a subprocess in the working directory `cwd` under the
+// scoped environment `env`, hand the captured `ProcessOutput` to `body`,
+// and return whatever `body` returns.
+//
+// This is the cwd-scoping companion to `with_env`: the concurrency-safe
+// successor to the dropped process-global `with_cwd` fixture (see the note
+// at the top of this file). Rather than calling `chdir(2)` — which sets a
+// per-*process* working directory and so corrupts sibling tasks the moment
+// the test runner goes parallel — the directory is applied to a *single*
+// child via `os::run_capture(args, env, cwd)` (#1167), which runs the child
+// in `cwd` with `posix_spawn_file_actions_addchdir_np` and never touches the
+// parent's cwd. Concurrent tests are unaffected.
+//
+// `cwd` is typically the absolute path handed to a `with_tmp_dir` body, so
+// the two compose: open a temp dir, then run a child inside it. An empty
+// `cwd` inherits the parent's working directory (identical to `with_env`);
+// pass a non-empty absolute path to scope it. In-process (non-subprocess)
+// cwd scoping is not offered — there is no per-thread cwd, so in-process
+// tests must use absolute paths.
+//
+// `body`, the `Env` constructors, the no-`![io]`-row fn-type, and the
+// `-> int` interim return shape are all exactly as documented for `with_env`
+// above. Like `with_env`, there is no teardown: a scoped cwd owns no host
+// resource — it is just an argument to the child spawn.
+fn with_cwd(args: string[], env: Env, cwd: string, body: fn (ProcessOutput) -> int) -> int ![io] {
+    let out = run_capture(args, env, cwd);
     return body(out);
 }

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -399,6 +399,7 @@ export { CompileExpect, assert_compiles, assert_does_not_compile } from "./compi
 // successor to the dropped process-global `with_env`: it runs `args` as a
 // subprocess under a scoped `os::Env` via `os::run_capture` and threads the
 // captured `ProcessOutput` to `body`, never mutating the parent `environ`.
-// (`with_cwd` stays omitted — no per-child cwd primitive yet; tracked in
-// #1107.) See `fixtures.sfn`.
-export { with_env, with_tmp_dir } from "./fixtures";
+// `with_cwd(args, env, cwd, body)` (issue #1168) is its cwd-scoping
+// companion: it runs the child in `cwd` via the same `os::run_capture`
+// (#1167 per-child cwd), with no process-global `chdir`. See `fixtures.sfn`.
+export { with_cwd, with_env, with_tmp_dir } from "./fixtures";

--- a/capsules/sfn/test/tests/fixtures_test.sfn
+++ b/capsules/sfn/test/tests/fixtures_test.sfn
@@ -25,10 +25,10 @@
 // separate multi-capture lowering bug). Single capture — the path the
 // `closure_single_capture` e2e fixture exercises and that #979 actually
 // rides — works; these tests stay within it deliberately.
-import { env_set, env_empty, ProcessOutput } from "sfn/os";
+import { ProcessOutput, env_empty, env_set } from "sfn/os";
 import { find } from "sfn/strings";
 
-import { with_env, with_tmp_dir } from "../src/mod";
+import { with_cwd, with_env, with_tmp_dir } from "../src/mod";
 
 // Scratch root for marker files. Prefer the runner's
 // `SAILFIN_TEST_SCRATCH`; fall back to `/tmp` for a direct
@@ -197,4 +197,69 @@ test "with_env: body return value threads back out" ![io] {
         return out.exit;
     });
     assert r == 7;
+}
+
+// ---------------------------------------------------------------------------
+// with_cwd — scoped per-child working-directory runner (#1168)
+// ---------------------------------------------------------------------------
+// `with_cwd(args, env, cwd, body)` runs `args` in working directory `cwd`
+// via `os::run_capture(args, env, cwd)` (#1167 per-child cwd, no global
+// `chdir`), threading the captured `ProcessOutput` to `body`. These tests
+// prove: the child runs in the scoped cwd, it composes with `with_tmp_dir`,
+// and the parent's cwd is untouched. `env_empty()` is fine — `posix_spawnp`
+// resolves bare binary names (`ls`/`pwd`/`sh`) via the parent's PATH even
+// when the child env is empty (same as the with_env tests above). Each body
+// lambda captures at most one local, honoring the single-capture constraint.
+// The child runs in the temp dir handed down by `with_tmp_dir`: a marker
+// file written into that dir shows up in a bare `ls` (which lists the cwd),
+// proving the child's cwd is the scoped dir. Also exercises nesting.
+test "with_cwd: child runs in the scoped cwd (nested under with_tmp_dir)" ![io] {
+    let r = with_tmp_dir(fn (dir: string) -> int {
+        fs.writeFile(dir + "/sfn-cwd-marker.txt", "x");
+        return with_cwd(["ls"], env_empty(), dir, fn (out: ProcessOutput) -> int {
+            if out.exit != 0 { return -1; }
+            if find(out.stdout, "sfn-cwd-marker.txt", 0) >= 0 { return 1; }
+            return 0;
+        });
+    });
+    assert r == 1;
+}
+
+// A scoped cwd never leaks into the parent: an inherited-cwd child (empty
+// cwd) reports the parent's working directory, and that reading is identical
+// before and after a `with_cwd` into a different directory — proving no
+// process-global `chdir` happened. The pwd strings are ferried out through
+// marker files (the body returns `int`, so it cannot return the string).
+test "with_cwd: parent process cwd is unchanged by a scoped child cwd" ![io] {
+    let m_before = _marker("cwd-before");
+    let m_after = _marker("cwd-after");
+    let _a = with_cwd(["pwd"], env_empty(), "", fn (out: ProcessOutput) -> int {
+        fs.writeFile(m_before, out.stdout);
+        return 0;
+    });
+    let _mid = with_tmp_dir(fn (dir: string) -> int {
+        return with_cwd(["pwd"], env_empty(), dir, fn (out: ProcessOutput) -> int {
+            return out.exit;
+        });
+    });
+    let _b = with_cwd(["pwd"], env_empty(), "", fn (out: ProcessOutput) -> int {
+        fs.writeFile(m_after, out.stdout);
+        return 0;
+    });
+    let before = fs.readFile(m_before);
+    let after = fs.readFile(m_after);
+    assert before.length > 0;
+    assert before == after;
+    _cleanup(m_before);
+    _cleanup(m_after);
+}
+
+// The captured `ProcessOutput` threads back through the helper: a body
+// returning the child's exit code is the helper's return value (mirrors
+// the with_env result-threading contract).
+test "with_cwd: body return value threads back out" ![io] {
+    let r = with_cwd(["sh", "-c", "exit 5"], env_empty(), "", fn (out: ProcessOutput) -> int {
+        return out.exit;
+    });
+    assert r == 5;
 }

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -248,7 +248,7 @@ fn _split_top_level_comma(text: string) -> string[] {
 }
 
 // Strip the leading `__env: i8*` parameter (synthesised by
-// `_synthesize_lifted_function` in `lambda_lowering.sfn`) from a
+// `_synthesize_lifted_function_rewritten` in `lambda_lowering.sfn`) from a
 // lifted function's parameter type list, leaving just the
 // user-visible parameter types for the call-site signature.
 fn _strip_env_parameter(parameter_types: string[]) -> string[] {

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -108,6 +108,15 @@ struct _BlockRewriteResult {
     block: Block;
 }
 
+// Result of synthesising a lifted function whose body has itself been
+// rewritten through the lifting walker. Carries the updated context so
+// nested lifted functions (and the advanced counter) propagate back to
+// the caller — see `_synthesize_lifted_function_rewritten`.
+struct _LiftedFnResult {
+    ctx: LiftContext;
+    statement: Statement;
+}
+
 // Public entry point. `analyze_lambda_captures` is invoked here so
 // callers don't have to thread the records list in — and so the
 // pass owns the precondition that records key by body span.
@@ -335,51 +344,9 @@ fn _find_mutable_capture_name(captures: Capture[]) -> string {
 // Body re-parse: the parser stashes only raw tokens on the lambda
 // body. `analyze_lambda` in `typecheck_captures.sfn` re-parses via
 // `parse_block` for the same reason; we follow that pattern so the
-// emitted body sees structured statements.
-fn _synthesize_lifted_function(lambda: Expression, lambda_id: int) -> Statement {
-    return _synthesize_lifted_function_with_captures(lambda, lambda_id, []);
-}
-
-// Synthesise the lifted top-level function. When `captures.length > 0`,
-// prepends a `Statement.ExpressionStatement` wrapping the env-load
-// prologue marker as the first statement of the body. The marker is
-// recognised by `lower_instruction_range` (see #687 in
-// `instructions.sfn`): it emits the A2 prologue lines and registers
-// the loaded SSA temps as `LocalBinding[]` so capture references in
-// the body resolve through the existing name-resolution path.
-fn _synthesize_lifted_function_with_captures(lambda: Expression, lambda_id: int, captures: Capture[]) -> Statement {
-    let mut parameters: Parameter[] = [];
-    parameters.push(Parameter {
-        name: "__env", type_annotation: TypeAnnotation { text: "i8*" }, default_value: null, mutable: false, span: null
-    });
-    let mut original_index: int = 0;
-    loop {
-        if original_index >= lambda.parameters.length { break; }
-        parameters.push(lambda.parameters[original_index]);
-        original_index += 1;
-    }
-
-    let signature = FunctionSignature {
-        name: lifted_function_name(lambda_id),
-        is_async: false,
-        parameters: parameters,
-        return_type: lambda.return_type,
-        effects: [],
-        type_parameters: [],
-        name_span: null
-    };
-
-    let parsed_body = _reparse_lambda_body(lambda.body);
-    let body_with_prologue = _prepend_capture_prologue(parsed_body, lambda_id, captures);
-    let no_decorators: Decorator[] = [];
-    return Statement.FunctionDeclaration {
-        signature: signature,
-        body: body_with_prologue,
-        decorators: no_decorators,
-        is_unsafe: false
-    };
-}
-
+// emitted body sees structured statements. The re-parsed body is then
+// rewritten through the lifting walker so lambdas nested inside it are
+// lifted too (#1614) — see `_synthesize_lifted_function_rewritten`.
 // Prepend the env-load prologue marker statement to a re-parsed
 // lambda body when the lambda has captures. Non-capturing lambdas
 // return the block unchanged so #686's IR shape is preserved.
@@ -414,6 +381,53 @@ fn _reparse_lambda_body(body: Block) -> Block {
     let body_parser = Parser { tokens: body.tokens, index: 0 };
     let parsed = parse_block(body_parser);
     return parsed.block;
+}
+
+// Synthesise the lifted top-level function for `lambda`, recursively
+// lifting any lambdas NESTED inside its body (#1614). The lambda's own
+// id is `lambda_id`; the incoming `ctx.counter` must already be advanced
+// past it so nested lambdas claim later ids. The re-parsed body is run
+// through `_rewrite_block`, which lifts inner lambdas and appends their
+// synthesised functions to `ctx.lifted` — without this descent, a HOF
+// call nested inside a lifted lambda body (e.g. `outer(fn (s) {
+// return call_it(fn (x) { ... }); })`) leaves the inner lambda as a bare
+// `<lambda>` placeholder and the call lowers through a null callee
+// pointer (returns the zero-initialised slot, inner lambda never runs).
+// The capture prologue is prepended AFTER the rewrite so its marker
+// statement is never itself walked.
+fn _synthesize_lifted_function_rewritten(ctx: LiftContext, lambda: Expression, lambda_id: int, captures: Capture[]) -> _LiftedFnResult {
+    let mut parameters: Parameter[] = [];
+    parameters.push(Parameter {
+        name: "__env", type_annotation: TypeAnnotation { text: "i8*" }, default_value: null, mutable: false, span: null
+    });
+    let mut original_index: int = 0;
+    loop {
+        if original_index >= lambda.parameters.length { break; }
+        parameters.push(lambda.parameters[original_index]);
+        original_index += 1;
+    }
+
+    let signature = FunctionSignature {
+        name: lifted_function_name(lambda_id),
+        is_async: false,
+        parameters: parameters,
+        return_type: lambda.return_type,
+        effects: [],
+        type_parameters: [],
+        name_span: null
+    };
+
+    let parsed_body = _reparse_lambda_body(lambda.body);
+    let rewritten = _rewrite_block(ctx, parsed_body);
+    let body_with_prologue = _prepend_capture_prologue(rewritten.block, lambda_id, captures);
+    let no_decorators: Decorator[] = [];
+    let lifted_fn = Statement.FunctionDeclaration {
+        signature: signature,
+        body: body_with_prologue,
+        decorators: no_decorators,
+        is_unsafe: false
+    };
+    return _LiftedFnResult { ctx: rewritten.ctx, statement: lifted_fn };
 }
 
 // ── Block rewriter ──────────────────────────────────────────────────
@@ -718,14 +732,26 @@ fn _rewrite_lambda(ctx: LiftContext, lambda: Expression, owned_env: boolean) -> 
         return ExpressionRewriteResult { ctx: ctx, expression: lambda };
     }
 
-    // Non-capturing path — unchanged from #686.
+    // Non-capturing path (#686). Reserve this lambda's id, advance the
+    // counter past it, then descend into the body so nested lambdas claim
+    // later ids and are lifted too (#1614). The parent's synthesised
+    // function is appended after the descent (order is irrelevant — lifted
+    // functions resolve by name).
     if record.captures.length == 0 {
         let lambda_id = ctx.counter;
-        let lifted_fn = _synthesize_lifted_function(lambda, lambda_id);
-        let mut new_lifted: Statement[] = ctx.lifted;
-        new_lifted.push(lifted_fn);
-        let new_ctx: LiftContext = LiftContext {
+        let descend_ctx: LiftContext = LiftContext {
             counter: (ctx.counter + 1) as int,
+            lifted: ctx.lifted,
+            records: ctx.records,
+            signatures: ctx.signatures,
+            bindings: ctx.bindings
+        };
+        let no_captures: Capture[] = [];
+        let synth = _synthesize_lifted_function_rewritten(descend_ctx, lambda, lambda_id, no_captures);
+        let mut new_lifted: Statement[] = synth.ctx.lifted;
+        new_lifted.push(synth.statement);
+        let new_ctx: LiftContext = LiftContext {
+            counter: synth.ctx.counter,
             lifted: new_lifted,
             records: ctx.records,
             signatures: ctx.signatures,
@@ -752,11 +778,18 @@ fn _rewrite_lambda(ctx: LiftContext, lambda: Expression, owned_env: boolean) -> 
     }
 
     let lambda_id = ctx.counter;
-    let lifted_fn = _synthesize_lifted_function_with_captures(lambda, lambda_id, record.captures);
-    let mut new_lifted: Statement[] = ctx.lifted;
-    new_lifted.push(lifted_fn);
-    let new_ctx: LiftContext = LiftContext {
+    let descend_ctx: LiftContext = LiftContext {
         counter: (ctx.counter + 1) as int,
+        lifted: ctx.lifted,
+        records: ctx.records,
+        signatures: ctx.signatures,
+        bindings: ctx.bindings
+    };
+    let synth = _synthesize_lifted_function_rewritten(descend_ctx, lambda, lambda_id, record.captures);
+    let mut new_lifted: Statement[] = synth.ctx.lifted;
+    new_lifted.push(synth.statement);
+    let new_ctx: LiftContext = LiftContext {
+        counter: synth.ctx.counter,
         lifted: new_lifted,
         records: ctx.records,
         signatures: ctx.signatures,


### PR DESCRIPTION
## Summary

Picking up #1168 surfaced a foundational compiler miscompile, so this PR bundles the fix with the feature. Bundling keeps it to **one PR with no seed cut**: `make compile` builds the fixed compiler from the old seed, and that compiler then compiles the consumer in the same self-host pass (per `.claude/rules/seed-dependency.md`).

## Part 1 — Compiler fix (epic #1609, first-class function values)

A higher-order call that passes a lambda argument, when made **from inside another lambda's body**, never invoked the passed lambda and returned `0`. Top-level HOF calls and plain (non-HOF) calls nested in lambdas worked fine.

Minimal repro (pure, no capsules, no capture):
```sfn
fn call_it(body: fn (int) -> int) -> int { return body(5); }
fn outer(body: fn (string) -> int) -> int { return body("hi"); }

let r = outer(fn (s: string) -> int {
    return call_it(fn (x: int) -> int { return x + 1; });  // r == 0, inner never runs
});
```

**Root cause:** the lambda-lifting pre-pass synthesized a lifted top-level function per lambda but **never recursively rewrote that lifted function's body**, so a lambda nested in another lambda's body stayed a raw `Expression.Lambda`, emitted as the bare `<lambda>` placeholder (a null callee), and the HOF call dispatched through a null function pointer. Distinct from #1610 (capturing i64/ptr env-store) — the failing case captures nothing; this is a pure dispatch failure.

**Fix** (`compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn`): add `_synthesize_lifted_function_rewritten`, which re-parses the body, runs it through `_rewrite_block` (lifting nested lambdas and appending their synthesized functions), then prepends the capture prologue *after* the rewrite, threading an updated `LiftContext` back. Both arms of `_rewrite_lambda` reserve `lambda_id = ctx.counter`, advance the counter before descent so nested lambdas claim later ids, then push the parent's lifted fn with the extended counter. Lifted functions resolve by name, so push order is immaterial and the module-monotonic counter invariant holds. Removed the now-dead `_synthesize_lifted_function[_with_captures]` helpers (and updated a stale doc-comment cross-reference in `core_call_resolution.sfn`).

## Part 2 — Feature: `sfn/test::with_cwd` (#1168)

`with_cwd(args, env, cwd, body)` — the cwd-scoping companion to `with_env`, a thin per-child wrapper over `os::run_capture(args, env, cwd)` (#1167 per-child cwd, no process-global `chdir`). Composes with `with_tmp_dir`. Its nesting test was the path that exposed the Part 1 miscompile.

- `capsules/sfn/test/src/fixtures.sfn` — add `with_cwd`; rewrite the header (it documented why `with_cwd` was "dropped").
- `capsules/sfn/test/src/mod.sfn` — export `with_cwd` + comment update.
- `capsules/sfn/test/tests/fixtures_test.sfn` — 3 tests: child-runs-in-cwd (nested under `with_tmp_dir`, marker-file `ls` rather than symlink-flaky `pwd`), parent-cwd-unchanged, return-threading.
- `.claude/rules/no-bash-e2e.md` — corrected the now-stale note (both `with_env` and `with_cwd` fixtures ship).

## Verification

- Repro: top-level / plain-nested / HOF-nested all correct after the fix.
- Closure/lambda regression suite green: `array_{map,filter,reduce}_closure`, `closure_capture` (7/7), `untyped_lambda_callback` (7/7), closure lifting/emission integration, lambda unit tests.
- All 12 `sfn/test` fixtures tests pass, including the three `with_cwd` tests.
- `make compile` self-hosts; `sfn fmt --check` clean on every touched `.sfn`.
- Reviewer (Opus) approved: no correctness risk in lambda-id allocation or recursion.
- `make check` (full triple-pass gate) running locally; CI runs the full gate too.

Closes #1168

https://claude.ai/code/session_01XS95HYAHtaaBoLcVgMDwUN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XS95HYAHtaaBoLcVgMDwUN)_