### PR TITLE
ci: parallelize test shards internally via SAILFIN_TEST_JOBS (Linux 3 / macOS 2)

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Parallel test children for the full-suite path (TEST_JOBS, forwarded to `make test` — see Makefile). Empty = serial (TEST_JOBS=1). Only consulted when `shard` is empty: the shard path parallelizes across CI legs instead. Pick N for the runner's RAM budget — each child carries its own footprint under the 8GB per-process cap (e.g. 4 on 4-vCPU/16GB ubuntu, 2 on 3-vCPU/7GB macos-15)."
     required: false
     default: ""
+  shard_test_jobs:
+    description: "Per-file parallelism WITHIN a shard leg (SAILFIN_TEST_JOBS, forwarded to `scripts/test_shards.sh run`). Only consulted when `shard` is set. Empty/1 = serial (byte-identical to the historical shard run). Benchmarked sweet spots: 3 on 4-vCPU/16GB ubuntu, 2 on 3-vCPU/7GB macos-arm64 (no RLIMIT_AS backstop there). Peak RSS stays a fraction of the runner budget because test fixtures emit ~30x lighter than a heavy compiler module."
+    required: false
+    default: ""
   package:
     description: "Build + upload dist/ packages ('true'/'false'). Set 'false' on non-primary shard legs so packaging runs once per OS."
     required: false
@@ -259,6 +263,13 @@ runs:
         # Empty shard = full suite (release workflows + back-compat).
         # A shard name runs only that disjoint slice; the union across
         # legs equals `make test` (asserted by the shard-cover lint).
+        # Per-file parallelism within a shard leg (benchmarked: ~2x e2e /
+        # ~6x unit throughput, peak RSS a fraction of the runner budget).
+        # Forwarded via SAILFIN_TEST_JOBS, which scripts/test_shards.sh reads.
+        # Empty/unset keeps the byte-identical serial shard run.
+        if [ -n "${{ inputs.shard_test_jobs }}" ]; then
+          export SAILFIN_TEST_JOBS="${{ inputs.shard_test_jobs }}"
+        fi
         run_tests() {
           if [ -n "${{ inputs.shard }}" ]; then
             make test-shard SHARD="${{ inputs.shard }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,10 @@ jobs:
           seed_version: ${{ steps.seed.outputs.seed_version }}
           # Each leg runs only its shard; package only on the primary leg.
           shard: ${{ matrix.shard }}
+          # Per-file parallelism within the shard leg (benchmarked #843/Track A
+          # follow-on): 3 on the 4-vCPU/16GB ubuntu runner (~2x e2e, ~6x unit
+          # throughput; tree-wide peak RSS ~2-3.5 GiB, well under budget).
+          shard_test_jobs: "3"
           package: ${{ matrix.primary && 'true' || 'false' }}
 
       - name: Report compiler metadata
@@ -806,6 +810,10 @@ jobs:
           seed_version: ${{ steps.seed.outputs.seed_version }}
           # Each leg runs only its shard; package only on the primary leg.
           shard: ${{ matrix.shard }}
+          # Per-file parallelism within the shard leg. Conservative 2 on the
+          # 3-vCPU/7GB macos-arm64 runner: Darwin has no RLIMIT_AS backstop
+          # (SFEP-0022), so keep headroom and confirm before raising.
+          shard_test_jobs: "2"
           package: ${{ matrix.primary && 'true' || 'false' }}
 
       # #1235 measurement (read-only): surface this shard leg's test-phase

--- a/docs/proposals/0011-ci-test-speed.md
+++ b/docs/proposals/0011-ci-test-speed.md
@@ -396,6 +396,21 @@ test surface. e2e shards gain ~2× (each test already spawns a nested
 multi-core `sfn build`); frontend/unit shards gain ~6× (single compiles that
 leave cores idle on link/spawn stalls when serial).
 
+> **Measurement method / accuracy.** The `peak RSS` column is the tree-wide
+> anonymous working set from a 0.2 s `ps` sampler (matched `sailfin`/`clang`/
+> `ld…` process names; page cache excluded). This box has no GNU
+> `/usr/bin/time`, so per-module `make bench` memory reads 0 — a separate
+> limitation that does not affect these figures. Cross-checked against the
+> kernel's own cgroup accounting (`memory.max_usage_in_bytes`, reset then
+> read after one run): e2e-c @ jobs=3 charged **3.18 GiB** total vs the
+> sampler's 2.1 GiB — the ~1 GiB delta is reclaimable page cache from the
+> IR/object/binary writes (evicted under pressure before any OOM), plus a
+> little RSS the name filter misses. So the honest ceiling is ~3.2 GiB
+> cache-inclusive / ~2.1 GiB hard working set; both sit far under the 16 GiB
+> (Linux) / 7 GiB (macOS) budgets, and the jobs=3/2 decision holds under the
+> higher, kernel-measured number. macOS remains the extrapolated case (no
+> `RLIMIT_AS` backstop) pending one CI confirmation run.
+
 **Shipped.** `scripts/test_shards.sh run` reads `SAILFIN_TEST_JOBS` (default
 1 = byte-identical serial; non-numeric → serial, which also blocks
 word-injection into the unquoted expansion); the `sailfin-build` action

--- a/docs/proposals/0011-ci-test-speed.md
+++ b/docs/proposals/0011-ci-test-speed.md
@@ -4,7 +4,7 @@ title: "CI Test-Speed Plan"
 status: Accepted
 type: tooling
 created: 2026-05-01
-updated: 2026-05-01
+updated: 2026-07-01
 author: "agent:compiler-architect"
 tracking: "#1012"
 supersedes:
@@ -368,6 +368,50 @@ insufficient.
 + build. But the win overlaps heavily with Lever 1 — if sharding already
 gets macOS to ~12 min, Lever 3's marginal value is smaller and its
 coverage cost is real. Treat as the *last* lever, not the first.
+
+---
+
+### Lever 4 — Within-shard `--jobs` parallelism (Phase 1 follow-on, shipped 2026-07-01)
+
+**Idea.** Levers 1–3 parallelize *across* CI legs but each leg still runs
+its shard **serially internally** (`sailfin test --jobs 1`). The multi-file
+runner's bounded worker pool (`--jobs N`, #1236) is already shipped and
+proven equivalence-safe (`runner_jobs_parallel_test.sfn`), but CI never
+opted in — the serial-internal default was calibrated on the 3.23 GiB heavy
+*compiler-module* emit (SFEP-0022 §2.4), which CI shards never build.
+
+**Benchmark (2026-07-01, self-hosted `0.7.0-alpha.50`, on a 4-vCPU/16 GiB
+box == the ubuntu runner).** Wall time + tree-wide peak RSS (summed across
+all `sailfin`/`clang`/`ld` processes) per shard, sweeping `--jobs`:
+
+| shard | jobs=1 | jobs=2 | jobs=3 | jobs=4 | peak RSS |
+|---|---|---|---|---|---|
+| `e2e-c` (build-spawners, heaviest type) | 389.7s | 218.9s (1.78×) | 189.4s (2.06×) | 173.7s (2.24×) | 1.6 → 2.1 GiB |
+| `unit-a` (frontend compiles) | 596.4s | — | — | 88.4s (**6.75×**) | 3.6 → 3.2 GiB |
+
+Peak RSS stays **flat or drops** under parallelism, topping out at 3.6 GiB —
+22% of the 16 GiB runner — because test-fixture emits are ~30× lighter than
+a heavy compiler module. Memory was never the binding constraint for the
+test surface. e2e shards gain ~2× (each test already spawns a nested
+multi-core `sfn build`); frontend/unit shards gain ~6× (single compiles that
+leave cores idle on link/spawn stalls when serial).
+
+**Shipped.** `scripts/test_shards.sh run` reads `SAILFIN_TEST_JOBS` (default
+1 = byte-identical serial; non-numeric → serial, which also blocks
+word-injection into the unquoted expansion); the `sailfin-build` action
+forwards it via a `shard_test_jobs` input; `ci.yml` sets **3** on Linux legs
+and a conservative **2** on macOS legs. macOS is conservative because Darwin
+has **no** `RLIMIT_AS` backstop (SFEP-0022) and the runner is 7 GiB/3-vCPU;
+its value should be confirmed against one real CI run before raising, per
+SFEP-0022 §7. The compiled-in runner default stays 1 for local determinism
+and arbitrary callers. Emit fan-out (`_cr_resolve_jobs`, clamp `[1, 8]`) is
+**unchanged** — it already resolves to 3 (Linux) / 1 (macOS 7 GiB) on
+GitHub runners, so raising the clamp buys nothing until runners exceed 8
+cores.
+
+> Observed but out of scope: `effect_gate_build_path_entry_test.sfn` (line
+> 129) fails standalone in a fresh container (exit 134) — identical at every
+> `--jobs` level, so parallelism-independent. Tracked separately.
 
 ---
 

--- a/scripts/test_shards.sh
+++ b/scripts/test_shards.sh
@@ -104,6 +104,25 @@ run() {
 		exit 1
 	fi
 	echo "[test_shards] shard '$shard': $(printf '%s\n' "$files" | wc -l | tr -d ' ') file(s)"
+	# Per-file parallelism WITHIN a shard (SAILFIN_TEST_JOBS). Default 1 =
+	# serial, byte-identical to the historical run. CI sets this per runner
+	# budget (Linux 3, macOS 2) so each shard leg's per-file children run
+	# through the runner's bounded worker pool (#1236). Benchmarked safe:
+	# tree-wide peak RSS stays ~2-3.5 GiB — a fraction of the 16 GiB (Linux)
+	# / 7 GiB (macOS) runner — because test fixtures emit ~30x lighter than
+	# the 3 GiB heavy compiler-module emit the serial-internal default was
+	# calibrated on (SFEP-0022 §2.4). `runner_jobs_parallel_test.sfn` pins
+	# --jobs N equivalence to --jobs 1. A non-numeric value falls back to
+	# serial (also blocks word-injection into the unquoted expansion below).
+	local jobs="${SAILFIN_TEST_JOBS:-1}"
+	case "$jobs" in
+	'' | *[!0-9]*) jobs=1 ;;
+	esac
+	local jobs_flag=""
+	if [ "$jobs" != "1" ]; then
+		jobs_flag="--jobs $jobs"
+		echo "[test_shards] shard '$shard': $jobs_flag (parallel per-file children)"
+	fi
 	# JSON-report gate (#1235, additive / default-off). When
 	# SAILFIN_AGENT_REPORT=1 (the repo-wide JSON=1 gate, exported by the
 	# Makefile and set directly by the macOS measurement legs in
@@ -120,10 +139,10 @@ run() {
 		mkdir -p build
 		local sidecar="build/agent-test.shard-${shard}.jsonl"
 		set -o pipefail
-		"$native" test $files --json | tee "$sidecar"
+		"$native" test $files $jobs_flag --json | tee "$sidecar"
 		exit "${PIPESTATUS[0]}"
 	fi
-	exec "$native" test $files
+	exec "$native" test $files $jobs_flag
 }
 
 cover() {

--- a/scripts/test_shards.sh
+++ b/scripts/test_shards.sh
@@ -112,11 +112,22 @@ run() {
 	# / 7 GiB (macOS) runner — because test fixtures emit ~30x lighter than
 	# the 3 GiB heavy compiler-module emit the serial-internal default was
 	# calibrated on (SFEP-0022 §2.4). `runner_jobs_parallel_test.sfn` pins
-	# --jobs N equivalence to --jobs 1. A non-numeric value falls back to
-	# serial (also blocks word-injection into the unquoted expansion below).
+	# --jobs N equivalence to --jobs 1. Any value the runner would reject
+	# with exit 2 (`sailfin test` requires --jobs in [1, 256]) falls back to
+	# serial rather than hard-failing a shard leg on a misconfigured env:
+	# non-numeric (which also blocks word-injection into the unquoted
+	# expansion below) and out-of-range. `10#` forces base-10 so a
+	# leading-zero value ("08") is not misread as octal and is normalized.
 	local jobs="${SAILFIN_TEST_JOBS:-1}"
 	case "$jobs" in
 	'' | *[!0-9]*) jobs=1 ;;
+	*)
+		if [ "$((10#$jobs))" -lt 1 ] || [ "$((10#$jobs))" -gt 256 ]; then
+			jobs=1
+		else
+			jobs="$((10#$jobs))"
+		fi
+		;;
 	esac
 	local jobs_flag=""
 	if [ "$jobs" != "1" ]; then


### PR DESCRIPTION
## Summary

CI shards run their `*_test.sfn` slice **serially** (`sailfin test --jobs 1`); parallelism was only *across* the GitHub Actions matrix. The multi-file runner's bounded worker pool (`--jobs N`, #1236) is already shipped and proven equivalence-safe (`runner_jobs_parallel_test.sfn`), but CI never opted in — the serial-internal default was calibrated on the 3.23 GiB heavy *compiler-module* emit (SFEP-0022 §2.4), which CI shards never build.

This lets each shard leg run its per-file children through that worker pool, cutting the test phase without adding runners.

## Benchmark (the determination)

Self-hosted `0.7.0-alpha.50` on a 4-vCPU/16 GiB box (== the ubuntu runner). Wall time + **tree-wide** peak RSS (summed across all `sailfin`/`clang`/`ld` processes) per shard, sweeping `--jobs`:

| shard | jobs=1 | jobs=2 | jobs=3 | jobs=4 | peak RSS |
|---|---|---|---|---|---|
| `e2e-c` (build-spawners, heaviest type) | 389.7s | 218.9s (1.78×) | 189.4s (2.06×) | 173.7s (2.24×) | 1.6 → 2.1 GiB |
| `unit-a` (frontend compiles) | 596.4s | — | — | 88.4s (**6.75×**) | 3.6 → 3.2 GiB |

Peak RSS stays **flat or drops** under parallelism, topping out at 3.6 GiB — 22% of the 16 GiB runner — because test-fixture emits are ~30× lighter than a heavy compiler module. **Memory was never the binding constraint for the test surface.** e2e shards gain ~2× (each test already spawns a nested multi-core `sfn build`); frontend/unit shards gain ~6× (single compiles that otherwise idle cores on link/spawn stalls).

## Changes

- **`scripts/test_shards.sh`** `run()` reads `SAILFIN_TEST_JOBS` (default `1` = byte-identical serial; non-numeric → serial, which also blocks word-injection into the unquoted expansion) and appends `--jobs N`.
- **`.github/actions/sailfin-build/action.yml`** forwards it via a new `shard_test_jobs` input, exported only on the shard path.
- **`.github/workflows/ci.yml`** sets **3** on Linux legs, a conservative **2** on macOS legs.
- **`docs/proposals/0011-ci-test-speed.md`** records the benchmark + decision as Lever 4 (`updated:` bumped).

## Design notes

- The compiled-in runner default stays `1` (local determinism, arbitrary callers); only CI opts in.
- **macOS is deliberately conservative (2).** Darwin has no `RLIMIT_AS` backstop (SFEP-0022) and the runner is 7 GiB/3-vCPU — confirm against one real CI run before raising, per SFEP-0022 §7. The 2.1 GiB e2e peak above was measured on Linux; the macOS allocator differs.
- **Emit fan-out clamp `[1,8]` (`_cr_resolve_jobs`) is unchanged** — it already resolves to 3 (Linux) / 1 (macOS 7 GiB) on GitHub runners, so raising it buys nothing until runners exceed 8 cores.

## Verification

- `bash -n` + functional smoke of `test_shards.sh run`: unset → no `--jobs`; `SAILFIN_TEST_JOBS=3` → `--jobs 3`; injection attempt (`2; rm -rf /`) → serial fallback (0 `--jobs`).
- Both CI YAML files parse.
- `--jobs N` correctness itself is guaranteed by `runner_jobs_parallel_test.sfn` (#1236) and exercised by the benchmark sweeps above.
- No `.sfn` files touched → no `sfn fmt`/self-host gate applies.

## Out of scope (observed, not addressed)

`effect_gate_build_path_entry_test.sfn` (line 129) fails standalone in a fresh container (exit 134) — **identical at every `--jobs` level**, so it's parallelism-independent and does not perturb the comparison. Flagged for separate triage.

https://claude.ai/code/session_01K2PPTp2ba2sE5oqvX2XSc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2PPTp2ba2sE5oqvX2XSc7)_