### PR TITLE
refactor(cli): migrate check command to cli/commands/check.sfn

### DIFF
--- a/compiler/src/cli/commands/check.sfn
+++ b/compiler/src/cli/commands/check.sfn
@@ -1,0 +1,74 @@
+// compiler/src/cli/commands/check.sfn
+//
+// `check` subcommand (CLI modularization epic #1671 / tracker #1675,
+// Phase B — SFEP-0027 §3.4, command #5). Migrates `check` off the legacy
+// hand-rolled dispatch (`cli_main.sfn`) into the per-command
+// `command_def()` + `run()` pattern that `version.sfn` established and the
+// other Phase B commands (`lock`, `package`, `config`, `emit`) extended.
+//
+// `run` reconstructs the legacy positional args slice and delegates to
+// `handle_check_command(args, binary_dir)` in `cli_check.sfn` **verbatim**
+// — output, the `--json` envelope schema, and exit codes are
+// byte-identical to today (parity oracles: the `check_*_test.sfn` family
+// under `compiler/tests/e2e/`). The handler stays in `cli_check.sfn` and
+// is reused as-is; this migration is the `command_def()` + dispatch
+// wiring, not a rewrite.
+//
+// `binary_dir` is sourced from the driver-parsed `CliContext` (Issue 2.2)
+// instead of the legacy `_legacy_dispatch_check(args, binary_dir)` extra
+// param. The handler threads it to `_resolve_check_self_path` for
+// subprocess-per-module staging.
+//
+// `--quiet` / `-q` / `--json` / `--allow-bare-assert` are boolean flags;
+// `[path...]` is a variadic positional (Issue 1.11, #800) that accepts
+// zero tokens — a bare `sfn check` parses ok and reaches `run`, which
+// reconstructs `["check"]` and lets the handler default the path list to
+// ".". `-h` / `--help` are owned by the parser (the usage-error exit-2
+// path in `cli/main.sfn`), matching every other migrated command.
+import {
+    Command,
+    Matches,
+    arg_variadic,
+    command,
+    flag,
+    flag_short,
+    has_flag,
+    positionals,
+    with_arg,
+    with_flag
+} from "sfn/cli";
+
+import { handle_check_command } from "../../cli_check";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `check`, registered on the v2 root via
+// `with_subcommand`. Three boolean flags (`--quiet`/`-q`, `--json`,
+// `--allow-bare-assert`) and a variadic `[path...]` positional.
+fn command_def() -> Command {
+    return with_arg(with_flag(with_flag(with_flag(command("check", "Type-check and effect-check Sailfin source files"), flag_short("quiet", "q", "Suppress the human diagnostic stream")), flag("json", "Emit a machine-readable JSON envelope on stdout")), flag("allow-bare-assert", "Opt out of the W0210 bare-assert-in-test warning")), arg_variadic("path", "Files or directories to check (default: .)"));
+}
+
+// Reconstruct the legacy positional args slice from the typed matches and
+// delegate to `handle_check_command` verbatim. `args[0]` is "check" (the
+// handler skips it); absent flags are omitted so the handler applies its
+// own `--json` ⇒ quiet coupling and its own empty-path ⇒ "." default
+// exactly as before. `binary_dir` comes from the driver-parsed
+// `CliContext`.
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let mut args: string[] = ["check"];
+    if has_flag(matches, "quiet") { args.push("--quiet"); }
+    if has_flag(matches, "json") { args.push("--json"); }
+    if has_flag(matches, "allow-bare-assert") {
+        args.push("--allow-bare-assert");
+    }
+    let paths: string[] = positionals(matches, "path");
+    let mut pi: int = 0;
+    loop {
+        if pi >= paths.length { break; }
+        args.push(paths[pi]);
+        pi += 1;
+    }
+    return handle_check_command(args, ctx.binary_dir);
+}
+
+export { command_def, run };

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -39,6 +39,7 @@ import {
 import { sailfin_cli_main_legacy } from "../cli_main";
 import { number_to_string } from "../num_format";
 import { command_def as add_command_def, run as add_run } from "./commands/add";
+import { command_def as check_command_def, run as check_run } from "./commands/check";
 import { command_def as config_command_def, run as config_run } from "./commands/config";
 import { command_def as emit_command_def, run as emit_run } from "./commands/emit";
 import { command_def as fmt_command_def, run as fmt_run } from "./commands/fmt";
@@ -85,13 +86,33 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         i += 1;
     }
 
-    // Root command registers ONLY `version`, sourced from its own
-    // module via `command_def()`. The version string is not set on the
-    // command (`with_version`) because `version.run` prints it itself —
-    // resolving it eagerly here would add a filesystem read to every
-    // `build` / `run` invocation. `parse()` skips argv[0] (the program
-    // name), so a synthetic "sfn" head is prepended before parsing.
-    let root: Command = with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(with_subcommand(command("sfn", "Sailfin compiler"), version_command_def()), guillermo_command_def()), init_command_def()), login_command_def()), add_command_def()), publish_command_def()), fmt_command_def()), test_command_def()), config_command_def()), lock_command_def()), package_command_def()), emit_command_def());
+    // Root command, composed from each subcommand's `command_def()`. Built
+    // incrementally (one `with_subcommand` reassignment per command) rather
+    // than as a single deeply-nested expression: the pinned seed miscompiles
+    // a `with_subcommand(...)` chain at this depth, emitting code that
+    // segfaults at runtime while constructing the tree (#1773 — adding the
+    // 13th command tipped the nested form over). The reassignment form is
+    // semantically identical and codegens cleanly, and scales to the
+    // remaining `build` / `run` migrations (SFEP-0027 §3.4) without
+    // re-tripping the limit. The version string is not set on the command
+    // (`with_version`) because `version.run` prints it itself — resolving it
+    // eagerly here would add a filesystem read to every `build` / `run`
+    // invocation. `parse()` skips argv[0] (the program name), so a synthetic
+    // "sfn" head is prepended before parsing.
+    let mut root: Command = command("sfn", "Sailfin compiler");
+    root = with_subcommand(root, version_command_def());
+    root = with_subcommand(root, guillermo_command_def());
+    root = with_subcommand(root, init_command_def());
+    root = with_subcommand(root, login_command_def());
+    root = with_subcommand(root, add_command_def());
+    root = with_subcommand(root, publish_command_def());
+    root = with_subcommand(root, fmt_command_def());
+    root = with_subcommand(root, test_command_def());
+    root = with_subcommand(root, config_command_def());
+    root = with_subcommand(root, lock_command_def());
+    root = with_subcommand(root, package_command_def());
+    root = with_subcommand(root, emit_command_def());
+    root = with_subcommand(root, check_command_def());
 
     // Preserve the legacy `--emit` long-flag alias (`sfn --emit llvm x.sfn`):
     // the legacy dispatch treated `--emit` as the first token identically to
@@ -269,6 +290,23 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if ctx.trace_argv { _v2_trace_argv(argv); }
         if result.ok { return test_run(result.matches, ctx); }
         print("usage: sfn test [--json] [-k NAME] [--tag TAG] [--update-snapshots] [--no-test-cache] [--jobs N] <suite...>");
+        return 2;
+    }
+
+    // `sfn check [--quiet] [--json] [--allow-bare-assert] [path...]` — the
+    // registered subcommand matched. The variadic `[path...]` accepts zero
+    // tokens, so a bare `sfn check` (and every flag combination) parses ok
+    // and dispatches to `check.run`, which reconstructs the legacy positional
+    // slice and delegates to `handle_check_command` (the body stays in
+    // `cli_check.sfn`, reused verbatim — SFEP-0027 §3.4 command #5). A non-ok
+    // parse that still descended into `check` (an unrecognized flag, or
+    // `--help`) is a usage error (exit 2) — the parser owns flag validation.
+    // The literal `2` mirrors the dispatches above (the `sfn/cli` `EXIT_*`
+    // constants lower to 0 here).
+    if strings_equal(subcommand(result.matches), "check") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return check_run(result.matches, ctx); }
+        print("usage: sfn check [--quiet] [--json] [--allow-bare-assert] [path...]");
         return 2;
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -70,7 +70,6 @@ import {
 } from "./capsule_resolver";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
 import { sailfin_cli_main_v2 } from "./cli/main";
-import { handle_check_command } from "./cli_check";
 import {
     _atomic_rename_into_place,
     _env_flag,
@@ -783,10 +782,6 @@ fn _legacy_dispatch_run(args: string[], runtime_root: string, binary_dir: string
     return run_rc;
 }
 
-fn _legacy_dispatch_check(args: string[], binary_dir: string) -> int ![io] {
-    return handle_check_command(args, binary_dir);
-}
-
 // Historical C ABI boundary — the now-retired C driver called
 // `sailfin_cli_main__cli_main` with an `int64_t` return type.
 // After M5.5 (#473) the only callers are `sailfin_cli_main_v2`
@@ -864,7 +859,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     if strings_equal(cmd, "-h") { _let10 = true; }
     if strings_equal(cmd, "--help") { _let10 = true; }
     let is_help = _let10;
-    let is_check = strings_equal(cmd, "check");
     // #1502: internal self-host validator. Intentionally absent from
     // `_usage()` — driven by `make check` / CI, not end users.
     let is_selfhost = strings_equal(cmd, "selfhost");
@@ -899,8 +893,8 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // `sfn fmt` migrated to `sfn/cli` (epic #351, Issue 3.4) — handled
     // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    if is_check { return _legacy_dispatch_check(args, binary_dir); }
-
+    // `sfn check` migrated to `sfn/cli` (epic #1671, Phase B) — handled
+    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
     // #1502: internal self-host fixed-point validator (undocumented).
     if is_selfhost { return handle_selfhost_command(args, binary_dir); }
 
@@ -1131,4 +1125,4 @@ fn main(argv: string[]) -> int ![io, clock] {
     // returns its exit code up through here rather than calling `exit()`.
     sfn_arena_telemetry_dump(label as * u8);
     return exit_code;
-}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (`cli_main` itself imports  // `handle_check_command` from  // `cli_check`, and the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.
+}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.


### PR DESCRIPTION
## Summary
- Migrate `sfn check` off the legacy hand-rolled dispatch onto the v2 `sfn/cli` `command_def()` + `run(matches, ctx)` pattern, registered on the v2 root (new module `compiler/src/cli/commands/check.sfn`).
- `run` reconstructs the legacy positional args slice and delegates to `handle_check_command(args, binary_dir)` in `cli_check.sfn` **verbatim**, sourcing `binary_dir` from `ctx.binary_dir`. Output, the `--json` envelope schema, and exit codes are behavior-identical — `handle_check_command` is reused as-is, not rewritten.
- Remove the `is_check` flag, the `_legacy_dispatch_check` arm, and the now-unused `handle_check_command` import from `cli_main.sfn`.

Design: SFEP-0027 (`docs/proposals/0027-cli-rss-modularization.md`) §3.4 — command #5. Phase B of epic #1671 / tracker #1675.

Closes #1773

## Acceptance Criteria
- [x] `check` is defined via `command_def()` and registered on the v2 root in `cli/main.sfn`.
- [x] `run(matches, ctx)` reuses `handle_check_command`, passing `ctx.binary_dir`; behavior identical to today (including `--json`).
- [x] The `is_check` flag and the `_legacy_dispatch_check` arm are removed from `sailfin_cli_main_legacy`.
- [x] The existing `check` e2e peers pass unchanged.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes.

## Map reconciliation
Advisory `## Files Affected` matched the tree, with one addition driven by a seed codegen bug discovered at pickup (see below):
- `compiler/src/cli/commands/check.sfn` — new command module (as mapped).
- `compiler/src/cli/main.sfn` — register + dispatch (as mapped) **plus** restructuring the root `Command` construction from a single deeply-nested `with_subcommand(...)` expression into the equivalent incremental (reassignment) form. This is the same registration surface named in `In:`, expressed in a form the pinned seed compiles correctly — not new scope.
- `compiler/src/cli_main.sfn` — remove the legacy `check` dispatch arm + `is_check` flag + unused import (as mapped).
- `compiler/src/cli_check.sfn` — `handle_check_command` reused verbatim (unchanged).

## ⚠️ Seed codegen bug discovered (follow-up worth filing)
Registering the **13th** v2 subcommand surfaced a genuine miscompilation: the pinned seed (`v0.7.0-alpha.50`) miscompiles a `with_subcommand(...)` call chain at this nesting depth. The seed compiles the source without error, but the **emitted binary segfaults at runtime** while constructing the root `Command` tree — affecting **every** v2 command (`version`, `guillermo`, `check`, …), not just `check`. The 12-deep baseline was fine; the 13th level tipped it over. `make compile` reported `status: pass` for the *seed→binary* step, then the freshly-built binary crashed on the very next `emit` invocation — i.e. `make compile` alone did not catch it; only running the new binary did.

**Workaround in this PR:** build the root incrementally (one `with_subcommand` reassignment per command) instead of one nested expression. Semantically identical, codegens cleanly, and scales to the remaining `build`/`run` migrations (SFEP-0027 §3.4) without re-tripping the limit. The underlying codegen bug (deeply-nested call expressions) remains and should be tracked separately.

## Verification
```bash
make clean-build && make compile      # status: pass (self-hosts)
build/native/sailfin version          # sfn 0.7.0-alpha.50+dev... (no segfault)
build/native/sailfin check examples/basics/hello-world.sfn   # checked 1 files: ok
build/native/sailfin check --json examples/basics/hello-world.sfn  # valid sailfin-check/1 envelope
build/native/sailfin check -q examples/basics/hello-world.sfn      # short flag honored

# check e2e parity family — all green
build/native/sailfin test compiler/tests/e2e/check_json_schema_test.sfn          # 15/15
build/native/sailfin test compiler/tests/e2e/check_build_agree_module_global_test.sfn  # 1/1
# (also: check_compiler_src, check_cross_module_conformance, check_effect_call_site_caret,
#  check_effect_try_block_escape, check_phase_ledger, check_resolver_scan_memo — all pass)

make test   # unit 185/185, integration 42/42, e2e 170/170, capsules 38/38 — status: pass
```

## Files Changed
- `compiler/src/cli/commands/check.sfn` (new)
- `compiler/src/cli/main.sfn` (import, incremental root construction, dispatch block)
- `compiler/src/cli_main.sfn` (removed `is_check`, `_legacy_dispatch_check`, unused import; trimmed a stale comment clause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfRze1mjDFUEiKSZ4Fi4mc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfRze1mjDFUEiKSZ4Fi4mc)_