### PR TITLE
refactor(cli): migrate emit command to cli/commands/emit.sfn

### DIFF
--- a/compiler/src/cli/commands/emit.sfn
+++ b/compiler/src/cli/commands/emit.sfn
@@ -1,0 +1,184 @@
+// compiler/src/cli/commands/emit.sfn
+//
+// `emit` subcommand (CLI modularization epic #1671 / tracker #1675,
+// Phase B — SFEP-0027 §3.4, command #4). Migrates `emit` off the legacy
+// hand-rolled dispatch (`cli_main.sfn`'s `_legacy_dispatch_emit`) into the
+// per-command `command_def()` + `run()` pattern that `version.sfn`
+// established and `config`/`lock`/`package` extended.
+//
+// Unlike those three, `emit` has no `handle_emit_command` to delegate to —
+// the body was inline in `cli_main.sfn`, so it migrates wholesale into
+// `run` here. The hand-rolled argv walk becomes typed `sfn/cli` match
+// accessors; the three mode branches (`llvm` / `sailfin` / `native`), the
+// import-context staging, and the native resolve-gate are reproduced
+// byte-for-byte (parity oracles:
+// `compiler/tests/e2e/subprocess_emit_clean_env_test.sfn`,
+// `compiler/tests/e2e/effect_gate_build_path_test.sfn`).
+//
+// Flag-order semantics: `--no-retry` aliases `--attempts 1` (applied after
+// `--attempts` so it wins), and `--no-validate` overrides `--validate`,
+// matching the legacy last-wins toggles for the only invocations that pass
+// both. `--attempts N` keeps the legacy `emit_parse_nonneg_int` parse (a
+// bad or `< 1` value is ignored, preserving the default of 1) rather than a
+// `flag_int`, so a malformed value stays a no-op instead of a parse error.
+//
+// A missing flag value, an unrecognized flag, a wrong positional count, or
+// `--help` makes the parse non-ok while still marking `emit` as descended;
+// the v2 dispatch in `cli/main.sfn` returns the usage error (exit 2) there
+// — the parser owns argument validation, replacing the legacy `_usage()`
+// branches. `binary_dir` is threaded from the driver-parsed `CliContext`,
+// replacing the legacy handler's extra param.
+import {
+    Command,
+    Matches,
+    arg,
+    command,
+    flag,
+    flag_value,
+    flag_value_short,
+    get,
+    get_or,
+    has_flag,
+    with_arg,
+    with_flag
+} from "sfn/cli";
+
+import { _write_llvm_text } from "../../build/cache";
+import { _read_import_deps, _resolve_self_path } from "../../build/paths";
+import { stage_capsule_imports_for_emit } from "../../capsule_resolver";
+import { emit_llvm_with_retry, emit_parse_nonneg_int } from "../../emit_helpers";
+import {
+    compile_to_llvm_with_module_timed,
+    compile_to_sailfin,
+    module_name_from_path,
+    print_llvm_with_module,
+    print_native_text_with_module_gated,
+    write_native_text_file_with_module_gated
+} from "../../main";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `emit`, registered on the v2 root via
+// `with_subcommand`. One boolean `--timing`, the `-o` short value flag,
+// three value flags (`--module-name`, `--import-context`, `--attempts`),
+// four boolean toggles (`--no-retry`, `--validate`, `--no-validate`,
+// `--no-resolve-gate`), and two required positionals (`mode`, `path`).
+fn command_def() -> Command {
+    return with_arg(with_arg(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(with_flag(command("emit", "Emit intermediate representation for a Sailfin source file"), flag("timing", "Report per-phase emit timings (llvm only; single attempt, no validate)")), flag_value_short("o", "o", "Write output to this path instead of stdout")), flag_value("module-name", "Module slug override for symbol mangling")), flag_value("import-context", "Root of the staged import-context tree for cross-module effect checking")), flag_value("attempts", "Emit+validate attempt count (N >= 1; llvm -o only)")), flag("no-retry", "Single emit attempt (alias for --attempts 1)")), flag("validate", "Round-trip the emitted IR through llvm-as/clang")), flag("no-validate", "Disable IR validation (default)")), flag("no-resolve-gate", "Skip the native-emit lowering dry-run gate (build-internal)")), arg("mode", "Output form: llvm | sailfin | native")), arg("path", "Sailfin source file to emit"));
+}
+
+// Reproduce the legacy `_legacy_dispatch_emit` body against typed matches.
+// Flag reads mirror the hand-rolled walk; the mode dispatch is verbatim.
+fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
+    let timing: boolean = has_flag(matches, "timing");
+    let out_path: string = get_or(matches, "o", "");
+    // Stage D PR3: explicit module-name override for symbol mangling of
+    // cross-capsule deps; empty falls back to `module_name_from_path(path)`.
+    let module_name_override: string = get_or(matches, "module-name", "");
+    // #957: root of the staged import-context tree. When set, the llvm-emit
+    // path reads `<root>/<module-name>.import-deps` so callee-effect
+    // transitivity (`E0402`) is enforced on the build path.
+    let import_context_root: string = get_or(matches, "import-context", "");
+    // #515: `--attempts N` (N >= 1) sets the emit+validate attempt count via
+    // the same nonneg parse the legacy body used; a bad / `< 1` value is
+    // ignored so the bare CLI stays byte-for-byte behaviour-preserving.
+    let mut emit_attempts: int = 1;
+    let attempts_raw: string = get_or(matches, "attempts", "");
+    if attempts_raw.length > 0 {
+        let parsed = emit_parse_nonneg_int(attempts_raw);
+        if parsed >= 1 { emit_attempts = parsed; }
+    }
+    // `--no-retry` == `--attempts 1`; applied after `--attempts` so it wins.
+    if has_flag(matches, "no-retry") { emit_attempts = 1; }
+    // `--validate` / `--no-validate` toggle the llvm-as/clang round-trip;
+    // `--no-validate` wins to match the legacy explicit-off.
+    let mut emit_validate: boolean = has_flag(matches, "validate");
+    if has_flag(matches, "no-validate") { emit_validate = false; }
+    // #906: build-internal per-module native emits skip the lowering
+    // dry-run gate via `--no-resolve-gate`.
+    let skip_resolve_gate: boolean = has_flag(matches, "no-resolve-gate");
+
+    let mode: string = get(matches, "mode");
+    let path: string = get(matches, "path");
+    if !fs.exists(path) {
+        print("file not found: " + path);
+        return 1;
+    }
+    // #1370: a user-facing `emit llvm` (no `--module-name` /
+    // `--import-context`, i.e. NOT a build-internal worker emit) stages the
+    // consumer capsule's dependencies into the import-context tree first,
+    // exactly as `check` / `build` / `run` do — otherwise a cold `emit llvm`
+    // of a capsule importing e.g. sfn/http `serve` finds no staged
+    // `.sfn-asm` and the #1323 gate hijacks the call. Scoped to `llvm` (the
+    // lowering stage the gate runs in); `native` is import-context-free by
+    // design (#906) and `sailfin` is a transpile.
+    // `stage_capsule_imports_for_emit` no-ops unless the entry's
+    // capsule.toml declares `[dependencies]`, so a bare runtime/prelude emit
+    // is untouched.
+    if strings_equal(mode, "llvm") && module_name_override.length == 0
+        && import_context_root.length == 0 {
+        let emit_stage_exe = _resolve_self_path(ctx.binary_dir);
+        let emit_staged = stage_capsule_imports_for_emit(path, emit_stage_exe, "");
+        if !emit_staged {
+            print.err("sfn emit: warning: capsule import staging incomplete; imported capsule calls may not resolve");
+        }
+    }
+    let source = fs.readFile(path);
+    let mut module_name = module_name_from_path(path);
+    if module_name_override.length > 0 { module_name = module_name_override; }
+    let has_out = out_path.length > 0;
+    if strings_equal(mode, "llvm") {
+        if has_out {
+            if timing {
+                // --timing keeps the single-attempt, no-validate path: it
+                // reports per-phase emit timings, which a retry loop would
+                // distort.
+                let llvm = compile_to_llvm_with_module_timed(source, module_name);
+                _write_llvm_text(out_path, llvm);
+            } else {
+                // #515: route through the shared retry+validator cascade.
+                // Empty `import_asm_paths` degrades to the legacy
+                // in-module-only effect gate.
+                let mut import_asm_paths: string[] = [];
+                if import_context_root.length > 0 {
+                    import_asm_paths = _read_import_deps(import_context_root, module_name);
+                }
+                let ok = emit_llvm_with_retry(path, module_name, out_path, import_asm_paths, emit_attempts, emit_validate, false);
+                if !ok { return 1; }
+            }
+        } else {
+            if timing {
+                print(compile_to_llvm_with_module_timed(source, module_name));
+            } else {
+                if !print_llvm_with_module(source, module_name) { return 1; }
+            }
+        }
+        return 0;
+    }
+    if strings_equal(mode, "sailfin") {
+        if has_out {
+            fs.writeFile(out_path, compile_to_sailfin(source));
+        } else { print(compile_to_sailfin(source)); }
+        return 0;
+    }
+    if strings_equal(mode, "native") {
+        // #906: gate the native emit on the same lowering `[fatal]` that
+        // `build` / `emit llvm` reject, so `emit native` fails closed on
+        // unresolved-callee inputs. The build's per-module subprocess emit
+        // passes `--no-resolve-gate` to opt out (no cross-module import
+        // context in isolation); it stays fail-closed via the later LLVM
+        // lowering stage (#631).
+        let run_gate = !skip_resolve_gate;
+        if has_out {
+            if !write_native_text_file_with_module_gated(source, module_name, out_path, run_gate) {
+                return 1;
+            }
+        } else {
+            if !print_native_text_with_module_gated(source, module_name, run_gate) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    print("unknown emit mode: " + mode);
+    return 2;
+}

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -40,6 +40,7 @@ import { sailfin_cli_main_legacy } from "../cli_main";
 import { number_to_string } from "../num_format";
 import { command_def as add_command_def, run as add_run } from "./commands/add";
 import { command_def as config_command_def, run as config_run } from "./commands/config";
+import { command_def as emit_command_def, run as emit_run } from "./commands/emit";
 import { command_def as fmt_command_def, run as fmt_run } from "./commands/fmt";
 import { command_def as guillermo_command_def, run as guillermo_run } from "./commands/guillermo";
 import { command_def as init_command_def, run as init_run } from "./commands/init";
@@ -90,13 +91,21 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // resolving it eagerly here would add a filesystem read to every
     // `build` / `run` invocation. `parse()` skips argv[0] (the program
     // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def()), lock_command_def()), package_command_def());
+    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def()), lock_command_def()), package_command_def()), emit_command_def());
 
+    // Preserve the legacy `--emit` long-flag alias (`sfn --emit llvm x.sfn`):
+    // the legacy dispatch treated `--emit` as the first token identically to
+    // the `emit` subcommand. `sfn/cli`'s `parse()` would otherwise see it as
+    // an unknown root flag, so normalize the leading `--emit` to `emit`
+    // before parsing — the only place the alias is recognized now that the
+    // legacy `is_emit` arm is removed.
     let mut parse_argv: string[] = ["sfn"];
     let mut j: int = 0;
     loop {
         if j >= args.length { break; }
-        parse_argv.push(args[j]);
+        if j == 0 && strings_equal(args[0], "--emit") {
+            parse_argv.push("emit");
+        } else { parse_argv.push(args[j]); }
         j += 1;
     }
 
@@ -206,6 +215,24 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if ctx.trace_argv { _v2_trace_argv(argv); }
         if result.ok { return package_run(result.matches, ctx); }
         print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]");
+        return 2;
+    }
+
+    // `sfn emit [--timing] [-o OUTPUT] [--module-name SLUG]
+    // [--import-context DIR] [--attempts N] [--no-retry] [--validate]
+    // [--no-validate] [--no-resolve-gate] <llvm|sailfin|native> <file.sfn>`
+    // — the registered subcommand matched (including the normalized `--emit`
+    // alias). A clean parse dispatches to `emit.run`, which reproduces the
+    // legacy `_legacy_dispatch_emit` body against typed matches. A non-ok
+    // parse that still descended into `emit` (a value flag with no value, an
+    // unrecognized flag, a missing/surplus positional, or `--help`) is a
+    // usage error (exit 2) — the parser owns argument validation, replacing
+    // the legacy `_usage()` branches. The literal `2` mirrors the dispatches
+    // above (the `sfn/cli` `EXIT_*` constants lower to 0 here).
+    if strings_equal(subcommand(result.matches), "emit") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return emit_run(result.matches, ctx); }
+        print("usage: sfn emit [--timing] [-o OUTPUT] [--module-name SLUG] [--import-context DIR] [--attempts N] [--no-retry] [--validate] [--no-validate] [--no-resolve-gate] <llvm|sailfin|native> <file.sfn>");
         return 2;
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -10,8 +10,7 @@ import {
     _emit_capsule_artifact_sidecar,
     _print_cache_summary,
     _resolve_capsule_build_spec,
-    _resolve_sailfin_cache_dir_for_work,
-    _write_llvm_text
+    _resolve_sailfin_cache_dir_for_work
 } from "./build/cache";
 import { _do_determinism_check } from "./build/determinism";
 import { LinkResult, _clang_link_multi } from "./build/link";
@@ -20,9 +19,7 @@ import {
     _ends_with,
     _ensure_dir,
     _path_basename,
-    _path_join,
-    _read_import_deps,
-    _resolve_self_path
+    _path_join
 } from "./build/paths";
 import { _runtime_bundle_exists } from "./build/runtime_objs";
 import {
@@ -69,8 +66,7 @@ import {
     ProjectCapsuleResult,
     ResolverConsumer,
     empty_resolver_consumer,
-    prepare_project_capsules,
-    stage_capsule_imports_for_emit
+    prepare_project_capsules
 } from "./capsule_resolver";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
 import { sailfin_cli_main_v2 } from "./cli/main";
@@ -82,18 +78,12 @@ import {
     _mktemp_sibling_cmd
 } from "./cli_commands_utils";
 import { handle_selfhost_command } from "./cli_selfhost";
-import { emit_llvm_with_retry, emit_parse_nonneg_int } from "./emit_helpers";
 import { resolve_import_module_slug_for_module } from "./llvm/imports";
 import {
     compile_to_llvm_file_with_module,
     compile_to_llvm_with_module,
-    compile_to_llvm_with_module_timed,
-    compile_to_sailfin,
     module_name_from_path,
-    number_to_string,
-    print_llvm_with_module,
-    print_native_text_with_module_gated,
-    write_native_text_file_with_module_gated
+    number_to_string
 } from "./main";
 import { parse_native_imports_for_import } from "./native_ir_api";
 import { runtime_capsule_from_root } from "./runtime_capsule_resolver";
@@ -221,240 +211,6 @@ fn _path_strip_ext(name: string) -> string {
     }
     if last_dot < 0 { return name; }
     return substring(name, 0, last_dot);
-}
-
-fn _legacy_dispatch_emit(args: string[], binary_dir: string) -> int ![io, clock] {
-    let mut timing = false;
-    let mut out_path = "";
-    // Stage D PR3: explicit module name override. Lets the
-    // resolver's per-module compile (`_cr_compile_one`) shell
-    // out to a fresh subprocess for arena isolation while
-    // preserving the slug-based module name needed for symbol
-    // mangling of cross-capsule deps (where the slug is
-    // `<scope>/<name>/<rest>`, not what `module_name_from_path`
-    // would derive). Empty / not provided → fall back to
-    // `module_name_from_path(path)` so all existing call sites
-    // (humans + tests + build.sh) keep their current shape.
-    let mut module_name_override: string = "";
-    // #957: root of the staged import-context tree
-    // (`build/native/import-context`). When set, the llvm-emit
-    // path reads `<root>/<module-name>.import-deps` to load the
-    // cross-module effect table so callee-effect transitivity
-    // (`E0402`) is enforced on the build path.
-    let mut import_context_root: string = "";
-    // #515: single-shot `sfn emit llvm -o` can route through
-    // `emit_llvm_with_retry` (the same emit+probe+validate+retry
-    // cascade the resolver's multi-source path uses). Validation +
-    // retry are OPT-IN here (default: 1 attempt, no validate) so the
-    // bare CLI stays byte-for-byte behaviour-preserving — a
-    // single-file emit may legitimately reference runtime-provided
-    // externs that don't self-assemble in isolation, and forcing
-    // `llvm-as` on every emit would surface those as spurious
-    // failures (e.g. the exe-path test's Darwin leg). Callers that
-    // KNOW their IR is self-contained opt in: the Makefile
-    // cross-build staging passes `--validate`, and the resolver
-    // validates at its own layer. Flags: `--attempts N` (N >= 1)
-    // sets the count; `--no-retry` == `--attempts 1`;
-    // `--validate` / `--no-validate` toggle the `llvm-as`/`clang`
-    // round-trip.
-    let mut emit_attempts: int = 1;
-    let mut emit_validate: boolean = false;
-    // #906: build-internal per-module native emits set this (via
-    // `--no-resolve-gate`) to skip the lowering dry-run gate, which
-    // would otherwise reject legitimate cross-module calls that the
-    // import-context-free native stage cannot resolve in isolation.
-    let mut skip_resolve_gate: boolean = false;
-    let mut base_index = 1;
-    // Parse optional flags: --timing, --module-name <slug>,
-    // -o <path>, --attempts N, --no-retry, --validate,
-    // --no-validate in any order.
-    let mut consumed_flag: boolean = true;
-    loop {
-        if !consumed_flag { break; }
-        if base_index >= args.length { break; }
-        consumed_flag = false;
-        if strings_equal(args[base_index], "--timing") {
-            timing = true;
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "-o") {
-            base_index += 1;
-            if base_index >= args.length {
-                print(_usage());
-                return 2;
-            }
-            out_path = args[base_index];
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--module-name") {
-            base_index += 1;
-            if base_index >= args.length {
-                print(_usage());
-                return 2;
-            }
-            module_name_override = args[base_index];
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--import-context") {
-            base_index += 1;
-            if base_index >= args.length {
-                print(_usage());
-                return 2;
-            }
-            import_context_root = args[base_index];
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--attempts") {
-            base_index += 1;
-            if base_index >= args.length {
-                print(_usage());
-                return 2;
-            }
-            let parsed = emit_parse_nonneg_int(args[base_index]);
-            if parsed >= 1 { emit_attempts = parsed; }
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--no-retry") {
-            emit_attempts = 1;
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--validate") {
-            emit_validate = true;
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--no-validate") {
-            emit_validate = false;
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-        if strings_equal(args[base_index], "--no-resolve-gate") {
-            skip_resolve_gate = true;
-            base_index += 1;
-            consumed_flag = true;
-            continue;
-        }
-    }
-    let _expected_args = base_index + 2;
-    if args.length != _expected_args {
-        print(_usage());
-
-        return 2;
-    }
-    let mode = args[base_index];
-    let _path_idx = base_index + 1;
-    let path = args[_path_idx];
-    if !fs.exists(path) {
-        print("file not found: " + path);
-
-        return 1;
-    }
-    // #1370: a user-facing `emit llvm` (no `--module-name` /
-    // `--import-context`, i.e. NOT a build-internal worker emit —
-    // every resolver/worker emit threads at least one of those flags)
-    // stages the consumer capsule's dependencies into the
-    // import-context tree first, exactly as `check` / `build` / `run`
-    // already do. Without this, a COLD `emit llvm` of a capsule that
-    // imports e.g. sfn/http `serve` finds no staged
-    // `build/native/import-context/sfn/http/*.sfn-asm`, so the imported
-    // `serve` never enters the lowering `functions` list and the #1323
-    // gate (`expression_lowering/native/core.sfn`) hijacks the call to
-    // the builtin `@sfn_serve`. A loose `.sfn` outside any capsule
-    // resolves to zero sources and is a no-op, preserving bare-emit
-    // behavior; the guard keeps the self-host worker emits unchanged.
-    // Scoped to `llvm`: that is the lowering stage the #1323 gate runs
-    // in; `native` emit is import-context-free by design (#906) and
-    // `sailfin` is a transpile, so neither needs staging.
-    // `stage_capsule_imports_for_emit` no-ops unless the entry's
-    // capsule.toml declares `[dependencies]`, so a bare runtime/prelude
-    // emit (the cross-windows path) is untouched (#1370 regression).
-    if strings_equal(mode, "llvm") && module_name_override.length == 0
-        && import_context_root.length == 0 {
-        let emit_stage_exe = _resolve_self_path(binary_dir);
-        let emit_staged = stage_capsule_imports_for_emit(path, emit_stage_exe, "");
-        if !emit_staged {
-            print.err("sfn emit: warning: capsule import staging incomplete; imported capsule calls may not resolve");
-        }
-    }
-    let source = fs.readFile(path);
-    let mut module_name = module_name_from_path(path);
-    if module_name_override.length > 0 { module_name = module_name_override; }
-    let has_out = out_path.length > 0;
-    if strings_equal(mode, "llvm") {
-        if has_out {
-            if timing {
-                // --timing keeps the single-attempt, no-validate
-                // path: it reports per-phase emit timings, which a
-                // retry loop would distort.
-                let llvm = compile_to_llvm_with_module_timed(source, module_name);
-                _write_llvm_text(out_path, llvm);
-            } else {
-                // #515: route through the shared retry+validator
-                // cascade. Empty `import_asm_paths` degrades to the
-                // legacy in-module-only effect gate (same as the
-                // bare `compile_to_llvm_file_with_module` call this
-                // replaced).
-                let mut import_asm_paths: string[] = [];
-                if import_context_root.length > 0 {
-                    import_asm_paths = _read_import_deps(import_context_root, module_name);
-                }
-                let ok = emit_llvm_with_retry(path, module_name, out_path, import_asm_paths, emit_attempts, emit_validate, false);
-                if !ok { return 1; }
-            }
-        } else {
-            if timing {
-                print(compile_to_llvm_with_module_timed(source, module_name));
-            } else {
-                if !print_llvm_with_module(source, module_name) { return 1; }
-            }
-        }
-        return 0;
-    }
-    if strings_equal(mode, "sailfin") {
-        if has_out {
-            fs.writeFile(out_path, compile_to_sailfin(source));
-        } else { print(compile_to_sailfin(source)); }
-        return 0;
-    }
-    if strings_equal(mode, "native") {
-        // #906: gate the native emit on the same lowering `[fatal]`
-        // that `build` / `emit llvm` reject, so `emit native` fails
-        // closed (rc != 0, no `.sfn-asm`) on unresolved-callee inputs
-        // instead of writing an artifact and exiting 0. The build's
-        // per-module subprocess emit passes `--no-resolve-gate`
-        // (`skip_resolve_gate`) to opt out: that stage emits
-        // intermediate `.sfn-asm` with no cross-module import context,
-        // so it must not gate here — the build stays fail-closed via
-        // its later LLVM lowering stage (#631).
-        let run_gate = !skip_resolve_gate;
-        if has_out {
-            if !write_native_text_file_with_module_gated(source, module_name, out_path, run_gate) {
-                return 1;
-            }
-        } else {
-            if !print_native_text_with_module_gated(source, module_name, run_gate) {
-                return 1;
-            }
-        }
-        return 0;
-    }
-    print("unknown emit mode: " + mode);
-
-    return 2;
 }
 
 fn _legacy_dispatch_build(args: string[], runtime_root: string, binary_dir: string) -> int ![io] {
@@ -1095,23 +851,13 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
                 + args[arg_index_trace]);
             arg_index_trace += 1;
         }
-        if args.length > 0 {
-            let cmd_check = args[0];
-            let eq_emit = strings_equal(cmd_check, "emit");
-            if eq_emit { print.err("cli: eq_emit=true"); } else {
-                print.err("cli: eq_emit=false");
-            }
-        }
     }
 
     // Pre-compute command checks to avoid patterns the compiler drops
     // (&&-chained .length checks with function calls get dropped from IR)
+    // `emit` / `--emit` migrated to `sfn/cli` (epic #1671, Phase B) — handled
+    // by `sailfin_cli_main_v2` before reaching this legacy dispatch.
     let cmd = args[0];
-    let is_emit_flag = strings_equal(cmd, "--emit");
-    let mut _let8: boolean = false;
-    if strings_equal(cmd, "emit") { _let8 = true; }
-    if is_emit_flag { _let8 = true; }
-    let is_emit = _let8;
     let is_build = strings_equal(cmd, "build");
     let is_run = strings_equal(cmd, "run");
     let mut _let10: boolean = false;
@@ -1122,11 +868,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // #1502: internal self-host validator. Intentionally absent from
     // `_usage()` — driven by `make check` / CI, not end users.
     let is_selfhost = strings_equal(cmd, "selfhost");
-    if trace_argv {
-        if is_emit { print.err("cli: cmd_is_emit=true"); }
-    }
-
-    if is_emit { return _legacy_dispatch_emit(args, binary_dir); }
 
     if is_build {
         return _legacy_dispatch_build(args, runtime_root, binary_dir);


### PR DESCRIPTION
## Summary
- Migrate the `emit` command off the legacy hand-rolled argv parser (`cli_main.sfn`'s `_legacy_dispatch_emit`) into the per-command `command_def()` + `run(matches, ctx)` pattern at `compiler/src/cli/commands/emit.sfn` (SFEP-0027 §3.4, command #4; epic #1671 / tracker #1675, Phase B).
- Unlike `config`/`lock`/`package`, `emit` has no `handle_emit_command` to delegate to — the inline body migrates wholesale into `run`, with the hand-rolled flag walk replaced by typed `sfn/cli` accessors and the three mode branches (`llvm`/`sailfin`/`native`), import-context staging, and native resolve-gate transcribed verbatim.
- Behavior-preserving: `--attempts` keeps the legacy `emit_parse_nonneg_int` parse (bad/`<1` ignored) rather than `flag_int`; `--no-retry` aliases `--attempts 1`; `--no-validate` overrides `--validate`. The legacy `--emit` long-flag alias is preserved by normalizing the leading token to `emit` before `parse()` in `cli/main.sfn`. The `is_emit` flag, `_legacy_dispatch_emit` body, emit-only imports, and debug traces are removed from the legacy dispatch.

Closes #1772

## Acceptance Criteria
- [x] `emit` defined via `command_def()` with the full typed-flag surface (`--timing`, `-o`, `--module-name`, `--import-context`, `--attempts`, `--no-retry`, `--validate`, `--no-validate`, `--no-resolve-gate`, positionals `mode`+`path`) and registered on the v2 root in `cli/main.sfn`.
- [x] `run(matches, ctx)` reproduces the inline `_legacy_dispatch_emit` behavior, including the `--timing`/`--attempts`/`--validate` handling and `--no-retry` → `--attempts 1` aliasing.
- [x] The `--emit` legacy long-flag alias still resolves to the migrated command.
- [x] The `is_emit` flag and the `_legacy_dispatch_emit` body are removed from `sailfin_cli_main_legacy`.
- [x] The existing `emit` e2e peers pass unchanged.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes.

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree (`cli/commands/emit.sfn` created; `cli/main.sfn` registration + `--emit` alias; `cli_main.sfn` legacy-body + `is_emit` removal). Additionally pruned the now-dead emit-only imports from `cli_main.sfn` (in-unit, behavior-neutral).

## Verification
```bash
make compile                                                            # self-host: pass
build/native/sailfin test compiler/tests/e2e/subprocess_emit_clean_env_test.sfn   # 5/5 pass
build/native/sailfin test compiler/tests/e2e/effect_gate_build_path_test.sfn      # 4/4 pass
make test    # unit 185/185, integration 42/42, e2e 170/170, capsules 38/38 — 0 failed
sfn fmt --check compiler/src/cli/commands/emit.sfn compiler/src/cli/main.sfn compiler/src/cli_main.sfn   # clean
```
Manual smoke confirmed parity: `emit llvm|sailfin|native`, `-o`, the `--emit` alias (identical output), unknown-mode (`unknown emit mode: …`, rc 2), and missing-file (`file not found: …`, rc 1).

## Files Changed
- `compiler/src/cli/commands/emit.sfn` — new command module (migrated body).
- `compiler/src/cli/main.sfn` — register on v2 root + dispatch arm + `--emit` alias normalization.
- `compiler/src/cli_main.sfn` — remove `_legacy_dispatch_emit`, `is_emit`, emit-only imports, debug traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AafFK1pBYA4YUUJkFmL4hL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AafFK1pBYA4YUUJkFmL4hL)_