### PR TITLE
refactor(cli): migrate config command to cli/commands/config.sfn

### DIFF
--- a/compiler/src/cli/commands/config.sfn
+++ b/compiler/src/cli/commands/config.sfn
@@ -1,0 +1,62 @@
+// compiler/src/cli/commands/config.sfn
+//
+// `config` subcommand (CLI modularization epic #1671 / tracker #1675,
+// Phase B — SFEP-0027 §3.4, command #1). Migrates `config` off the
+// legacy hand-rolled dispatch (`cli_main.sfn`) into the per-command
+// `command_def()` + `run()` pattern that `version.sfn` established.
+//
+// `config` is the first migrated command with **nested subcommands**
+// (`get`/`set`/`unset`/`list`); `sfn/cli`'s `parse()` owns the descent,
+// and `run` reconstructs the legacy positional args slice
+// (`["config", <sub>, <key>, <value>]`) so it can delegate to the
+// existing `handle_config_command` body **verbatim**. Phase C (#1676)
+// owns deleting that body and relocating its logic — until then this is a
+// behavior-preserving move: the reconstructed slice drives the same
+// handler the legacy dispatch called, so output and exit codes are
+// byte-identical to today (parity oracle:
+// `compiler/tests/e2e/config_test.sfn`).
+import {
+    Command,
+    Matches,
+    arg,
+    command,
+    get,
+    subcommand,
+    with_arg,
+    with_subcommand
+} from "sfn/cli";
+
+import { handle_config_command } from "../../cli_commands";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `config`, registered on the v2 root via
+// `with_subcommand`. The four leaf subcommands mirror the legacy
+// handler's `get`/`set`/`unset`/`list` dispatch: `get`/`unset` take a
+// `<key>`, `set` takes `<key> <value>`, `list` takes none.
+fn command_def() -> Command {
+    let get_cmd: Command = with_arg(command("get", "Print a config value"), arg("key", "Config key"));
+    let set_cmd: Command = with_arg(with_arg(command("set", "Set a config value"), arg("key", "Config key")), arg("value", "Config value"));
+    let unset_cmd: Command = with_arg(command("unset", "Remove a config value"), arg("key", "Config key"));
+    let list_cmd: Command = command("list", "List resolved config values");
+    return with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("config", "Manage sfn configuration"), get_cmd), set_cmd), unset_cmd), list_cmd);
+}
+
+// Reconstruct the legacy positional args slice from the typed matches and
+// delegate to `handle_config_command` verbatim. `subcommand(matches)`
+// returns the leaf name (`get`/`set`/`unset`/`list`), or `"config"` for a
+// bare `sfn config` with no subcommand — which the handler answers with
+// its usage message, matching the legacy behavior. `ctx` is part of the
+// per-command contract but unused here (config sources no driver state).
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let sub: string = subcommand(matches);
+    let mut args: string[] = ["config"];
+    if strings_equal(sub, "config") { return handle_config_command(args); }
+    args.push(sub);
+    if strings_equal(sub, "get") { args.push(get(matches, "key")); }
+    if strings_equal(sub, "set") {
+        args.push(get(matches, "key"));
+        args.push(get(matches, "value"));
+    }
+    if strings_equal(sub, "unset") { args.push(get(matches, "key")); }
+    return handle_config_command(args);
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -32,12 +32,14 @@ import {
     command,
     parse,
     subcommand,
+    subcommand_path,
     with_subcommand
 } from "sfn/cli";
 
 import { sailfin_cli_main_legacy } from "../cli_main";
 import { number_to_string } from "../num_format";
 import { command_def as add_command_def, run as add_run } from "./commands/add";
+import { command_def as config_command_def, run as config_run } from "./commands/config";
 import { command_def as fmt_command_def, run as fmt_run } from "./commands/fmt";
 import { command_def as guillermo_command_def, run as guillermo_run } from "./commands/guillermo";
 import { command_def as init_command_def, run as init_run } from "./commands/init";
@@ -86,7 +88,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // resolving it eagerly here would add a filesystem read to every
     // `build` / `run` invocation. `parse()` skips argv[0] (the program
     // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def());
+    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def());
 
     let mut parse_argv: string[] = ["sfn"];
     let mut j: int = 0;
@@ -205,6 +207,34 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if result.ok { return test_run(result.matches, ctx); }
         print("usage: sfn test [--json] [-k NAME] [--tag TAG] [--update-snapshots] [--no-test-cache] [--jobs N] <suite...>");
         return 2;
+    }
+
+    // `sfn config <get|set|unset|list> [key] [value]` — the registered
+    // subcommand matched. `config` is the first migrated command with
+    // nested subcommands, so `subcommand(result.matches)` returns the
+    // *leaf* (e.g. "get") rather than "config"; the dispatch therefore
+    // gates on the descent path's root (`subcommand_path[0]`). A clean
+    // parse dispatches to `config.run`, which reconstructs the legacy
+    // positional slice and delegates to `handle_config_command`. A non-ok
+    // parse that descended into `config` is a usage error (exit 2): the
+    // `unknown_subcommand` / `unknown_flag` kinds carry a non-empty
+    // diagnostic (e.g. `config quantum` → "unknown subcommand 'quantum'",
+    // preserving the e2e parity oracle), so that message is printed when
+    // present; the help/version kinds (`--help` / `-h` / `--version`) carry
+    // an empty message, so a fixed usage line is printed instead — never a
+    // blank line. Either way the exit code is the legacy `2`.
+    let config_path: string[] = subcommand_path(result.matches);
+    if config_path.length > 0 {
+        if strings_equal(config_path[0], "config") {
+            if ctx.trace_argv { _v2_trace_argv(argv); }
+            if result.ok { return config_run(result.matches, ctx); }
+            if result.error.message.length > 0 {
+                print(result.error.message);
+            } else {
+                print("usage: sfn config <get|set|unset|list> [key] [value]");
+            }
+            return 2;
+        }
     }
 
     let mut handled_version: boolean = false;

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -75,7 +75,7 @@ import {
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
 import { sailfin_cli_main_v2 } from "./cli/main";
 import { handle_check_command } from "./cli_check";
-import { handle_config_command, handle_lock_command, handle_package_command } from "./cli_commands";
+import { handle_lock_command, handle_package_command } from "./cli_commands";
 import {
     _atomic_rename_into_place,
     _env_flag,
@@ -1036,10 +1036,6 @@ fn _legacy_dispatch_lock(args: string[]) -> int ![io] {
     return handle_lock_command(args);
 }
 
-fn _legacy_dispatch_config(args: string[]) -> int ![io] {
-    return handle_config_command(args);
-}
-
 fn _legacy_dispatch_check(args: string[], binary_dir: string) -> int ![io] {
     return handle_check_command(args, binary_dir);
 }
@@ -1133,7 +1129,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     let is_help = _let10;
     let is_package = strings_equal(cmd, "package");
     let is_lock = strings_equal(cmd, "lock");
-    let is_config = strings_equal(cmd, "config");
     let is_check = strings_equal(cmd, "check");
     // #1502: internal self-host validator. Intentionally absent from
     // `_usage()` — driven by `make check` / CI, not end users.
@@ -1170,8 +1165,8 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
 
     // `sfn login` migrated to `sfn/cli` (epic #351, Issue 3.2) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    if is_config { return _legacy_dispatch_config(args); }
-
+    // `sfn config` migrated to `sfn/cli` (epic #1671, Phase B) — handled
+    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn fmt` migrated to `sfn/cli` (epic #351, Issue 3.4) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     if is_check { return _legacy_dispatch_check(args, binary_dir); }
@@ -1406,4 +1401,4 @@ fn main(argv: string[]) -> int ![io, clock] {
     // returns its exit code up through here rather than calling `exit()`.
     sfn_arena_telemetry_dump(label as * u8);
     return exit_code;
-}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_lock_command` / `handle_config_command` /  // `handle_package_command` from `cli_commands`, and the v2 CLI root  // imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.
+}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_lock_command` / `handle_package_command` from  // `cli_commands`, and the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.


### PR DESCRIPTION
## Summary
- Migrate the `config` command off the legacy hand-rolled dispatch into the `sfn/cli`-based per-command module pattern (`command_def()` + `run(matches, ctx)`), registered on the v2 root — epic #1671 Phase B, SFEP-0027 §3.4.
- `config` is the first migrated command with **nested subcommands** (`get`/`set`/`unset`/`list`); `run()` reconstructs the legacy positional args slice and delegates to `handle_config_command` **verbatim**, so behavior is byte-identical (Phase C / #1676 owns deleting that body).
- Remove the `is_config` flag, the `_legacy_dispatch_config` arm, and the now-unused `handle_config_command` import from `cli_main.sfn`.

Closes #1769

## Acceptance Criteria
- [x] `config` is defined via `command_def()` with nested `get`/`set`/`unset`/`list` and registered on the v2 root in `cli/main.sfn`.
- [x] `run(matches, ctx)` reuses `handle_config_command`; behavior is identical to today.
- [x] The `is_config` flag and the `_legacy_dispatch_config` arm are removed from the legacy dispatch.
- [x] The existing `config` e2e peer passes unchanged (`compiler/tests/e2e/config_test.sfn`, all 16 tests).
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes.

## Implementation notes
- The dispatch arm gates on `subcommand_path(result.matches)[0] == "config"` rather than `subcommand() == "config"`, because the parser returns the **leaf** name (e.g. `"get"`) for a nested invocation. No collision with the sibling arms (which gate on their flat leaf).
- On a failed descent the arm prints `result.error.message` when non-empty (the `unknown_subcommand` / `unknown_flag` kinds carry the "unknown subcommand" text the e2e oracle pins) and falls back to a fixed usage line for the empty-message help/version kinds (`config --help` / `-h` / `--version`) — never a blank line. Exit code is the legacy `2` either way. (This empty-message fallback was added in response to the code review; the `--help` path is otherwise uncovered by the oracle.)

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree (`cli/commands/config.sfn` new; `cli/main.sfn` + `cli_main.sfn` edited; `cli_commands.sfn` body reused unchanged).

## Verification
```bash
make compile                                              # self-host: pass
build/native/sailfin test compiler/tests/e2e/config_test.sfn   # 16/16 pass
make test                                                 # unit 185/185, integration 42/42, e2e 170/170, capsules 38/38
sfn fmt --check <touched .sfn>                            # clean
# manual parity spot-checks:
sfn config --help            # -> "usage: sfn config <get|set|unset|list> [key] [value]", exit 2
sfn config quantum registry  # -> "error: unknown subcommand 'quantum'\nrun 'sfn config --help' for usage", exit 2
```

## Files Changed
- `compiler/src/cli/commands/config.sfn` — new command module (`command_def()` + `run()`).
- `compiler/src/cli/main.sfn` — import + register `config` on the v2 root; add the nested-subcommand dispatch arm; import `subcommand_path`.
- `compiler/src/cli_main.sfn` — remove the `config` legacy dispatch (`is_config`, `_legacy_dispatch_config`) and drop the unused import; refresh the import-cycle comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xBTxhfgnc7taSRdbWrfhY

---
_Generated by [Claude Code](https://claude.ai/code/session_011xBTxhfgnc7taSRdbWrfhY)_