### PR TITLE
refactor(cli): migrate run command to cli/commands/run.sfn

### DIFF
--- a/compiler/src/cli/commands/run.sfn
+++ b/compiler/src/cli/commands/run.sfn
@@ -1,0 +1,182 @@
+// compiler/src/cli/commands/run.sfn
+//
+// `run` subcommand (CLI modularization epic #1671 / tracker #1675,
+// Phase B — SFEP-0027 §3.4, command #7). Migrates `run` off the legacy
+// hand-rolled dispatch (`cli_main.sfn`'s inline `_legacy_dispatch_run` —
+// no `handle_run_command` existed; the body was entirely inline) into the
+// per-command `command_def()` + `run()` pattern that `version.sfn`
+// established and `build.sfn` (command #6) extended.
+//
+// `run` = build-then-exec: it shares the Phase A `compiler/src/build/`
+// modules with `build` but has a smaller surface (no `-p`, no `-o`, no
+// `--work-dir`, no `--json`, no `--check-determinism`). The hand-rolled
+// argv walk becomes typed `sfn/cli` match accessors; the build-then-exec
+// body is reproduced verbatim (parity oracles:
+// `compiler/tests/e2e/run_cache_flags_test.sfn`,
+// `compiler/tests/e2e/run_scratch_isolation_test.sfn`,
+// `compiler/tests/e2e/cli_bare_file_dispatch_test.sfn`,
+// `compiler/tests/e2e/runtime_implicit_capsule_link_test.sfn`).
+//
+// Bare-file dispatch (`sfn foo.sfn`) re-invokes `["run", foo.sfn]` from
+// `sailfin_cli_main_legacy`, which routes back through `sailfin_cli_main_v2`
+// to this command — so the bare-file path shares this exact body.
+//
+// The `runtime_root` empty→"runtime" bundle fallback is reproduced from the
+// legacy caller (it is a filesystem probe, not argv parsing, so
+// `parse_driver_prefix` deliberately does not apply it). `binary_dir` is
+// threaded from the driver-parsed `CliContext`, replacing the legacy
+// handler's extra param.
+import {
+    Command,
+    Matches,
+    arg_variadic,
+    command,
+    flag,
+    has_flag,
+    positionals,
+    with_arg,
+    with_flag
+} from "sfn/cli";
+
+import { _print_cache_summary, _resolve_sailfin_cache_dir_for_work } from "../../build/cache";
+import { _clang_link_multi } from "../../build/link";
+import { _ends_with, _ensure_dir } from "../../build/paths";
+import { _runtime_bundle_exists } from "../../build/runtime_objs";
+import { cache_root, merge_cache_stats, resolve_build_cache_config } from "../../build_cache";
+import { empty_resolver_consumer, prepare_project_capsules } from "../../capsule_resolver";
+import {
+    compile_to_llvm_file_with_module,
+    module_name_from_path,
+    number_to_string
+} from "../../main";
+import { runtime_capsule_from_root } from "../../runtime_capsule_resolver";
+import { CliContext } from "../context";
+
+// The `sfn/cli` definition for `run`, registered on the v2 root via
+// `with_subcommand`. Three boolean flags and a variadic positional
+// `[file]`; `run` has no value flags (no `-o`/`-p`/`--work-dir`).
+fn command_def() -> Command {
+    let mut cmd: Command = command("run", "Compile and run a Sailfin source file");
+    cmd = with_flag(cmd, flag("no-cache", "Disable the build cache for this invocation"));
+    cmd = with_flag(cmd, flag("clean", "Clear the build cache before building"));
+    cmd = with_flag(cmd, flag("cache-trace", "Print per-artifact cache hit/miss trace"));
+    cmd = with_arg(cmd, arg_variadic("file", "Sailfin source file (or prebuilt executable) to run"));
+    return cmd;
+}
+
+// Reproduce the legacy `_legacy_dispatch_run` body against typed matches.
+// Flag reads replace the hand-rolled argv walk; the build-then-exec body is
+// verbatim. The `runtime_root` empty→"runtime" fallback is applied here (not
+// in `parse_driver_prefix`) because it is a filesystem probe, not argv
+// parsing.
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let no_cache_flag: boolean = has_flag(matches, "no-cache");
+    let clean_flag: boolean = has_flag(matches, "clean");
+    let cache_trace_flag: boolean = has_flag(matches, "cache-trace");
+    // Legacy semantics: exactly one positional. Zero (missing file) and
+    // more than one both printed usage and returned 2.
+    let _run_positionals: string[] = positionals(matches, "file");
+    if _run_positionals.length != 1 {
+        print("usage: sfn run [--no-cache] [--clean] [--cache-trace] <file.sfn>");
+        return 2;
+    }
+    let input_path: string = _run_positionals[0];
+
+    let binary_dir: string = ctx.binary_dir;
+    let mut runtime_root: string = ctx.runtime_root;
+    if runtime_root.length == 0 {
+        if _runtime_bundle_exists("runtime") { runtime_root = "runtime"; }
+    }
+
+    // If the argument doesn't look like Sailfin source, treat it as an executable.
+    if !_ends_with(input_path, ".sfn") {
+        return process.run([input_path]);
+    }
+
+    if !fs.exists(input_path) {
+        print("file not found: " + input_path);
+
+        return 1;
+    }
+
+    // #1411: route the top-level `run.ll`/`run` executable under the
+    // per-invocation scratch when one is set (`SAILFIN_TEST_SCRATCH`),
+    // exactly as `sfn build` does. Bare-file dispatch delegates here
+    // (`["run", cmd]`), so it inherits this too. Without it, two concurrent
+    // `sfn run`/bare-dispatch children in the parallel `sfn test --jobs N`
+    // pool both write the fixed `build/sailfin/run` and clobber each other's
+    // executable — a test asserting on the run's stdout then sees another
+    // fixture's output (non-deterministic, #1411). Empty scratch resolves to
+    // `build/sailfin`, keeping the default invocation byte-for-byte.
+    let run_cache_dir = _resolve_sailfin_cache_dir_for_work("");
+    _ensure_dir(run_cache_dir);
+
+    let ll_path = run_cache_dir + "/run.ll";
+    let exe_path = run_cache_dir + "/run";
+
+    // Resolve and compile capsule deps before lowering the main file. The
+    // unified resolver covers relative imports, manifest-declared capsule
+    // deps, and workspace-implicit imports in one pass. CLI overrides
+    // (`--no-cache` / `--clean` / `--cache-trace`) layer on top of env-var
+    // defaults (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`).
+    let run_cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
+    // `sfn run` has no `-p` plumbing yet, so the consumer is always empty:
+    // relative-import `.ll`s take the legacy flat layout. `sailfin_exe` /
+    // `work_dir` stay empty; threading `binary_dir` lets
+    // `prepare_project_capsules` upgrade to subprocess isolation only when
+    // the resolved closure is large enough to otherwise OOM.
+    let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), "", "", binary_dir);
+    let capsule_lls = run_capsule_result.ll_paths;
+
+    let source = fs.readFile(input_path);
+    let module_name = module_name_from_path(input_path);
+    let ok = compile_to_llvm_file_with_module(source, module_name, ll_path, "");
+    if !ok {
+        print("failed to compile LLVM for: " + input_path);
+
+        return 1;
+    }
+
+    let mut all_lls: string[] = [ll_path];
+    let mut rli: int = 0;
+    loop {
+        if rli >= capsule_lls.length { break; }
+        all_lls.push(capsule_lls[rli]);
+        rli += 1;
+    }
+    // Issue #940: same implicit-capsule fallback as `sfn build` (no-op for
+    // `-p` / declared-dep, load-bearing for a no-dep `sfn run <file>`).
+    let mut run_runtime_caps = run_capsule_result.runtime_capsules;
+    if run_runtime_caps.length == 0 {
+        run_runtime_caps = runtime_capsule_from_root(runtime_root);
+    }
+    // Shared runtime-object cache root (#1096); empty under `--no-cache` to
+    // leave the persistent store untouched.
+    let mut run_shared_cache_root: string = "";
+    if run_cache_config.enabled { run_shared_cache_root = cache_root(); }
+    let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "", run_shared_cache_root);
+    let link_rc = link_result.rc;
+    if link_rc != 0 {
+        // A native link failure is a real compiler/runtime bug to fix at the
+        // source — never paper over it. Fail closed with the clang exit code
+        // (the prior `process.run(["sfn", "run", input_path])` "seed
+        // fallback" recursed into itself forever on a persistent failure,
+        // #969).
+        print("link failed (clang exit=" + number_to_string(link_rc) + ")");
+        return link_rc;
+    }
+
+    // Cache summary mirrors `sfn build`: quiet for builds with no cache
+    // activity (no manifest deps, or `--no-cache`). Runtime object-cache
+    // stats fold in alongside the `.ll` module cache total (#915), gated on
+    // `run_cache_config.enabled` so `--no-cache` stays quiet.
+    let mut run_cache_stats = run_capsule_result.stats;
+    if run_cache_config.enabled {
+        run_cache_stats = merge_cache_stats(run_capsule_result.stats, link_result.stats);
+    }
+    _print_cache_summary(run_cache_stats);
+    let run_rc = process.run([exe_path]);
+    return run_rc;
+}
+
+export { command_def, run };

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -50,6 +50,7 @@ import { command_def as lock_command_def, run as lock_run } from "./commands/loc
 import { command_def as login_command_def, run as login_run } from "./commands/login";
 import { command_def as package_command_def, run as package_run } from "./commands/package";
 import { command_def as publish_command_def, run as publish_run } from "./commands/publish";
+import { command_def as run_command_def, run as run_run } from "./commands/run";
 import { command_def as test_command_def, run as test_run } from "./commands/test";
 import { command_def as version_command_def, run as version_run } from "./commands/version";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./context";
@@ -115,6 +116,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     root = with_subcommand(root, emit_command_def());
     root = with_subcommand(root, check_command_def());
     root = with_subcommand(root, build_command_def());
+    root = with_subcommand(root, run_command_def());
 
     // Preserve the legacy `--emit` long-flag alias (`sfn --emit llvm x.sfn`):
     // the legacy dispatch treated `--emit` as the first token identically to
@@ -375,6 +377,20 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         if ctx.trace_argv { _v2_trace_argv(argv); }
         if result.ok { return build_run(result.matches, ctx); }
         print("usage: sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)");
+        return 2;
+    }
+
+    // `sfn run [--no-cache] [--clean] [--cache-trace] <file.sfn>` — the
+    // registered subcommand matched. A clean parse dispatches to `run.run`,
+    // which reproduces the legacy `_legacy_dispatch_run` build-then-exec body
+    // against typed matches. A non-ok parse that still descended into `run`
+    // (an unrecognized flag, or `--help`) is a usage error (exit 2) — the
+    // parser owns argument validation. Bare-file dispatch (`sfn foo.sfn`)
+    // re-enters here as `["run", foo.sfn]` from the legacy fallthrough.
+    if strings_equal(subcommand(result.matches), "run") {
+        if ctx.trace_argv { _v2_trace_argv(argv); }
+        if result.ok { return run_run(result.matches, ctx); }
+        print("usage: sfn run [--no-cache] [--clean] [--cache-trace] <file.sfn>");
         return 2;
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -212,149 +212,6 @@ fn _path_strip_ext(name: string) -> string {
     return substring(name, 0, last_dot);
 }
 
-fn _legacy_dispatch_run(args: string[], runtime_root: string, binary_dir: string) -> int ![io] {
-    // run [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>
-    let mut input_path: string = "";
-    let mut no_cache_flag: boolean = false;
-    let mut clean_flag: boolean = false;
-    let mut cache_trace_flag: boolean = false;
-
-    let mut ri: int = 1;
-    loop {
-        if ri >= args.length { break; }
-        let a = args[ri];
-        if strings_equal(a, "--no-cache") {
-            no_cache_flag = true;
-            ri += 1;
-            continue;
-        }
-        if strings_equal(a, "--clean") {
-            clean_flag = true;
-            ri += 1;
-            continue;
-        }
-        if strings_equal(a, "--cache-trace") {
-            cache_trace_flag = true;
-            ri += 1;
-            continue;
-        }
-        // Positional argument: the source file (or executable).
-        if input_path.length > 0 {
-            print(_usage());
-            return 2;
-        }
-        input_path = a;
-        ri += 1;
-    }
-    if input_path.length == 0 {
-        print(_usage());
-
-        return 2;
-    }
-
-    // If the argument doesn't look like Sailfin source, treat it as an executable.
-    if !_ends_with(input_path, ".sfn") {
-        return process.run([input_path]);
-    }
-
-    if !fs.exists(input_path) {
-        print("file not found: " + input_path);
-
-        return 1;
-    }
-
-    // #1411: route the top-level `run.ll`/`run` executable under the
-    // per-invocation scratch when one is set (`SAILFIN_TEST_SCRATCH`),
-    // exactly as `sfn build` does (line ~2322). Bare-file dispatch
-    // delegates here (`["run", cmd]`), so it inherits this too. Without
-    // it, two concurrent `sfn run`/bare-dispatch children in the
-    // parallel `sfn test --jobs N` pool both write the fixed
-    // `build/sailfin/run` and clobber each other's executable — a test
-    // asserting on the run's stdout then sees another fixture's output
-    // (non-deterministic, #1411). Empty scratch resolves to
-    // `build/sailfin`, keeping the default invocation byte-for-byte.
-    let run_cache_dir = _resolve_sailfin_cache_dir_for_work("");
-    _ensure_dir(run_cache_dir);
-
-    let ll_path = run_cache_dir + "/run.ll";
-    let exe_path = run_cache_dir + "/run";
-
-    // Resolve and compile capsule deps before lowering the main file.
-    // The unified resolver covers relative imports, manifest-declared
-    // capsule deps, and workspace-implicit imports in one pass —
-    // text-level fallback retired with Stage B. CLI overrides
-    // (`--no-cache` / `--clean` / `--cache-trace`) layer on top of
-    // env-var defaults (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`).
-    let run_cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
-    // `sfn run` has no `-p` plumbing yet, so the consumer is
-    // always empty: relative-import `.ll`s take the legacy
-    // flat layout (Stage C2b2). When `sfn run -p` lands, this
-    // becomes a one-line update mirroring `sfn build`.
-    // Stage D PR3 / #1405 Bug 2: `sfn run` keeps the in-process
-    // compile path for small fixtures (its typical use case). It
-    // doesn't take `-p` yet, so `sailfin_exe`/`work_dir` stay empty;
-    // threading `binary_dir` lets `prepare_project_capsules` upgrade
-    // to subprocess isolation only when the resolved closure is large
-    // enough to otherwise OOM (a whole-compiler-importing `sfn run`).
-    let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), "", "", binary_dir);
-    let capsule_lls = run_capsule_result.ll_paths;
-
-    let source = fs.readFile(input_path);
-    let module_name = module_name_from_path(input_path);
-    let ok = compile_to_llvm_file_with_module(source, module_name, ll_path, "");
-    if !ok {
-        print("failed to compile LLVM for: " + input_path);
-
-        return 1;
-    }
-
-    let mut all_lls: string[] = [ll_path];
-    let mut rli: int = 0;
-    loop {
-        if rli >= capsule_lls.length { break; }
-        all_lls.push(capsule_lls[rli]);
-        rli += 1;
-    }
-    // Issue #940: same implicit-capsule fallback as `sfn build`
-    // (no-op for `-p` / declared-dep, load-bearing for a no-dep
-    // `sfn run <file>`).
-    let mut run_runtime_caps = run_capsule_result.runtime_capsules;
-    if run_runtime_caps.length == 0 {
-        run_runtime_caps = runtime_capsule_from_root(runtime_root);
-    }
-    // Shared runtime-object cache root (#1096); empty under
-    // `--no-cache` to leave the persistent store untouched.
-    let mut run_shared_cache_root: string = "";
-    if run_cache_config.enabled { run_shared_cache_root = cache_root(); }
-    let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "", run_shared_cache_root);
-    let link_rc = link_result.rc;
-    if link_rc != 0 {
-        // A native link failure is a real compiler/runtime bug to
-        // fix at the source — never paper over it. The prior
-        // `process.run(["sfn", "run", input_path])` "seed fallback"
-        // re-invoked `sfn run`, so on any persistent link failure
-        // it recursed into itself forever (#969). Fail closed with
-        // the clang exit code instead.
-        print("link failed (clang exit=" + number_to_string(link_rc) + ")");
-        return link_rc;
-    }
-
-    // Cache summary mirrors `sfn build`: quiet for builds with no
-    // cache activity (no manifest deps, or `--no-cache`), and the
-    // human-readable counterpart of the eventual `--json` build
-    // report's `cache` field. Runtime object-cache stats fold in
-    // alongside the `.ll` module cache total (#915), gated on
-    // `run_cache_config.enabled` so `--no-cache` stays quiet (see
-    // the `sfn build` fold site for the rationale).
-    let mut run_cache_stats = run_capsule_result.stats;
-    if run_cache_config.enabled {
-        run_cache_stats = merge_cache_stats(run_capsule_result.stats, link_result.stats);
-    }
-    _print_cache_summary(run_cache_stats);
-    let run_rc = process.run([exe_path]);
-    return run_rc;
-}
-
 // Historical C ABI boundary — the now-retired C driver called
 // `sailfin_cli_main__cli_main` with an `int64_t` return type.
 // After M5.5 (#473) the only callers are `sailfin_cli_main_v2`
@@ -426,7 +283,6 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // `emit` / `--emit` migrated to `sfn/cli` (epic #1671, Phase B) — handled
     // by `sailfin_cli_main_v2` before reaching this legacy dispatch.
     let cmd = args[0];
-    let is_run = strings_equal(cmd, "run");
     let mut _let10: boolean = false;
     if strings_equal(cmd, "-h") { _let10 = true; }
     if strings_equal(cmd, "--help") { _let10 = true; }
@@ -435,10 +291,10 @@ fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
     // `_usage()` — driven by `make check` / CI, not end users.
     let is_selfhost = strings_equal(cmd, "selfhost");
 
-    if is_run {
-        return _legacy_dispatch_run(args, runtime_root, binary_dir);
-    }
-
+    // `sfn run` migrated to `sfn/cli` (epic #1671, Phase B) — handled by
+    // `sailfin_cli_main_v2` before reaching this legacy dispatch. Bare-file
+    // dispatch (`sfn foo.sfn`) re-enters as `["run", foo.sfn]` and routes
+    // through v2 to `cli/commands/run.sfn`.
     // `sfn test` migrated to `sfn/cli` (epic #351, Issue 3.8) — handled
     // by `sailfin_cli_main_v2` before reaching this legacy dispatch.
     if is_help {


### PR DESCRIPTION
## Summary
- Migrate `sfn run` off the legacy hand-rolled `_legacy_dispatch_run` argv walk into the v2 `sfn/cli` command-module pattern — new `compiler/src/cli/commands/run.sfn` with `command_def()` + `run(matches, ctx) -> int [io]`, sharing the Phase A `compiler/src/build/` modules (link, cache, paths, runtime_objs) with `build`.
- Register `run` on the v2 root in `cli/main.sfn` and remove the `is_run` flag, the `if is_run` arm, and the `_legacy_dispatch_run` body from `sailfin_cli_main_legacy`.
- Behavior-preserving move (SFEP-0027 §3.4, command #7, Phase B), mirroring the merged `build` migration (#6). Bare-file dispatch (`sfn foo.sfn`) still re-enters as `["run", foo.sfn]` and now routes through v2 to the shared `run` body.

Closes #1775

## Acceptance Criteria
- [x] `run` defined via `command_def()` with `--no-cache` / `--clean` / `--cache-trace` + a `<file>` positional, registered on the v2 root in `cli/main.sfn`.
- [x] `run(matches, ctx)` reproduces the inline `_legacy_dispatch_run` behavior, importing the `build/` modules directly.
- [x] The `is_run` flag and the `_legacy_dispatch_run` body are removed from `sailfin_cli_main_legacy`.
- [x] Bare-file dispatch still works (shares the `run` code path) — `cli_bare_file_dispatch_test.sfn` green.
- [x] Existing `run` e2e peers pass unchanged.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` passes (self-host).
- [x] `make test` passes (3 pre-existing flaky `serve_*` socket failures excluded — see Verification).

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree. Touched exactly `cli/commands/run.sfn` (new), `cli/main.sfn`, `cli_main.sfn`; the `build/` modules were imported (consumed), not modified.

## Notes
- **Behavior parity preserved verbatim:** `resolve_build_cache_config(no_cache, cache_trace, clean)` argument order; the empty `cache_dir` (6th) arg to `_clang_link_multi` (the documented `run`≠`build` divergence — `run` has no `--work-dir`); `_resolve_sailfin_cache_dir_for_work("")` scratch routing (#1411); the runtime_root empty→`"runtime"` fallback (now applied inside `run()`); the implicit-runtime-capsule fallback (#940); and the `cache_config.enabled` gates on the shared cache root and stats merge.
- **Positional handling:** legacy printed usage + returned 2 for both zero and >1 positionals; reproduced via `arg_variadic("file")` + a `length != 1` guard.
- **No `.success` guard:** legacy `run` had no `if !capsule_result.success` guard (unlike `build`, which gained one in #991). That pre-existing divergence is preserved deliberately.
- **Deferred import cleanup:** the now-unused imports left in `cli_main.sfn` (e.g. `_clang_link_multi`, `prepare_project_capsules`, `cache_root`) are deferred to the SFEP-0027 Phase C residue sweep (§3.5), matching how the merged `build`/`emit` migrations left theirs.

## Verification
```bash
make compile        # self-host: pass

# run parity oracles (all green on the freshly self-hosted binary):
build/native/sailfin test compiler/tests/e2e/run_cache_flags_test.sfn            # PASS (6/6)
build/native/sailfin test compiler/tests/e2e/run_scratch_isolation_test.sfn      # PASS (1/1)
build/native/sailfin test compiler/tests/e2e/cli_bare_file_dispatch_test.sfn     # PASS (3/3)
build/native/sailfin test compiler/tests/e2e/runtime_implicit_capsule_link_test.sfn  # PASS (2/2)

make test
#   unit: 185/185, integration: 42/42, capsules: 38/38 — all pass
#   e2e: 167/170 — the 3 failures are the flaky serve_* socket family
#   (serve_keepalive, serve_loopback, serve_reuseaddr_restart). They pass
#   in isolation on this binary AND fail on the untouched seed binary, so
#   they are pre-existing timing flakes under the parallel pool, not a
#   regression from this CLI-only change (a run refactor has no path to
#   serve sockets).
```

## Files Changed
- `compiler/src/cli/commands/run.sfn` — new command module (migrated body + `build/` imports)
- `compiler/src/cli/main.sfn` — register + dispatch `run`
- `compiler/src/cli_main.sfn` — remove `is_run` flag + `_legacy_dispatch_run`; keep bare-file dispatch routing through v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKmbyVPZMBakUAomeGKbuV)_