### PR TITLE
refactor(cli): migrate lock command to cli/commands/lock.sfn

### DIFF
--- a/compiler/src/cli/commands/lock.sfn
+++ b/compiler/src/cli/commands/lock.sfn
@@ -1,0 +1,57 @@
+// compiler/src/cli/commands/lock.sfn
+//
+// `lock` subcommand (CLI modularization epic #1671 / tracker #1675,
+// Phase B — SFEP-0027 §3.4, command #2). Migrates `lock` off the legacy
+// hand-rolled dispatch (`cli_main.sfn`) into the per-command
+// `command_def()` + `run()` pattern that `version.sfn` established and
+// `config.sfn` (command #1) extended.
+//
+// `lock` is a thin command: a single `--work-dir DIR` value flag and no
+// positionals. `sfn/cli`'s `parse()` owns flag validation, and `run`
+// reconstructs the legacy positional args slice (`["lock", "--work-dir",
+// <dir>]`) so it can delegate to the existing `handle_lock_command` body
+// **verbatim**. Phase C (#1676) owns deleting that body and relocating
+// its logic — until then this is a behavior-preserving move: the
+// reconstructed slice drives the same handler the legacy dispatch called,
+// so output and exit codes are byte-identical to today (parity oracle:
+// `compiler/tests/e2e/lock_test.sfn`).
+//
+// A missing `--work-dir` value, an unrecognized flag, or `--help` makes
+// the parse non-ok while still marking `lock` as descended; the v2
+// dispatch in `cli/main.sfn` returns the usage error (exit 2) there — the
+// parser owns argument validation, matching the legacy handler's
+// "requires a directory argument" / unknown-flag guards.
+import {
+    Command,
+    Matches,
+    command,
+    flag_value,
+    get_or,
+    with_flag
+} from "sfn/cli";
+
+import { handle_lock_command } from "../../cli_commands";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `lock`, registered on the v2 root via
+// `with_subcommand`. One optional `--work-dir DIR` value flag; no
+// positionals.
+fn command_def() -> Command {
+    return with_flag(command("lock", "Write the workspace lockfile (workspace.lock)"), flag_value("work-dir", "Directory to discover the workspace root from (defaults to $PWD)"));
+}
+
+// Reconstruct the legacy positional args slice from the typed matches and
+// delegate to `handle_lock_command` verbatim. An absent `--work-dir`
+// leaves the slice at `["lock"]`, so the handler falls back to `$PWD`
+// exactly as before; when present, the value is forwarded as
+// `["lock", "--work-dir", <dir>]`. `ctx` is part of the per-command
+// contract but unused here (lock sources no driver state).
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let mut args: string[] = ["lock"];
+    let work_dir: string = get_or(matches, "work-dir", "");
+    if work_dir.length > 0 {
+        args.push("--work-dir");
+        args.push(work_dir);
+    }
+    return handle_lock_command(args);
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -43,6 +43,7 @@ import { command_def as config_command_def, run as config_run } from "./commands
 import { command_def as fmt_command_def, run as fmt_run } from "./commands/fmt";
 import { command_def as guillermo_command_def, run as guillermo_run } from "./commands/guillermo";
 import { command_def as init_command_def, run as init_run } from "./commands/init";
+import { command_def as lock_command_def, run as lock_run } from "./commands/lock";
 import { command_def as login_command_def, run as login_run } from "./commands/login";
 import { command_def as publish_command_def, run as publish_run } from "./commands/publish";
 import { command_def as test_command_def, run as test_run } from "./commands/test";
@@ -88,7 +89,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // resolving it eagerly here would add a filesystem read to every
     // `build` / `run` invocation. `parse()` skips argv[0] (the program
     // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def());
+    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def()), lock_command_def());
 
     let mut parse_argv: string[] = ["sfn"];
     let mut j: int = 0;
@@ -170,6 +171,24 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if ctx.trace_argv { _v2_trace_argv(argv); }
         if result.ok { return publish_run(result.matches, ctx); }
         print("usage: sfn publish [path]");
+        return 2;
+    }
+
+    // `sfn lock [--work-dir DIR]` — the registered subcommand matched. A
+    // clean parse dispatches to `lock.run`, which reconstructs the legacy
+    // positional slice and delegates to `handle_lock_command` (the
+    // workspace-lock body stays in `cli_commands.sfn` until Phase C). A
+    // non-ok parse that still descended into `lock` (a `--work-dir` with
+    // no value, an unrecognized flag, or `--help`) is a usage error (exit
+    // 2), matching the legacy handler's "requires a directory argument" /
+    // unknown-flag guards — the parser owns argument validation, so the
+    // misuse never reaches `lock.run`. The literal `2` mirrors the `init` /
+    // `login` / `add` / `publish` dispatches above (the `sfn/cli` `EXIT_*`
+    // constants lower to 0 here).
+    if strings_equal(subcommand(result.matches), "lock") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return lock_run(result.matches, ctx); }
+        print("usage: sfn lock [--work-dir DIR]");
         return 2;
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -75,7 +75,7 @@ import {
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
 import { sailfin_cli_main_v2 } from "./cli/main";
 import { handle_check_command } from "./cli_check";
-import { handle_lock_command, handle_package_command } from "./cli_commands";
+import { handle_package_command } from "./cli_commands";
 import {
     _atomic_rename_into_place,
     _env_flag,
@@ -1032,10 +1032,6 @@ fn _legacy_dispatch_package(args: string[]) -> int ![io] {
     return handle_package_command(args);
 }
 
-fn _legacy_dispatch_lock(args: string[]) -> int ![io] {
-    return handle_lock_command(args);
-}
-
 fn _legacy_dispatch_check(args: string[], binary_dir: string) -> int ![io] {
     return handle_check_command(args, binary_dir);
 }
@@ -1128,7 +1124,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     if strings_equal(cmd, "--help") { _let10 = true; }
     let is_help = _let10;
     let is_package = strings_equal(cmd, "package");
-    let is_lock = strings_equal(cmd, "lock");
     let is_check = strings_equal(cmd, "check");
     // #1502: internal self-host validator. Intentionally absent from
     // `_usage()` — driven by `make check` / CI, not end users.
@@ -1161,8 +1156,8 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     if is_package { return _legacy_dispatch_package(args); }
 
-    if is_lock { return _legacy_dispatch_lock(args); }
-
+    // `sfn lock` migrated to `sfn/cli` (epic #1671, Phase B) — handled
+    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn login` migrated to `sfn/cli` (epic #351, Issue 3.2) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn config` migrated to `sfn/cli` (epic #1671, Phase B) — handled
@@ -1401,4 +1396,4 @@ fn main(argv: string[]) -> int ![io, clock] {
     // returns its exit code up through here rather than calling `exit()`.
     sfn_arena_telemetry_dump(label as * u8);
     return exit_code;
-}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_lock_command` / `handle_package_command` from  // `cli_commands`, and the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.
+}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_package_command` from  // `cli_commands`, and the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.


### PR DESCRIPTION
## Summary
- Migrate `lock` off the legacy hand-rolled dispatch into the per-command `command_def()` + `run()` pattern in `compiler/src/cli/commands/lock.sfn` (SFEP-0027 §3.4, command #2; Phase B of epic #1671 / tracker #1675). Mirrors the `config.sfn` analog (command #1).
- `command_def()` defines `lock` with its `--work-dir DIR` value flag; `run(matches, ctx)` reconstructs the legacy positional slice (`["lock", "--work-dir", <dir>]`) and delegates to the existing `handle_lock_command` body **verbatim** — a behavior-preserving move (workspace-lock body stays in `cli_commands.sfn` until Phase C / #1676).
- Remove the `is_lock` flag and the `_legacy_dispatch_lock` arm from `sailfin_cli_main_legacy`, drop the now-unused `handle_lock_command` import, and register `lock` on the v2 root.

Closes #1770

## Acceptance Criteria
- [x] `lock` is defined via `command_def()` (with `--work-dir`) and registered on the v2 root in `cli/main.sfn`.
- [x] `run(matches, ctx)` reuses `handle_lock_command`; behavior identical to today.
- [x] The `is_lock` flag and the `_legacy_dispatch_lock` arm are removed from `sailfin_cli_main_legacy`.
- [x] The existing `lock` e2e peer passes unchanged.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes.

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree. `compiler/src/cli_commands.sfn` was read (the `handle_lock_command` body reused) but is unchanged, as scoped.

## Verification
```bash
make compile        # status:pass — self-host holds
build/native/sailfin test compiler/tests/e2e/lock_test.sfn   # PASS (all 4 tests)
make test           # unit 185/185, integration 42/42, e2e 170/170, capsules 38/38 — status:pass
build/native/sailfin fmt --check compiler/src/cli/commands/lock.sfn compiler/src/cli/main.sfn compiler/src/cli_main.sfn  # clean
# smoke (usage-error path is parser-owned → exit 2):
build/native/sailfin lock --bogus        # usage: sfn lock [--work-dir DIR] ; rc=2
build/native/sailfin lock --work-dir     # usage: sfn lock [--work-dir DIR] ; rc=2
build/native/sailfin --help | grep lock  # sfn lock [--work-dir DIR]
```

## Files Changed
- `compiler/src/cli/commands/lock.sfn` — new command module (`command_def()` + `run()`).
- `compiler/src/cli/main.sfn` — import, root registration, dispatch arm.
- `compiler/src/cli_main.sfn` — remove legacy `lock` dispatch arm, `is_lock` flag, `_legacy_dispatch_lock`, and the unused import.

## Notes
- SFEP-0027 stays `Accepted` — this is one slice of the multi-command Phase B migration; remaining commands and the `cli_commands.sfn` deletion (Phase C / #1676) are out of scope.

https://claude.ai/code/session_011U9o8Ry9FZvSoVu4tL4kyD

---
_Generated by [Claude Code](https://claude.ai/code/session_011U9o8Ry9FZvSoVu4tL4kyD)_