### PR TITLE
refactor(cli): migrate package command to cli/commands/package.sfn

### DIFF
--- a/compiler/src/cli/commands/package.sfn
+++ b/compiler/src/cli/commands/package.sfn
@@ -1,0 +1,73 @@
+// compiler/src/cli/commands/package.sfn
+//
+// `package` subcommand (CLI modularization epic #1671 / tracker #1675,
+// Phase B — SFEP-0027 §3.4, command #3). Migrates `package` off the
+// legacy hand-rolled dispatch (`cli_main.sfn`) into the per-command
+// `command_def()` + `run()` pattern that `version.sfn` established and
+// `lock.sfn` (command #2) extended.
+//
+// `run` reconstructs the legacy positional args slice and delegates to
+// `handle_package_command` **verbatim** — output and exit codes are
+// byte-identical to today (parity oracle:
+// `compiler/tests/e2e/sfn_package_test.sfn`). The `--installer` / `-p`
+// mutual-exclusion stays inside `handle_package_command` and is
+// preserved automatically by delegation. Phase C (#1676) owns deleting
+// that body and relocating its logic.
+//
+// A missing value for a value flag, an unrecognized flag, or `--help`
+// makes the parse non-ok while still marking `package` as descended;
+// the v2 dispatch in `cli/main.sfn` returns the usage error (exit 2)
+// there — the parser owns argument validation.
+import {
+    Command,
+    Matches,
+    command,
+    flag,
+    flag_value,
+    flag_value_short,
+    get_or,
+    has_flag,
+    with_flag
+} from "sfn/cli";
+
+import { handle_package_command } from "../../cli_commands";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `package`, registered on the v2 root via
+// `with_subcommand`. Four optional value flags, one boolean flag, and one
+// short value flag `-p`.
+fn command_def() -> Command {
+    return with_flag(with_flag(with_flag(with_flag(with_flag(command("package", "Package a capsule or the compiler for distribution"), flag_value("target", "Platform target (e.g. linux-x86_64); auto-detected if absent")), flag_value("out", "Output directory (default: dist)")), flag_value("compiler-bin", "Path to the compiler binary (default: build/native/sailfin)")), flag("installer", "Package the compiler installer bundle")), flag_value_short("p", "p", "Capsule path to package (user-capsule mode)"));
+}
+
+// Reconstruct the legacy positional args slice from the typed matches and
+// delegate to `handle_package_command` verbatim. Absent flags are omitted
+// from the slice so the handler applies its own defaults (`out` → "dist",
+// `compiler-bin` → "build/native/sailfin") and its own mutual-exclusion
+// check exactly as before. `ctx` is part of the per-command contract but
+// unused here (package sources no driver state).
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let mut args: string[] = ["package"];
+    let target: string = get_or(matches, "target", "");
+    if target.length > 0 {
+        args.push("--target");
+        args.push(target);
+    }
+    let out_dir: string = get_or(matches, "out", "");
+    if out_dir.length > 0 {
+        args.push("--out");
+        args.push(out_dir);
+    }
+    let compiler_bin: string = get_or(matches, "compiler-bin", "");
+    if compiler_bin.length > 0 {
+        args.push("--compiler-bin");
+        args.push(compiler_bin);
+    }
+    if has_flag(matches, "installer") { args.push("--installer"); }
+    let capsule_path: string = get_or(matches, "p", "");
+    if capsule_path.length > 0 {
+        args.push("-p");
+        args.push(capsule_path);
+    }
+    return handle_package_command(args);
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -45,6 +45,7 @@ import { command_def as guillermo_command_def, run as guillermo_run } from "./co
 import { command_def as init_command_def, run as init_run } from "./commands/init";
 import { command_def as lock_command_def, run as lock_run } from "./commands/lock";
 import { command_def as login_command_def, run as login_run } from "./commands/login";
+import { command_def as package_command_def, run as package_run } from "./commands/package";
 import { command_def as publish_command_def, run as publish_run } from "./commands/publish";
 import { command_def as test_command_def, run as test_run } from "./commands/test";
 import { command_def as version_command_def, run as version_run } from "./commands/version";
@@ -89,7 +90,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // resolving it eagerly here would add a filesystem read to every
     // `build` / `run` invocation. `parse()` skips argv[0] (the program
     // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def()), lock_command_def());
+    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def()), lock_command_def()), package_command_def());
 
     let mut parse_argv: string[] = ["sfn"];
     let mut j: int = 0;
@@ -189,6 +190,22 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if ctx.trace_argv { _v2_trace_argv(argv); }
         if result.ok { return lock_run(result.matches, ctx); }
         print("usage: sfn lock [--work-dir DIR]");
+        return 2;
+    }
+
+    // `sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]`
+    // — the registered subcommand matched. A clean parse dispatches to
+    // `package.run`, which reconstructs the legacy positional slice and
+    // delegates to `handle_package_command` (the packaging body stays in
+    // `cli_commands.sfn` until Phase C). A non-ok parse that still descended
+    // into `package` (a value flag with no value, an unrecognized flag, or
+    // `--help`) is a usage error (exit 2) — the parser owns argument
+    // validation. The literal `2` mirrors the dispatches above (the `sfn/cli`
+    // `EXIT_*` constants lower to 0 here).
+    if strings_equal(subcommand(result.matches), "package") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return package_run(result.matches, ctx); }
+        print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]");
         return 2;
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -75,7 +75,6 @@ import {
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
 import { sailfin_cli_main_v2 } from "./cli/main";
 import { handle_check_command } from "./cli_check";
-import { handle_package_command } from "./cli_commands";
 import {
     _atomic_rename_into_place,
     _env_flag,
@@ -1028,10 +1027,6 @@ fn _legacy_dispatch_run(args: string[], runtime_root: string, binary_dir: string
     return run_rc;
 }
 
-fn _legacy_dispatch_package(args: string[]) -> int ![io] {
-    return handle_package_command(args);
-}
-
 fn _legacy_dispatch_check(args: string[], binary_dir: string) -> int ![io] {
     return handle_check_command(args, binary_dir);
 }
@@ -1123,7 +1118,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     if strings_equal(cmd, "-h") { _let10 = true; }
     if strings_equal(cmd, "--help") { _let10 = true; }
     let is_help = _let10;
-    let is_package = strings_equal(cmd, "package");
     let is_check = strings_equal(cmd, "check");
     // #1502: internal self-host validator. Intentionally absent from
     // `_usage()` — driven by `make check` / CI, not end users.
@@ -1154,8 +1148,8 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn publish` migrated to `sfn/cli` (epic #351, Issue 3.9) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    if is_package { return _legacy_dispatch_package(args); }
-
+    // `sfn package` migrated to `sfn/cli` (epic #1671, Phase B) — handled
+    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn lock` migrated to `sfn/cli` (epic #1671, Phase B) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn login` migrated to `sfn/cli` (epic #351, Issue 3.2) — handled
@@ -1396,4 +1390,4 @@ fn main(argv: string[]) -> int ![io, clock] {
     // returns its exit code up through here rather than calling `exit()`.
     sfn_arena_telemetry_dump(label as * u8);
     return exit_code;
-}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_package_command` from  // `cli_commands`, and the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.
+}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_check_command` from  // `cli_check`, and the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.


### PR DESCRIPTION
## Summary
- Migrate the `package` command off the legacy hand-rolled dispatch in `cli_main.sfn` onto the v2 `sfn/cli` `command_def()` + `run()` pattern, mirroring the already-migrated `lock` command (SFEP-0027 §3.4, command #3; epic #1671 / tracker #1675, Phase B).
- New `compiler/src/cli/commands/package.sfn` declares the flag surface (`--target`, `--out`, `--compiler-bin`, `--installer`, `-p`) and a `run()` that reconstructs the legacy positional args slice and delegates to `handle_package_command` **verbatim** — defaults and the `--installer`/`-p` mutual-exclusion stay inside that body, so behavior/output/exit-codes are byte-identical to today.
- Register `package` on the v2 root and remove the `is_package` flag, the `_legacy_dispatch_package` arm, and the now-unused `handle_package_command` import from `cli_main.sfn`. The handler body stays in `cli_commands.sfn` (Phase C / #1676 owns its relocation).

Closes #1771

## Acceptance Criteria
- [x] `package` is defined via `command_def()` with the flag surface above and registered on the v2 root in `cli/main.sfn`.
- [x] `run(matches, ctx)` reuses `handle_package_command`; behavior identical to today, including the `--installer`/`-p` mutual-exclusion error.
- [x] The `is_package` flag and the `_legacy_dispatch_package` arm are removed from `sailfin_cli_main_legacy`.
- [x] The existing `package` e2e peer passes unchanged.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes (see Verification note on pre-existing parallel-pool flakiness).

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree exactly (`cli/commands/package.sfn` created, `cli/main.sfn` + `cli_main.sfn` edited; `cli_commands.sfn` body left in place per scope).

## Design note: `-p` flag
Declared `flag_value_short("p", "p", ...)` — long name = the short letter, mirroring how `test.sfn` declares `-k`. This keeps `-p` working without introducing a new long-form synonym (e.g. `--capsule-path`), preserving the exact legacy surface. `run()` reads it back via `get_or(matches, "p", "")` and re-emits `-p`.

## Verification
```bash
make compile
# → status: pass (self-hosts with the new module wired into the v2 root)

build/native/sailfin test compiler/tests/e2e/sfn_package_test.sfn
# → PASS (all 6 tests): compiler mode, user-capsule (-p), installer mode,
#   --installer/-p mutual-exclusion ("incompatible"), missing --compiler-bin,
#   -p without prior build (no sidecar)

build/native/sailfin fmt --check compiler/src/cli/commands/package.sfn \
  compiler/src/cli/main.sfn compiler/src/cli_main.sfn
# → clean

make test
# → unit 185/185, integration 42/42, capsules 38/38 all pass.
#   e2e: 4 failures (http_capsule_serve_gate, make_report_contract,
#   serve_loopback, serve_reuseaddr_restart) — all pass when run SERIALLY;
#   they fail only under the parallel e2e pool (exit 134 SIGABRT, resource
#   contention under the 8 GiB self-cap). Pre-existing/environmental: this
#   diff touches zero serve/http/emit/make-report code.
```

## Files Changed
- `compiler/src/cli/commands/package.sfn` (new) — `command_def()` + `run()` for `package`.
- `compiler/src/cli/main.sfn` — import, root registration, dispatch arm.
- `compiler/src/cli_main.sfn` — remove `is_package`, `_legacy_dispatch_package`, and the unused import; refresh a stale import-cycle comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01By7gFqUFhwS1CDsgAg1FbD)_