### PR TITLE
docs(sfep): draft 8 SFEPs for language gaps; refresh stale CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,9 +222,12 @@ When adding features or making design choices:
   add keywords for constructs that can't be library functions. AI constructs
   (`model`, `prompt`, `tool`, `pipeline`) are migrating to the `sfn/ai` capsule;
   the `![model]` effect stays as a language-level capability gate.
-- **Fix the foundation first.** Integer types, `Result<T, E>`, generic
-  constraints, hierarchical effects, and effect polymorphism are prerequisites
-  for everything else.
+- **Fix the foundation first.** `int`/`float` and `Result<T, E>` + `?` have
+  landed; the remaining prerequisites for everything else are **generic
+  constraints + monomorphization** (the root blocker for real collections,
+  typed higher-order fns, and `Result` `From<E>` — see
+  `docs/proposals/draft-generic-constraints.md`), hierarchical effects, and
+  effect polymorphism.
 - **Chase timeless problems.** Effects and capability security matter in 20 years;
   AI API wrappers change every 6 months. Language syntax is permanent; library
   APIs can iterate.
@@ -237,16 +240,20 @@ Prefer the new forms where the parser already accepts them. Full plan:
 1. **Type annotations: `:` not `->`** — `x: number`, not `x -> number`, for params,
    vars, fields. Return types keep `->`. Parser accepts both (`TypeSep = "->" | ":"`).
 2. **String interpolation: `${ }` not `{{ }}`** — parser change pending; keep
-   `{{ }}` until updated.
-3. **Integer types** — `int` (i64) / `float` (f64) will replace `number`
-   (`number` becomes an alias for `float`). Not yet in parser.
-4. **`Result<T, E>` + `?` operator** — typed error handling. Not yet in parser.
+   `{{ }}` until updated. Design record: `docs/proposals/draft-string-interpolation-dollar.md`.
+3. **Integer types** — `int` (i64) / `float` (f64) are recognized;
+   `number` is now an alias for `float` (`typecheck_types.sfn`). Shipped.
+   The sized-int family (`i8`..`u64`) is still absent — see
+   `docs/proposals/draft-sized-integer-types.md`.
+4. **`Result<T, E>` + `?` operator** — typed error handling. Shipped: `Result`
+   lives in `runtime/prelude.sfn`; the postfix `?` is `Expression.TryOperator`
+   (`ast.sfn`), typecheck `E0810`–`E0812` (SFEP-0012, `docs/status.md`).
 5. **Closures with capture** — lambdas must capture enclosing variables.
 6. **Lambda short form: `fn(x) => expr`** — an additive expression-bodied lambda
    alongside the block form `fn(x) -> T { ... }`; the `fn` lead-in stays (keeps
-   zero-lookahead dispatch and avoids the match-arm `=>` collision). Accepted in
-   `docs/proposals/0029-lambda-syntax.md`; parser change pending — keep the block
-   form until it ships.
+   zero-lookahead dispatch and avoids the match-arm `=>` collision). Shipped
+   (SFEP-0029 `Implemented`, #1683; desugars to a single-`return` block in
+   `parser/expressions.sfn`).
 
 ## Deferred / Not Yet Shipped
 
@@ -266,7 +273,14 @@ Prefer the new forms where the parser already accepts them. Full plan:
 - `PII<T>` / `Secret<T>` parsed, no runtime enforcement (post-1.0)
 - `model` / `prompt` / `tool` / `pipeline` blocks emit metadata only (migrating
   to the `sfn/ai` capsule)
-- No concurrency runtime (`routine`, `spawn`, `channel`, `await`)
+- **Concurrency runtime — v0 works, not complete.** `routine {}` lowers to a real
+  structured-concurrency nursery (join-all, no orphaned tasks); `channel()` is a
+  working bounded MPMC queue; `spawn`/`await`/`parallel` route through a real
+  thread-pool scheduler (`docs/status.md`). Still partial: `await` typing isn't
+  wired into the live typecheck walk (#829), `async fn` is structural-only,
+  channels are untyped/pointer-width, and there's no cancel-on-fault or `sfn/sync`
+  API yet. Structured concurrency is a pillar, so this is the active workstream —
+  not "not shipped."
 
 The 1.0 critical path (runtime enablement phases, effect-system hardening) and
 the LLM-adoption strategy live in the roadmap and `docs/status.md` — those

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,9 @@ Prefer the new forms where the parser already accepts them. Full plan:
    `{{ }}` until updated. Design record: `docs/proposals/draft-string-interpolation-dollar.md`.
 3. **Integer types** — `int` (i64) / `float` (f64) are recognized;
    `number` is now an alias for `float` (`typecheck_types.sfn`). Shipped.
-   The sized-int family (`i8`..`u64`) is still absent — see
+   The sized-int family (`i8`..`u64`) is recognized and lowered but only
+   half-real (unsigned widths collapse to signed LLVM types, and there is no
+   defined overflow or literal-range checking) — see
    `docs/proposals/draft-sized-integer-types.md`.
 4. **`Result<T, E>` + `?` operator** — typed error handling. Shipped: `Result`
    lives in `runtime/prelude.sfn`; the postfix `?` is `Expression.TryOperator`

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -60,6 +60,29 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0035](./0035-prelude-mirror-signature-derivation.md) | Deriving Prelude-Mirror Registry Signatures from the Prelude | Accepted | runtime |
 | [0036](./0036-tls-runtime.md) | TLS termination + upstream TLS for the native runtime (OpenSSL) | Accepted | runtime |
 
+## Drafts under review (numbers assigned at merge)
+
+Per SFEP-0001 §2, a draft keeps its `draft-<slug>.md` name and `sfep: TBD`
+front-matter until it merges, at which point it claims `max + 1` and gets an
+Index row. The following drafts are in review — a cohesive slate closing the
+language gaps surfaced by the 2026-07 grammar/object-model audit:
+
+| Draft | Title | Type |
+|---|---|---|
+| [`draft-generic-constraints`](./draft-generic-constraints.md) | Generic Type Parameter Constraints and Monomorphization | language |
+| [`draft-generic-collections`](./draft-generic-collections.md) | Generic Collections — Map, Set, and Tuple | language |
+| [`draft-sized-integer-types`](./draft-sized-integer-types.md) | Sized Integer Types and Overflow Semantics | language |
+| [`draft-interface-signature-conformance`](./draft-interface-signature-conformance.md) | Signature-Checked Interface Conformance | language |
+| [`draft-exhaustive-match`](./draft-exhaustive-match.md) | Compile-Time Match Exhaustiveness Checking | language |
+| [`draft-derive`](./draft-derive.md) | Derivable Interface Implementations (`@derive`) | language |
+| [`draft-string-interpolation-dollar`](./draft-string-interpolation-dollar.md) | String Interpolation with `${ }` (migrating off `{{ }}`) | language |
+| [`draft-nullable-access-operators`](./draft-nullable-access-operators.md) | Nullable Access Operators (`?.` and `??`) | language |
+
+`draft-generic-constraints` is the root foundation: `draft-generic-collections`,
+`draft-derive`, and SFEP-0028 all depend on it. Draft diagnostic codes are
+pre-deconflicted (`E0303`; `E0711`–`E0715`; `E0820`–`E0822`; `E0823`/`W0823`;
+`E0824`–`E0825`).
+
 ## Subdirectories
 
 - [`design-notes/`](./design-notes/) — single-issue implementation design gates.

--- a/docs/proposals/draft-derive.md
+++ b/docs/proposals/draft-derive.md
@@ -1,0 +1,491 @@
+---
+sfep: TBD
+title: Derivable Interface Implementations (@derive)
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/preview/derive.md
+---
+
+# SFEP-XXXX — Derivable Interface Implementations (@derive)
+
+## 1. Summary
+
+Introduce `@derive(Eq, Hash, Debug, Clone, Ord)` as a **compiler-recognized
+decorator** on `struct` and `enum` declarations. For each named derivable, the
+compiler synthesizes the corresponding standard-library interface implementation
+directly from the type's fields (structs) or variants-and-payloads (enums) — so
+`@derive(Eq, Hash)` on a struct produces field-by-field `Eq` and `Hashable`
+method bodies without the author writing them. The mechanism reuses the existing
+`Decorator` AST node (`compiler/src/ast.sfn:284-292`), adds **no new syntax**, and
+is not a macro system: a fixed, closed set of five derivables is expanded by a
+dedicated post-typecheck pass into ordinary `MethodDeclaration`s before the
+emitter runs. This is the feature that lets user-defined types satisfy the
+`Eq` / `Hashable` / `Ord` bounds the generics-constraints and generic-collections
+work depends on — the enabler that makes user types usable as `Map`/`Set` keys.
+
+## 2. Motivation
+
+Sailfin's object model is nominal `struct` / `enum` + `interface` with an explicit
+`implements` clause; conformance is checked structurally against interface members
+(`compiler/src/typecheck_types.sfn:95-134`) and interfaces lower to vtables
+(`compiler/src/llvm/rendering_helpers.sfn:49-107`). To make a user type comparable,
+hashable, cloneable, or printable today, the author must hand-write the entire
+interface implementation — an `equals` method that compares every field, a `hash`
+method that folds every field, a `clone` method that copies every field, and so on.
+
+This boilerplate is:
+
+- **The single largest metaprogramming gap.** Rust (`#[derive(Debug, Eq, Clone)]`)
+  and Swift (`Equatable`/`Hashable`/`Codable` synthesis via macros) make these
+  free; users arriving from those languages take structural `Eq`/`Hash`/`Debug`/
+  `Clone`/`Ord` for granted. It is the #1 thing they reach for and do not find.
+- **Error-prone.** A hand-written `hash` that forgets a field, or an `equals` that
+  compares the wrong subset of fields, is a silent correctness bug — exactly the
+  kind of hazard the `Hashable`/`Eq` contract exists to prevent.
+- **A hard prerequisite for generic collections.** A `Map<K, V>` or `Set<K>` needs
+  `K: Hashable + Eq`. Without derive, every key type must hand-roll both interfaces,
+  which makes the ergonomic story for the generic collections work
+  (`draft-generic-collections.md`) unacceptable. Derive is what turns "you may use
+  any type as a key" from a promise into a one-line reality.
+- **Repetitive in the compiler itself.** The compiler's own AST and IR structs are
+  prime candidates for derived `Eq`/`Debug`/`Clone` once the feature lands (post-
+  seed), reducing hand-maintained boilerplate in `ast.sfn` and `native_ir.sfn`.
+
+There is no existing lever. There is no macro system, no `comptime`, no reflection,
+and no derive anywhere in the tree. Decorators exist as an AST node but are almost
+entirely **inert metadata** — `@policy`, for instance, is "Parsed only, no compiler
+or runtime effect" (`docs/status.md:212`). This proposal gives a small, closed set
+of decorator names real, enforced compiler meaning without opening the general
+macro door.
+
+## 3. Design
+
+### 3.1 Surface syntax
+
+`@derive(...)` is applied to a `struct` or `enum` declaration using the grammar the
+parser already accepts for decorators-with-arguments
+(`compiler/src/parser/declarations.sfn`, applied to structs and enums; the AST node
+is `StructDeclaration.decorators` / `EnumDeclaration.decorators`,
+`compiler/src/ast.sfn:373,394`):
+
+```sfn
+@derive(Eq, Hash, Debug, Clone)
+struct Point {
+    x: int;
+    y: int;
+}
+
+@derive(Eq, Ord, Debug)
+enum Color {
+    Red,
+    Green,
+    Rgb { r: int; g: int; b: int },
+}
+```
+
+Each argument to `@derive(...)` is a **bare identifier** naming a derivable. The
+five recognized names, and the standard-library interface each generates an
+implementation of:
+
+| Derivable | Interface generated | Synthesized member(s) |
+|---|---|---|
+| `Eq` | `Eq` | `equals(other: Self) -> bool` |
+| `Hash` | `Hashable` | `hash() -> int` |
+| `Debug` | `Debug` (a.k.a. `Display` surface) | `debug() -> string` |
+| `Clone` | `Clone` | `clone() -> Self` |
+| `Ord` | `Ord` (a.k.a. `Comparable`) | `compare(other: Self) -> int` |
+
+These are the **same interfaces** that `draft-generic-constraints.md` uses as
+constraint bounds (`K: Hashable + Eq`, `T: Ord`). Derive is the primary means by
+which a user type comes to satisfy those bounds. The interface names are owned by
+that SFEP / the prelude; this proposal consumes them and must match their exact
+member signatures (see §3.6). If the constraint SFEP has not fixed the final
+interface names, this proposal tracks them — derivable-name → interface-name is a
+lookup table in one place (`derive.sfn`, §3.3) and is trivially retargeted.
+
+`@derive()` with no arguments is a no-op (warning: empty derive list, `W0710`). An
+unrecognized name inside `@derive(...)` — e.g. `@derive(Serialize)` — is a hard
+error `E0711` "`Serialize` is not a derivable interface (known: Eq, Hash, Debug,
+Clone, Ord)". User-defined derivables are explicitly **out of scope** (§3.8), so
+the set is closed and the error is exhaustive.
+
+### 3.2 What each derivable generates
+
+Semantics are **structural**, computed from the declaration the decorator sits on.
+
+**Struct, over fields `f_1 .. f_n`:**
+
+- **`Eq`** → `equals(other: Self) -> bool`: `self.f_1 == other.f_1 && … &&
+  self.f_n == other.f_n`. Each field comparison uses `==` on the field type, which
+  itself resolves to that field type's `Eq` (recursively derived or hand-written).
+  Zero-field struct → `return true`.
+- **`Hash`** → `hash() -> int`: a fold over field hashes, e.g. seeded FNV/`31*h + …`
+  combine of `self.f_i.hash()` in field order. Zero-field struct → a fixed constant.
+- **`Debug`** → `debug() -> string`: `"Point { x: " + self.x.debug() + ", y: " +
+  self.y.debug() + " }"` — the type name, then `field: value` pairs in declaration
+  order, delegating to each field's own `debug()`.
+- **`Clone`** → `clone() -> Self`: construct a fresh `Self { f_1: self.f_1.clone(),
+  … }`. For value/scalar fields `clone()` is identity; for owned/heap fields it is a
+  deep field-wise clone (interacts with the ownership floor — see §4).
+- **`Ord`** → `compare(other: Self) -> int`: lexicographic over fields in
+  declaration order — compare `f_1`; if non-zero return it, else `f_2`, etc.;
+  returns `<0 / 0 / >0`. Requires each field type to be `Ord` (`compare`-capable);
+  a field type that is not `Ord` → `E0712` "cannot derive `Ord` for `Point`: field
+  `x` of type `Widget` does not implement `Ord`". The analogous field-capability
+  check applies to `Eq`/`Hash`/`Clone` (each field must itself satisfy the derived
+  interface), reported as `E0712` with the offending field named.
+
+**Enum, over variants `V_1 .. V_m`:**
+
+- **`Eq`** → `equals`: variants equal iff same variant *and*, for payload-carrying
+  variants, all payload fields pairwise equal (a `match` on `self` with a nested
+  discriminant/payload check against `other`). Different variants → `false`.
+- **`Hash`** → `hash`: combine the variant discriminant (its index) with the fold
+  of payload-field hashes for that variant.
+- **`Debug`** → `debug`: `"Red"` for a unit variant; `"Rgb { r: …, g: …, b: … }"`
+  for a payload variant, delegating to payload-field `debug()`.
+- **`Clone`** → `clone`: reconstruct the same variant with field-wise cloned
+  payload.
+- **`Ord`** → `compare`: first by variant declaration order (earlier variant <
+  later); ties broken lexicographically over the shared variant's payload fields.
+
+The enum forms are **variant-aware**: they pattern-match on the receiver (and the
+argument, for binary operations) using the existing `MatchStatement` / `MatchCase`
+AST (`compiler/src/ast.sfn:412`). No new expression forms are introduced — the
+synthesized bodies are ordinary Sailfin the parser and typechecker already model.
+
+### 3.3 Mechanism: a post-typecheck synthesis pass
+
+The core mechanism is a **new pass, `derive_expand`, that runs after type checking
+resolves fields and interfaces, and before the native emitter**. Placement in the
+existing driver (`compiler/src/main.sfn`): typecheck runs (e.g.
+`typecheck_has_errors_with_prelude` at `main.sfn:82,205,259`), and only if it is
+clean does emission proceed (`emit_native_text_with_module_name`,
+`main.sfn:217,271`). `derive_expand` is invoked on the `Program` **between those two
+points** — after typecheck has confirmed the declaration is well-formed (fields
+have known, resolved types; the type is not already implementing the target
+interface in a conflicting way), and before `emit_native` walks the AST.
+
+The pass is mechanically simple and lives in a new module
+`compiler/src/derive.sfn`:
+
+1. Walk every top-level `StructDeclaration` / `EnumDeclaration` in the `Program`.
+2. For each, scan `decorators` for a decorator named `derive`
+   (`decorator_names(...)`, `compiler/src/ast.sfn:294`). Skip declarations without
+   one.
+3. Parse the `@derive(...)` `arguments: DecoratorArgument[]` into a list of
+   derivable identifiers. Validate each against the closed set (§3.1); emit
+   `E0711` for unknowns and stop expanding that declaration.
+4. For each valid derivable, run the derivable-name → interface-name lookup, then
+   check the type does not already declare a method of the target member name in
+   `methods` (structs) — if it does, that is a conflict (`E0713` "`Point` both
+   derives and hand-implements `equals`"; the author should drop one). This
+   prevents silent shadowing.
+5. **Field-capability check** (§3.2): confirm each field/payload type satisfies the
+   derived interface. This uses the same resolved type information the typechecker
+   already computed; failures are `E0712`.
+6. **Synthesize** a `MethodDeclaration` per derivable (structural body per §3.2),
+   pushing it onto the declaration's `methods` list, and add the target interface
+   to `implements_types` if not already present so the vtable/conformance machinery
+   picks it up. For enums (which have no `methods`/`implements_types` field today —
+   `EnumDeclaration`, `compiler/src/ast.sfn:389-395`), see §3.4.
+
+After `derive_expand`, the rest of the pipeline sees **ordinary methods and an
+ordinary `implements` clause**. The emitter (`emit_native.sfn`), LLVM lowering
+(`llvm/lowering/entrypoints.sfn`), vtable rendering
+(`rendering_helpers.sfn:49-107`), and conformance checking all operate unchanged —
+they never learn that these methods were synthesized. This is the key design
+choice: **derive is desugaring, not a codegen special case.** The blast radius is
+one new pass plus the AST hooks it writes into; emit and lowering are untouched.
+
+Because the synthesized methods are plain AST, they are also **re-typechecked in
+place** is unnecessary (typecheck already ran), but the synthesis must produce
+well-typed AST by construction. To keep this honest, `derive_expand` re-runs the
+narrow conformance/signature check on each synthesized method (§3.6) rather than
+trusting itself blindly — cheap, and it catches a synthesis bug as a compiler
+diagnostic instead of malformed IR.
+
+### 3.4 Enums: methods and conformance
+
+`EnumDeclaration` today has no `methods` or `implements_types` fields
+(`compiler/src/ast.sfn:389-395`), whereas `StructDeclaration` has both
+(`ast.sfn:366-374`). Enums cannot currently carry method implementations or an
+`implements` clause. Two options:
+
+- **(A) Extend `EnumDeclaration`** with `methods: MethodDeclaration[]` and
+  `implements_types: TypeAnnotation[]`, mirroring `StructDeclaration`. This is the
+  clean, general answer and is almost certainly wanted independently (users will
+  expect enums to implement interfaces). But it is a **`EnumDeclaration` AST layout
+  change**, which is seed-layout-sensitive (a released seed may treat the node with
+  a fixed shape). It must therefore land additively and be seed-gated before the
+  compiler *uses* enum methods in its own source.
+- **(B) Lower enum derivables to free functions** (`Color_equals(self, other)`,
+  dispatched without a vtable) for the initial ship, deferring enum interface
+  conformance until (A) lands.
+
+**Decision: (A), staged.** Extending `EnumDeclaration` is the correct model and
+unblocks user-defined enum interface impls generally, not just derive. It lands as
+an additive AST change in its own step (new fields default-empty; the old seed
+never populates them, so it round-trips), the seed is cut, and only then does the
+enum-derive path populate them. Until that seed is pinned, `@derive` on an enum is a
+diagnostic `E0714` "deriving on enums requires a newer compiler" — an honest gate,
+not a half-feature (per "don't ship unfinished safety claims"). Struct derive ships
+first and does not wait on this.
+
+### 3.5 Effect: derived methods are pure
+
+Every synthesized method (`equals`, `hash`, `debug`, `clone`, `compare`) is `![pure]`
+— structural comparison/hashing/cloning/formatting performs no `io`/`net`/etc. The
+synthesizer stamps the empty/`pure` effect set on the generated `FunctionSignature`
+(`effects: []`). See §4.
+
+### 3.6 Conformance to signature-checked interfaces
+
+`draft-interface-signature-conformance.md` tightens `implements` conformance from
+"a method of the right *name* exists" (today's check,
+`typecheck_types.sfn:121-128`, which only tests `contains_string(method_names,
+member.name)`) to a full **signature** match (parameter and return types). Derived
+methods **must pass that stricter check.** This is a constraint on the synthesizer,
+not a problem: the synthesizer knows the exact interface member signature it is
+targeting (it looked the interface up in §3.3 step 4), so it emits a
+`FunctionSignature` that matches by construction — same parameter names/types, same
+return type, same effect set.
+
+Concretely, the ordering is:
+
+1. This SFEP's synthesizer generates methods that match the *current* interface
+   member signatures.
+2. When signature-checked conformance lands, the derived methods already match
+   (they were generated from the signature), so they pass with no change.
+
+To avoid drift, `derive_expand` reuses the interface member's own
+`FunctionSignature` as the template for the synthesized method's signature
+(copying parameter/return annotations from the interface definition, filling in the
+body), rather than reconstructing the signature independently. That guarantees the
+derived signature is *definitionally* the interface signature. The two SFEPs are
+mutually reinforcing: signature-checked conformance is what makes "derived impls are
+correct" a checked property rather than a hopeful one.
+
+### 3.7 Worked expansion (illustrative)
+
+```sfn
+@derive(Eq, Debug)
+struct Point { x: int; y: int; }
+```
+
+expands (conceptually, before emit) to:
+
+```sfn
+struct Point implements Eq, Debug {
+    x: int;
+    y: int;
+
+    fn equals(other: Point) -> bool ![pure] {
+        return self.x == other.x && self.y == other.y;
+    }
+
+    fn debug() -> string ![pure] {
+        return "Point { x: " + self.x.debug() + ", y: " + self.y.debug() + " }";
+    }
+}
+```
+
+The right-hand side is entirely ordinary Sailfin. Nothing downstream of
+`derive_expand` distinguishes it from a hand-written impl.
+
+### 3.8 Explicitly out of scope for 1.0
+
+- **User-defined derive macros.** Only the five built-in derivables are recognized;
+  the set is closed and hardcoded in `derive.sfn`. A general "define your own
+  `@derive(Foo)`" mechanism is a macro system, which is explicitly deferred to
+  post-1.0 and would get its own SFEP. This keeps the feature **bounded and
+  non-macro**: it is table-driven desugaring of five known names, not a
+  metaprogramming facility.
+- **Field-level attributes** (`@derive`-skip a field, custom hash for a field, etc.)
+  — post-1.0.
+- **`Serialize`/`Deserialize`/`Codable`-style derives** — depend on a serialization
+  library surface that does not exist; post-1.0.
+- **Recursive-type cycle handling for `Debug`/`Hash`** beyond what the structural
+  fold naturally gives — a self-referential type (a struct containing itself through
+  a pointer) will produce infinite recursion in `debug`/`hash`; the initial ship
+  detects a **direct** self-referential derivable field and errors (`E0715`) rather
+  than emitting non-terminating code. Indirect cycles are documented as a known
+  limitation.
+
+## 4. Effect & capability impact
+
+Minimal and deliberately so. Every synthesized method is `![pure]`:
+structural equality, hashing, comparison, and formatting are pure computations, and
+field-wise `clone` is pure by the same argument the runtime's owned-buffer clone is
+pure. The synthesizer stamps `effects: []` on each generated `FunctionSignature`, so
+no capability is granted or required by deriving. A type that derives `Debug` does
+**not** thereby gain `![io]` — `debug()` returns a `string`; it is the *caller* who
+prints it that needs `io`. This keeps derive out of the effect-system surface
+entirely: it is a code-synthesis convenience, not a capability.
+
+One interaction worth stating: **`Clone` and the ownership floor.** The native
+runtime enforces a unique-ownership / no-aliased-mutation memory-safety floor
+(`ownership_checker.sfn`, epic #1209). Derived `clone` produces a genuinely
+independent copy (field-wise deep clone for owned fields), which is exactly what the
+ownership model wants — `clone` is the sanctioned way to get a second owned value,
+so derived `Clone` is *aligned with* the floor, not in tension with it. The
+synthesizer must emit field clones that go through each field type's own `clone`
+(recursively), never a shallow aliasing copy, so a derived `clone` never
+manufactures an aliased mutable owner. The field-capability check (§3.2) guarantees
+every field is itself `Clone` before `clone` is synthesized.
+
+## 5. Self-hosting impact
+
+**Passes changed:** exactly one new pass (`derive_expand`) is inserted into the
+driver between typecheck and emit; a small AST extension for enums (§3.4). The
+lexer, parser, effect checker, native emitter, and LLVM lowering are **unchanged** —
+they see synthesized methods as ordinary methods.
+
+- **Parser / AST:** `@derive(Eq, ...)` already parses today (decorators-with-args on
+  structs/enums, `parser/declarations.sfn`; `Decorator`/`DecoratorArgument`,
+  `ast.sfn:284-292`). No parser change for structs. The only AST change is the
+  additive `EnumDeclaration` extension (§3.4), which round-trips through an old seed
+  because the new fields default empty and the old seed never populates them.
+- **Typecheck:** `derive_expand` runs *after* typecheck, so typecheck is not
+  modified for the mechanism. (The field-capability and conflict diagnostics
+  E0711–E0715 live in `derive.sfn`, not `typecheck.sfn`.) When signature-checked
+  conformance (`draft-interface-signature-conformance.md`) lands, derived methods
+  pass it by construction (§3.6).
+- **Self-hosting invariant.** The compiler source **does not use `@derive` on
+  itself** in the initial ship — the feature lands additively and the compiler's own
+  AST/IR structs keep their hand-written (or absent) impls until a seed containing
+  `derive_expand` is pinned. This decouples self-hosting from the feature exactly as
+  SFEP-0023 decouples decorators: `make compile` builds the new compiler from the
+  old seed (which never sees `@derive` because the compiler source doesn't use it),
+  and the new compiler then expands `@derive` for *user* code. Only after the
+  `derive_expand`-containing seed is pinned may the compiler dogfood `@derive` on its
+  own structs — a separate, later step, and one that requires the struct-derive path
+  first, then the enum extension seed for any enum use.
+- **Seed-dependency (per `.claude/rules/seed-dependency.md`).** The `derive_expand`
+  capability and its first *external* consumer (a test fixture / user code) are
+  bundled in one PR — `make compile` builds the new compiler from the old seed and
+  that compiler compiles the fixture in the same pass, so **no seed cut is needed to
+  ship the feature.** A seed cut is only needed for the compiler to *dogfood* derive
+  on its own source (and, separately, for the enum-methods AST extension before enum
+  derive is used in-tree) — both queued against the cadence, not reactive.
+
+## 6. Alternatives considered
+
+- **A general macro / `comptime` system.** Deriving is the textbook motivating case
+  for compile-time metaprogramming. Rejected for 1.0: a macro system is a large,
+  open-ended language surface with its own hygiene, phasing, and effect questions,
+  and it dilutes the three pillars. The five built-in derivables cover the
+  overwhelming majority of real demand as **closed, table-driven desugaring** with a
+  tiny surface. A macro system can come later and subsume `@derive` as a built-in
+  set without breaking this design.
+- **Reflection at runtime** (a runtime `TypeInfo` that `equals`/`hash`/`debug`
+  consult generically). Rejected: it defeats static dispatch (interfaces lower to
+  vtables today), imposes a runtime metadata cost on every type, and pushes what can
+  be a compile-time correctness guarantee into runtime. Derive-as-desugaring keeps
+  everything static and monomorphic.
+- **A new keyword (`derive Eq for Point { }` or `deriving`).** Rejected per
+  "libraries/markers over keywords" and "boring syntax wins": a keyword can never
+  become an identifier, and the decorator grammar already expresses "attach
+  compiler-recognized metadata to a declaration." `@derive(...)` reads like Rust's
+  `#[derive(...)]`, which is exactly the prior art users expect — the boring choice.
+- **Special-casing derived types in the emitter / LLVM lowering** (synthesize IR
+  directly, skipping AST). Rejected: it duplicates every codegen path for the derived
+  case, is far harder to keep correct as the object model evolves, and bypasses the
+  conformance checker. Expanding to AST before emit means one code path, checked by
+  the existing machinery.
+- **Making the built-in interfaces (`Eq`/`Hashable`/…) auto-implemented for all
+  types** (implicit conformance, Go-style). Rejected: it conflicts with nominal
+  `implements` conformance, makes "is this type hashable?" invisible at the
+  declaration site, and would silently make every type a valid map key even when its
+  fields are not hashable. Explicit `@derive` keeps the author's intent — and the
+  field-capability check — at the declaration.
+
+## 7. Stage1 readiness mapping
+
+- [x] **Parses** — `@derive(Eq, ...)` on structs/enums parses today via the existing
+  decorator-with-arguments grammar; no parser change for structs. (Enum AST
+  extension in §3.4 is additive.)
+- [ ] **Type-checks / effect-checks** — the new `derive_expand` pass runs after
+  typecheck; synthesized methods are `![pure]` and pass conformance (and
+  signature-checked conformance once it lands, §3.6). E0711–E0715 diagnostics.
+- [ ] **Emits valid `.sfn-asm`** — synthesized `MethodDeclaration`s flow through
+  `emit_native.sfn` as ordinary methods; no emitter change.
+- [ ] **Lowers to LLVM IR** — ordinary methods + `implements` → existing vtable
+  lowering (`rendering_helpers.sfn:49-107`); no lowering change.
+- [ ] **Regression coverage** — §8.
+- [ ] **Self-hosts** — feature lands additively; compiler source does not use
+  `@derive` on itself until a `derive_expand`-containing seed is pinned (§5).
+- [ ] **`sfn fmt --check` clean** — on the new `derive.sfn` and any touched files.
+- [ ] **Documented** — `docs/status.md` (flip `@derive` from absent to shipped once
+  enforced end-to-end) and `reference/preview/derive.md` → `reference/spec/` on ship.
+
+## 8. Test plan
+
+`compiler/tests/unit/`:
+
+- **Parse/recognition:** `@derive(Eq, Hash, Debug, Clone, Ord)` on a struct is
+  recognized; `@derive()` warns `W0710`; `@derive(Serialize)` errors `E0711`.
+- **Struct `Eq`:** two `Point{1,2}` values compare equal; `Point{1,2}` vs
+  `Point{1,3}` unequal; zero-field struct always equal.
+- **Struct `Hash`:** equal values hash equal (the `Eq`/`Hash` contract);
+  distinct-fielded values hash distinctly for a representative sample.
+- **Struct `Ord`:** lexicographic ordering across fields; `compare` returns the
+  sign of the first differing field.
+- **Struct `Debug`/`Clone`:** `debug()` renders `Type { field: value, ... }`;
+  `clone()` produces an independent, field-equal copy.
+- **Enum forms:** `Eq`/`Hash`/`Ord`/`Debug`/`Clone` across unit and payload
+  variants; different variants unequal; variant-declaration-order dominates `Ord`.
+- **Field-capability errors:** `@derive(Ord)` on a struct with a non-`Ord` field →
+  `E0712` naming the field; likewise `Eq`/`Hash`/`Clone`.
+- **Conflict:** a struct that both `@derive(Eq)` and hand-writes `equals` → `E0713`.
+- **Enum gate (pre-extension seed):** `@derive` on an enum → `E0714` until the
+  §3.4 seed is pinned; after, the enum forms above.
+- **Self-referential guard:** a directly self-referential derivable field → `E0715`.
+
+`compiler/tests/integration/`:
+
+- **Conformance:** a `@derive(Eq, Hash)` struct satisfies an `implements Eq,
+  Hashable` requirement and passes signature-checked conformance
+  (`draft-interface-signature-conformance.md`) with no hand-written method.
+
+`compiler/tests/e2e/` (`*_test.sfn`, per `.claude/rules/no-bash-e2e.md`):
+
+- **Map/Set key end-to-end:** compile and run a fixture that uses a `@derive(Eq,
+  Hash)` struct as a `Map`/`Set` key (bundled with `draft-generic-collections.md`),
+  asserting insert/lookup/dedup behavior — the payoff test proving derive enables
+  keys. Thread `SAILFIN_TEST_SCRATCH`/`PATH` per the build-isolation rule.
+- **Runtime behavior:** a fixture that prints `debug()`, clones, and compares
+  derived values, asserting on captured stdout.
+
+## 9. References
+
+- **AST / current state:** `compiler/src/ast.sfn:284-292` (`Decorator` /
+  `DecoratorArgument`), `:254-264` (`MethodDeclaration`, `EnumVariant`),
+  `:366-395` (`StructDeclaration`, `EnumDeclaration`); `docs/status.md:212`
+  (`@policy` "Parsed only, no compiler or runtime effect").
+- **Conformance & vtables:** `compiler/src/typecheck_types.sfn:95-134`
+  (`check_struct_implements_interfaces`); `compiler/src/llvm/rendering_helpers.sfn:49-107`
+  (vtable type/constant rendering).
+- **Pipeline placement:** `compiler/src/main.sfn:82,205,259` (typecheck gate) →
+  `:217,271` (`emit_native_text_with_module_name`) — `derive_expand` inserts
+  between.
+- **Related SFEPs:** `draft-generic-constraints.md` (the interfaces `@derive`
+  targets are the constraint bounds `K: Hashable + Eq`, `T: Ord`);
+  `draft-generic-collections.md` (derived `Hash`/`Eq` → usable as `Map`/`Set`
+  keys — the payoff consumer); `draft-interface-signature-conformance.md` (derived
+  impls must pass signature-checked conformance, §3.6); **SFEP-0023**
+  (`0023-capsule-decorators.md`) — contrast: those are *user-imported* decorators
+  resolved to library functions; `@derive` is a *compiler-recognized*, closed-set
+  decorator with no library resolution. Both share the "reuse the `Decorator` AST
+  node, no new syntax" principle and both avoid editing the `Decorator` struct
+  layout.
+- **Rules:** `.claude/rules/seed-dependency.md` (bundle capability + consumer; no
+  seed cut to ship, seed cut only to dogfood), `.claude/rules/selfhost-invariant.md`.
+- **Prior art:** Rust `#[derive(Debug, Eq, Hash, Clone, PartialOrd)]`; Swift
+  automatic `Equatable`/`Hashable` synthesis and the macro-based `Codable`.

--- a/docs/proposals/draft-exhaustive-match.md
+++ b/docs/proposals/draft-exhaustive-match.md
@@ -1,0 +1,617 @@
+---
+sfep: TBD
+title: Compile-Time Match Exhaustiveness Checking
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/spec/08-patterns.md
+---
+
+# SFEP-XXXX — Compile-Time Match Exhaustiveness Checking
+
+## 1. Summary
+
+Add a compile-time exhaustiveness check for `match` on enum-typed and
+`bool`-typed scrutinees: a `match` that omits a variant (or a `bool` case) and
+carries no unconditional wildcard/binding arm becomes a **build error** at
+`sfn check` / typecheck time, naming the specific uncovered variant(s) with a
+fix-it hint. Today this gap is caught only at *runtime*, via the
+`match_exhaustive_failed` trap (`runtime/prelude.sfn:701`) — the exact "parsed
+but not enforced" pattern the project's design framework flags as worse than
+absent. The runtime backstop stays as defense-in-depth for scrutinees whose
+type the frontend cannot statically resolve today (#829), but the compile-time
+check becomes the primary guarantee, matching Rust's and Swift's `match`/
+`switch` exhaustiveness.
+
+## 2. Motivation
+
+Sailfin's enums are real tagged unions — an `i32` (or narrower) discriminant
+tag plus a max-payload byte region, computed and stored per-enum in
+`EnumTypeInfo` (`compiler/src/llvm/lowering/lowering_phase_types.sfn:45-69`,
+`tag_type`/`tag_size`/`max_payload_size`/`variants`). `match` already
+destructures them with real variant patterns
+(`Response.Ok { value }`/`Response.Error { code, message }`), guards, literals,
+and `_` (`docs/status.md:173`: "`match` | Shipped | Literals, `_`, guards,
+enum-variant destructuring"; spec `site/src/content/docs/docs/reference/spec/08-patterns.md:11-27`).
+The declarations chapter states the intended semantics outright: "Enum values
+are matched exhaustively with `match`"
+(`site/src/content/docs/docs/reference/spec/03-declarations.md:111-112`).
+
+That statement is not true today. Grepping `compiler/src/typecheck.sfn` for
+"exhaustive" finds nothing — the typecheck pass never inspects a `MatchStatement`
+for variant coverage. `docs/status.md:177` says so plainly: "Pattern-match
+exhaustiveness | Partial | Runtime backstop (`match_exhaustive_failed`)". A
+program with
+
+```sfn
+enum Response { Ok { value: int }, Error { code: int, message: string } }
+
+fn handle(r: Response) -> int {
+    match r {
+        Response.Ok { value } => value,
+    }
+}
+```
+
+compiles clean under `sfn check` and `make compile` today. It only fails at
+**runtime**, and only on the one input path that happens to hit
+`Response.Error` — `match_exhaustive_failed` raises a `ValueError`
+("Non-exhaustive match for value ...", `runtime/prelude.sfn:701-704`). This is
+exactly a correctness bug the type system exists to prevent: the two pillars
+that make Sailfin's enums valuable (effects and capabilities aside) are
+undermined if a refactor that adds a variant (say, `Response.Timeout`) silently
+compiles every existing exhaustive-looking `match` without a peep, and the
+first sign of trouble is a production crash on the new variant.
+
+Concretely this is worse than "no exhaustiveness feature at all" per the
+project's "don't ship unfinished safety claims" principle (`CLAUDE.md`): the
+spec prose already tells users their `match` is checked, and it is not. Rust
+(`match` non-exhaustive → `E0004`) and Swift (`switch` must be exhaustive)
+both reject this at compile time; this SFEP closes the gap for Sailfin's
+canonical sum-type case.
+
+**Interesting existing asset:** the LLVM lowering pass *already computes*
+variant-coverage per `match` — but purely to decide whether to terminate the
+merge block with `unreachable` (a codegen optimization) rather than falling
+through to the runtime trap. See `lower_match_instruction`
+(`compiler/src/llvm/lowering/instructions_match.sfn:825-834`):
+
+```sfn
+let mut match_exhaustive: boolean = has_unconditional_default;
+if !match_exhaustive {
+    if !has_guarded_cases {
+        if subject_enum_info != null {
+            match_exhaustive = matched_enum_tags.length == subject_enum_info.variants.length;
+        } else if union_payload_types.length > 0 {
+            match_exhaustive = matched_union_variants.length == union_payload_types.length;
+        }
+    }
+}
+```
+
+This is the right *algorithm* (guarded arms excluded, tag-set-equality test)
+at the wrong *pipeline stage* to serve as a user-facing diagnostic: it runs
+deep in LLVM lowering (`build`/`run` only, not `sfn check`), it has no access
+to source spans for a `sfn check`-shaped diagnostic, and its silence on the
+non-exhaustive case is deliberate (it falls through to
+`match_exhaustive_failed` instead of erroring). This SFEP moves the
+*user-facing gate* to typecheck — where `sfn check` runs it before any IR
+exists — while leaving the lowering-level `match_exhaustive` computation
+alone (it continues to drive the `unreachable`-vs-trap codegen choice; see
+§5).
+
+## 3. Design
+
+### 3.1 Scope for 1.0
+
+- **In scope:** exhaustiveness over a `match` scrutinee that is **statically
+  known to be a named `enum` type** (the high-value case — Sailfin's sum-type
+  surface), and over a `bool`-typed scrutinee (`true`/`false`).
+- **Shallow, variant-level only.** Coverage is computed at the level of "is
+  each variant *name* covered by some arm," not at the level of the payload
+  fields a variant-destructuring arm binds. `Response.Ok { value }` counts as
+  full coverage of `Ok` regardless of which fields it binds or ignores; there
+  is no deeper structural/nested-pattern exhaustiveness (e.g. exhaustiveness
+  over a payload field that is itself an enum). A nested enum payload still
+  requires its own `_`/binding wildcard, or its own dedicated `match`, if the
+  outer arm needs to narrow further. This mirrors Rust's variant-level
+  exhaustiveness (which *does* recurse into structural patterns) only at the
+  first level — full recursive struct/tuple-pattern exhaustiveness is
+  explicitly **out of scope** for 1.0 and left as a documented limitation
+  (see §6).
+- **Out of scope:** exhaustiveness over infinite/large domains — `int`,
+  `float`, `string` literal patterns. These stay wildcard-required forever;
+  there is no proposal to ever require literal-pattern exhaustiveness over an
+  unbounded domain (Rust doesn't either, short of range-pattern totality
+  tricks this project has no reason to chase). A `match` on an `int`
+  scrutinee with only literal arms and no `_` is unaffected by this SFEP and
+  continues to rely on the runtime backstop (documented limitation).
+- **Non-enum, non-bool scrutinees** (inline `string | int` unions, plain
+  structs, primitives other than `bool`) are unaffected — same reasoning as
+  SFEP-0034 §3.6's `is` v1 scope cut: the frontend has no live
+  expression-type inference (#829), so the scrutinee's static type is not
+  reliably resolvable in the general case. See §3.3 for exactly which cases
+  *are* staticaly resolvable without #829, and how.
+
+### 3.2 Where this runs: typecheck, not effect-checker or lowering
+
+The check is added as a typecheck-phase pass, hooked at the existing
+`MatchStatement` arm in `check_statement`
+(`compiler/src/typecheck.sfn:569-588`) — the site that already walks the
+scrutinee expression, each case's pattern/guard/body, and produces the
+`Diagnostic[]` that feeds `check_program_scopes` → `typecheck_diagnostics_full`
+→ `sfn check`'s exit code. This is deliberate:
+
+- It is the **earliest point in the pipeline** exhaustiveness can be checked
+  meaningfully — before effect-checking, before native-IR emission, before
+  any LLVM lowering exists. `sfn check` (parse + typecheck + effect-check,
+  no IR/codegen) is the compiler's fast inner loop
+  (`docs/proposals/0004-check-architecture.md`); exhaustiveness is a
+  type-level property and belongs there, not gated behind a full `make
+  compile`.
+- It reuses the walk that's already threading `bindings`/`imports`/
+  `top_level` through every statement — no new traversal infrastructure.
+- The **second**, existing `MatchStatement` site
+  (`compiler/src/typecheck.sfn:1337-1349`, inside
+  `walk_statement_expressions`) is the nested-in-expression-position walk
+  (used for expression-level diagnostics inside larger constructs); it is
+  **not** duplicated with the exhaustiveness check to avoid double-reporting
+  the same `match` twice when it also appears in statement position — see
+  §3.6.
+
+### 3.3 Resolving the scrutinee's static type without expression-type inference
+
+The central design question is: how does typecheck know a `match` scrutinee is
+of enum type `Foo`, given typecheck has **no expression-type inference**
+(#829) — `SymbolEntry` (`compiler/src/typecheck_types.sfn:71-91`) carries only
+`name`/`kind`/`span`/generic/C-ABI flags, no type. This is the same
+constraint that keeps `E0814` (`await` non-future) and `E0815` (channel-send
+mismatch) as pure, test-driven helper functions with no live wiring
+(`compiler/src/typecheck.sfn:1223-1230`), and that made SFEP-0034 scope `is`
+to a narrower, structurally-resolvable case rather than wait for #829.
+
+This SFEP takes the same **name-based, pattern-driven** approach the LLVM
+lowering pass already uses successfully for the analogous problem
+(`resolve_match_subject_annotation`,
+`compiler/src/llvm/lowering/instructions_match.sfn:97-122`, and
+`_match_extract_call_target`/`resolve_match_subject_call_annotation` at
+lines 130-165) — but resolve the **enum identity from the patterns
+themselves**, which sidesteps needing the scrutinee's declared type at all
+for the common case:
+
+1. **Collect top-level enum declarations once per compile unit.** A new pass,
+   `collect_enum_variant_sets(program: Program) -> EnumVariantSet[]`, walks
+   `program.statements` for `Statement.EnumDeclaration` nodes (`ast.sfn:389-394`)
+   and builds `{ name: string, variant_names: string[] }` for each — pure name
+   extraction from `variants: EnumVariant[]` (`ast.sfn:260-264`), no type
+   inference needed; this is exactly the same level of information
+   `register_top_level_symbol`'s `EnumDeclaration` arm already touches
+   (`compiler/src/typecheck.sfn:318-320`), just capturing the variant list
+   too instead of only the enum's own name.
+2. **Infer the scrutinee's candidate enum from its case patterns, not its
+   declared type.** For a `MatchStatement`, walk `statement.cases[i].pattern`.
+   A pattern of `Expression.Struct { type_name, fields }`
+   (`ast.sfn:77`) with `type_name.length == 2` — the `Enum.Variant { ... }`
+   shorthand the parser already produces for `Response.Ok { value }`
+   (`compiler/src/parser/statements.sfn:845`, `expression_from_tokens`) —
+   names its enum directly as `type_name[0]` and its variant as
+   `type_name[1]`. If **every** non-wildcard, non-guarded case pattern in the
+   `match` resolves to `Struct` patterns naming the *same* enum (found in the
+   set from step 1), that enum is the match's resolved scrutinee type and its
+   `variant_names` is the coverage universe. This needs **no** knowledge of
+   the scrutinee expression's own declared type — the patterns are
+   self-describing. This covers the dominant real-world shape (destructuring
+   match over an enum with `Enum.Variant { ... }` arms) with zero
+   type-inference dependency.
+3. **Fallback: unqualified variant-name patterns.** A shorthand pattern that
+   names only the variant (bare `Ok { value }`, without the `Response.`
+   qualifier) is not disambiguated by the pattern alone if multiple enums
+   share a variant name. For 1.0, this SFEP requires the **qualified** form
+   (`Enum.Variant { ... }`) for the exhaustiveness check to activate; an
+   unqualified variant pattern is treated as *not statically resolvable* and
+   the `match` is skipped by the check (falls back to the runtime-only
+   backstop) rather than guessed at — no false positives. (Today's
+   `docs/status.md:173`/spec examples already write the qualified form in
+   every worked example, so this is not a regression on real code.)
+4. **`bool` scrutinees** are resolved independent of enum-declaration lookup:
+   if every non-wildcard, non-guarded case pattern is a `BooleanLiteral`
+   (`ast.sfn:64`, text `"true"`/`"false"`) and at least one case pattern in
+   the match is a `BooleanLiteral`, the coverage universe is the two-element
+   set `{true, false}` — no scrutinee-type resolution needed at all, since
+   `bool` has no subtypes to disambiguate.
+5. **Mixed/ambiguous matches are not checked.** If the case patterns don't
+   uniformly resolve to one of (3.3.2) or (3.3.4) — e.g. a mix of `Struct`
+   patterns naming different enums (a static-type error the effect/type
+   checker doesn't otherwise catch today, out of scope here), or `Raw`
+   patterns the parser couldn't structure — the exhaustiveness check
+   declines silently (no diagnostic, matching the "decline, don't guess"
+   discipline SFEP-0034 §3.6 established for `is` on non-enum operands). This
+   keeps the check **sound but incomplete**: it never fires a wrong
+   diagnostic, but it also does not yet catch every non-exhaustive match in
+   the language. Widening the resolvable cases (declared-type flow from
+   `let`/parameter annotations) is the natural follow-up once #829 lands.
+
+### 3.4 Guards do not count as coverage
+
+An arm with a non-empty guard (`case.guard != null` and, per the existing
+`guard_has_text` check the lowering pass already performs at
+`instructions_match.sfn:419-426`, a guard with actual trimmed text) does
+**not** count toward covering its variant, because the guard may evaluate to
+`false` and fall through. This matches Rust and Swift:
+
+```sfn
+match r {
+    Response.Ok { value } if value > 0 => print("positive"),
+    Response.Ok { value } => print("non-positive"),   // still required
+    Response.Error { code, message } => print.err(message),
+}
+```
+
+Concretely: the coverage set for step 3.3.2 is built only from **unguarded**
+case patterns. This is a direct mirror of the lowering pass's own
+`has_guarded_cases` / `!guard_has_text` gating on `matched_enum_tags`
+(`instructions_match.sfn:411-491`) — the typecheck-level pass reimplements
+the same rule so `sfn check` and `build`/`run` agree (see §5).
+
+### 3.5 The diagnostic
+
+New diagnostic code **`E0823`** (the next free slot in the `E08xx` typecheck
+range; `E0801`–`E0819` are taken across `typecheck_types.sfn`/`typecheck.sfn`/
+`atomics.sfn`/`byte_load.sfn`/`core_member_lowering.sfn`, and the sibling
+in-flight draft `docs/proposals/draft-generic-constraints.md` has claimed
+`E0820`–`E0822`):
+
+```
+error[E0823]: non-exhaustive match over enum `Response`
+  --> src/handlers.sfn:14:5
+   |
+14 |     match r {
+   |     ^^^^^^^^ missing variant(s): `Error`
+   |
+   = help: add an arm for `Response.Error { .. }`, or a wildcard `_ => ...` arm
+```
+
+Factory: `make_match_non_exhaustive_diagnostic(enum_name: string,
+missing_variants: string[], span: SourceSpan?) -> Diagnostic`, added to
+`typecheck_types.sfn` beside the other `E08xx` factories
+(`make_await_non_future_diagnostic` et al., `typecheck_types.sfn:607-620`),
+following the same shape:
+
+```sfn
+struct Diagnostic {
+    code: string;       // "E0823"
+    severity: string;   // "error"
+    message: string;    // "non-exhaustive match over enum `Response`: missing variant(s): `Error`"
+    file_path: string;
+    primary: Token?;    // spans the `match` keyword / subject expression
+    suggestion: FixSuggestion?;  // "add an arm for `Response.Error { .. }`, or a wildcard `_` arm"
+}
+```
+
+`missing_variants` (plural) lists **every** uncovered variant, not just the
+first, so a multi-variant addition (e.g. adding two new variants to an enum
+with ten call sites) reports the complete gap per site in one pass rather
+than a fix-iterate-refail loop.
+
+**Secondary, optional diagnostic — redundant-arm warning.** A `W08xx`
+warning, **`W0823`** (warnings and errors are independently numbered per the
+existing `W01xx` load-warning precedent noted in the `Diagnostic.suggestion`
+comment, `typecheck_types.sfn:60-62`), for an arm whose pattern can never
+match because an earlier unguarded arm in the same `match` already covers its
+variant/literal:
+
+```sfn
+match r {
+    Response.Ok { value } => value,
+    Response.Ok { value } => value * 2,   // W0823: unreachable — `Ok` already covered above
+    Response.Error { code, message: _ } => 0,
+}
+```
+
+This is a **nice-to-have, secondary to the exhaustiveness error** — mark it
+optional for the initial implementation slice. It reuses the exact same
+coverage-set bookkeeping (3.3) computed for the exhaustiveness check (an arm
+is redundant if its variant/literal is already in the accumulated coverage
+set *before* processing it, and it is itself unguarded), so the marginal
+implementation cost is a few lines once the accumulator exists — but it is
+severable: shipping `E0823` alone with `W0823` deferred to a fast-follow is
+an acceptable, independently valid slice, whereas shipping `W0823` without
+`E0823` would not be (the error is the actual safety claim).
+
+### 3.6 Avoiding double-reporting between the two `MatchStatement` walk sites
+
+`typecheck.sfn` walks `MatchStatement` in two places: the statement-position
+arm in `check_statement` (line 569, feeds `sfn check`'s primary diagnostics)
+and the expression-position arm in `walk_statement_expressions` (line 1337,
+used when a `match` is nested inside another construct's expression walk —
+e.g. inside an `if`/`for`/`with` body via `walk_block_expressions`). Both
+currently duplicate the pattern/guard/body walk structure. The exhaustiveness
+check is added **only** to the statement-position site (line 569); the
+expression-position site is left untouched (it already exists purely to
+surface *nested* expression diagnostics like undefined symbols inside guard
+conditions, not top-level statement diagnostics, and a `MatchStatement` always
+also appears via the statement-position walk when it's the direct body of a
+block — see `check_block`'s dispatch). This avoids a `match` reachable from
+both walk paths triggering `E0823` twice for the same source span.
+
+### 3.7 Worked example (`docs/status.md`-cited case)
+
+```sfn
+enum Response {
+    Ok { value: int },
+    Error { code: int, message: string },
+}
+
+fn handle(r: Response) -> int {
+    match r {
+        Response.Ok { value } => value,
+    }
+}
+```
+
+Before this SFEP: compiles clean; traps at runtime with
+`match_exhaustive_failed` the first time `handle` is called with
+`Response.Error`. After this SFEP: `sfn check` (and `make compile`) rejects
+this with `E0823`, naming `Error` as the missing variant, before any binary
+exists.
+
+## 4. Effect & capability impact
+
+None. Exhaustiveness checking is a pure type-level static analysis over
+`Statement.EnumDeclaration` and `MatchStatement` AST shape; it introduces no
+new runtime behavior, no new effect, and does not touch the effect checker
+(`effect_checker.sfn`) or capability manifests. The new diagnostic is
+emitted from the typecheck pass exactly like the existing `E08xx` family.
+
+## 5. Self-hosting impact
+
+Passes touched, in pipeline order:
+
+- **Lexer** — no change.
+- **Parser** — no change. The `Struct`/`BooleanLiteral` pattern shapes this
+  design reads already exist (`ast.sfn:77`, `ast.sfn:64`); no new syntax.
+- **AST** — no new node. `Statement.EnumDeclaration` and `MatchCase`/pattern
+  shapes are read, not modified.
+- **Typecheck** (`compiler/src/typecheck.sfn`, `compiler/src/typecheck_types.sfn`) —
+  the substantive change:
+  - New pass `collect_enum_variant_sets` (new file
+    `compiler/src/typecheck_match_exhaustiveness.sfn`, kept separate from the
+    already-large `typecheck.sfn`/`typecheck_types.sfn` per the project's
+    per-file memory-footprint discipline — see `lowering_phase_types.sfn`'s
+    own "Extracted... to reduce per-file memory footprint" precedent).
+  - New pass `check_match_exhaustiveness(statement: Statement, enum_sets:
+    EnumVariantSet[]) -> Diagnostic[]` in the same new file, called from the
+    `MatchStatement` arm of `check_statement`
+    (`compiler/src/typecheck.sfn:569-588`) after the existing pattern/guard/
+    body walk, threading in the `enum_sets` computed once per
+    `typecheck_diagnostics_full` call (`compiler/src/typecheck.sfn:174-195`,
+    alongside the existing `collect_top_level_symbols`/
+    `collect_interface_definitions` calls).
+  - New diagnostic factories `make_match_non_exhaustive_diagnostic` /
+    (optionally) `make_match_redundant_arm_diagnostic` in
+    `typecheck_types.sfn`, following the `E08xx` factory shape at lines
+    591-638.
+- **Effect checker** — no change (§4).
+- **Native Emitter** (`emit_native.sfn`) — no change; a `match` that fails
+  `E0823` never reaches emission (typecheck failure stops the pipeline before
+  IR generation, per the standard `sfn check`/`make compile` gate ordering).
+- **LLVM Lowering** (`compiler/src/llvm/lowering/instructions_match.sfn`) —
+  **no functional change.** The existing `match_exhaustive` computation
+  (lines 825-834) and the runtime `match_exhaustive_failed` fallback stay
+  exactly as they are today. This is deliberate, not an oversight:
+  - It remains the **defense-in-depth** backstop for the scrutinees §3.3
+    declines to check statically (unqualified variant patterns, mixed/
+    ambiguous matches, non-enum/non-bool scrutinees) — those still reach
+    lowering unchecked by typecheck, so the `unreachable`-vs-trap choice
+    still matters for them.
+  - It also remains correct **even for the now-statically-guaranteed
+    exhaustive matches**: once `E0823` passes, `match_exhaustive` at lowering
+    time is definitionally `true` for that same match (same tag-set-equality
+    algorithm, same guard exclusion — §3.4 explicitly mirrors
+    `instructions_match.sfn:411-491`'s `has_guarded_cases`/`!guard_has_text`
+    gating), so lowering already emits `unreachable` instead of a trap call
+    for these matches today. The typecheck gate and the lowering computation
+    independently agree; there is no need to delete or thread a "already
+    proven exhaustive" flag through IR — recomputing a cheap tag-set
+    equality at lowering time is not a performance concern (it is O(variant
+    count) per match, not a fixed-point analysis) and keeps lowering
+    self-contained, which matters for the modules that consume
+    `instructions_match.sfn` without ever calling into typecheck (e.g. a
+    hypothetical future direct-emit path).
+  - **Runtime prelude** (`runtime/prelude.sfn:701-704`) — no change to
+    `match_exhaustive_failed`; it keeps its `E0` role for the unchecked
+    residual and is documented as such (§3.1, §6).
+
+**Self-hosting invariant preserved.** This is a strictly **additive**
+diagnostic gate. The old pinned seed contains no reference to `E0823` and no
+compiler-source `match` is non-exhaustive today (every `match` across
+`compiler/src/*.sfn` already writes exhaustive arms or a trailing `_`, by
+construction — the compiler was written before this gate existed but its
+authors already follow the discipline the gate now enforces); grep-auditing
+`compiler/src/**/*.sfn` for enum `match`es without a trailing `_`/binding
+wildcard is part of the implementation's first verification step (§8) to
+confirm this before the gate is wired live. `make compile` builds the new
+compiler (containing the new check) from the old seed; that new compiler then
+self-hosts by compiling the (already-exhaustive) compiler source in the same
+pass. **No seed cut required** — this is a single-consumer, compiler-source
+capability with no separate downstream consumer to bundle against (the
+"consumer" is `sfn check`/`make compile` itself, exercised in the same PR).
+Per `.claude/rules/seed-dependency.md`, this is squarely the bundle case: one
+PR, `make compile` self-hosts against the old seed with the new gate active
+in the same pass.
+
+## 6. Alternatives considered
+
+- **Full recursive structural exhaustiveness (nested enum payloads,
+  tuple/struct patterns), matching Rust's decision-tree algorithm exactly.**
+  Rejected for 1.0 — Rust's usefulness/exhaustiveness matrix algorithm is
+  substantially more machinery than variant-level coverage, and Sailfin's
+  `match` patterns today only destructure one level (`Enum.Variant { field,
+  ... }`); there is no nested-pattern surface yet to make deep exhaustiveness
+  pay for itself. Shallow variant-level coverage catches the overwhelming
+  majority of real bugs (the "I added a variant and forgot a call site"
+  class) at a fraction of the implementation cost. Deep exhaustiveness is a
+  natural post-1.0 extension once nested destructuring patterns exist.
+- **Requiring the scrutinee's declared type via `let x: Enum = ...` /
+  parameter annotation flow, instead of inferring the enum from the case
+  patterns.** Considered and rejected as the *primary* mechanism (though
+  compatible as a future widening): this is exactly the #829
+  expression-type-inference dependency that SFEP-0034 explicitly declined to
+  block on for `is`. Pattern-driven inference (§3.3) delivers the same
+  practical coverage for the dominant `Enum.Variant { ... }` shape without
+  waiting on #829, and composes cleanly with declared-type flow as a later,
+  strictly additive widening (more matches become checkable; no match that
+  passes today would start failing).
+- **Checking exhaustiveness at LLVM lowering time (extending the existing
+  `match_exhaustive` computation into a hard diagnostic) instead of
+  typecheck.** Rejected: lowering only runs on `build`/`run`, not `sfn
+  check`, so this would leave the fast inner loop blind to the exact defect
+  the feature exists to catch, contradicting the project's validation-ladder
+  design (`sfn check` as the cheap, IR-free gate,
+  `docs/proposals/0004-check-architecture.md`). It would also require
+  threading source spans through lowering, which today works from
+  `.sfn-asm`-rendered text, not original AST spans — a strictly harder place
+  to produce a good diagnostic than typecheck, which still holds the AST.
+- **Treating any non-exhaustive match as a warning, not an error.** Rejected
+  — per "don't ship unfinished safety claims," a warning that's silently
+  ignorable (as most warnings are, in practice) does not close the gap the
+  spec already claims is closed (`03-declarations.md:111-112`, "matched
+  exhaustively"). This must be a hard build error to be an honest claim.
+- **Requiring the fully-qualified `Enum.Variant` form and rejecting the
+  unqualified shorthand (`Ok { value }`) outright as a parse/type error.**
+  Rejected — the unqualified shorthand is existing, valid syntax
+  (`docs/status.md:173`); this SFEP only declines to *check* exhaustiveness
+  for matches using it (§3.3.3), it does not restrict what's legal to write.
+  Disambiguating the unqualified form needs either #829 or a
+  single-enum-in-scope heuristic, both deferred.
+- **Shipping the redundant-arm warning (`W0823`) as a required part of this
+  slice.** Rejected as a hard requirement — marked optional/secondary (§3.5)
+  since it is a code-quality lint, not a soundness gap; the exhaustiveness
+  error is the safety-critical deliverable and should not be gated on the
+  warning's completion.
+
+## 7. Stage1 readiness mapping
+
+- [ ] **Parses** — N/A (no new syntax; existing `match` syntax unchanged).
+- [ ] **Type-checks / effect-checks** — `E0823` non-exhaustive-match error
+  wired live into `check_statement`'s `MatchStatement` arm; `W0823`
+  redundant-arm warning (optional slice).
+- [ ] **Emits valid `.sfn-asm`** — N/A; a match that fails `E0823` never
+  reaches emission. Matches that pass are emitted exactly as before (no
+  `.sfn-asm` shape change).
+- [ ] **Lowers to LLVM IR** — no change required (§5); the existing
+  `match_exhaustive` computation in `instructions_match.sfn` already agrees
+  with the new typecheck-level gate by construction (same algorithm, guard
+  exclusion mirrored per §3.4).
+- [ ] **Regression coverage** — see §8.
+- [ ] **Self-hosts** — `make compile` after auditing `compiler/src/**/*.sfn`
+  for any enum `match` lacking a trailing wildcard (expected: none found,
+  per §5's construction argument, but must be verified before flipping the
+  gate live).
+- [ ] **`sfn fmt --check` clean** — every touched `.sfn` file.
+- [ ] **Documented** — `docs/status.md:177` flips from "Partial | Runtime
+  backstop" to "Shipped (enum + bool scrutinees; shallow variant-level)";
+  `site/src/content/docs/docs/reference/spec/08-patterns.md`'s stability
+  note (line 9) and exhaustiveness bullet (line 27) updated to reflect the
+  compile-time guarantee and its scope cut (§3.1).
+
+(All boxes unchecked — this SFEP is a design record, not yet implemented.)
+
+## 8. Test plan
+
+- **`compiler/tests/unit/typecheck_match_exhaustiveness_test.sfn`**:
+  - A `match` over an enum with a qualified `Enum.Variant { ... }` arm per
+    variant compiles with zero `E0823` diagnostics.
+  - A `match` missing one variant produces exactly one `E0823` naming that
+    variant.
+  - A `match` missing multiple variants produces one `E0823` listing all of
+    them (§3.5's `missing_variants` plurality).
+  - A `match` with a trailing `_` (or bare-identifier binding) wildcard arm
+    compiles with zero `E0823` regardless of variant coverage.
+  - A guarded arm covering the only occurrence of a variant does **not**
+    count as coverage — `E0823` still fires for that variant (§3.4).
+  - A `bool` scrutinee `match` with both `true` and `false` arms compiles
+    clean; missing one produces `E0823`.
+  - An unqualified variant-name pattern (`Ok { value }` without `Response.`)
+    does not trigger `E0823` even when non-exhaustive (§3.3.3 decline case) —
+    asserts the "sound but incomplete" behavior explicitly, so a future
+    widening's regression test has a documented baseline to diff against.
+  - A non-enum, non-bool scrutinee (e.g. `int` literal patterns without `_`)
+    is unaffected — zero `E0823` (out of scope, §3.1).
+- **`compiler/tests/unit/typecheck_match_redundant_arm_test.sfn`** (if the
+  optional `W0823` slice ships): an arm whose variant is already covered by
+  an earlier unguarded arm produces `W0823`; a guarded earlier arm does not
+  suppress the later arm's necessity and produces no `W0823`.
+- **`compiler/tests/integration/match_exhaustiveness_check_test.sfn`**: drives
+  `sfn check` (per `docs/proposals/0004-check-architecture.md`'s
+  frontend-only contract) against a fixture source string containing the
+  §3.7 worked example; asserts the JSON diagnostic envelope contains
+  `E0823` and the process exits non-zero. A companion fixture with the
+  missing arm added asserts a clean, zero-diagnostic exit.
+- **`compiler/tests/e2e/`**: no new e2e test required — this is a pure
+  frontend diagnostic with no codegen/runtime surface to exercise beyond
+  what integration coverage already proves; the existing lowering-level
+  `match` e2e coverage (build-and-run enum `match` programs) is unaffected
+  and continues to validate the `unreachable`/runtime-trap codegen path
+  untouched by this change (§5).
+- **Self-host audit**: before wiring the gate live, grep
+  `compiler/src/**/*.sfn` for every `match <enum-typed-subject>` and confirm
+  each has a trailing wildcard or full qualified-variant coverage — the
+  concrete verification for §5's "no seed cut, single-PR bundle" claim.
+  `make compile` (exit 0) is the final self-hosting proof.
+
+## 9. References
+
+- `docs/status.md:173,177` — `match` feature-matrix row; the exhaustiveness
+  gap this SFEP closes.
+- `site/src/content/docs/docs/reference/spec/08-patterns.md` — §8 Pattern
+  Matching (pattern forms, stability note, exhaustiveness bullet to be
+  updated on graduation).
+- `site/src/content/docs/docs/reference/spec/03-declarations.md:109-112` —
+  §3.4/§3.5 enum semantics; the "matched exhaustively" claim this SFEP makes
+  true.
+- `compiler/src/ast.sfn:389-394` (`Statement.EnumDeclaration`), `:260-264`
+  (`EnumVariant`), `:412-416` (`Statement.MatchStatement`), `:241-245`
+  (`MatchCase`), `:77` (`Expression.Struct`), `:62-64` (literal expressions).
+- `compiler/src/typecheck.sfn:569-588` (statement-position `MatchStatement`
+  walk — the new check's hook site), `:1337-1349` (expression-position
+  walk — deliberately not duplicated, §3.6), `:873-893`
+  (`register_match_pattern_bindings`), `:1164-1168` (`walk_match_pattern`),
+  `:318-320` (`register_top_level_symbol`'s `EnumDeclaration` arm), `:174-195`
+  (`typecheck_diagnostics_full` — where `enum_sets` collection is threaded
+  in), `:1223-1230` (the `#829`-gated concurrency type-rule precedent this
+  design follows the shape of).
+- `compiler/src/typecheck_types.sfn:54-69` (`Diagnostic`/`FixSuggestion`
+  shape), `:591-638` (`E0813`–`E0815` factory precedent this SFEP's
+  `E0823` factory mirrors).
+- `compiler/src/llvm/lowering/lowering_phase_types.sfn:45-69` — enum tag/
+  max-payload-size layout (`EnumTypeInfo`), confirming enums are real tagged
+  unions.
+- `compiler/src/llvm/lowering/instructions_match.sfn:97-165`
+  (`resolve_match_subject_annotation`/`resolve_match_subject_call_annotation`
+  — the name-based, no-type-inference resolution precedent this SFEP's
+  §3.3 follows), `:825-834` (the existing `match_exhaustive` computation
+  this SFEP leaves untouched at the lowering layer), `:411-491`
+  (`has_guarded_cases`/`!guard_has_text` gating this SFEP's §3.4 mirrors).
+- `runtime/prelude.sfn:701-704` (`match_exhaustive_failed` — the runtime
+  backstop kept as defense-in-depth, §3.1/§5).
+- `docs/proposals/0004-check-architecture.md` — `sfn check` as the fast,
+  IR-free analysis gate this check is designed to run inside.
+- `docs/proposals/0034-is-type-guard.md` — prior art for scoping a
+  frontend feature to the statically-resolvable case rather than blocking on
+  #829 expression-type inference; the "decline, don't guess" discipline this
+  SFEP's §3.3.5 follows.
+- `docs/proposals/draft-generic-constraints.md` — sibling in-flight draft
+  claiming `E0820`–`E0822`; this SFEP claims the next free block,
+  `E0823`(–`W0823`), to avoid collision.
+- Issue #829 — expression-type inference (tracked dependency for widening
+  §3.3's resolvable-case set in a follow-up, not a blocker for this SFEP's
+  1.0 scope).
+- Rust `E0004` (non-exhaustive `match`), Swift's exhaustive `switch`
+  requirement — prior art for the "hard compile error, not a lint" decision
+  (§6).

--- a/docs/proposals/draft-generic-collections.md
+++ b/docs/proposals/draft-generic-collections.md
@@ -1,0 +1,426 @@
+---
+sfep: TBD
+title: Generic Collections — Map, Set, and Tuple
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/preview/collections.md
+---
+
+# SFEP-XXXX — Generic Collections — Map, Set, and Tuple
+
+> Design record for the aggregate-collection gap: Sailfin ships arrays and a
+> concrete `StrMap`, but has no generic `Map<K, V>`, no `Set<T>`, and no tuple
+> type. See [`0001-sfep-process.md`](./0001-sfep-process.md) for the process.
+
+## 1. Summary
+
+Sailfin has exactly two aggregate literal shapes in the AST —
+`Expression.Array{elements}` and `Expression.Object{fields}` /
+`Expression.Struct{type_name, fields}` (`compiler/src/ast.sfn:75-77`) — and one
+hash-map data structure, the concrete non-generic string→string `StrMap`
+(`runtime/sfn/collections.sfn`; `docs/status.md:193`). There is **no** generic
+`Map<K, V>`, **no** `Set<T>`, and **no** tuple type anywhere in the tree. This
+is the single most glaring standard-library gap versus Go (`map`/slice
+literals), Rust (`HashMap`/`HashSet`/tuples), TypeScript (`Map`/`Set`), and
+Swift (`Dictionary`/`Set`/tuples). This SFEP designs three additions:
+`Map<K: Hashable, V>` and `Set<T: Hashable>` as **library generic types backed
+by compiler-known layouts** (the generalization of the `StrMap` precedent), and
+tuples `(A, B, ...)` as a **language-level structural type** with literal
+syntax, type syntax, and `.0` / `.1` positional access. Map and set are
+monomorphized per instantiation exactly as the generics and typed-HOF work
+prescribe; tuples get a dedicated AST node lowering to a fixed-layout struct.
+`Map<string, string>` supersedes `StrMap`, which becomes a deprecated alias.
+
+## 2. Motivation
+
+Every non-trivial program needs keyed lookup, membership testing, and small
+heterogeneous grouping. Today Sailfin offers none of these generically:
+
+```sfn
+// Keyed lookup — only string→string, via a bespoke import surface:
+import { str_map_new, str_map_set, str_map_get } from "runtime/sfn/collections";
+let m = str_map_new();
+str_map_set(m, "ada", "1815");   // string keys and string values ONLY
+
+// What every other language spells trivially, and Sailfin cannot express:
+let counts: Map<string, int> = ...;   // no int-valued map
+let seen: Set<int> = ...;             // no set at all
+let pair: (int, string) = (1, "ada"); // no tuple type or literal
+fn divmod(a: int, b: int) -> (int, int) { ... } // no multi-return via tuple
+```
+
+Who hits it: essentially everyone, and the compiler itself. The compiler
+routinely wants a `Map<string, SomeNode>` (symbol tables, interned-string
+tables, per-module caches) and today either falls back to `StrMap`
+(string-valued only, so structured values get serialized) or hand-rolls
+parallel arrays with linear scans. `StrMap` exists precisely as a documented
+stopgap: its own header (`runtime/sfn/collections.sfn:5-7`) and
+`docs/status.md:193` both say it "becomes a deprecated alias when generic
+`HashMap<K, V>` lands with the generic-constraints epic." Tuples are the
+missing lightweight product type: without them, multi-value return and ad-hoc
+grouping force a named `struct` per call site, which is boilerplate the
+structural pair-type removes.
+
+The status quo is insufficient because the workarounds are not merely verbose —
+they are lossy (`StrMap` stringifies non-string values), slow (parallel-array
+maps are O(N) per lookup), and they leak an implementation-specific API surface
+into every consumer instead of a uniform generic vocabulary.
+
+## 3. Design
+
+This SFEP consumes, and does **not** re-specify, the generic type-parameter
+constraint system designed in `draft-generic-constraints.md` (the
+`Hashable` / `Eq` bounds and the monomorphization pass). That constraint system
+is a **hard dependency** (§7 dependencies): `Map<K, V>` and `Set<T>` cannot ship
+until `<K: Hashable>` bounds are solvable and monomorphizable. Tuples do **not**
+depend on generics and can land independently.
+
+### 3.1 Tuples — language-level structural product type
+
+Tuples are a structural, positionally-indexed, fixed-arity product type. They
+are a language feature (not a library type) because their literal syntax, type
+syntax, and positional field access must be understood by the parser, type
+checker, and lowering directly.
+
+**Type syntax:** `(A, B)`, `(A, B, C)`, … — a parenthesized, comma-separated
+list of ≥ 2 type annotations. `(A)` is **not** a tuple; it is a parenthesized
+type equal to `A` (matching Rust and Swift). The one-tuple is deliberately
+unspellable to keep parenthesization unambiguous.
+
+**Literal syntax:** `(a, b)`, `(a, b, c)`, … — a parenthesized, comma-separated
+list of ≥ 2 expressions, **or** a single expression with a trailing comma
+`(a,)`. This resolves the parser ambiguity with parenthesized grouping (below).
+
+**Access:** `t.0`, `t.1`, … — a constant integer field selector. The index must
+be an integer literal in bounds of the tuple's arity; a non-literal or
+out-of-range index is a type error (`E09xx`, "tuple index must be a constant in
+`0..arity`"). Tuples are **not** indexable with `t[i]` (that stays for arrays,
+whose element type is uniform; tuples are heterogeneous so a runtime index has
+no single result type).
+
+**Parser ambiguity resolution.** The lexer already produces `(` … `)`; today
+`(expr)` parses as a grouped expression. The disambiguation rule is purely
+structural and requires **zero lookahead beyond the closing paren**:
+
+- After parsing the first parenthesized expression, if the next token is `,`,
+  it is a tuple; continue parsing comma-separated elements until `)`. Arity ≥ 2
+  (or the single-element trailing-comma form `(a,)`) is therefore a tuple.
+- If the closing `)` follows immediately (no comma), it is a grouped
+  expression, unchanged.
+
+The same rule applies in type position: `(A, B)` after the first type sees `,`
+→ tuple type; `(A)` sees `)` → parenthesized type = `A`. This is the identical
+rule Rust and Swift use and matches "boring syntax wins."
+
+**AST.** Tuples need dedicated nodes; they cannot reuse `Array` (heterogeneous
+element types, positional access) or `Object`/`Struct` (no field names). Per the
+`ast.sfn` variant-slotting discipline (each field name occupies one union slot;
+appended fields keep positional GEP indexing stable — see the `Assignment`
+`rhs`-not-`value` note at `compiler/src/ast.sfn:159`), add a new expression
+variant and a new member-access form:
+
+```sfn
+// in enum Expression, appended after existing variants:
+Tuple { elements: Expression[], span: SourceSpan? },
+// tuple positional access `t.0`; `index` is the constant selector.
+// A distinct variant (not Member, whose `member` is a string name) so the
+// typechecker/lowering read a numeric slot without string-parsing.
+TupleIndex { object: Expression, index: int, span: SourceSpan? },
+```
+
+`elements` reuses the `Expression[]` slot already present on `Array` and `Call`
+(`arguments`) etc.; because enum reads slot by field **name**, the new
+`elements` on `Tuple` shares the existing `elements` name-slot with `Array` —
+which is safe here because both are `Expression[]` with identical semantics
+(they are never read from the same node). If sharing proves risky under the
+seed's name-keyed GEP model, use a fresh name (`tuple_elements`) — the
+implementer picks based on the `ast.sfn` slotting audit; the recommendation is
+to reuse `elements` (same type, no collision) and fall back to `tuple_elements`
+only if the audit shows a hazard. Tuple **types** ride the existing
+`TypeAnnotation { text }` (`compiler/src/ast.sfn:12-14`) — the annotation text
+is `"(A, B)"` and the type checker parses tuple structure from that text, the
+same way it already parses `T[]` and generic `Foo<T>` from annotation text; no
+new type-AST node is required.
+
+**Lowering.** A tuple of arity N lowers to an **anonymous fixed-layout struct**
+`{ T0, T1, …, T(N-1) }` — an LLVM literal struct type with the natural ABI of
+each field. `Tuple` literal → `insertvalue`/`alloca`+`store` sequence exactly
+as struct literals lower today; `TupleIndex{ i }` → `extractvalue`/GEP at
+constant offset `i`. There is no runtime metadata and no boxing — tuples are
+zero-overhead value types, identical in layout to an unnamed `struct`. Tuple
+types are structurally equal iff arity and per-position types match.
+
+### 3.2 `Map<K: Hashable, V>` and `Set<T: Hashable>` — library generic types
+
+These are **library** types (defined in `runtime/sfn/collections.sfn`), generic
+over their type parameters, backed by the same open-addressed hash-table layout
+`StrMap` already uses (FNV-1a, linear probing, tombstone deletion, load-factor
+resize — `runtime/sfn/collections.sfn:20-52`). The only differences from
+`StrMap` are (1) the key/value arrays are `K[]` / `V[]` instead of `string[]`,
+and (2) hashing and equality are dispatched through the `Hashable` / `Eq`
+bounds from `draft-generic-constraints.md` instead of the hard-coded
+`_fnv1a(string)`:
+
+```sfn
+struct Map<K: Hashable, V> {
+    slot_state: int[];   // 0 empty | 1 live | 2 tombstone (as StrMap)
+    slot_key: K[];
+    slot_val: V[];
+    cap: int; count: int; used: int;
+}
+struct Set<T: Hashable> {
+    slot_state: int[];
+    slot_elem: T[];
+    cap: int; count: int; used: int;
+}
+
+fn map_new<K: Hashable, V>() -> Map<K, V> { ... }
+fn map_set<K: Hashable, V>(m: Map<K, V>, key: K, value: V) -> Map<K, V> { ... }
+fn map_get<K: Hashable, V>(m: Map<K, V>, key: K) -> V? { ... }
+fn map_has<K: Hashable, V>(m: Map<K, V>, key: K) -> bool { ... }
+fn map_delete<K: Hashable, V>(m: Map<K, V>, key: K) -> Map<K, V> { ... }
+fn map_keys<K: Hashable, V>(m: Map<K, V>) -> K[] { ... }
+fn map_len<K: Hashable, V>(m: Map<K, V>) -> int { ... }
+// Set mirrors: set_new / set_add / set_has / set_delete / set_elems / set_len.
+```
+
+`Hashable` supplies `hash(self) -> int`; `Eq` supplies structural `==` for probe
+comparison. For key types where the compiler can `derive(Hash, Eq)` (see
+`draft-derive.md`), user structs become usable as keys for free; primitive keys
+(`int`, `string`, `bool`) get built-in `Hashable`/`Eq` instances. `string`
+keys reuse the existing `_fnv1a` mix; `int` keys hash by value-mix; struct keys
+fold their derived field hashes.
+
+**Higher-order methods.** `Map`/`Set` support `map` / `filter` / `reduce` /
+`each` over their entries, consistent with SFEP-0028 (typed array HOFs): e.g.
+`m.filter(fn (k, v) => v > 0)`, `s.map(fn (x) => x * 2)`. These are defined in
+terms of the array HOFs over the live-slot projection, so they inherit
+SFEP-0028's monomorphized closure-dispatch seam rather than introducing a new
+one — this SFEP does not re-specify HOF lowering.
+
+### 3.3 Literal syntax for maps and sets — collision resolution
+
+The obvious `{ k: v, ... }` map literal **collides** with the existing
+`Expression.Object { fields }` (`compiler/src/ast.sfn:76`), which already owns
+`{ ... }` for anonymous-object / struct-shorthand literals. Overloading `{}` to
+mean "map when keys are expressions, object when keys are identifiers" is a
+context-sensitive parse that violates "boring syntax wins" and would make LLM
+codegen error-prone (the CLAUDE.md "AI agents are users" principle). Three
+options were weighed (§6); the **recommendation** is:
+
+- **Map literal:** `[k: v, k2: v2]` — bracket-delimited, `key: value` pairs.
+  This reuses the `[` … `]` bracket family (already the array-literal
+  delimiter, so it reads as "keyed array"), and the `key: value` inner form is
+  unambiguous because array elements are bare expressions while map entries
+  carry a `:` separator. The empty map is `[:]` (a single colon disambiguates
+  the empty map from the empty array `[]`), matching Swift's `[:]`.
+- **Set literal:** there is no low-friction distinct bracket form that does not
+  re-collide, so **sets have no dedicated literal**; construct via
+  `Set.from([a, b, c])` / `set_from([a, b, c])` (an array → set constructor).
+  A set literal is deferred (§10) rather than shipped with a syntax we would
+  regret. This keeps the keyword/syntax budget honest ("keywords are
+  expensive").
+
+**Desugaring.** `[k: v, k2: v2]` desugars, in the parser, to a `Map` literal
+AST node (a sibling of `Tuple`), which the typechecker resolves to a concrete
+`Map<K, V>` from the unified key/value types and which lowering emits as a
+sequence of `map_new` + `map_set` calls (or a bulk `_map_from_pairs` builder to
+avoid intermediate reallocs). A dedicated AST node (not a raw call desugar in
+the parser) keeps the literal's source span intact for diagnostics:
+
+```sfn
+// in enum Expression, appended:
+MapLiteral { keys: Expression[], values: Expression[], span: SourceSpan? },
+```
+
+`keys`/`values` are parallel arrays (entry `i` is `keys[i]: values[i]`),
+matching the runtime `slot_key`/`slot_val` layout and keeping both fresh
+name-slots (no collision with `Object.fields`).
+
+### 3.4 `StrMap` supersession and deprecation path
+
+`Map<string, string>` is the exact generalization of `StrMap`. Once generics
+land:
+
+1. `StrMap` and its `str_map_*` free functions stay in
+   `runtime/sfn/collections.sfn` as **deprecated aliases** — `str_map_new()`
+   forwards to `map_new<string, string>()`, etc. — so existing consumers
+   (including any compiler-internal use) keep compiling.
+2. `docs/status.md:193` flips `StrMap` from "Shipped bridge" to "Deprecated
+   alias of `Map<string, string>`."
+3. Compiler-internal `StrMap` uses migrate to `Map<K, V>` opportunistically
+   (e.g. a symbol table that wants `Map<string, Symbol>` instead of stringified
+   values), tracked as follow-up issues, not as a big-bang rewrite.
+4. The aliases are removed no earlier than one release after the deprecation is
+   documented, and only once no compiler-source consumer remains (the
+   self-host invariant forbids removing a symbol the pinned seed's compiler
+   source still imports).
+
+### 3.5 Monomorphization
+
+Consistent with `draft-generic-constraints.md` and SFEP-0028: each concrete
+`(K, V)` / `T` instantiation of `Map` / `Set` (and each generic collection
+function) is **monomorphized** at the call site. The key/value arrays lower to
+`K[]` / `V[]` with the element's natural width (using the `elem_size` already
+threaded through the array allocator, per SFEP-0028 §3(A)); `hash`/`==` resolve
+to the concrete `Hashable`/`Eq` instance for `K`/`T`. No boxing, no `any` slots.
+
+## 4. Effect & capability impact
+
+None. `Map`, `Set`, and tuple construction/access are pure value operations
+below the I/O layer, exactly like arrays and `StrMap` (which uses only structs,
+arrays, and loops — `runtime/sfn/collections.sfn:8-11`). No collection operation
+requires or grants a capability; `![io]` etc. attach only to adapters a caller
+writes around these primitives. A user-supplied HOF callback (`m.filter(fn ...)`)
+carries whatever effects its own body requires, propagated by the existing
+effect checker through the closure call — unchanged by this SFEP. No new
+capability surface.
+
+## 5. Self-hosting impact
+
+Passes touched, in pipeline order:
+
+- **Lexer** (`lexer.sfn`): no new tokens. `(`, `)`, `,`, `[`, `]`, `:`, `.`,
+  integer literals already exist. Tuple/map literals and `.0` access are new
+  *token sequences*, not new tokens.
+- **Parser** (`parser/`): (a) tuple literal / tuple type disambiguation
+  (comma-after-first-element rule, §3.1); (b) `.<int>` postfix as `TupleIndex`
+  distinct from `.<name>` `Member`; (c) `[k: v]` map literal and `[:]` empty
+  map. All are **additive** — the old parser produced `Object`/grouped-expr for
+  these token shapes; the new forms are only recognized where the old parser
+  had no valid parse (a bare `(a, b)` in expression position was previously an
+  error or a comma-operator that Sailfin does not have). This additivity is
+  what preserves the self-host bootstrap: the pinned seed compiles the new
+  compiler source, and the new compiler is the first to *emit* tuple/map
+  literals — so the compiler source must not use tuples/maps until they are in
+  the pinned seed (the standard capability-before-consumer discipline,
+  `.claude/rules/seed-dependency.md`).
+- **AST** (`ast.sfn`): add `Tuple`, `TupleIndex`, `MapLiteral` variants,
+  appended per the GEP-stability convention (`compiler/src/ast.sfn:60`).
+- **Typecheck** (`typecheck.sfn`): tuple structural typing + constant-index
+  bounds checking; `Map`/`Set` generic-constraint solving (delegated to the
+  `draft-generic-constraints.md` solver — this SFEP adds the `Hashable`/`Eq`
+  requirement at map/set key positions, not the solver).
+- **Effect checker** (`effect_checker.sfn`): recurse into `Tuple.elements`,
+  `TupleIndex.object`, `MapLiteral.keys`/`.values` — mechanical, same pattern
+  as `Array`.
+- **Emitter / LLVM lowering** (`emit_native.sfn`, `llvm/lowering/`): tuple →
+  anonymous struct (`insertvalue`/`extractvalue`); map literal → `map_new` +
+  `map_set` sequence; monomorphized `Map`/`Set` bodies per instantiation.
+- **Runtime** (`runtime/sfn/collections.sfn`): generic `Map`/`Set` structs and
+  functions; `StrMap` demoted to aliases.
+
+**Bundling.** Per `.claude/rules/seed-dependency.md`, the map/set *runtime
+bodies* consume the generics/monomorphization *compiler capability*; they must
+land bundled with that capability (or after it is in the pinned seed) so
+`make compile` self-hosts in one pass. Tuples are self-contained (a language
+feature with no runtime consumer) and can land as a standalone bundle: the
+parser/AST/typecheck/lowering all move together, and the compiler source does
+not use tuples until the tuple-capable compiler is the pinned seed. Whether to
+split "tuples" from "map/set" is a grooming decision; the natural split is
+**two bundles** — tuples first (no generics dependency), then map/set (gated on
+`draft-generic-constraints.md`).
+
+## 6. Alternatives considered
+
+- **`{ k: v }` map literals (overload `Object`)** — rejected. It makes `{}`
+  context-sensitive (object vs map depends on whether keys are identifiers or
+  expressions), which is a fragile parse and a systematic LLM-codegen trap
+  ("AI agents are users"). Swift/Rust both keep maps out of the brace-object
+  syntax for the same reason.
+- **`Map { ... }` constructor-call literal only, no bracket form** — viable and
+  the most conservative (no new literal syntax at all), but it makes the
+  single most common data structure verbose at every use site. Rejected as the
+  *primary* spelling; `Set.from([...])` uses exactly this shape because sets are
+  rarer and the collision-free bracket budget is spent on maps.
+- **Set literal `{ a, b, c }`** — rejected: re-collides with `Object`/block and
+  a bare `{a, b}` is genuinely ambiguous with a block of two expression
+  statements. Deferred behind `Set.from`.
+- **Tuples via `Struct`/`Object` with positional field names (`_0`, `_1`)** —
+  rejected: it fakes positional access with string field names, loses the
+  arity-in-the-type structural equality, and forces the typechecker to
+  special-case magic names. A first-class `Tuple`/`TupleIndex` node is cleaner
+  and lowers to the same struct anyway.
+- **One-tuples `(A)` as tuples** — rejected: makes every parenthesized
+  expression ambiguous; matching Rust/Swift, `(A)` is grouping and `(A,)` is the
+  one-tuple (which we do not otherwise need).
+- **Boxed/`any`-slot map values** — rejected for the same reasons SFEP-0028 §3(B)
+  rejects boxing: allocation storm, the scalar-in-`any`-slot stringification
+  hazard, and value-type unsoundness. Monomorphization is the principled answer.
+- **Ship `Map`/`Set` before generic constraints (hand-written per-type)** —
+  rejected: that is what `StrMap` already is, and multiplying it per key/value
+  pair (`IntMap`, `StrIntMap`, …) is the combinatorial explosion generics
+  exist to prevent.
+
+## 7. Stage1 readiness mapping
+
+Nothing here is built yet — this is a Draft design record. **Dependency:**
+`draft-generic-constraints.md` must be Accepted-and-Implemented (the
+`Hashable`/`Eq` bounds + monomorphization) before `Map`/`Set` can clear these
+boxes; `draft-derive.md` (`Hash`/`Eq` derivation) makes user structs usable as
+keys but is not strictly required for primitive-keyed maps. Tuples have no such
+dependency and can clear the checklist independently.
+
+- [ ] Parses (tuple literal/type, `.N` access, `[k: v]` / `[:]` map literal)
+- [ ] Type-checks / effect-checks (tuple structural typing; `Hashable`/`Eq`
+      key bounds via the constraints solver)
+- [ ] Emits valid `.sfn-asm`
+- [ ] Lowers to LLVM IR (tuple → anonymous struct; monomorphized `Map`/`Set`)
+- [ ] Regression coverage (§8)
+- [ ] Self-hosts (bundled with generics capability per §5)
+- [ ] `sfn fmt --check` clean (formatter serializes tuples/maps canonically)
+- [ ] Documented in `docs/status.md` + `reference/preview/collections.md`
+
+## 8. Test plan
+
+Unit (parser/typecheck) + e2e (`compiler/tests/{unit,integration,e2e}/`):
+
+- **Tuple parse:** `(1, "a")` → `Tuple` node with two elements; `(1)` →
+  grouped expr (not a tuple); `(1,)` → one-tuple; `(int, string)` in a
+  parameter/return annotation → tuple type; `(int)` → parenthesized `int`.
+- **Tuple typecheck:** `let t: (int, string) = (1, "a"); t.0 + 1` typechecks;
+  `t.1 + 1` is a type error (string + int); `t.2` is out-of-range error;
+  `t[0]` is rejected (tuples not index-subscriptable).
+- **Tuple lowering (e2e):** a fixture returning `(int, int)` from `divmod`,
+  destructured via `.0`/`.1`, printing the sum — proves the anonymous-struct
+  lowering round-trips.
+- **Map literal parse/typecheck:** `["ada": 1815, "grace": 1906]` infers
+  `Map<string, int>`; `[:]` is the empty map; heterogeneous values
+  (`["a": 1, "b": "x"]`) are a type error.
+- **Map/Set runtime (e2e, gated on generics):** `Map<string, int>` insert /
+  get / has / delete / len parity with the `StrMap` 10k-insert smoke test;
+  `Set<int>` add/has/dedup; a `Map<StructKey, V>` using derived `Hash`/`Eq`.
+- **`StrMap` alias:** the existing `str_map_*` tests still pass against the
+  forwarding aliases (no regression for current consumers).
+- **HOF over collections:** `m.filter(...)` / `s.map(...)` consistent with the
+  SFEP-0028 fixtures.
+- **Negative — key without `Hashable`:** a `Map<K, V>` where `K` lacks a
+  `Hashable` instance is rejected with a constraint diagnostic.
+- `make compile` self-hosts; `make check` triple-pass green.
+
+## 9. References
+
+- `draft-generic-constraints.md` — **hard dependency**: the `Hashable` / `Eq`
+  bounds and monomorphization pass this SFEP consumes for `Map`/`Set` keys.
+  This SFEP does not re-specify the constraint system.
+- **SFEP-0028** (`0028-typed-array-higher-order-fns.md`) — typed / generic
+  array HOFs; `Map`/`Set` `map`/`filter`/`reduce` reuse its monomorphized
+  closure-dispatch seam.
+- `draft-derive.md` — `Hash` / `Eq` derivation that makes user structs usable
+  as map/set keys without hand-written instances.
+- **SFEP-0012** (`0012-result-and-question-operator.md`) — shares the
+  generic-constraint + monomorphization dependency; sequencing coordinates.
+- `runtime/sfn/collections.sfn` — the `StrMap` precedent (open-addressed hash
+  table) that `Map`/`Set` generalize; the deprecation target.
+- `docs/status.md:192-193` — "Generic type constraints (Planned)" and the
+  `StrMap` "deprecated alias when generic `HashMap<K, V>` lands" note this
+  SFEP fulfills.
+- `compiler/src/ast.sfn:75-77` — the existing `Array` / `Object` / `Struct`
+  aggregate variants and (`:60`, `:159`) the variant field-slotting / GEP
+  stability convention new nodes must follow.

--- a/docs/proposals/draft-generic-constraints.md
+++ b/docs/proposals/draft-generic-constraints.md
@@ -1,0 +1,541 @@
+---
+sfep: TBD
+title: Generic Type Parameter Constraints and Monomorphization
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/preview/generics.md
+---
+
+# SFEP-XXXX — Generic Type Parameter Constraints and Monomorphization
+
+## 1. Summary
+
+Sailfin already **parses** generic type-parameter bounds — `fn sort<T:
+Comparable>(...)`, `struct Map<K: Hashable, V> {...}` — but the bound is inert:
+it is stored on the AST node and thrown away. This SFEP makes bounds *mean*
+something end-to-end. Two coupled mechanisms:
+
+1. **Constraint enforcement (typecheck).** A bound `T: Comparable` is an
+   **interface bound**. At every generic *instantiation site* (a call to a
+   generic function, a use of a generic struct/enum/type-alias with concrete
+   type arguments), the typechecker verifies each concrete type argument
+   *implements* every bound interface, reusing the existing
+   struct-implements-interface conformance machinery. A failure is a new
+   diagnostic, `E0820`, with the bound and the offending type named.
+
+2. **Monomorphization (lowering).** A generic function/struct is lowered by
+   **generating one specialized copy per distinct concrete instantiation** —
+   the same strategy Rust and Swift use, giving the zero-cost, statically
+   dispatched performance the language positions for. This generalizes the
+   *only* monomorphization precedent that already ships: enum-payload generics
+   (#830), which specialize their payload layout per instantiation but were
+   never lifted to functions or structs.
+
+This SFEP is the **root foundation** for the generics work: it is the direct
+predecessor of generic collections (`draft-generic-collections.md`), typed
+higher-order array functions (SFEP-0028), `Result<T, E>` ergonomics
+(`From<E>` / `E: Error` bounds, SFEP-0012), and `derive` (`draft-derive.md`).
+None of those can be enforced or lowered soundly until bounds are checked and
+generic bodies monomorphize.
+
+## 2. Motivation
+
+### 2.1 The gap is a shipped, unenforced safety surface
+
+The bound already parses. `TypeParameter` carries it
+([`compiler/src/ast.sfn:16-20`](../../compiler/src/ast.sfn#L16-L20)):
+
+```sfn
+struct TypeParameter {
+    name: string;
+    bound: TypeAnnotation?;   // parses today; nothing reads it
+    span: SourceSpan?;
+}
+```
+
+`parse_type_parameter_clause`
+([`compiler/src/parser/declarations.sfn:313-381`](../../compiler/src/parser/declarations.sfn#L313-L381))
+splits each slice on a top-level `:`, keeps the left as `name` and the right as
+`bound`. It is shared verbatim by `fn`, `struct`, `interface`, and `type`
+declarations (nine call sites in that file), so `T: Comparable` attaches
+uniformly wherever a `<...>` clause is legal. The native IR even *parses past*
+the bound already: `parse_enum_header_type_parameters`
+([`compiler/src/native_ir_parser_defs.sfn:503-528`](../../compiler/src/native_ir_parser_defs.sfn#L503-L528))
+explicitly strips `: Display` off `Foo<T : Display, E>` to recover the bare
+name.
+
+But `check_type_parameters`
+([`compiler/src/typecheck_types.sfn:1556-1572`](../../compiler/src/typecheck_types.sfn#L1556-L1572))
+does **exactly one thing**: reject duplicate parameter *names*. It never reads
+`type_parameter.bound`. So today:
+
+```sfn
+interface Comparable { fn compare(other: Self) -> int; }
+
+fn sort<T: Comparable>(items: T[]) -> T[] { ... }
+
+struct NotComparable { x: int; }
+
+// Compiles clean today. The bound `T: Comparable` is silently ignored,
+// even though NotComparable does not implement Comparable. The body's
+// `a.compare(b)` call then has no basis to lower.
+let bad = sort([NotComparable { x: 1 }, NotComparable { x: 2 }]);
+```
+
+This is precisely the "parsed but not enforced" anti-pattern the project's
+design framework forbids: a safety-shaped syntax that teaches users a guarantee
+the compiler does not provide.
+
+### 2.2 It is the foundation the whole 1.0 generics story stands on
+
+`docs/status.md` records the blast radius directly:
+
+- **line 191** — "Generic type inference: Partial — type params captured;
+  coverage limited."
+- **line 192** — "Generic type constraints: **Planned** — `fn sort<T:
+  Comparable>`, real `Array<T>` / `HashMap<K, V>` / `Channel<T>`."
+- **line 193** — `StrMap` (the concrete string→string map) is explicitly "the
+  concrete-now bridge until generic `HashMap<K, V>` lands with the
+  generic-constraints epic — it becomes a deprecated alias when generics ship."
+- **line 186** — `Result<T, E>` ships, but "`From<E>` coercion and the `E:
+  Error` bound gate on generic constraints."
+- **SFEP-0028 §** — typed `float[]` / `string[]` / struct-array `.map` /
+  `.filter` / `.reduce` are "gated on generic type constraints"; today only
+  pointer-width `int[]` works because there is no way to monomorphize the
+  element type.
+
+Every one of those is blocked on the same two missing mechanisms: *check the
+bound* and *specialize the body*. Shipping them one-off (as `StrMap` and the
+`int[]`-only HOFs already are) accretes concrete stand-ins that must later be
+retired. This SFEP is the shared root that lets them all be built generically
+and soundly.
+
+### 2.3 Monomorphization is required, not optional, for these consumers
+
+A generic body cannot lower without knowing the concrete layout of `T`:
+
+- A generic collection stores `T` by value → must know `sizeof(T)` and the
+  element GEP stride (exactly the problem #830 solved for enum payloads, and
+  the problem the typed-HOF work in SFEP-0028 is stuck on).
+- A `T: Comparable` call `a.compare(b)` must resolve to the *concrete* method
+  of the substituted type.
+- `Result<T, E>` returning `?` must coerce `E` via `From<E>` for the concrete
+  error type.
+
+There is no lowering path today that does per-type body specialization for
+functions or structs. #830 does it *only* for enum payload fields at match/
+construct sites. This SFEP generalizes that machinery into a real
+monomorphization pass.
+
+## 3. Design
+
+Four parts: (3.1) what a bound *is*, (3.2) how the typechecker enforces it,
+(3.3) how bodies monomorphize, (3.4) the standard-library interfaces the bounds
+name.
+
+### 3.1 Bounds are interface bounds
+
+A bound is a comma-free, `+`-separated list of **interface** type annotations:
+
+```sfn
+fn sort<T: Comparable>(items: T[]) -> T[] ![pure] { ... }
+struct Map<K: Hashable + Eq, V> { ... }          // multiple bounds
+type Pair<A: Display, B: Display> = { first: A, second: B };
+interface Container<T: Eq> { fn has(x: T) -> bool; }
+```
+
+Grammar (an additive refinement of the *already-parsed* form — the parser
+splits on `:` today; this adds `+` splitting on the bound side):
+
+```
+TypeParamClause := "<" TypeParam ("," TypeParam)* ">"
+TypeParam       := Ident (":" BoundList)?
+BoundList       := TypeRef ("+" TypeRef)*
+TypeRef         := Ident TypeArgs?          // e.g. Comparable, From<ParseError>
+```
+
+Semantics:
+
+- Each `TypeRef` in a `BoundList` names an **interface** (`interface Comparable
+  { ... }`). Naming a non-interface (a struct, enum, or unknown name) is
+  `E0821` ("bound must be an interface").
+- A concrete type argument `C` **satisfies** bound `I` iff `C` implements `I`
+  — i.e. `C` declares `implements I` and structurally conforms (the exact test
+  already run by `check_struct_implements_interfaces`,
+  [`typecheck_types.sfn:95-134`](../../compiler/src/typecheck_types.sfn#L95-L134)).
+- Multiple bounds are conjunctive: `K: Hashable + Eq` requires `K` to implement
+  **both**.
+- Bounds are **not** transitive supertrait chains in v1 (an interface does not
+  yet declare `interface Ord: Eq`). That is a deliberate deferral (§6) — v1
+  bounds name only directly-required interfaces, matching what the conformance
+  checker can already prove.
+
+Type-parameter names in scope (`T`) satisfy a bound `I` iff the parameter's own
+declared bound already includes `I` (bound propagation): inside `fn sort<T:
+Comparable>`, `T` itself is treated as `Comparable`, so calling `helper<U:
+Comparable>(x: U)` with a `T`-typed argument type-checks. This is what lets
+generic bodies call other bounded generics.
+
+### 3.2 Enforcement — the typecheck pass
+
+Enforcement is added in `compiler/src/typecheck_types.sfn`, reusing the
+interface-conformance surface that already lives there. Two new
+responsibilities:
+
+**(a) Validate bounds at *declaration* time.** Extend
+`check_type_parameters` (currently duplicate-name only,
+[`typecheck_types.sfn:1556-1572`](../../compiler/src/typecheck_types.sfn#L1556-L1572))
+to take the interface table and, for each parameter with a non-null `bound`,
+parse the bound into a `BoundList` (reuse `parse_type_arguments` /
+`split_top_level_commas` already in this file; add a `+` splitter) and check
+each named `TypeRef` resolves to an interface via `resolve_interface_annotation`
+([`typecheck_types.sfn:136-149`](../../compiler/src/typecheck_types.sfn#L136-L149)).
+An unresolved or non-interface name → `E0821`. This runs once per declaration;
+it is cheap and needs no instantiation context.
+
+**(b) Verify satisfaction at each *instantiation* site.** A new checker,
+`check_generic_instantiation(callee_or_type, type_arguments, interfaces,
+declared_params) -> Diagnostic[]`, runs wherever concrete type arguments meet a
+declared bounded parameter:
+
+- **Generic function calls.** When the typecheck call-resolution path binds a
+  call to a generic `fn` declaration, it infers or reads the concrete type
+  arguments (inference is already "Partial", status line 191 — this SFEP does
+  not expand inference, it consumes whatever the existing binder produced, and
+  falls back to explicit `sort::<Widget>(...)` turbofish when inference cannot
+  resolve `T`). For each `(param, concrete_arg)` where `param.bound != null`,
+  run the satisfaction test.
+- **Generic type uses.** A `let m: Map<Widget, int> = ...`, a struct-literal
+  `Map<Widget, int> { ... }`, and an `implements Container<Widget>` annotation
+  each carry concrete arguments for a bounded declaration. Parse the arguments
+  (`parse_type_arguments`, already used by
+  `validate_interface_annotation`, [`typecheck_types.sfn:169-188`](../../compiler/src/typecheck_types.sfn#L169-L188)),
+  zip against the declared `type_parameters`, and run the satisfaction test per
+  bounded position.
+
+The satisfaction test itself, `type_satisfies_bound(concrete: string, bound:
+TypeRef, interfaces) -> bool`, is a thin wrapper over the existing conformance
+logic:
+
+1. If `concrete` is an in-scope type parameter, consult *its* declared bounds
+   (bound propagation, §3.1).
+2. Otherwise resolve `concrete` to its struct/enum declaration and ask whether
+   it `implements` the bound interface — the same predicate
+   `check_struct_implements_interfaces` computes, factored into a reusable
+   `struct_implements(struct_decl, interface_name) -> bool`.
+
+**Diagnostics** (new codes — `E0820`+ is the first free slot; the typecheck
+band is E0801–E0819 today per `typecheck_types.sfn`, and ownership owns
+E0901–E0907, so this SFEP claims **E0820–E0822**):
+
+| Code | Condition | Message shape |
+|---|---|---|
+| `E0820` | Type argument does not satisfy a bound | `type ` + C + ` does not satisfy bound ` + I + ` on type parameter ` + name + ` of ` + decl (with a fix-it: "add `implements I` to `C`") |
+| `E0821` | Bound names a non-interface / unknown type | `bound ` + I + ` on type parameter ` + name + ` is not an interface` |
+| `E0822` | Type-argument arity mismatch against a *generic function* | mirrors the struct/interface arity diagnostics already at `typecheck_types.sfn:169-188`, extended to `fn` |
+
+Worked failure:
+
+```
+error[E0820]: type NotComparable does not satisfy bound Comparable
+  --> src/main.sfn:9:14
+   |
+ 9 | let bad = sort([NotComparable { x: 1 }]);
+   |           ^^^^ required by type parameter T of fn sort<T: Comparable>
+   = help: add `implements Comparable` to `struct NotComparable` and a
+           `compare(other: Self) -> int` method
+```
+
+### 3.3 Lowering — monomorphization
+
+**Strategy: monomorphize.** For each *distinct* set of concrete type arguments
+a generic declaration is instantiated with, emit one specialized copy with the
+type parameters substituted by concrete types. This is the Rust/Swift model and
+the systems-performance default the language is positioned for: no boxing, no
+per-call indirection, `T`-typed values stored inline at their real width, and
+`T: Comparable` method calls resolved to the concrete method at emit time (a
+direct call, not a vtable dispatch).
+
+**Generalize #830, don't reinvent it.** The enum-payload path already does the
+hard part — recover declared type parameters from a header
+(`parse_enum_header_type_parameters`,
+[`native_ir_parser_defs.sfn:503-528`](../../compiler/src/native_ir_parser_defs.sfn#L503-L528)),
+parse a concrete argument list angle-bracket-aware (`enum_inst_parse_args`,
+[`llvm/type_mapping.sfn:164-203`](../../compiler/src/llvm/type_mapping.sfn#L164-L203)),
+detect which fields reference a parameter
+(`enum_inst_annotation_references_param`,
+[`llvm/type_mapping.sfn:210+`](../../compiler/src/llvm/type_mapping.sfn#L210)),
+and substitute per instantiation at match/construct sites. This SFEP lifts that
+substitution engine from "enum payload fields at use sites" to "any generic
+declaration body."
+
+Pipeline shape:
+
+1. **Instantiation collection (new pass, `compiler/src/llvm/monomorphize.sfn`).**
+   After typecheck/effect-check, before native emit, walk the program and
+   collect the set of concrete instantiations reached: `(decl_name,
+   [concrete_args])` tuples for every generic `fn`/`struct`/`enum`/`type` use.
+   Seed the worklist from non-generic (`@main`-reachable) code and close it
+   transitively — a generic body instantiating another generic adds to the
+   worklist (this is what handles `sort<T>` calling `helper<T>`). Deduplicate
+   by a **mangled key** (below). This closure is finite because the language
+   has no polymorphic recursion in v1 (§6 defers it, guarded by a
+   depth/instantiation-count cap that raises a compiler-internal error rather
+   than looping).
+
+2. **Specialization.** For each collected instantiation, clone the declaration's
+   `.sfn-asm` / native-IR body and substitute each type-parameter token with its
+   concrete type — reusing the #830 substitution primitives, generalized to walk
+   a whole function/struct body rather than a single payload field. The mangled
+   name is `<base>$<arg1>$<arg2>...` (angle brackets and commas are not legal in
+   LLVM symbol names, so a `$`-separated mangling mirrors how `channel:<kind>`
+   already disambiguates monomorphized channel element kinds at
+   [`core.sfn:807-813`](../../compiler/src/llvm/expression_lowering/native/core.sfn#L807)).
+   A concrete-argument-free (non-generic) declaration keeps its bare name — zero
+   change for the 99% of the compiler that is non-generic.
+
+3. **Call/site rewriting.** Rewrite each generic call/construct site to target
+   the mangled specialization. Bounded method calls (`a.compare(b)` where `a:
+   T` and `T: Comparable`) resolve, in the specialized copy where `T = Widget`,
+   to `Widget.compare` — a direct static call. This is the payoff of interface
+   *bounds* (compile-time) versus interface *values* (the existing dynamic
+   fat-pointer dispatch, which stays available for `let x: Comparable = ...`).
+
+4. **Emit.** The specialized declarations flow through the *unchanged* native
+   emitter and LLVM lowering as ordinary monomorphic declarations — because
+   after substitution they *are* monomorphic. No new `.sfn-asm` opcodes; the IR
+   is just more (specialized) functions/structs.
+
+**Layout obligation.** A monomorphized struct/collection stores `T` inline at
+its concrete width. The >8-byte by-value payload limitation noted for enums
+(status line 168, "`>8-byte by-value payload layouts not yet emitted`") is a
+*shared* constraint: v1 monomorphization covers pointer-width and pointer-typed
+`T` (structs are boxed pointers already; `int`/`float`/`bool`/`string`/`ptr`
+are pointer-width), which is exactly the set the existing channel/enum
+monomorphization handles. Full arbitrary-width by-value aggregate `T` is
+tracked as the same follow-up that gates enum payloads and typed HOFs (§9),
+not re-solved here.
+
+### 3.4 Standard-library interfaces
+
+The bounds name interfaces that must exist in the prelude/std. This SFEP
+introduces the minimal set the immediate consumers need; each is an ordinary
+`interface` (no new language surface):
+
+```sfn
+interface Eq         { fn eq(other: Self) -> bool; }
+interface Comparable { fn compare(other: Self) -> int; }   // <0 / 0 / >0
+interface Hashable   { fn hash() -> int; }
+interface Display    { fn to_string() -> string; }
+interface From<T>    { fn from(value: T) -> Self; }         // enables From<E>
+```
+
+`From<T>` is the bound `Result` error coercion needs (SFEP-0012, status line
+186): `?` on a `Result<T, E1>` inside a `-> Result<U, E2>` function is legal iff
+`E2: From<E1>`, coercing via `E2.from(e1)`. That rule is *out of scope to
+implement here* (it is SFEP-0012's follow-up), but this SFEP is its prerequisite
+— it is what makes `E2: From<E1>` a checkable, monomorphizable bound.
+
+`Comparable`/`Hashable`/`Eq` are what `draft-generic-collections.md`'s
+`sort`/`HashMap<K: Hashable + Eq, V>` require. Providing them here (as inert
+interface declarations) lets the collections SFEP be pure library code over
+this foundation.
+
+## 4. Effect & capability impact
+
+**No new effects, no taxonomy change.** Bounds and monomorphization are a
+type-system feature; the canonical six (`clock`, `gpu`, `io`, `model`, `net`,
+`rand`, per SFEP-0017) are untouched, and `check_type_parameters` runs in
+typecheck, strictly before the effect checker.
+
+One interaction to specify: **effect transparency through specialization.** A
+generic body carries its own declared effect row (`fn read_all<T>(...) ![io]`);
+monomorphization clones the body verbatim, so each specialization inherits the
+*same* effect annotation — specialization neither adds nor drops effects. The
+effect checker runs on the *pre-monomorphization* generic declaration (once),
+not per specialization, so effect diagnostics remain single-sited and the O(1)
+effect-check cost does not multiply by instantiation count. A bounded method
+call `a.compare(b)` is `![pure]` unless the interface method itself declares an
+effect; the interface method's declared effects are the effects the caller must
+already cover, exactly as for any ordinary method call. No capability-manifest
+(`E0403`) interaction: bounds never widen a capsule's authorized surface.
+
+## 5. Self-hosting impact
+
+Passes touched, in pipeline order:
+
+- **Lexer / parser** — *no change*. `<T: Comparable + Eq>` already tokenizes and
+  parses; the only parser refinement is splitting the bound side on `+`
+  (additive, inside `parse_type_parameter_clause`), which the current seed's
+  parser produces as a single `bound_text` today and the new one splits. The
+  old seed ignores `+` in a bound (it stores the whole text); so no source the
+  compiler currently uses breaks.
+- **AST** — *no change*. `TypeParameter.bound` already exists
+  (`ast.sfn:16-20`); this SFEP reads it. No node shape change → the seed's
+  positional GEP layout is stable.
+- **Typecheck** — the substantive change: extend `check_type_parameters`,
+  add `check_generic_instantiation` + `type_satisfies_bound` +
+  `struct_implements`, add `E0820`–`E0822`. All within
+  `typecheck_types.sfn`, reusing `resolve_interface_annotation` /
+  `parse_type_arguments` already there.
+- **Effect checker** — *no change* (§4).
+- **Native emit** — consumes the new monomorphization pass's specialized
+  declarations as ordinary monomorphic ones. No opcode change.
+- **LLVM lowering** — new `compiler/src/llvm/monomorphize.sfn` (instantiation
+  collection + specialization), generalizing the #830 substitution helpers in
+  `llvm/type_mapping.sfn`. Downstream lowering is unchanged because specialized
+  declarations are monomorphic.
+
+**Self-hosting invariant.** The feature is **additive and non-self-referential
+at first**: the compiler's own source does not yet use bounded generics or
+generic collections, so the *old seed* compiles the *new compiler* fine (the new
+typecheck logic is dead-but-correct until the compiler source opts in). Ordering:
+
+1. Land constraint enforcement + monomorphization (this SFEP) — compiler source
+   still uses no bounded generics, so it self-hosts under the old seed.
+2. Cut a seed containing the new compiler.
+3. *Then* consumer SFEPs (generic collections, typed HOFs) may use bounded
+   generics in library/compiler code, self-hosting under the seed from step 2.
+
+This is the standard additive-then-consume order. Because the *only* consumer
+in this SFEP is the standard-library interface declarations (§3.4) — which are
+inert `interface`s the old seed already parses — **no seed-cut gate is created
+by this SFEP itself**; the gate is between this SFEP and its downstream
+consumers, and is handled per `.claude/rules/seed-dependency.md` when those are
+groomed (bundle each consumer with the compiler-source capability it needs, or
+queue the cut).
+
+## 6. Alternatives considered
+
+**A. Dictionary passing / interface fat-pointers (the runtime-dispatch
+alternative).** Sailfin already has interface *values*: a `let c: Comparable =
+widget` is a `{data_ptr, vtable_ptr}` fat pointer with dynamic dispatch. A
+generic `fn sort<T: Comparable>` could be compiled *once*, with `T` erased to a
+fat pointer and `a.compare(b)` an indirect vtable call — Java/Go's model, and
+Rust's `dyn Trait`. **Rejected as the default** because it defeats the language's
+systems-performance positioning: every element access boxes, every method call
+indirects, and `T`-typed collection storage can no longer be inline at native
+width (it becomes a pointer, reintroducing exactly the layout indirection
+monomorphization removes). It is, however, kept explicitly as a **fallback for
+code-size / compile-time**: monomorphization's cost is code duplication and
+longer builds (a real concern given the 60–90 min self-host, per
+`docs/proposals/0006-build-architecture.md`). If instantiation-count blowup
+becomes a build-time problem, a per-declaration `#[dyn]` opt-in (or a compiler
+heuristic that shares a dictionary-passing copy for cold, non-perf-critical
+generics) can be layered on *without* changing the bound semantics — the bound
+is the same interface either way. Monomorphization is the default; dictionary
+passing is the escape hatch, not the base case.
+
+**B. Structural (duck-typed) bounds instead of interface bounds.** Let `T:
+{ compare(T) -> int }` require a shape without a named interface. **Rejected** —
+"boring syntax wins": named interface bounds match Rust/Swift/TypeScript
+constraints and reuse the conformance machinery wholesale; structural bounds
+would need a new subtyping engine for zero expressiveness gain over declaring
+the interface.
+
+**C. Enforce bounds but keep erasing (no monomorphization).** Check `T:
+Comparable`, then compile the body once with `T` as an opaque pointer.
+**Rejected** — this is alternative A's runtime cost without A's honesty about it,
+and it still cannot lower inline `T`-width collection storage, so it does not
+actually unblock `draft-generic-collections.md`. Enforcement without
+specialization is a half-feature.
+
+**D. Do nothing / keep concrete stand-ins (`StrMap`, `int[]`-only HOFs).**
+**Rejected** — each stand-in is technical debt slated for removal (status line
+193 names `StrMap` a future "deprecated alias"), and the count only grows
+(`FloatMap`? `WidgetMap`?). This SFEP is the root that lets them be one generic
+implementation.
+
+## 7. Stage1 readiness mapping
+
+- [x] **Parses** — already true (`parse_type_parameter_clause`); the only add is
+  `+`-splitting the bound, an additive parser refinement.
+- [ ] **Type-checks / effect-checks** — the core deliverable: `E0820`–`E0822`
+  in `typecheck_types.sfn`. No effect-check change (§4).
+- [ ] **Emits valid `.sfn-asm`** — via monomorphization emitting specialized
+  monomorphic declarations; no new opcodes.
+- [ ] **Lowers to LLVM IR** — new `llvm/monomorphize.sfn` generalizing the #830
+  substitution helpers; specialized declarations lower through the unchanged
+  backend.
+- [ ] **Regression coverage** — §8.
+- [ ] **Self-hosts** — additive, non-self-referential first (§5); compiler
+  source opts in only after a seed cut.
+- [ ] **`sfn fmt --check` clean** — on every touched `.sfn`.
+- [ ] **Documented** — `docs/status.md` lines 191–193 flip from Planned/Partial;
+  `reference/preview/generics.md` (the `graduates-to` target).
+
+Remains `Accepted`, not `Implemented`, until enforcement **and**
+monomorphization ship end-to-end and self-host — enforcement alone would be
+"parsed and checked but not lowered," which does not unblock the consumers.
+
+## 8. Test plan
+
+`compiler/tests/unit/`:
+
+- `generic_bound_satisfied_test.sfn` — `sort<T: Comparable>` over a type that
+  `implements Comparable` type-checks clean.
+- `generic_bound_violation_test.sfn` — `assert_does_not_compile` that a type
+  missing the interface raises `E0820`, with the bound + type named.
+- `generic_bound_not_interface_test.sfn` — `T: SomeStruct` raises `E0821`.
+- `generic_multi_bound_test.sfn` — `K: Hashable + Eq` requires both; missing
+  either raises `E0820` naming the specific unmet bound.
+- `generic_bound_propagation_test.sfn` — inside `fn f<T: Comparable>`, calling
+  `g<U: Comparable>(x: T)` type-checks (T satisfies its own bound); calling
+  `h<U: Hashable>(x: T)` does **not**.
+- `generic_arg_arity_fn_test.sfn` — `E0822` on `sort<int, int>` (arity 2 vs 1).
+
+`compiler/tests/integration/`:
+
+- `monomorphize_two_instantiations_test.sfn` — `id<T>(x: T)` called with `int`
+  and `string` emits two distinct mangled specializations; snapshot the IR
+  symbol names (`id$int`, `id$string`).
+- `monomorphize_transitive_test.sfn` — `outer<T>` calling `inner<T>` closes the
+  worklist so `inner$Widget` is emitted.
+
+`compiler/tests/e2e/`:
+
+- `generic_sort_run_test.sfn` — a `sort<T: Comparable>` over a `Widget[]`
+  compiles to a binary and runs, producing correctly ordered output (proves the
+  `a.compare(b)` bounded call resolved to the concrete method).
+- `generic_pair_struct_run_test.sfn` — a `Pair<A: Display, B: Display>` struct
+  instantiated at `<int, string>` builds and prints both fields (proves struct
+  monomorphization + inline field layout).
+
+Regression guard: the existing #830 enum-payload tests must stay green — the
+generalized substitution engine must not change enum-payload behavior.
+
+## 9. References
+
+- **Gap sites (this tree):** `compiler/src/ast.sfn:16-20` (inert `bound`);
+  `compiler/src/typecheck_types.sfn:1556-1572` (`check_type_parameters`,
+  duplicate-name only) and `:95-149` / `:169-188` (conformance + arity machinery
+  to reuse); `compiler/src/parser/declarations.sfn:313-381` (shared bound parse);
+  `compiler/src/native_ir_parser_defs.sfn:503-528` and
+  `compiler/src/llvm/type_mapping.sfn:139-203+` (the #830 substitution
+  primitives to generalize).
+- **Status:** `docs/status.md` lines 168 (enum-payload monomorphization, #830),
+  186 (`Result` `From<E>`/`E: Error` gate), 191–193 (generic inference,
+  constraints, `StrMap` bridge).
+- **Related SFEPs (consumers — this SFEP is their predecessor):**
+  `draft-generic-collections.md` (real `Array<T>` / `HashMap<K, V>` /
+  `Channel<T>` — depends on this); SFEP-0028
+  (`0028-typed-array-higher-order-fns.md`, typed `map`/`filter`/`reduce` —
+  depends on this); SFEP-0012 (`0012-result-and-question-operator.md`, whose
+  `From<E>` coercion and `E: Error` bound need this); `draft-derive.md`
+  (structural `derive(Eq, Hashable, ...)` — generates the very `implements`
+  clauses this SFEP checks bounds against).
+- **Prior art:** Rust monomorphization + trait bounds; Swift generic
+  specialization; the #830 enum-payload per-instantiation model as the in-tree
+  precedent.
+- **Build cost context:** `docs/proposals/0006-build-architecture.md` (why
+  instantiation-count blowup is a real self-host-time risk, motivating the
+  dictionary-passing fallback in §6-A).
+- **Process:** `docs/proposals/0001-sfep-process.md`;
+  `.claude/rules/selfhost-invariant.md`; `.claude/rules/seed-dependency.md`
+  (bundle-vs-split for the downstream consumers).

--- a/docs/proposals/draft-interface-signature-conformance.md
+++ b/docs/proposals/draft-interface-signature-conformance.md
@@ -1,0 +1,664 @@
+---
+sfep: TBD
+title: Signature-Checked Interface Conformance
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/spec/06-types.md
+---
+
+# SFEP-XXXX — Signature-Checked Interface Conformance
+
+> Design record for closing the interface-conformance soundness gap tracked in
+> `docs/status.md` ("Interface conformance validation | Partial | Basic checks;
+> variance not enforced"). This is a correctness/soundness fix, not a new
+> feature: today's name-only conformance check can install a wrong-typed
+> function pointer into an interface vtable slot, which is then called
+> indirectly at the interface's expected type.
+
+## 1. Summary
+
+`check_struct_implements_interfaces` (`compiler/src/typecheck_types.sfn:95-134`)
+currently verifies interface conformance by name only: a struct "implements" an
+interface if it has a method for every member *name* the interface declares. It
+never compares parameter types, arity, or return type against the interface's
+declared signature. Because interface method calls lower to an indirect call
+through a vtable slot whose function-pointer type is derived from the *call
+site*, not from the *installed function* (`core_call_emission.sfn:558-596`), a
+struct method with the same name but an incompatible signature is silently
+installed into that slot and called through the wrong LLVM function type — a
+type-unsound indirect call, not merely a missing diagnostic. This proposal
+extends `check_struct_implements_interfaces` to check arity, parameter types,
+and return type for exact compatibility (1.0 has no variance), adds a new
+diagnostic family (`E0303`) distinct from the existing missing-member
+diagnostic (`E0301`), and ships the tightening behind the same
+`SAILFIN_EFFECT_ENFORCE`-style transitional severity knob the effect system
+used to migrate the in-tree corpus before flipping to hard-error.
+
+## 2. Motivation
+
+### The bug, precisely
+
+`check_struct_implements_interfaces` walks each `implements` annotation,
+resolves the interface declaration by name via `resolve_interface_annotation`
+(`typecheck_types.sfn:136-149`), and for each interface member does exactly
+one check:
+
+```sfn
+if !contains_string(method_names, member.name) {
+    diagnostics.push(make_missing_interface_member_diagnostic(statement.name, interface_name, member.name));
+}
+```
+
+`method_names` is built by pushing `statement.methods[_mi].signature.name` for
+every struct method (`:98-104`) — names only, no signature data retained. The
+three adjacent validators don't fill the gap either:
+
+- `validate_interface_annotation` (`:169-188`) checks only generic
+  type-*argument arity* on the `implements Container<T>` annotation itself
+  (does the struct supply the right number of type arguments) — it never looks
+  at method bodies.
+- `check_interface_members` (`:785-808`) validates the *interface declaration*
+  is well-formed (`check_function_signature` → `check_type_parameters`, plus a
+  duplicate-member-name check) — it runs over the interface, never cross-checks
+  against any implementing struct.
+- `check_struct_methods` (called from `typecheck.sfn:463`) validates the
+  struct's own methods in isolation — again, no cross-check against interfaces
+  it claims to implement.
+
+So today, this compiles with **zero diagnostics**:
+
+```sfn
+interface Greeter {
+    fn greet(self, name: string) -> string;
+}
+
+struct Loud {
+    volume: int;
+}
+impl Loud {
+    // same name "greet", wrong arity AND wrong param/return types —
+    // accepted today because only the name is checked.
+    fn greet(self) -> int {
+        return self.volume;
+    }
+}
+```
+(Sailfin does not have a separate `impl` block — methods live directly in the
+`struct` body per `03-declarations.md` §3.3 — but the shape of the mismatch is
+the same wherever `fn greet` is declared inside `struct Loud { ... }` with
+`implements Greeter`.)
+
+### Why this is a soundness bug, not a missing lint
+
+Interface-typed values lower to a two-word trait object `{ i8*, i8* }` (data
+pointer + vtable pointer; `rendering_helpers.sfn:31-44`). The vtable itself is a
+struct of function-pointer-typed slots, one per interface member, populated at
+each `implements`-resolution site by `bitcast (<fn-ptr-type> @<method> to
+<fn-ptr-type>)` (`rendering_helpers.sfn:72-107`) — `<fn-ptr-type>` there is
+whatever the *actual* struct method's signature lowers to.
+
+A dynamic dispatch call site (`core_call_emission.sfn:507-660`, the
+`trait_dispatch__<Interface>__<method>` path) does the reverse: it builds
+`function_type` from the **call site's own operand types**
+(`fp_param_types` built from `final_operands`, `:558-567`) plus the
+**interface's declared `llvm_return`**, then loads the raw `i8*` from the
+vtable slot and `bitcast`s it to that call-site-derived function type
+(`:576-596`) before calling through it.
+
+If the installed method's real signature differs from the interface's declared
+signature — different parameter count, different parameter LLVM types
+(`i64` vs a boxed struct pointer, for instance), or a different return type —
+the `bitcast` reinterprets a function pointer as having a type it does not
+actually have. Calling through it is undefined behavior at the LLVM level:
+arguments land in the wrong registers/stack slots, the return value is
+misinterpreted, and in the aggregate-parameter/return case this manifests as
+memory corruption, not merely "the wrong number came back." This is the same
+class of hazard the project already treats as urgent for owned-value handling
+(#1205-style aliasing corruption) — an indirect call through a mismatched
+function type is a compiler-introduced memory-safety bug, reachable from
+ordinary, valid-looking source with no unsafe/extern escape hatch involved.
+
+### Who hits it, and why silently
+
+Any interface with more than a trivial single-signature member is at risk the
+moment a struct's method for that name drifts from the interface (a common
+refactor mistake: renaming a parameter's type, adding an optional parameter,
+changing `-> string` to `-> string?`). There is no compiler feedback — `sfn
+check` is green, `make compile` succeeds, and the failure only surfaces at
+runtime as a crash or corrupted data, often far from the actual defect. Per
+the project principle "don't ship unfinished safety claims," a name-only check
+that market-facing docs and the interface's own type signature imply is a real
+contract is actively worse than no check: it teaches users the `implements`
+clause is verified when it is not.
+
+## 3. Design
+
+### 3.1 Scope of the check
+
+Extend `check_struct_implements_interfaces` so that, for each interface
+member the struct has a same-named method for, it additionally verifies:
+
+1. **Arity** — the struct method's `parameters` list has the same length as
+   the interface member's `parameters` list.
+2. **Parameter types, pairwise, in order** — after substituting the
+   interface's type parameters with the concrete arguments from the
+   `implements Container<T>` annotation (see §3.3), each pair of parameter
+   type-annotation texts must be *exactly equal* (no variance — see §3.4).
+3. **Return type** — same substitution-then-exact-text-equality rule applied
+   to `return_type` (interface member's, possibly absent/`void`, vs. the
+   struct method's).
+4. **`self` receiver** — both signatures' first parameter, by convention
+   named `self` (per `03-declarations.md` §3.3/§3.5: "the first parameter is
+   bare `self`"), is a structural fixture, not a type to compare. It is
+   **excluded** from the parameter-type comparison entirely: `self` carries no
+   `type_annotation` today (bare `self`, no `: Type` suffix — confirmed by
+   every interface/struct example in the spec), so comparing it as a normal
+   parameter would either vacuously pass (both sides `null`) or, if a future
+   syntax allows an explicit `self: T` receiver annotation, incorrectly reject
+   valid conformance. The rule: **if the first parameter's name is exactly
+   `"self"` on both sides, skip it for the type comparison and start the
+   pairwise walk at index 1; require both sides to agree on whether index 0 is
+   present and named `self`** (a member with a `self` receiver cannot be
+   satisfied by a method without one, and vice versa — that mismatch is
+   reported as an arity/shape mismatch under the same new diagnostic, not
+   silently ignored).
+
+This mirrors the existing exact-match philosophy of `check_try_operator`'s
+`?`-operator error-type check (`E0812`, `typecheck_types.sfn:420-438`): "`?`
+requires an exact match (no `From` coercion yet)" is the same posture applied
+here to interface parameter/return types, for the same reason — this compiler
+pass has no expression-type inferencer (#829) and no subtyping/variance
+lattice, so anything short of exact text equality (after substitution) is
+unimplementable without a much larger prerequisite.
+
+### 3.2 New function: `check_interface_member_signature_match`
+
+Add a pure helper next to `check_struct_implements_interfaces`:
+
+```sfn
+fn check_interface_member_signature_match(
+    struct_name: string,
+    interface_name: string,
+    member: FunctionSignature,
+    method: MethodDeclaration,
+    substitution: TypeSubstitution
+) -> Diagnostic[]
+```
+
+Called from inside the existing `_mbi` loop in
+`check_struct_implements_interfaces`, **only when** the name lookup already
+found a matching struct method (i.e. it runs alongside, not instead of, the
+existing `E0301` missing-member check — a member that's missing by name still
+reports `E0301` and is not also signature-checked, since there is nothing to
+compare against). The loop needs the matched `MethodDeclaration`, not just the
+boolean `contains_string` result, so `check_struct_implements_interfaces`
+changes its lookup from `contains_string(method_names, member.name)` to a new
+helper `find_method_by_name(statement.methods, member.name) -> MethodDeclaration?`
+that returns the method (or `null`), used for both the existing missing-member
+branch (`null` case, unchanged `E0301`) and the new signature check (non-null
+case).
+
+`check_interface_member_signature_match` body, in order:
+
+1. **Shape/arity check.** Compare `self`-receiver presence (§3.1 rule) between
+   `member.parameters` and `method.signature.parameters`. If they disagree, or
+   if the non-`self` parameter counts differ, emit **one** `E0303` diagnostic
+   summarizing the arity/shape mismatch (message shows both full rendered
+   signatures — see §3.5) and return early (no point comparing types
+   position-by-position against a misaligned list).
+2. **Parameter type check.** Walk the non-`self` parameters pairwise. For each
+   interface parameter, apply `apply_type_substitution` (already exists,
+   `typecheck_types.sfn:271-291`) with `substitution` to its
+   `type_annotation.text`, then compare the substituted text against the
+   struct method parameter's `type_annotation.text` via `strings_equal`
+   (`string_utils`, already imported). On any mismatch push **one** `E0303`
+   for that parameter, naming the parameter, expected substituted type, and
+   actual type; continue checking remaining parameters (report every
+   mismatched parameter in one pass, not just the first — matches the existing
+   convention of returning a `Diagnostic[]` rather than stopping at first
+   error, as seen throughout `typecheck_types.sfn`).
+3. **Return type check.** Same substitution + `strings_equal` comparison
+   between `member.return_type` and `method.signature.return_type`, treating
+   `null` (no declared return type / implicit void) on both sides as a match,
+   and a `null`/non-`null` mismatch as a failure. Emit **one** `E0303` if
+   mismatched.
+
+All three checks are independent (not early-return after step 1's arity check
+fails to find a mismatch) — a caller can have both a wrong parameter type and
+a wrong return type; both are reported in the same pass, consistent with the
+compiler's general practice of surfacing all diagnostics per node rather than
+one-at-a-time.
+
+### 3.3 Generic interfaces: instantiating the member signature
+
+For `interface Container<T> { fn get(self, index: int) -> T?; fn len(self) ->
+int; }` implemented as `struct IntList { ... } ` with `implements
+Container<int>`, the member's declared return type text is `T?` — this must be
+substituted to `int?` before comparing against the struct's actual `fn
+get(self, index: int) -> int?` method.
+
+`check_struct_implements_interfaces` already has everything needed to build
+this substitution — it is the same shape `resolve_enum_variant_field_type`
+uses (`typecheck_types.sfn:299-319`):
+
+```sfn
+let provided_arguments = parse_type_arguments(annotation.text);   // already computed for arity validation
+let substitution = build_type_substitution(interface_definition.type_parameters, provided_arguments);
+```
+
+`build_type_substitution` and `apply_type_substitution` already exist unchanged
+(`:225-291`) — this proposal adds no new substitution machinery, only a new
+call site. Compute `substitution` once per `implements` annotation (right
+after the existing `validate_interface_annotation` call, which already
+guarantees arity is correct — §3.1's signature check only runs when arity
+validated cleanly, so a `substitution` with mismatched-length `olds`/`news`
+never reaches the per-member comparison) and thread it into
+`check_interface_member_signature_match` for every member of that
+`implements` entry.
+
+For a non-generic interface (`expected_count == 0`), `parse_type_arguments`
+returns `[]` and `build_type_substitution` naturally produces an empty
+substitution — `apply_type_substitution` is then a no-op passthrough (no
+identifier matches `substitution.olds` because it's empty), so the same code
+path handles both generic and non-generic interfaces without a branch.
+
+### 3.4 Compatibility rule: exact match, no variance (1.0 scope)
+
+Per the project's "fix the foundation first" and "don't ship unfinished safety
+claims" principles, this check does not attempt covariant return types,
+contravariant parameters, or any subtyping relaxation — those require a real
+type lattice this compiler does not have (types are compared as post-
+substitution annotation *text*, per the existing `type_is_result` / `?`-operator
+precedent, `typecheck_types.sfn:355-378`). **Exact textual equality after
+substitution** is the complete 1.0 rule:
+
+- `int` matches `int`; `int` does **not** match `int?` (nullability is part of
+  the type text and is not unified).
+- `T?` (substituted to `int?`) matches only literal `int?`, not `int` and not
+  `Optional<int>` or any other spelling.
+- Whitespace/formatting differences in the annotation text must not cause a
+  false mismatch — reuse `trim_text` (already used throughout this file, e.g.
+  `:184`) on both sides before `strings_equal`, so `fn get(self, index:int)`
+  and `fn get(self, index: int)` compare equal.
+- No structural equivalence for compound types beyond substitution — `Array<T>`
+  substituted to `Array<int>` must match a literal `Array<int>` spelling on the
+  struct method; `int[]` is a *different* spelling and does not match
+  `Array<int>` even if they denote the same runtime type today. This is a
+  known, documented limitation (type annotations are compared as strings, not
+  as resolved types — the same limitation `apply_type_substitution`'s own
+  docstring already lives with) and is not a regression this proposal
+  introduces; tightening it further needs the type-annotation resolver work
+  generic constraints will need anyway (§6, cross-reference to
+  `draft-generic-constraints.md`).
+
+### 3.5 New diagnostic: `E0303`
+
+The missing-member diagnostic is `E0301`
+(`make_missing_interface_member_diagnostic`, `:2085-2097`); the type-argument-
+arity family is `E0302` (`make_interface_type_argument_mismatch_diagnostic` and
+its two siblings, `:1865-1907`). `E0303` is the next free code in that family
+(confirmed clear — a repo-wide scan of `compiler/src` finds no existing
+`E0303` use). One diagnostic factory, parameterized by a `kind` so the three
+sub-cases (§3.2 steps 1–3) share rendering plumbing but produce
+distinguishable messages:
+
+```sfn
+// E0303 — struct method signature does not match the interface member's
+// declared signature (arity, a parameter type, or the return type).
+fn make_interface_signature_mismatch_diagnostic(
+    struct_name: string,
+    interface_name: string,
+    member_name: string,
+    expected_signature: string,
+    actual_signature: string,
+    detail: string,          // e.g. "parameter `index`: expected `int`, got `string`"
+    span: SourceSpan?
+) -> Diagnostic {
+    return Diagnostic {
+        code: "E0303",
+        severity: "error",
+        message: "struct " + struct_name + " implements " + interface_name
+            + " but method `" + member_name + "` does not match the interface's"
+            + " declared signature: " + detail
+            + ". Expected `" + expected_signature + "`, found `" + actual_signature + "`.",
+        file_path: "",
+        primary: token_from_name(member_name, span),
+        suggestion: null
+    };
+}
+```
+
+`expected_signature` / `actual_signature` are the full rendered `fn name(params)
+-> return` text (reuse or extend `format_interface_signature`'s sibling
+formatting helpers) so the user sees the whole shape, not just the one
+differing token — this matches how `E0812`'s `?`-operator diagnostic names
+both full types rather than only the mismatched token. `suggestion` starts
+`null` (no auto-fix in v1 — the fix depends on developer intent, whether the
+struct method or the interface declaration is wrong, mirroring why
+`make_missing_interface_member_diagnostic` also carries no `suggestion`
+today); a fix-it (retype the parameter to match) is a natural fast-follow once
+this ships, tracked separately.
+
+### 3.6 Enforcement severity: transitional flag, mirroring `SAILFIN_EFFECT_ENFORCE`
+
+This is a **backward-incompatible tightening**: any struct/interface pair in
+an existing capsule that "conforms" today only because names match — with a
+divergent parameter or return type — newly fails to compile once this ships
+as a hard error. The effect system shipped an identical class of tightening
+(Phase D of `docs/proposals/0008-effect-validation.md`, flipping the default
+from warning to error only after an in-tree audit) behind
+`SAILFIN_EFFECT_ENFORCE`; this proposal reuses that exact transitional shape
+rather than inventing a new one.
+
+Add `SAILFIN_INTERFACE_ENFORCE` (a distinct env var — interface conformance
+and effect enforcement are unrelated concerns and must not share a toggle),
+read via a new `interface_gate.sfn`, structurally identical to
+`effect_gate.sfn` (`compiler/src/effect_gate.sfn:58-83`):
+
+```sfn
+fn resolve_interface_enforcement(raw: string) -> string {
+    if raw == "off" { return "off"; }
+    if raw == "warning" { return "warning"; }
+    return "error";   // unset / "" / "error" → default
+}
+
+fn read_interface_enforcement_env() -> string ![io] {
+    return env.get("SAILFIN_INTERFACE_ENFORCE");
+}
+```
+
+Ship this feature with the **default already at "error"** for
+`E0303` specifically — unlike the effect system's Phase B (which *shipped*
+warning-by-default and flipped later), here the migration path is: (a) land
+the checker with `E0303` gated by `SAILFIN_INTERFACE_ENFORCE`, **defaulted to
+`"warning"` for one release cycle** so the in-tree compiler corpus and any
+existing capsules get one alpha cycle of visibility before the check is
+fatal, then (b) a fast-follow flips the unset default to `"error"` once an
+audit (mirroring the effect system's Phase C in-tree audit) confirms
+`compiler/src/*.sfn` itself has no violations. This two-step landing (warn
+first release, error next) is the one deliberate divergence from a
+same-PR error-default — justified because, unlike a fresh new diagnostic
+class the effect system didn't have before, this specifically *replaces* a
+check that previously reported nothing at all, so the blast radius on
+unaudited downstream capsules is unknown at land time. `E0301` (missing
+member) is unaffected — it stays an unconditional hard error exactly as
+today; only the *new* `E0303` signature-mismatch class is gated by
+`SAILFIN_INTERFACE_ENFORCE` during the transition. `=off` skips only the
+`E0303` signature comparison (§3.2), never the `E0301` name-presence check
+or the `E0302` arity check — both continue to run unconditionally, matching
+how `SAILFIN_EFFECT_ENFORCE=off` still runs `sfn check`'s own gate
+(`effect_gate.sfn:28-34`) even while skipping the *build*-path gate.
+
+Wire the severity into `check_struct_implements_interfaces`'s call site in
+`typecheck.sfn` the same way `validate_and_render_effects_with_capabilities`
+threads `severity` onto each `EffectViolation` before rendering
+(`effect_gate.sfn:141-148`): the new `E0303` `Diagnostic`s get their
+`severity` field overwritten by the resolved enforcement level before being
+appended to the returned `Diagnostic[]`, so "warning" mode still surfaces the
+message (visibility) without failing `make compile` / `sfn check`.
+
+### 3.7 Worked example
+
+```sfn
+interface Container<T> {
+    fn get(self, index: int) -> T?;
+    fn len(self) -> int;
+}
+
+struct IntList {
+    items: int[];
+}
+
+// OK: `get` and `len` both match Container<int>'s instantiated signatures.
+struct GoodIntList {
+    items: int[];
+    fn get(self, index: int) -> int? { return null; }
+    fn len(self) -> int { return 0; }
+    implements Container<int>;
+}
+
+// E0303: `get`'s return type is `int`, but Container<int>.get is `int?`.
+struct BadIntList {
+    items: int[];
+    fn get(self, index: int) -> int { return 0; }
+    fn len(self) -> int { return 0; }
+    implements Container<int>;
+}
+```
+
+(Field/method/`implements` ordering above follows the existing
+`03-declarations.md` §3.3 struct-body shape; exact placement of `implements`
+is unaffected by this proposal.)
+
+## 4. Effect & capability impact
+
+None. `check_struct_implements_interfaces` and the new
+`check_interface_member_signature_match` are pure functions over already-parsed
+`Statement`/`FunctionSignature`/`MethodDeclaration` AST data — no new effectful
+operation is introduced anywhere in the typecheck pass itself. The one
+`![io]`-effectful piece, `read_interface_enforcement_env` (an `env.get` call,
+mirroring `read_effect_enforcement_env`), is confined to the same build-path
+orchestration layer the effect gate already lives in (`main.sfn` /
+`tools/check.sfn` call sites), not the pure typecheck core. No capability
+manifest surface changes: `SAILFIN_INTERFACE_ENFORCE` is a compiler-internal
+transitional knob, not a capsule-declarable capability.
+
+## 5. Self-hosting impact
+
+Passes touched, in pipeline order:
+
+- **AST** (`ast.sfn`) — no change. `FunctionSignature`, `MethodDeclaration`,
+  `Parameter`, `TypeAnnotation` all already carry every field this check reads
+  (`parameters`, `return_type`, `type_annotation.text`, `name`).
+- **Type Checker** (`typecheck_types.sfn`) — the only pipeline stage that
+  changes:
+  - `check_struct_implements_interfaces` (`:95-134`) gains the substitution
+    computation (§3.3) and replaces its `contains_string` boolean lookup with
+    a `find_method_by_name` lookup that also drives the new signature check.
+  - New `find_method_by_name(methods: MethodDeclaration[], name: string) ->
+    MethodDeclaration?` helper.
+  - New `check_interface_member_signature_match` (§3.2).
+  - New `make_interface_signature_mismatch_diagnostic` (§3.5, `E0303`).
+- **New file `compiler/src/interface_gate.sfn`** (§3.6) — the
+  `SAILFIN_INTERFACE_ENFORCE` read + severity resolution, structurally mirrors
+  `effect_gate.sfn`. Wired into the same `main.sfn` / `tools/check.sfn`
+  call sites that currently invoke `validate_and_render_effects*`, so the
+  severity-overwrite happens at the same orchestration layer, not inside
+  `typecheck_types.sfn` itself (keeping that file's functions pure, per its
+  existing convention — none of its `check_*` functions read the environment
+  today).
+- **Effect Checker, Native Emitter, LLVM Lowering** — no change. This proposal
+  is purely a *rejection* of programs the pipeline would otherwise lower
+  unsoundly; it adds no new IR shape, no new lowering path, and does not touch
+  `emit_native.sfn` or any file under `llvm/`. (The vtable/dispatch mechanism
+  in `core_call_emission.sfn` and `rendering_helpers.sfn` described in §2 is
+  cited to establish *why* the check matters — it is not modified by this
+  proposal. A previously-accepted mismatched program simply becomes a
+  diagnostic instead of reaching that lowering code at all.)
+
+**Self-hosting invariant.** This is additive to the compiler's own source: the
+compiler's `interface`/`implements` usages are checked against the same rule
+their consumers are. Before landing, run `make compile` with
+`SAILFIN_INTERFACE_ENFORCE=warning` and read the emitted warnings — if
+`compiler/src/*.sfn` itself has zero pre-existing signature drifts (expected,
+since the compiler was written assuming exact conformance informally), the
+warning-mode landing and the later error-mode flip both self-host cleanly with
+no compiler-source changes required. If the audit *does* find drift in
+`compiler/src/*.sfn`, fixing those call sites is a prerequisite sub-step before
+the warning-to-error flip (not before the initial warning-mode land) — this
+mirrors exactly how the effect system's Phase C audit (11 debug-trace routines)
+preceded Phase D's default flip (`effect_gate.sfn:19-26`). Both landing steps
+are single-PR, no-seed-cut changes per `.claude/rules/seed-dependency.md`: the
+capability (`E0303` check + gate) and its only consumer (the compiler's own
+`interface`/`implements` declarations, already present in the pinned seed's
+grammar) ship together — `make compile` builds the new compiler from the old
+seed, and that new compiler self-checks its own `implements` sites in the same
+pass. No new seed is required for either the warning-default landing or the
+later error-default flip.
+
+## 6. Alternatives considered
+
+- **Do nothing / leave it a documented "Partial" limitation.** Rejected — this
+  is not a missing convenience feature, it is a reachable memory-safety hazard
+  (§2). `docs/status.md`'s own "Partial" note already flags it; this proposal
+  closes it rather than leaving a soundness hole documented-but-open
+  indefinitely.
+- **Enforce only arity, not full type equality.** Rejected — arity-only still
+  permits the `bitcast`-to-wrong-function-type hazard whenever a parameter's
+  *type* (not count) diverges (e.g. `int` vs a boxed struct pointer), which is
+  exactly the case most likely to corrupt memory (aggregate/pointer ABI
+  mismatch) rather than merely misread an integer.
+- **Enforce with structural/variance-aware type equality (covariant returns,
+  contravariant parameters) instead of exact match.** Rejected for 1.0 — the
+  compiler has no expression-type inferencer or type lattice (#829); building
+  one is a much larger prerequisite than this fix, and the project's "fix the
+  foundation first" principle puts real subtyping behind more basic
+  primitives (integer types, `Result<T,E>`, generic constraints) that don't
+  yet exist either. Exact-match-after-substitution is implementable today with
+  the substitution machinery that already exists (§3.3) and matches the
+  precedent already set by the `?`-operator's `E0812` exact-match rule.
+- **Fatal from day one, no transitional flag.** Rejected — mirrors exactly why
+  the effect system didn't do this either (`effect_gate.sfn` Phase B/C/D
+  history): an unknown amount of existing capsule code may rely on today's
+  name-only conformance without ever having hit the runtime hazard, and a
+  same-PR hard break with no visibility window is more disruptive than
+  necessary. The two-step warning-then-error landing gives one alpha cycle of
+  signal.
+- **Fold this into the general effect-enforcement flag
+  (`SAILFIN_EFFECT_ENFORCE`) instead of a new one.** Rejected — interface
+  conformance and capability/effect enforcement are unrelated axes (one is a
+  type-soundness check, the other is a capability-security check); sharing a
+  toggle would force an operator who wants to silence one to also silence the
+  other, and would misuse a flag whose name and existing documentation
+  (`docs/status.md`, `0008-effect-validation.md`) is specifically about
+  effects.
+- **Runtime (rather than compile-time) signature check — e.g. tag the vtable
+  slot with a signature hash and check it at dispatch.** Rejected — Sailfin's
+  differentiator is compile-time capability/type enforcement; a runtime check
+  adds cost to every dynamic dispatch call for a defect class that is fully
+  determinable at compile time (all types involved are statically known at
+  the `implements` site). It would also only convert a memory-corruption bug
+  into a runtime panic, not prevent the unsound program from being accepted at
+  all.
+
+## 7. Stage1 readiness mapping
+
+- [ ] **Parses** — no parser change required; `implements`, `interface`, and
+  struct-method syntax already parse today. (N/A — this proposal touches no
+  grammar.)
+- [ ] **Type-checks / effect-checks** — `check_interface_member_signature_match`
+  + `E0303` + `find_method_by_name`, wired into
+  `check_struct_implements_interfaces`; `interface_gate.sfn`'s severity
+  threading. Not yet implemented.
+- [ ] **Emits valid `.sfn-asm`** — N/A; this proposal rejects programs before
+  emission, it adds no new IR shape.
+- [ ] **Lowers to LLVM IR** — N/A; no lowering change (§5).
+- [ ] **Regression coverage** — see §8, not yet written.
+- [ ] **Self-hosts** — `make compile` with `SAILFIN_INTERFACE_ENFORCE=warning`
+  must succeed with zero `E0303` warnings against `compiler/src/*.sfn`'s own
+  `interface`/`implements` sites before the error-mode flip; not yet run.
+- [ ] **`sfn fmt --check` clean** — applies to `interface_gate.sfn` and the
+  `typecheck_types.sfn` diff once written.
+- [ ] **Documented in `docs/status.md` + spec** — `docs/status.md`'s
+  "Interface conformance validation" row flips from "Partial" to "Shipped"
+  (warning-mode landing keeps it "Partial" with an updated note; only the
+  error-default flip graduates it to "Shipped", consistent with "parsed but
+  not enforced is not shipped"). `graduates-to:
+  reference/spec/06-types.md` — interfaces have no existing spec-chapter
+  section yet (`03-declarations.md` §3.5 currently covers `interface`
+  declaration syntax only); this proposal's graduation adds the conformance
+  rule to `06-types.md` as the canonical home for interface *type* semantics,
+  cross-linked from `03-declarations.md` §3.5.
+
+## 8. Test plan
+
+- **`compiler/tests/unit/interface_signature_conformance_test.sfn`** —
+  direct unit coverage of `check_interface_member_signature_match` /
+  `check_struct_implements_interfaces`:
+  - Matching arity + parameter types + return type → no diagnostics.
+  - Wrong parameter type (non-generic interface) → one `E0303`, message names
+    both types.
+  - Wrong return type → one `E0303`.
+  - Wrong arity (extra/missing non-`self` parameter) → one `E0303`, shape
+    message, no attempted pairwise type comparison.
+  - Missing `self` receiver on one side only → one `E0303` (shape mismatch),
+    distinct from the "both have `self`, compare from index 1" path.
+  - Generic interface (`Container<T>` / `implements Container<int>`): member
+    return type `T?` substituted to `int?` matches a real `int?` method,
+    rejects a real `int` or `string?` method.
+  - Multiple simultaneous mismatches (both a parameter and the return type
+    wrong) → two `E0303` diagnostics in one pass, not one.
+  - Whitespace-only differences (`int` vs ` int `) → no false-positive
+    mismatch (trim before compare).
+  - Existing `E0301` (missing member) and `E0302` (arity) behavior unchanged —
+    regression-guard the current passing tests in this file's neighborhood
+    (`typecheck_types.sfn`'s existing interface tests, if any, must still
+    pass unmodified).
+- **`compiler/tests/integration/interface_enforcement_gate_test.sfn`** —
+  `SAILFIN_INTERFACE_ENFORCE` contract: `resolve_interface_enforcement("off"
+  | "warning" | "" | "error")` returns the right severity string (mirrors
+  `effect_gate_test.sfn`'s existing shape for `resolve_effect_enforcement`, if
+  present — reuse that test's structure); a `warning`-mode run surfaces the
+  diagnostic without a non-zero build exit; an `error`-mode (or unset, once
+  flipped) run fails the build; `off` skips only `E0303`, not `E0301`/`E0302`.
+- **`compiler/tests/e2e/interface_signature_mismatch_test.sfn`** — an
+  `![io]` e2e test (per `.claude/rules/no-bash-e2e.md`) that spawns
+  `sfn check` against a fixture source string containing the exact `Loud`/
+  `Greeter`-shaped mismatch from §2, asserting the captured stderr contains
+  `E0303` and does not contain a successful build marker; a companion
+  positive-case fixture (matching signatures) asserts a clean `sfn check`
+  exit.
+- **Self-host verification** — `make compile` (first with
+  `SAILFIN_INTERFACE_ENFORCE=warning` to confirm zero in-tree violations
+  surface as warnings, then a full `make check` once the checker lands) per
+  `.claude/rules/selfhost-invariant.md`.
+
+## 9. References
+
+- `docs/status.md` — "Interface conformance validation | Partial | Basic
+  checks; variance not enforced" (the row this proposal closes); the
+  Diagnostics section describing the shared `diagnostics_render.sfn` renderer
+  and `E05xx`/`E06xx` families used as an env-var/severity precedent.
+- `docs/proposals/0008-effect-validation.md` — the `SAILFIN_EFFECT_ENFORCE`
+  Phase B/C/D transitional-severity precedent this proposal's
+  `SAILFIN_INTERFACE_ENFORCE` mirrors structurally.
+- `compiler/src/effect_gate.sfn` — the concrete file structure
+  (`resolve_*_enforcement`, `read_*_enforcement_env`, severity-overwrite
+  wiring) `interface_gate.sfn` is modeled on line-for-line.
+- `compiler/src/typecheck_types.sfn:95-134` (`check_struct_implements_interfaces`),
+  `:136-149` (`resolve_interface_annotation`), `:169-188`
+  (`validate_interface_annotation`), `:225-291` (`TypeSubstitution` /
+  `build_type_substitution` / `apply_type_substitution` — reused unchanged),
+  `:355-438` (the `?`-operator `type_is_result` / `E0810`–`E0812` exact-match
+  precedent), `:785-808` (`check_interface_members`), `:1865-1907` (the
+  `E0302` arity-diagnostic family), `:2085-2097`
+  (`make_missing_interface_member_diagnostic`, `E0301`).
+- `compiler/src/llvm/expression_lowering/native/core_call_emission.sfn:507-660`
+  — the `trait_dispatch__<Interface>__<method>` vtable dispatch lowering that
+  makes this a soundness bug, not a missing lint (call-site-derived
+  `function_type` bitcast onto the loaded vtable slot).
+- `compiler/src/llvm/rendering_helpers.sfn:31-107` — trait-object layout
+  (`{ i8*, i8* }`), vtable type definitions, and vtable-constant population
+  (`bitcast (<fn-ptr-type> @<method> to <fn-ptr-type>)`).
+- `site/src/content/docs/docs/reference/spec/03-declarations.md` §3.3, §3.5 —
+  current documented `struct`/`interface`/`implements` syntax (bare `self`
+  receiver convention this proposal's §3.1 rule depends on).
+- `draft-generic-constraints.md` (forthcoming SFEP) — constraint satisfaction
+  for generic bounds (`fn foo<T: Container>(...)`) will need to answer "does
+  `T` satisfy `Container`" using the same conformance check this proposal
+  hardens; today's name-only check would let an ill-typed `T` satisfy a bound
+  it does not actually meet, silently propagating this same vtable hazard into
+  generic-constraint-gated code. This proposal is a direct prerequisite.
+- `draft-derive.md` (forthcoming SFEP) — derived interface implementations
+  (e.g. a future `#[derive(Serializable)]`-style mechanism) must produce
+  methods that pass this same signature check; deriving is only sound if the
+  generated method's signature is verified against the interface exactly like
+  a hand-written one, so this proposal's checker is the gate derive-generated
+  impls run through, not a parallel bespoke validation path.
+- `.claude/rules/seed-dependency.md` — the bundle-not-split reasoning in §5.

--- a/docs/proposals/draft-nullable-access-operators.md
+++ b/docs/proposals/draft-nullable-access-operators.md
@@ -1,0 +1,630 @@
+---
+sfep: TBD
+title: Nullable Access Operators (?. and ??)
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/preview/nullability.md
+---
+
+# SFEP-XXXX — Nullable Access Operators (`?.` and `??`)
+
+> Design record for the null-safe navigation (`?.`) and null-coalescing (`??`)
+> operators over Sailfin's existing `T?` nullable types. Related: SFEP-0012
+> (the postfix Result `?` / `TryOperator` — the disambiguation this SFEP must
+> get right), SFEP-0034 (`x is T` narrowing — the machinery reused here).
+
+## 1. Summary
+
+Sailfin already models absence with a `T?` nullable-type suffix (Kotlin/
+TypeScript style) baked into `TypeAnnotation.text`, used pervasively in the
+compiler's own AST (`TypeParameter.bound: TypeAnnotation?`, `ImportSpecifier`
+aliases, `Parameter.type_annotation: TypeAnnotation?`, and dozens more in
+`compiler/src/ast.sfn`), with `Expression.NullLiteral` as the literal
+(`ast.sfn:65`). What it lacks is *ergonomic access* to those values: there is
+no null-safe navigation `?.` and no null-coalescing `??`, so every use of a
+`T?` requires a hand-written `if x != null { ... }` guard. This SFEP adds two
+front-end-only operators — `a?.b` (evaluates to `null` if `a` is `null`, else
+`a.b`, short-circuiting the rest of the chain to a nullable result) and
+`a ?? b` (yields `a` if non-null, else `b`, stripping nullability) — plus the
+optional-index (`a?.[i]`) and optional-call (`a?.(args)`) forms for chain
+completeness. Both desugar to guarded expressions over the existing `null`
+literal, `!= null` comparison, and control flow; **no new runtime, no new IR
+opcode, and no exception involvement**. The load-bearing design problem is
+disambiguating `?.` and `??` from the postfix Result `?` (`TryOperator`,
+SFEP-0012) and the ternary `?` (`Conditional`, #1690), all of which share the
+`?` glyph — solved at the lexer by tokenizing `?.` and `??` as distinct
+two-char symbols, exactly as `..`, `&&`, and `<=` are today.
+
+## 2. Motivation
+
+**Who hits it, how often.** Absence is everywhere in the compiler's own source.
+`compiler/src/ast.sfn` alone declares nullable fields on `TypeParameter.bound`,
+`SourceSpan?` on nearly every expression variant, `Parameter.type_annotation`,
+`Parameter.default_value`, `Channel.element_type`, `Channel.capacity`,
+`Serve.port`, `MatchCase.guard`, `ElseBranch.statement`/`body`, and many more.
+Every read of one of these today is a manual guard:
+
+```sfn
+// The status quo — reading a nullable field safely.
+let mut bound_text: string = "";
+if param.bound != null {
+    bound_text = param.bound.text;
+}
+
+// A two-level access needs a nested guard:
+let mut label: string = "anon";
+if node.span != null {
+    // ... still cannot reach node.span.start_line in one expression
+}
+```
+
+This is verbose, error-prone (a forgotten guard is a null dereference), and the
+exact boilerplate `?.`/`??` exist to remove in every language that has nullable
+types (Kotlin `?.`/`?:`, TypeScript `?.`/`??`, C# `?.`/`??`, Swift `?.`/`??`).
+
+**Why the status quo is insufficient.** The `T?` type already ships and is spec'd
+(`site/.../reference/spec/06-types.md:58` — *"Optional types: `T?` — the value
+is `T` or `null`"*). The type exists but the ergonomics do not, which is the
+worst of both worlds: the language *invites* nullable modelling (the compiler
+uses it pervasively) but forces callers to hand-roll the access pattern. Adding
+`?.`/`??` is the "boring syntax wins" completion of a feature already half-built
+— it matches the conventions every LLM has seen thousands of times, reducing
+generated-code error rates (CLAUDE.md "AI agents are users").
+
+**Why now.** These are pure front-end sugar over constructs that already lower
+(member access, index, call, `!= null`, and the statement-hoist continuation
+rewrite proven by `desugar_try_in_block`). They add no runtime and no new safety
+*claim* — a `?.` chain is exactly as safe as the `if != null` it desugars to, so
+there is no "parsed but not enforced" trap.
+
+## 3. Design
+
+### 3.1 Overview and worked examples
+
+```sfn
+// Null-safe navigation: null if the receiver is null, else the member.
+let text: string? = param.bound?.text;      // string? — null when bound is null
+
+// Chains short-circuit: any null link yields null for the whole chain.
+let line: int? = node.span?.start_line;
+
+// Null-coalescing strips nullability with a fallback.
+let bound_text: string = param.bound?.text ?? "<none>";   // string, never null
+
+// Optional index and optional call (chain completeness):
+let first: Item? = maybeList?.[0];
+let result: int? = maybeFn?.(arg);
+
+// Combined with `??` for a total expression:
+let n: int = lookup(key)?.count ?? 0;
+```
+
+- `a?.b` — if `a` is `null`, the whole expression is `null` (type `B?`); else it
+  is `a.b`. If `a`'s member `b` is itself nullable, the result stays `B?` (no
+  double-nullable — `T??` normalizes to `T?`).
+- `a?.[i]` — if `a` is `null`, `null`; else `a[i]`, result `Elem?`.
+- `a?.(args)` — if `a` is `null`, `null`; else `a(args)`, result `Ret?`.
+- `a ?? b` — if `a` is non-null, `a` (as its non-null type); else `b`. Result
+  type is the non-null type of `a` unified with the type of `b`.
+
+### 3.2 The disambiguation problem (load-bearing)
+
+After SFEP-0012 (Result `?`) and #1690 (ternary `?`), the single-char `?` symbol
+already carries **three** meanings, all resolved in the expression parser today:
+
+| Form | Meaning | Where resolved (today) |
+|---|---|---|
+| type suffix `Config?` | nullable **type** | type-annotation scanner (`collect_type_annotation_until`) — never enters expression parsing |
+| postfix `expr?` | Result error-propagation (`TryOperator`) | `parse_postfix_chain` `?` arm (`expressions.sfn:1318`) |
+| infix `cond ? a : b` | ternary (`Conditional`) | base-precedence seam in `parse_expression_bp` (`expressions.sfn:370`) |
+
+The existing postfix/ternary split (`expressions.sfn:1318-1344`) is a
+**lookahead** disambiguation: when a `?` is seen in postfix position, the parser
+peeks past it — if a top-level `:` follows a branch-start token
+(`is_ternary_marker`), the `?` is left unconsumed for the ternary seam;
+otherwise it is a `TryOperator`. Adding `?.` and `??` on top of this by
+*character lookahead alone* would deepen an already-subtle seam.
+
+**Decision: tokenize `?.` and `??` as distinct two-char symbols in the lexer**
+(`is_two_char_symbol`, `lexer.sfn:446`), joining `..`, `&&`, `||`, `==`, `<=`,
+`+=`, etc. This is the single most important design choice and it makes every
+downstream production trivial:
+
+- The lexer's maximal-munch pass (`lexer.sfn:333`) already emits the longest
+  matching symbol. `a?.b` lexes as `[a] [?.] [b]`; `a ?? b` lexes as
+  `[a] [??] [b]`; a bare `a?` still lexes `[a] [?]` (single `?`), and
+  `cond ? a : b` still lexes `[cond] [?] [a] [:] [b]`. **A `?` immediately
+  followed by `.` or `?` is a different *token* than a standalone `?`** — the
+  ambiguity is resolved before the parser ever runs, so `TryOperator` and
+  `Conditional` are untouched.
+- The one adjacency to reason about is `a?.b` vs. *"Result-`?` then member
+  access"* (`(a?).b`). **Rule: `?.` is always the null-safe access token; there
+  is no `(a?).b` reading.** Because `?.` is lexed as one token, `a?.b` can only
+  parse as null-safe access. To write Result-propagation-then-member you insert
+  whitespace: `a? .b` lexes as `[a] [?] [.] [b]` (the `?` is not immediately
+  followed by `.`), and separately, member access on a `Result`-unwrapped value
+  is the far rarer intent. This is the same maximal-munch rule that already makes
+  `a..b` a range (never `a.` `.b`) and `a==b` an equality (never `a=` `=b`). It
+  is boring and matches Kotlin/TypeScript/Swift, where `?.` is likewise a single
+  lexical token that wins over `?` `.`.
+- **`a ?? b` vs. Result-`?` then ternary-`?`.** `a?? b : c` would be a
+  degenerate reading; `??` as one token forecloses it — `a ?? b` is always
+  coalescing. A Result-propagate feeding a ternary condition is written
+  `a? ? b : c` (whitespace) or, idiomatically, parenthesized `(a?) ? b : c`.
+
+**Consequence for `TryOperator` lookahead:** the existing ternary-vs-try
+lookahead in `parse_postfix_chain` (`expressions.sfn:1338`,
+`is_ternary_marker`) is *narrowed* by this change, not broken: it now only ever
+sees a **single** `?` token (a `?.`/`??` never reaches it because the lexer
+produced a two-char token the postfix loop's `strings_equal(sym, "?")` guard
+does not match). The `??`/`?.` arms are new, separate productions.
+
+### 3.3 Lexer
+
+`compiler/src/lexer.sfn` — add two arms to `is_two_char_symbol` (`lexer.sfn:446`):
+
+```sfn
+if value == "?." { return true; }
+if value == "??" { return true; }
+```
+
+No other lexer change. Maximal munch (`lexer.sfn:333`) already consumes the
+two-char symbol when the pair matches. **Migration-safe:** the old seed lexes
+`?.` as `[?] [.]` and `??` as `[?] [?]`; because the compiler source contains no
+`?.`/`??` until a post-SFEP follow-up (§5), the old seed never needs the new
+tokenization to build the new compiler.
+
+### 3.4 Parser
+
+`compiler/src/parser/expressions.sfn` — two additions in `parse_postfix_chain`
+(`expressions.sfn:1177`), placed in the postfix `Symbol` loop alongside the
+existing `.` / `(` / `[` / `?` arms:
+
+**(a) `?.` arm** (null-safe member / index / call). When the current token is the
+symbol `?.`:
+
+```
+postfix := primary (
+      "." ident
+    | "(" args ")"
+    | "[" expr "]"
+    | "as" type | "is" type
+    | "?"                       // TryOperator (single ?)
+    | "?." ident                // OptionalMember
+    | "?." "[" expr "]"         // OptionalIndex
+    | "?." "(" args ")"         // OptionalCall
+)*
+```
+
+After consuming `?.`, dispatch on the *next* token:
+- an `Identifier` → build `Expression.OptionalMember { object, member }`;
+- `[` → parse the index expression and `]`, build `Expression.OptionalIndex
+  { sequence, index }`;
+- `(` → parse the call arguments via the existing `parse_call_arguments`, build
+  `Expression.OptionalCall { callee, arguments }`.
+
+Left-associates through the loop, so `a?.b?.c` parses as `((a?.b)?.c)` and
+`a?.b()` parses as `(a?.b)(...)` — matching the plain `.`/`(` chain shape.
+
+**(b) `??` arm** — `??` is **infix**, not postfix, so it is handled in
+`parse_expression_bp`, not the postfix chain. Add `??` to `binary_precedence`
+(`expressions.sfn:2209`) at a tier **below `||` (1) and above range `..` (0)**;
+concretely `??` → precedence `1` requires re-numbering — instead insert `??` at
+its own tier between `..` and `||` by giving `??` precedence `1` and shifting
+`||`+ up by one, **or** (preferred, minimal-blast-radius) give `??` precedence
+**0** shared with `..` but make it **right-associative** via a dedicated seam.
+
+**Chosen rule (minimal, unambiguous):** treat `??` like the ternary/assignment
+seams — a **dedicated right-associative arm at base precedence**
+(`min_precedence == 0`) in `parse_expression_bp`, evaluated **after** the binary
+climb (so `a || b ?? c` groups as `(a || b) ?? c`, coalescing binds looser than
+`||`) but **before** the ternary and assignment seams (so `a ?? b ? c : d`
+groups as `(a ?? b) ? c : d`, and `x = a ?? b` groups as `x = (a ?? b)`). The
+right-hand side recurses at base precedence for right-associativity: `a ?? b ?? c`
+→ `a ?? (b ?? c)`. This mirrors the *exact* structure of the existing ternary
+seam (`expressions.sfn:370-410`) and assignment seam
+(`expressions.sfn:422-445`), so it is a copy of a proven pattern, not a new
+precedence-table entry that could perturb `||`/`&&` binding.
+
+> Precedence summary (loosest → tightest): `= / +=` (assignment) · `? :`
+> (ternary) · `??` (coalesce) · `||` · `&&` · … · postfix (`?.`, `.`, `()`,
+> `[]`, `?`). `??` is right-associative; `?.` is postfix-tight and
+> left-associative.
+
+### 3.5 AST
+
+`compiler/src/ast.sfn` — four new `Expression` variants, modelled field-for-field
+on their non-optional cousins so the field-name GEP-slot convention holds (see
+the `Assignment` field-name note at `ast.sfn:133-158`):
+
+```sfn
+// Null-safe member access `a?.b` — null if `object` is null, else `object.b`
+// (nullable result). Fields mirror `Member` (`object`, `member`, `span`) so
+// they share the enum's per-name field slots. Desugared to a guarded temp +
+// `!= null` test before native emission (emit_native_desugar_null.sfn), the
+// same statement-hoist strategy `desugar_try_in_block` uses for `?`.
+OptionalMember { object: Expression, member: string, span: SourceSpan? },
+// Null-safe index `a?.[i]`. Mirrors `Index` (`sequence`, `index`).
+OptionalIndex { sequence: Expression, index: Expression, span: SourceSpan? },
+// Null-safe call `a?.(args)`. Mirrors `Call` (`callee`, `arguments`, `span`).
+OptionalCall { callee: Expression, arguments: Expression[], span: SourceSpan? },
+// Null-coalescing `a ?? b` — `left` if non-null, else `right`. Right-assoc,
+// binds looser than `||`. Desugared to a guarded temp + `!= null` select.
+Coalesce { left: Expression, right: Expression, span: SourceSpan? },
+```
+
+`span` is appended last on every variant per the layout-stability convention at
+`ast.sfn:60`. No change to any existing variant.
+
+### 3.6 Type rules (`typecheck.sfn`)
+
+Per the discovery documented in SFEP-0034 §3.5 and the `TryOperator` arm
+(`typecheck.sfn:1090`), **the typecheck pass tracks names only — it performs no
+expression-type inference (#829)**. So, exactly like `Cast`, `Is`, `TryOperator`,
+and `Conditional`, the new nodes get **`walk_expression` recursion arms** (so
+inner diagnostics — undefined symbols, fn-value misuse, parse-error nodes — still
+fire), not a full nullable-type flow checker:
+
+```sfn
+if expression.variant == "OptionalMember" {
+    return walk_expression(expression.object, bindings, imports);
+}
+if expression.variant == "OptionalIndex" {
+    let mut d = walk_expression(expression.sequence, bindings, imports);
+    return d.concat(walk_expression(expression.index, bindings, imports));
+}
+if expression.variant == "OptionalCall" {
+    let mut d = walk_expression(expression.callee, bindings, imports);
+    // recurse each argument (as the Call arm does)
+    return d;
+}
+if expression.variant == "Coalesce" {
+    let mut d = walk_expression(expression.left, bindings, imports);
+    return d.concat(walk_expression(expression.right, bindings, imports));
+}
+```
+
+**The nullable *typing* semantics** below are the normative contract the language
+adopts; the **enforcement** of the "receiver must be `T?`" rule is scoped as a
+fast-follow gated on expression-type inference (#829), for the same reason
+SFEP-0034's non-enum `is` diagnostic is deferred — there is no consumer for a
+refined type in typecheck today. This keeps the SFEP honest: v1 ships the
+operators and their desugaring end-to-end (the ergonomic win), and the static
+"you used `?.` on a non-nullable" diagnostic follows when #829 lands. The typing
+contract:
+
+1. **`a?.b`**: `a` should have a nullable type `T?`. The chain's result type is
+   `B?` where `B` is the type of `T.b`. If `T.b` is itself nullable, the result
+   normalizes to `B?` (no `T??`).
+2. **`a?.[i]` / `a?.(args)`**: analogous — result is `Elem?` / `Ret?`.
+3. **`a ?? b`**: `a` should be `T?`; the expression **strips** nullability — its
+   type is `T` unified with the type of `b`. `T? ?? T` yields `T`. This is where
+   a `?.`-chain most naturally terminates into a total value.
+4. **`is`-narrowing tie-in (SFEP-0034).** `if x is T { ... }` already narrows
+   `x` to the tested variant in the then-branch via the lowering's
+   `narrowed_variant` machinery. A parallel **null-narrowing** — `if x != null`
+   refining `x: T?` to `T` in the then-branch — is the same shape and is the
+   natural home for future flow-based nullability enforcement; it is called out
+   here as the extension point but is **not** built in v1 (it, too, waits on
+   #829). `??` and `?.` do not require it: they desugar to explicit `!= null`
+   tests that need no narrowing substrate.
+
+No new E-codes are reserved for v1 (the existing range tops out near `E0816`;
+`typecheck_types.sfn`). When the #829-gated receiver-nullability diagnostic
+lands it reserves the next free `E08xx` slot, matching the numeric-code
+convention (SFEP-0012 §Type rules).
+
+### 3.7 Native IR — desugaring (the core lowering)
+
+Like `?` (`TryOperator`), the nullable operators lower by **AST→AST desugaring
+before native emission**, reusing the exact statement-hoist / continuation
+machinery in `desugar_try_in_block` (`emit_native_desugar_try.sfn`). Add a
+sibling pass, `emit_native_desugar_null.sfn`, run as a `Block -> Block` pre-pass
+(alongside the try desugarer). The AST/native-IR have **no** match-expression or
+if-expression form (only statements), so — exactly as the try desugarer does —
+each nullable operator hoists its receiver into a fresh temp, tests it against
+`null`, and threads the block remainder through.
+
+**`a?.b` desugars** (hoisting into a fresh `__opt_N` temp) to:
+
+```sfn
+let __opt_0 = a;                 // evaluate the receiver ONCE
+let mut __opt_0_r: B? = null;
+if __opt_0 != null {
+    __opt_0_r = __opt_0.b;       // plain Member access on the non-null temp
+}
+// ... uses of the original `a?.b` reference __opt_0_r ...
+```
+
+`a ?? b` desugars to:
+
+```sfn
+let __opt_1 = a;                 // evaluate the left ONCE
+let mut __opt_1_r: T = b;        // default to the fallback
+if __opt_1 != null {
+    __opt_1_r = __opt_1;         // non-null: use the left (as its non-null type)
+}
+// ... uses of `a ?? b` reference __opt_1_r ...
+```
+
+Chains and mixed `?.`/`??` fall out of the recursion, precisely as the try
+desugarer handles chained `?`: `a?.b ?? c` desugars the inner `a?.b` first
+(binding `__opt_0_r: B?`), then the `??` over that temp (binding `__opt_1_r: B`).
+Short-circuiting is preserved because the `.b` access only executes inside the
+`__opt_0 != null` arm. **The fresh-temp-per-operator discipline** (the `__opt_N`
+counter threaded through the block walk, mirroring `__try_N`) guarantees multiple
+operators in one expression (`a?.b + c?.d`) do not collide, and that each
+receiver is evaluated exactly once (correct for effectful receivers,
+`fs.read()?.len`).
+
+Because the desugared output is **only** `let`, `if`, `Member`/`Index`/`Call`,
+`!= null` (`Binary`), and `NullLiteral` — all of which already emit valid
+`.sfn-asm` — **no new native-IR opcode is introduced**, and the native
+formatter needs **no new serialization arm** for the optional nodes in the
+common (fully-desugared) path.
+
+**Fallback formatter arms (defensive, mirroring `TryOperator`).** The try
+desugarer leaves a `TryOperator` in place when it sits inside a ternary branch
+(where statement-hoist would change evaluation order), and the native formatter
+has a fallback `TryOperator` arm (`emit_native_format.sfn:259`) that serializes
+it to `operand?` text for the shadow re-parser. For symmetry and safety, the
+null desugarer likewise leaves an optional node in place inside a ternary/`??`
+branch, and `emit_native_format.sfn` gains fallback arms serializing to the
+lowering shadow re-parser's text form:
+
+- `OptionalMember` → `(object)?.member`
+- `OptionalIndex` → `(sequence)?.[index]`
+- `OptionalCall` → `(callee)?.(args)`
+- `Coalesce` → `(left) ?? (right)`
+
+with matching shadow re-parsers in `compiler/src/llvm/expression_lowering/
+native/core_parsing.sfn` (siblings of `parse_cast_expression` /
+`parse_is_expression` / `parse_ternary_expression`). This is the same
+"serialization-is-the-bridge" pattern the ternary and assignment nodes use
+(`emit_native_format.sfn:226`, `:243`). In practice the desugarer handles the
+overwhelming majority of sites, so these arms are the safety net, not the hot
+path.
+
+### 3.8 LLVM lowering
+
+**No new lowering code in the desugared path.** The `if __opt_N != null { ... }`
+form lowers through the existing `if`/`Binary(!=)`/`NullLiteral` paths, and the
+member/index/call inside the arm lowers through the existing
+`Member`/`Index`/`Call` lowering. The `!= null` test lowers to the same
+null-pointer / sentinel comparison the compiler already emits for hand-written
+`if x != null` guards (`NullLiteral` lowering, `emit_native_format.sfn:111`).
+The only lowering additions are the **defensive shadow re-parsers** (§3.7) for
+the ternary-branch fallback, which reuse the `strip_enclosing_parentheses` /
+top-level-scan helpers `parse_cast_expression` and `parse_is_expression` already
+provide.
+
+### 3.9 Effect checking
+
+`compiler/src/effect_checker.sfn` — four pass-through arms in
+`collect_effects_from_expression`, identical in spirit to the `Cast` / `Is` /
+`Conditional` / `TryOperator` arms (`effect_checker.sfn:888-982`). The operators
+add **no effect of their own** (they are control flow over a `null` test); the
+effectful surface is the receiver/arguments, which must be walked:
+
+```sfn
+if expression.variant == "OptionalMember" {
+    return collect_effects_from_expression(expression.object, imports);
+}
+if expression.variant == "OptionalIndex" {
+    let mut r = collect_effects_from_expression(expression.sequence, imports);
+    return merge_requirements(r, collect_effects_from_expression(expression.index, imports));
+}
+if expression.variant == "OptionalCall" {
+    // union of callee + each argument (as the Call form does)
+    ...
+}
+if expression.variant == "Coalesce" {
+    // BOTH sides: the left always evaluates; the right may. Union, like the
+    // ternary arm (either branch may run).
+    let mut r = collect_effects_from_expression(expression.left, imports);
+    return merge_requirements(r, collect_effects_from_expression(expression.right, imports));
+}
+```
+
+This is a **net tightening** identical to SFEP-0034's: if these ever parsed to
+`Raw` (they do not — they are new structured nodes) an effectful receiver would
+drop its effect; structuring them forces the operand walk. `fs.read()?.len`
+surfaces `![io]`.
+
+### 3.10 Formatter (`sfn fmt`)
+
+Source-level `sfn fmt` must round-trip `a?.b`, `a?.[i]`, `a?.(args)`, and
+`a ?? b` (verified `fmt --check`-stable). The canonical spacing is: **no space**
+around `?.` (like `.`), and **single spaces** around `??` (like `||`) —
+matching TypeScript/Kotlin convention and the "boring syntax wins" principle.
+The source formatter emits these forms directly from the structured nodes; the
+*native-IR* formatter arms (§3.7) are the separate lowering-bridge serialization.
+
+### 3.11 Scope
+
+**In v1 (this SFEP):** `?.` (member), `?.[]` (index), `?.(  )` (call), and `??`
+(coalesce), fully desugared and self-hosting; parser + AST + effect-walk +
+typecheck-walk + native desugar + fmt round-trip. Including index and call keeps
+the chain complete (`a?.b?.[0]?.(x) ?? d` is expressible), which is the whole
+point of an access-operator family — shipping only `?.member` would force a
+manual guard back in for the exact cases where chaining matters most.
+
+**Deferred fast-follows** (file as sub-issues):
+- **Static receiver-nullability diagnostic** (`?.`/`??` on a non-nullable type) —
+  blocked on expression-type inference (#829), the same blocker SFEP-0034's
+  non-enum `is` diagnostic carries.
+- **`if x != null` then-branch null-narrowing** (`T?` → `T`), the null analogue
+  of SFEP-0034's variant narrowing — a natural extension of the same
+  `narrowed_variant` machinery, deferred with #829.
+- **`!` non-null assertion operator** (`a!.b`, force-unwrap) — a separate,
+  safety-*loosening* construct; intentionally out of scope (it manufactures a
+  panic path, unlike `?.`/`??` which are total).
+
+## 4. Effect & capability impact
+
+Effect-transparent. `?.`, `?.[]`, `?.(  )`, and `??` add **no** effect and no
+capability-manifest change; each requires exactly the union of its operands'
+effects (§3.9), the same treatment `Cast`/`Is`/`Conditional`/`TryOperator`
+already receive. The change is a net *tightening* by construction: the operators
+are new structured nodes whose operands are always walked, so an effectful
+receiver (`fs.read()?.field`, `lookup()?.() ?? fallback()`) surfaces its
+capability rather than hiding behind a `Raw` degradation. This advances the same
+headline-integrity goal as epic #1180 (no effect-blind expression forms). No new
+effect keyword; `??`'s right branch is treated like a ternary branch (may run →
+its effects are required), which is conservative and sound.
+
+## 5. Self-hosting impact
+
+Passes touched, in pipeline order:
+
+- **Lexer** (`lexer.sfn`) — two arms in `is_two_char_symbol` (`?.`, `??`).
+- **Parser** (`parser/expressions.sfn`) — `?.` postfix arm (member/index/call
+  dispatch) in `parse_postfix_chain`; `??` right-associative base-precedence
+  seam in `parse_expression_bp` (copy of the ternary/assignment seam).
+- **AST** (`ast.sfn`) — `OptionalMember`, `OptionalIndex`, `OptionalCall`,
+  `Coalesce` variants (fields mirror `Member`/`Index`/`Call`; `span` last).
+- **Typecheck** (`typecheck.sfn`) — four `walk_expression` recursion arms
+  (names-only, per #829). No `SymbolEntry` change.
+- **Effect checker** (`effect_checker.sfn`) — four operand-walk arms.
+- **Native desugar** (new `emit_native_desugar_null.sfn`) — the `Block -> Block`
+  hoist/continuation pre-pass, a sibling of `emit_native_desugar_try.sfn`, wired
+  into the same emission entry point that already calls `desugar_try_in_block`.
+- **Native formatter** (`emit_native_format.sfn`) — four defensive fallback
+  serialization arms (the ternary-branch safety net).
+- **LLVM lowering** (`llvm/.../core_parsing.sfn`) — four shadow re-parsers for
+  the fallback arms; no new opcode, no new instruction lowering.
+
+**Self-hosting invariant preserved — BUNDLE, no seed cut.** The change is
+**additive** and the old seed is unaffected: the old lexer tokenizes `?.` as
+`[?][.]` and `??` as `[?][?]`, and the compiler source contains **no** `?.`/`??`
+usage in v1, so `make compile` builds the new compiler from the old pinned seed,
+and that freshly-built compiler is the first one that both *emits* and (in a
+follow-up) could *consume* the operators — all in one self-host pass. No
+`/pin-seed`, no seed cut (`.claude/rules/seed-dependency.md`: single consumer,
+same session → bundle). A **separate, opt-in follow-up** may migrate the
+compiler's own `if x != null` guards to `?.`/`??`, but only after a seed
+containing the operators exists — exactly the staging SFEP-0012 §Q6 and SFEP-0034
+§3.9 use.
+
+## 6. Alternatives considered
+
+- **Single-char lookahead (no new tokens), disambiguating `?.`/`??` in the
+  parser** like the existing try-vs-ternary seam. Rejected: it stacks a third
+  and fourth meaning onto the already-subtle `?` lookahead in
+  `parse_postfix_chain`, raising the odds of a regression in `TryOperator` /
+  `Conditional` parsing. Two-char tokenization resolves the ambiguity in the
+  lexer (maximal munch) *before* the parser runs — the same proven mechanism as
+  `..`/`&&`/`<=`, and how Kotlin/TypeScript/Swift lex `?.` themselves.
+- **`?:` (Elvis) instead of `??` for coalescing** (Kotlin's spelling). Rejected:
+  `?:` collides head-on with the ternary `? :` tokens and would be a genuine
+  lexical ambiguity (`a ?: b` vs `a ? x : b`). `??` (TypeScript/C#/Swift) is
+  unambiguous once tokenized and is the more widely-seen spelling for LLMs.
+- **A prelude `Option<T>` enum + `map`/`unwrap_or` methods** instead of syntax.
+  Rejected for v1: it duplicates the already-shipped `T?`/`null` model (there is
+  no `Option<T>` today, and adding one competes with `T?` for the same role),
+  and method-chaining on `Option` needs closures/generics ergonomics that the
+  `?.`/`??` sugar sidesteps entirely. `?.`/`??` are pure sugar over the *existing*
+  nullable model — no new type, no runtime.
+- **A new runtime null-check intrinsic.** Rejected: unnecessary. The desugaring
+  emits ordinary `!= null` + `if`, which already lower correctly; adding an
+  intrinsic would be gratuitous surface with no benefit.
+- **Full flow-based nullability enforcement in v1** (reject `?.` on a
+  non-nullable, narrow `T?`→`T` after `!= null`). Deferred, not rejected: it is
+  blocked on expression-type inference (#829), the same blocker SFEP-0034's
+  non-enum diagnostic carries. Shipping the operators' desugaring now (the
+  ergonomic win) and the static diagnostic when #829 lands avoids coupling a
+  usable feature to an unbuilt analysis — "fix the foundation first" without
+  blocking the sugar behind it.
+- **Including `!` force-unwrap in v1.** Rejected: `!` *loosens* safety (it
+  introduces a panic path), the opposite of `?.`/`??` which are total. It belongs
+  in its own SFEP with its own panic-semantics justification.
+
+## 7. Stage1 readiness mapping
+
+- [ ] **Parses** — `?.` postfix arm (member/index/call) + `??` base-precedence
+  seam produce structured `OptionalMember`/`OptionalIndex`/`OptionalCall`/
+  `Coalesce` nodes (no `Raw` fallthrough); `?.`/`??` lexed as two-char symbols.
+- [ ] **Type-checks / effect-checks** — `walk_expression` arms (names-only,
+  #829) + effect operand-walk arms; effectful receiver surfaces its effect. (The
+  static receiver-nullability *diagnostic* is a #829-gated fast-follow — hence
+  Draft/Accepted, not Implemented, until it lands.)
+- [ ] **Emits valid `.sfn-asm`** — `emit_native_desugar_null.sfn` rewrites the
+  operators to `let`/`if`/`!= null`/`Member`/`Index`/`Call`, all of which
+  already emit; defensive native-formatter fallback arms cover the
+  ternary-branch case.
+- [ ] **Lowers to LLVM IR** — desugared path reuses existing `if`/`Binary`/
+  `Member`/`Index`/`Call`/`NullLiteral` lowering; four shadow re-parsers for the
+  fallback. No new opcode.
+- [ ] **Regression coverage** — parser unit, effect-walk integration, and
+  build-and-run e2e tests (§8).
+- [ ] **Self-hosts** — `make compile`; old seed builds the new compiler
+  (additive, no `?.`/`??` in compiler source). No seed cut.
+- [ ] **`sfn fmt --check` clean** — every touched `.sfn`; source formatter
+  round-trips `a?.b` / `a ?? b`.
+- [ ] **Documented** — `docs/status.md` gains a nullable-operators row; the
+  `graduates-to` preview chapter `reference/preview/nullability.md` is authored;
+  spec `06-types.md` cross-links from the Optional-types row.
+
+## 8. Test plan
+
+Regression coverage under `compiler/tests/{unit,integration,e2e}/`:
+
+- **`compiler/tests/unit/parser_nullable_access_test.sfn`** — `a?.b` parses to
+  `OptionalMember` (object Identifier, `member`); `a?.[0]` to `OptionalIndex`;
+  `a?.(x)` to `OptionalCall`; `a ?? b` to `Coalesce`. Precedence: `a || b ?? c`
+  → `Coalesce{ left: Binary(||), right: c }`; `a ?? b ?? c` right-associates to
+  `Coalesce{ a, Coalesce{ b, c } }`; `a ?? b ? c : d` → `Conditional{ Coalesce,
+  c, d }`. Disambiguation: `a? .b` (whitespace) lexes `[a][?][.][b]` (Result-`?`
+  then member), while `a?.b` lexes `[a][?.][b]`; `a?` alone still parses
+  `TryOperator`; `cond ? a : b` still parses `Conditional`.
+- **`compiler/tests/unit/lexer_nullable_tokens_test.sfn`** — `?.` and `??` lex as
+  single `Symbol` tokens; `? .` / `? ?` (spaced) lex as two `?`/`.`/`?` tokens.
+- **`compiler/tests/integration/nullable_effect_walk_test.sfn`** — a pure caller
+  with `fs.read()?.len` / `readMaybe() ?? fallbackIo()` is rejected for the
+  missing `![io]`; the same body with `![io]` compiles (net-tightening proof).
+- **`compiler/tests/e2e/nullable_access_test.sfn`** — build and run a program
+  exercising: `?.` returning `null` when the receiver is null and the member
+  when non-null; a two-level chain short-circuiting on the first null; `??`
+  supplying the fallback and passing through the non-null; a receiver evaluated
+  **exactly once** (effectful receiver, assert single side effect); `?.[]` and
+  `?.(  )`. Thread `PATH` / `SAILFIN_TEST_SCRATCH` per
+  `.claude/rules/no-bash-e2e.md`.
+- **`compiler/tests/e2e/nullable_desugar_snapshot_test.sfn`** (optional) —
+  snapshot the desugared native IR for `a?.b ?? c` to lock the hoist/temp shape.
+- **Self-host** — `make compile` + the full suite; a converted example
+  (`examples/basics/nullable-access.sfn`) participates in the seedcheck corpus.
+
+## 9. References
+
+- SFEP-0012 (`docs/proposals/0012-result-and-question-operator.md`) — the postfix
+  Result `?` (`Expression.TryOperator`, `ast.sfn:111-114`); §"Disambiguating the
+  two `?`s" is the direct precedent this SFEP extends to a *third* and *fourth*
+  `?`-glyph meaning. The `desugar_try_in_block` statement-hoist strategy
+  (`emit_native_desugar_try.sfn`) is the model for `emit_native_desugar_null.sfn`.
+- SFEP-0034 (`docs/proposals/0034-is-type-guard.md`) — `x is T` narrowing; §3.5
+  documents the "typecheck tracks names only, #829 gates static type diagnostics"
+  reality this SFEP inherits, and its `narrowed_variant` machinery is the
+  extension point for future `T?`→`T` null-narrowing.
+- Spec `reference/spec/06-types.md:58` — Optional types `T?` (the type this SFEP
+  adds access operators for); line 63 (`Result<T, E>` roadmap note).
+- `.claude/rules/seed-dependency.md` — the bundle decision (single consumer,
+  additive, no seed cut).
+- Key source: `compiler/src/lexer.sfn:446` (`is_two_char_symbol`),
+  `:333` (maximal-munch symbol emit); `compiler/src/parser/expressions.sfn:1177`
+  (`parse_postfix_chain`, `:1318` the `?` arm), `:370`/`:422` (ternary/assignment
+  base-precedence seams — the `??` seam template), `:2209` (`binary_precedence`);
+  `compiler/src/ast.sfn:54` (`Expression` enum), `:65` (`NullLiteral`), `:68`
+  (`Member`), `:74` (`Index`), `:69` (`Call`); `compiler/src/typecheck.sfn:1060`
+  (`Cast`/`Is`/`TryOperator` walk arms); `compiler/src/effect_checker.sfn:888`
+  (`Cast`/`Is`/`Conditional`/`TryOperator` effect arms);
+  `compiler/src/emit_native_format.sfn:203` (`Cast`/`Is`/`Conditional`/
+  `TryOperator` native-IR serialization — the fallback-arm template);
+  `compiler/src/emit_native_desugar_try.sfn` (the hoist desugarer to mirror).
+- Prior art: TypeScript `?.`/`??`, C# `?.`/`??`, Swift `?.`/`??`, Kotlin
+  `?.`/`?:` (Elvis).

--- a/docs/proposals/draft-sized-integer-types.md
+++ b/docs/proposals/draft-sized-integer-types.md
@@ -1,0 +1,508 @@
+---
+sfep: TBD
+title: Sized Integer Types and Overflow Semantics
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/spec/06-types.md
+---
+
+# SFEP-XXXX — Sized Integer Types and Overflow Semantics
+
+## 1. Summary
+
+Sailfin recognises `int` (i64), `float` (f64), and a partial sized family
+(`i8`/`i16`/`i32`/`i64`, `u8`/`u16`/`u32`/`u64`, `usize`/`isize`, `f32`/`f64`)
+as type-name strings, and all of them already lower to real LLVM `iN`/`double`/
+`float` types through `map_primitive_type`
+([`compiler/src/llvm/type_mapping.sfn:859-897`](../../compiler/src/llvm/type_mapping.sfn#L859-L897)).
+But the family is only *half* real: unsigned widths collapse onto their signed
+LLVM twins (`u32`→`i32`, `u8`→`i8`), so the compiler **cannot tell signed from
+unsigned**; there is **no defined overflow behaviour**; there is **no
+literal-fits-in-type checking**; and there are **no typed literal suffixes**.
+This SFEP finishes the family into a first-class, sign-tracked set with defined
+overflow semantics (wrap in release / trap in debug, matching Rust), explicit
+`as`-cast conversions (no implicit widening or narrowing), and a `wrapping_*` /
+`checked_*` / `saturating_*` **library** surface (no new operators). It is
+foundational plumbing — "fix the foundation first" — and is deliberately
+independent of the generics workstream.
+
+## 2. Motivation
+
+**A "systems language" without a working sized-integer family is an outlier.**
+Rust, Go, Swift, Zig, and C all ship the full `{i,u}{8,16,32,64}` family with
+defined conversion and overflow rules. Sailfin's status matrix marks the numeric
+types "Shipped"
+([`docs/status.md:184`](../../docs/status.md#L184)), but that row describes the
+`int`/`float` (i64/f64) core plus bitwise/shift ops and the `as` matrix — not a
+sound sized family. Three concrete gaps make the current state unsafe to build
+on:
+
+1. **Signedness is silently lost.** `map_primitive_type` maps `u32`→`i32`,
+   `u16`→`i16`, `u8`→`i8`, `u64`→`i64`
+   ([`type_mapping.sfn:877-895`](../../compiler/src/llvm/type_mapping.sfn#L877-L895)).
+   The cast-lowering matrix documents the resulting footgun in a standing
+   "KNOWN LIMITATION" comment
+   ([`core_literals_lowering.sfn:1837-1845`](../../compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn#L1837-L1845)):
+
+   > "source-level unsigned widths (`u8`/`u16`/`u32`) collapse to `i8`/`i16`/`i32`
+   > … `255_u8 as u64` therefore lowers as `sext` and becomes `-1` (sign-
+   > extended) rather than `255` (zero-extended)."
+
+   Every `u*`→wider conversion is wrong today. `u8` value `255` widened to `u64`
+   yields `-1`. This is a miscompile, not a missing feature.
+
+2. **Overflow is undefined.** No `overflow`, `wrapping_*`, `checked_*`, or
+   `saturating_*` machinery exists anywhere in `compiler/src`
+   (a repo-wide search finds only unrelated build-cache/lifetime hits). Integer
+   arithmetic emits bare `add`/`sub`/`mul` with no defined behaviour on wrap and
+   no way for a user to *request* wrap, trap, or checked arithmetic. For a
+   memory-safety-floor language (ownership epic #1209) this is a hole: an
+   overflow that produces a bad index or length is exactly the class of bug the
+   ownership floor otherwise closes.
+
+3. **Literals are not range-checked and cannot be typed.** The lexer captures a
+   number as one generic `NumberLiteral` lexeme with no suffix support
+   ([`lexer.sfn:190-280`](../../compiler/src/lexer.sfn#L190-L280));
+   a trailing `u8`/`i16` lexes as a *separate* `Identifier` token. There is no
+   parse-time or check-time bounds check, so `let x: u8 = 300` compiles and
+   truncates silently. Rust/Swift reject this at compile time.
+
+**Who hits it:** anyone doing FFI (libc `mode_t`/`uid_t` are `u32`, `dev_t` is
+`u64`, `ssize_t` is `isize`), byte/buffer work (`u8` for bytes), bit-packing,
+checksums/hashing, and anyone porting Rust/Go/C code — which is the LLM-generated
+majority (AI agents are users; they emit `u32`/`usize`/`wrapping_add` from muscle
+memory and get silent miscompiles). The spec already *advertises* the family for
+"FFI and low-level use"
+([`spec/06-types.md:21-22`](../../site/src/content/docs/docs/reference/spec/06-types.md#L21-L22)),
+so the safety claim is being made without the enforcement behind it — precisely
+the "parsed but not enforced" anti-pattern.
+
+## 3. Design
+
+### 3.0 Scope split (1.0 vs. deferred)
+
+- **In 1.0 (this SFEP):** the full sized family as *distinct sign-tracked
+  types*; typed literal suffixes; literal-fits-in-type checking; explicit
+  `as`-cast conversions with correct sign/zero-extension and truncation; a
+  **defined default overflow semantics** (wrap in release / trap in debug); and
+  the `wrapping_*` overflow-safe method family as the escape valve for the
+  default trap. `f32` completes the float side.
+- **Deferred (post-1.0, designed here so the 1.0 surface doesn't paint us into
+  a corner):** `checked_*` (which needs `Result`/`Option` return shapes gated on
+  generics) and `saturating_*`. These are library methods, addable without any
+  syntax or new keyword once generic returns land.
+
+The core principle throughout: **libraries over keywords.** Overflow *policy*
+(wrap/checked/saturate) is expressed as method calls, never as new operators or
+keywords. Only the *default* behaviour and the type names are language-level.
+
+### 3.1 The type family (types are strings; add sign+width metadata)
+
+Sailfin threads type annotations as raw strings end-to-end (`TypeAnnotation {
+text: string }` at [`ast.sfn:12-14`](../../compiler/src/ast.sfn#L12-L14);
+`NativeFunction.return_type: string` at
+[`native_ir.sfn:73-77`](../../compiler/src/native_ir.sfn#L73-L77)). We keep that
+model — **no structured width field is added to the AST or IR.** Signedness and
+width are *derived* from the type-name string at each site that needs them, the
+same way `map_primitive_type` already resolves by string match. This is the
+minimal-blast-radius choice and keeps the `.sfn-asm` wire format unchanged.
+
+The canonical family, its LLVM lowering, and its signedness:
+
+| Sailfin type | LLVM type | Signed? | Notes |
+|---|---|---|---|
+| `i8` `i16` `i32` `i64` | `i8` `i16` `i32` `i64` | signed | `int` is an alias for `i64` |
+| `u8` `u16` `u32` `u64` | `i8` `i16` `i32` `i64` | **unsigned** | same LLVM repr; sign tracked in the frontend |
+| `usize` `isize` | `i64` | unsigned / signed | pointer-width; `i64` on all current 64-bit targets |
+| `f32` `f64` | `float` `double` | — | `float` is an alias for `f64`; `number` a deprecated alias for `float` |
+| `bool` | `i1` | — | distinct scalar kind (§spec 06); unchanged |
+
+**Sign is a frontend concept, not an LLVM concept.** LLVM integers are
+sign-agnostic; signedness lives in the *operations* (`sext` vs `zext`, `sdiv`
+vs `udiv`, `icmp slt` vs `icmp ult`). So the design adds a single source-of-truth
+helper — `integer_type_is_signed(name: string) -> boolean` and
+`integer_type_width(name: string) -> int` — colocated with `map_primitive_type`,
+and routes every width/sign-sensitive lowering decision through it. The `i*`
+names are signed, the `u*` names unsigned, `usize` unsigned, `isize` signed.
+
+**Recognition** extends the existing string-match resolvers rather than adding a
+new mechanism:
+
+- `is_extern_primitive_type`
+  ([`typecheck_types.sfn:1057-1075`](../../compiler/src/typecheck_types.sfn#L1057-L1075))
+  already accepts the whole family — no change needed for the FFI boundary.
+- The general type surface already flows through `map_type_annotation` →
+  `map_primitive_type`, which already maps every family member — so `let x: u16`
+  in ordinary (non-extern) code *already lowers*. The gap this SFEP closes is
+  correctness (sign) and safety (overflow, literal bounds), not mere recognition.
+
+### 3.2 Literals: default `i64`, optional typed suffix, range-checked
+
+**Default type.** An unsuffixed integer literal is `int` (i64); an unsuffixed
+decimal/exponent literal is `float` (f64). Unchanged — this is already the shipped
+default ([`spec/06-types.md:24-30`](../../site/src/content/docs/docs/reference/spec/06-types.md#L24-L30)).
+
+**Typed suffixes.** A literal may carry a type suffix to fix its type without an
+`as` cast: `100u8`, `-5i16`, `0xffu32`, `1_000_000i64`, `3.5f32`. Grammar: the
+suffix is one of the ten integer names (`i8 i16 i32 i64 u8 u16 u32 u64 usize
+isize`) or the two float names (`f32 f64`) immediately following the digit run
+(and after any `_` separators / fraction / exponent). An optional single `_`
+before the suffix is accepted for readability (`100_u8`) to match Rust and to
+sidestep the `e`-exponent ambiguity (`1e2` vs a hypothetical `1_e...`).
+
+**Lexer change.** Today the number scanner stops at the last digit/exponent byte
+and the suffix would lex as a separate `Identifier`
+([`lexer.sfn:274-280`](../../compiler/src/lexer.sfn#L274-L280)). Extend the
+scanner: after the numeric run, if the next bytes (optionally preceded by one
+`_`) spell one of the twelve suffix names, consume them into the same
+`NumberLiteral` lexeme. The token kind stays `NumberLiteral`; the suffix travels
+in the lexeme and is split off downstream (mirroring how the parser already
+disambiguates numeric literals). This is additive — a suffix-free literal lexes
+byte-for-byte identically, preserving self-host.
+
+**Literal-fits-in-type checking (`E0824`).** When a literal's type is fixed
+(either by suffix, or by a same-statement annotation such as
+`let x: u8 = 300`), the checker verifies the value fits the type's range:
+`u8 ∈ [0, 255]`, `i8 ∈ [-128, 127]`, `u16 ∈ [0, 65535]`, etc. Out-of-range is a
+compile error `E0824` with the type's range in the message and a fix-it
+suggesting the next-wider type. This is a new typecheck rule (there is no
+literal-bounds check anywhere today); it is a pure frontend check with no codegen
+dependency, and it mirrors the existing string-driven diagnostic style in
+`typecheck_types.sfn` (e.g. the `?`-operator rules at
+[`typecheck_types.sfn:402-438`](../../compiler/src/typecheck_types.sfn#L402-L438)).
+
+```sfn
+let a = 100u8;          // u8, in range — ok
+let b: u16 = 65535;     // in range — ok
+let c: u8 = 300;        // E0824: literal 300 out of range for `u8` (0..=255)
+let d = -5i16;          // i16 — ok
+let e = 4_000_000_000u32; // in range for u32 (max 4_294_967_295) — ok
+let f: i32 = 3_000_000_000; // E0824: out of range for `i32` (-2_147_483_648..=2_147_483_647)
+```
+
+### 3.3 Conversions: explicit `as` only (no implicit widening/narrowing)
+
+**No implicit conversions between integer types** — matching Rust's systems
+discipline. A `u16` does not implicitly become a `u32`; a value of one integer
+type flowing into a binding, argument, field, or arithmetic operand of a
+*different* integer type is an error with an `as` fix-it. This tightens today's
+behaviour: `dominant_type` currently *silently widens* same-kind pairs
+(`i8 ↔ i64` → `i64`) with explicit branches only for `i8`/`i32`/`i64`
+([`core_operands.sfn:2495-2557`](../../compiler/src/llvm/expression_lowering/native/core_operands.sfn#L2495-L2557))
+and no branches for `i16`/the whole `u*` family (they fall through to the
+`return first` catch-all — a latent ABI-mismatch bug the status note at
+[`status.md`](../../docs/status.md) already flags). Under this SFEP:
+
+- **Arithmetic and comparison require both operands to be the same integer
+  type.** Mixed integer widths/signs produce a `[fatal]` ABI-mismatch diagnostic
+  with an `as` fix-it — reusing the exact mechanism that already rejects
+  `int ↔ float`
+  ([`core_operands.sfn:2597-2607`](../../compiler/src/llvm/expression_lowering/native/core_operands.sfn#L2597-L2607)),
+  extended from the int/float kind-split to a per-`(width, sign)` identity.
+- **`dominant_type` stops silently widening across integer types.** Its
+  same-kind widening branches are removed for the integer family; only exact
+  identity (already the `first == second` fast path) passes without an explicit
+  cast. This is the tightening the spec's "coercion within a kind" note
+  ([`spec/06-types.md:32-54`](../../site/src/content/docs/docs/reference/spec/06-types.md#L32-L54))
+  currently permits and this SFEP retracts for integers (float `f32→f64` widening
+  via `fpext` is retained as a follow-on decision; see §6).
+
+**`as`-cast semantics (the correctness fix).** The `Cast` AST node already exists
+([`ast.sfn:95`](../../compiler/src/ast.sfn#L95)) and the effect checker already
+walks the operand
+([`effect_checker.sfn:888-897`](../../compiler/src/effect_checker.sfn#L888-L897),
+#1627). The lowering matrix
+([`core_literals_lowering.sfn:1823-1888`](../../compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn#L1823-L1888))
+is extended to choose the extend/truncate opcode from the **source type's
+signedness**, closing the standing KNOWN LIMITATION:
+
+| From → To | Rule | LLVM op |
+|---|---|---|
+| narrower → wider, **source signed** | sign-extend | `sext` |
+| narrower → wider, **source unsigned** | zero-extend | `zext` |
+| wider → narrower (any sign) | truncate | `trunc` |
+| same width, sign flip (`i32`↔`u32`) | bit-reinterpret, no instruction | (identity) |
+| int → float | signed → `sitofp`, unsigned → `uitofp` | |
+| float → int | signed target → `fptosi`, unsigned target → `fptoui` | |
+| `f32`↔`f64` | `fpext` / `fptrunc` | |
+| `bool` (i1) → int | `zext` (true→1) | (unchanged) |
+| any → `bool` via `as` | rejected; use a comparison | (unchanged, `E0537`-style) |
+
+The lowering already emits `sext`/`trunc`/`sitofp`/`fptosi`/`fpext`/`fptrunc`
+correctly *by width* — the only change is selecting `zext` vs `sext` and `uitofp`/
+`fptoui` vs the signed forms by consulting `integer_type_is_signed` on the
+**source** (for extension) and **target** (for float↔int). Because sign is
+tracked in the frontend, the lowering needs the source *Sailfin* type, not just
+the `LLVMOperand.llvm_type` (which is sign-agnostic). This is threaded via the
+already-present `parse.type_annotation` on the cast plus the operand's inferred
+Sailfin type; where the operand's Sailfin type is not available (untyped
+temporaries), the checker's inferred-type annotation carries it — the same
+kind-tag threading `spawn_future_kind` already relies on
+([`typecheck_types.sfn:464-481`](../../compiler/src/typecheck_types.sfn#L464-L481)).
+
+Truncation is defined as keeping the low N bits (two's-complement wrap);
+`300u16 as u8 == 44`. Sign/zero extension is defined by the **source** sign.
+These are the standard C/Rust `as` semantics and are documented normatively in
+the spec chapter.
+
+### 3.4 Overflow: default = trap in debug / wrap in release; `wrapping_*` escape
+
+**Default overflow semantics.** Integer `+`/`-`/`*` (and negation, `<<`) that
+overflow the operand type:
+
+- **trap in debug builds** (a runtime panic with a clear message, e.g.
+  `attempt to add with overflow (i32)`), and
+- **wrap (two's-complement) in release builds.**
+
+This is **Rust's model**, chosen deliberately over the three alternatives (§6):
+it gives developers a loud signal during development (catching the overflow bug
+where it happens) while paying zero steady-state cost in release. It composes
+cleanly with the ownership memory-safety floor (an overflowed length/index traps
+instead of silently producing an out-of-bounds value).
+
+**Build-mode plumbing.** The compiler already distinguishes build configurations
+through the driver; overflow-checking is gated on a debug/release flag threaded
+into `TypeContext`/lowering. In debug, integer `add`/`sub`/`mul` lower to the
+LLVM overflow intrinsics (`llvm.sadd.with.overflow.iN` / `uadd` per sign) and
+branch to a trap block calling a runtime `sfn_panic_int_overflow` helper; in
+release they lower to plain `add`/`sub`/`mul` (wrap). The per-sign choice
+(`sadd` vs `uadd`, `sdiv`/`udiv`, `icmp slt`/`ult` for comparisons) is again
+driven by `integer_type_is_signed`. Division/remainder by zero already needs a
+trap and rides the same helper path.
+
+**The `wrapping_*` escape valve (in 1.0).** To *request* wrap explicitly even in
+debug, integer types expose method-call helpers — **library functions in the
+prelude/runtime, not operators or keywords**:
+
+```sfn
+let a: u8 = 250;
+let b = a.wrapping_add(10u8);   // 4, never traps
+let c = a.wrapping_sub(255u8);  // wraps, never traps
+```
+
+`wrapping_add`/`wrapping_sub`/`wrapping_mul`/`wrapping_neg`/`wrapping_shl`/
+`wrapping_shr` are concrete per-width runtime functions (`sfn_wrapping_add_u8`,
+… `_i64`) dispatched by method call on an integer receiver — the same
+receiver-method dispatch the runtime already uses. They lower to plain wrapping
+LLVM ops regardless of build mode. Being ordinary functions, they add no
+keyword and can never shadow a variable name.
+
+**Deferred to post-1.0 (designed, not built):** `checked_add` → `Result`/
+`Option` (needs generic returns, gated on the generic-constraints foundation),
+and `saturating_add` → clamp to the type's min/max. Both are pure library
+additions requiring no further language change once generic returns exist.
+
+### 3.5 Worked end-to-end example
+
+```sfn
+fn checksum(bytes: u8[]) -> u32 ![pure] {
+    let mut sum: u32 = 0u32;
+    let mut i: int = 0;
+    loop {
+        if i >= bytes.length { break; }
+        // bytes[i] is u8; widen explicitly (zero-extend) to u32 to add
+        sum = sum.wrapping_add(bytes[i] as u32);
+        i += 1;
+    }
+    return sum;
+}
+
+fn narrow(x: u32) -> u8 ![pure] {
+    return x as u8;      // trunc — keeps low 8 bits, defined
+}
+
+// Rejected cases:
+//   let n: u8 = 300;              // E0824 — literal out of range for u8
+//   let s: u32 = an_i32_value;    // E0825 — implicit int-type conversion; use `as`
+//   let m = a_u16 + a_u32;        // [fatal] ABI mismatch — mixed integer widths; use `as`
+```
+
+## 4. Effect & capability impact
+
+**None to the effect system's semantics.** Integer types, casts, literals, and
+overflow policy are effect-free: a cast/arithmetic node carries no effect of its
+own, and the effect checker already walks the operand of `Cast`
+([`effect_checker.sfn:888-897`](../../compiler/src/effect_checker.sfn#L888-L897))
+so an effectful operand's requirement (`readByte() as u32`) still surfaces
+correctly. The `wrapping_*` methods are `![pure]` (arithmetic only). The
+debug-mode overflow **trap** is a runtime panic (like existing bounds/match
+backstops), not an effect — it needs no capability, exactly as
+`match_exhaustive_failed` and index-bounds traps do not. The canonical six
+effects and the taxonomy lock (SFEP-0017) are untouched.
+
+## 5. Self-hosting impact
+
+Passes that change, in pipeline order:
+
+1. **Lexer** (`lexer.sfn`) — number scanner consumes an optional trailing type
+   suffix into the `NumberLiteral` lexeme. **Additive:** suffix-free literals lex
+   identically, so the old seed and new source agree on every existing token.
+2. **Parser** (`parser/expressions.sfn`) — splits the suffix off the literal
+   lexeme and records the literal's fixed type. Additive; no grammar the old
+   seed rejects.
+3. **Typecheck** (`typecheck_types.sfn`, `typecheck.sfn`) — new
+   `integer_type_is_signed`/`integer_type_width` helpers; literal-range check
+   (`E0824`); implicit-integer-conversion rejection (`E0825`); the new
+   mixed-integer arithmetic rejection.
+4. **Emit / lowering** (`llvm/type_mapping.sfn`,
+   `llvm/expression_lowering/native/core_literals_lowering.sfn`,
+   `.../core_operands.sfn`) — sign-aware `as` opcodes (closes the KNOWN
+   LIMITATION), sign-aware `sdiv`/`udiv` and `icmp slt`/`ult`, and the
+   debug-mode overflow-intrinsic path with the release wrap fallback.
+5. **Runtime prelude** (`runtime/sfn/…`) — `sfn_wrapping_*_{i,u}{8,16,32,64}`
+   helpers and `sfn_panic_int_overflow`.
+
+**Self-hosting is preserved by additivity and staging.** The lexer/parser changes
+are additive (the old seed's tokenisation of the current, suffix-free compiler
+source is unchanged), and the compiler source does **not** adopt typed suffixes,
+`u*` types, or `wrapping_*` in the same PR that introduces them — the seed
+transition is:
+
+- **PR 1 (this capability):** land recognition + literal checking + sign-aware
+  casts + overflow default + `wrapping_*` in the compiler, **without using any of
+  it in `compiler/src`**. `make compile` builds the new compiler from the old
+  seed (which needs none of the new features to compile the *unchanged* compiler
+  source), then that new compiler self-hosts. No seed cut required — this bundles
+  the capability with a no-op consumer.
+- **After a seed cut** that pins the new binary: subsequent PRs may migrate
+  `compiler/src` FFI/byte code to real `u*`/`usize` spellings and `wrapping_*`.
+  Those migrations are gated behind the pinned seed per the seed-dependency rule.
+
+Because the *default* overflow behaviour in **release** is wrap (identical to
+today's bare `add`/`sub`/`mul`), and the compiler is built in release, turning on
+the overflow default does not change the emitted IR for the existing compiler
+source until debug builds opt in — the fixed-point self-host (`make check`) stays
+byte-identical for the release build.
+
+## 6. Alternatives considered
+
+- **Leave the family half-real (status quo).** Rejected: the `u*`→wider `sext`
+  miscompile is a live correctness bug (`255u8 as u64 == -1`), and the spec
+  already advertises the family — shipping the syntax without the semantics is
+  the "parsed but not enforced" anti-pattern.
+- **Structured width/sign field on `TypeAnnotation`/IR** instead of deriving from
+  the type-name string. Rejected: it would churn the AST, the `.sfn-asm` wire
+  format, and every pass that threads type strings, for zero expressiveness gain
+  — the rest of the compiler already resolves types by string match, and a
+  derive-on-demand helper is strictly less blast radius while giving the same
+  answer.
+- **Overflow default = always wrap (Go/C unsigned model).** Rejected as the
+  *default*: silent wrap hides real bugs (the class the ownership floor is
+  otherwise closing). Wrap remains available explicitly via `wrapping_*` and is
+  the *release* behaviour, but debug traps so bugs are found. Matching Rust here
+  also matches what LLM-generated code expects.
+- **Overflow default = always trap (Swift model).** Rejected as the *default*:
+  a trap on every release-build arithmetic imposes a steady-state branch cost and
+  a panic surface in hot paths (checksums, hashing) where wrap is the intended
+  semantics. Debug-trap / release-wrap gives the safety signal without the
+  release cost.
+- **Overflow default = saturate.** Rejected: saturation is a domain choice (DSP,
+  graphics), not a sane silent default for general arithmetic; it is offered as
+  an explicit `saturating_*` method post-1.0.
+- **`wrapping_*`/`checked_*` as operators or keywords** (e.g. `+%`, `+?`).
+  Rejected: violates "libraries over keywords" — a keyword can never be a
+  variable name, and these are expressible as ordinary methods with no
+  expressiveness loss. Boring, conventional method names also match Rust exactly,
+  reducing LLM error rates.
+- **Ship `checked_*`/`saturating_*` in 1.0.** Deferred: `checked_*` needs a
+  `Result`/`Option` return, which depends on the generic-constraints foundation
+  (companion `draft-generic-constraints.md`). Defining the default overflow
+  semantics and `wrapping_*` now is the load-bearing 1.0 slice; the checked/
+  saturating library methods slot in later with no language change.
+- **Retract `f32→f64` implicit widening too.** Left as a follow-on: floats are a
+  single kind in the current spec coercion model, and `fpext` widening is
+  lossless; this SFEP scopes the *integer* implicit-conversion retraction and
+  leaves the float-widening decision to the spec's existing kind rules.
+
+## 7. Stage1 readiness mapping
+
+- [ ] **Parses** — typed suffixes lex+parse (`lexer.sfn`, `parser/expressions.sfn`).
+- [ ] **Type-checks / effect-checks** — literal-range `E0824`, implicit-conversion
+      `E0825`, mixed-width arithmetic rejection; effect checker already walks
+      `Cast` operands (no change needed).
+- [ ] **Emits valid `.sfn-asm`** — type strings ride the existing string channel;
+      no wire-format change.
+- [ ] **Lowers to LLVM IR** — sign-aware `sext`/`zext`/`uitofp`/`fptoui`,
+      sign-aware `sdiv`/`udiv`/`icmp`, debug overflow-intrinsic path + release
+      wrap; `wrapping_*` runtime helpers.
+- [ ] **Regression coverage** — see §8.
+- [ ] **Self-hosts** — additive lexer/parser; compiler source unchanged in the
+      landing PR; migration behind a pinned seed (§5).
+- [ ] **`sfn fmt --check` clean** — formatter round-trips suffixed literals.
+- [ ] **Documented** — `docs/status.md` numeric rows updated;
+      `reference/spec/06-types.md` gains the sized-family, conversion, and
+      overflow sections.
+
+Per SFEP-0001 §4, this stays **Accepted** (not Implemented) until every box is
+checked and it self-hosts — the overflow *trap* especially must be enforced
+end-to-end, not merely parsed.
+
+## 8. Test plan
+
+Unit (`compiler/tests/unit/`):
+
+- `lexer_int_suffix_test.sfn` — `100u8`, `-5i16`, `0xffu32`, `1_000i64`,
+  `3.5f32`, `100_u8`; and that `1e` / `1e2` (exponent) still lex as float, not a
+  suffix.
+- `typecheck_int_literal_range_test.sfn` — `u8 = 300` → `E0824`; boundary values
+  (`255u8` ok, `256u8` error; `-128i8` ok, `-129i8` error; `u32` max ok / +1
+  error).
+- `typecheck_int_implicit_conversion_test.sfn` — `let s: u32 = an_i32` → `E0825`
+  with `as` fix-it; `a_u16 + a_u32` → ABI-mismatch `[fatal]`; same-type ops ok.
+- `sign_helpers_test.sfn` — `integer_type_is_signed`/`integer_type_width` truth
+  table for all ten integer names + `usize`/`isize`.
+
+Integration / e2e (`compiler/tests/e2e/`):
+
+- `int_cast_sign_test.sfn` — **the regression that closes the KNOWN
+  LIMITATION:** `255u8 as u64 == 255` (zext), `(-1i8) as i64 == -1` (sext),
+  `300u16 as u8 == 44` (trunc), `(-1i32) as u32` bit-reinterpret, `3.5f64 as i32
+  == 3`, `(-1i32) as f64 == -1.0`. Assert on runtime output via
+  `process.run_capture`.
+- `int_overflow_default_test.sfn` — a debug build of `i32` `add` that overflows
+  **traps** with the overflow message (build the fixture with the debug flag,
+  assert non-zero exit + message); the release build **wraps** to the two's-
+  complement value. Follows the build-and-run isolation rules
+  (`SAILFIN_TEST_SCRATCH`, threaded `PATH`).
+- `int_wrapping_methods_test.sfn` — `250u8.wrapping_add(10u8) == 4`,
+  `wrapping_sub`/`wrapping_mul`/`wrapping_neg` per width; never traps in debug.
+- `int_unsigned_arithmetic_test.sfn` — `u32` division/comparison use `udiv`/
+  `icmp ult` (a large `u32` compares `>` a small one where the signed
+  interpretation would flip).
+
+Snapshot: an IR snapshot (`expect_snapshot`) over a small module exercising
+`u8→u64` (zext), `i8→i64` (sext), and a debug overflow-checked `add` to lock the
+opcode selection.
+
+## 9. References
+
+- **Code (the gap):**
+  `compiler/src/llvm/type_mapping.sfn:859-897` (the u*→signed collapse),
+  `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn:1837-1845`
+  (the standing "KNOWN LIMITATION" comment),
+  `compiler/src/llvm/expression_lowering/native/core_operands.sfn:2495-2557`
+  (`dominant_type` — i8/i32/i64-only branches, silent same-kind widening),
+  `compiler/src/lexer.sfn:190-280` (no suffix support),
+  `compiler/src/typecheck_types.sfn:1057-1075` (`is_extern_primitive_type`
+  accept-list), `:464-481` (string-driven kind resolution precedent),
+  `compiler/src/ast.sfn:12-14` (`TypeAnnotation` is text), `:95` (`Cast` node),
+  `compiler/src/effect_checker.sfn:888-897` (Cast operand walk, #1627),
+  `compiler/src/native_ir.sfn:73-77` (string-threaded types).
+- **Status / spec:** `docs/status.md:184-185` (numeric types + bitwise ops
+  "Shipped"), `site/src/content/docs/docs/reference/spec/06-types.md`
+  (primitive table, sized-family FFI note, scalar coercion kinds).
+- **Related SFEPs / work:** SFEP-0025 §3.7 (`0025-native-runtime-architecture.md`,
+  the `int`/`float` numeric-types decision this extends), SFEP-0017
+  (`0017-hierarchical-effects.md`, the taxonomy lock this leaves untouched),
+  companion `draft-generic-constraints.md` (the generics foundation that
+  `checked_*` → `Result`/`Option` depends on — deferred post-1.0), `.claude/rules/
+  seed-dependency.md` (the bundle-vs-split seed rule applied in §5).
+- **Prior art:** Rust integer types + `as` semantics + debug-trap/release-wrap
+  overflow + `wrapping_*`/`checked_*`/`saturating_*`; Swift trapping arithmetic
+  and `&+` wrapping operators; Go's fixed-size `intN`/`uintN` with defined wrap.

--- a/docs/proposals/draft-string-interpolation-dollar.md
+++ b/docs/proposals/draft-string-interpolation-dollar.md
@@ -1,0 +1,487 @@
+---
+sfep: TBD
+title: String Interpolation with ${ } (migrating off {{ }})
+status: Draft
+type: language
+created: 2026-07-01
+updated: 2026-07-01
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to: reference/spec/09-strings.md
+---
+
+# SFEP-XXXX — String Interpolation with `${ }` (migrating off `{{ }}`)
+
+## 1. Summary
+
+Replace Sailfin's `{{ expr }}` string-interpolation syntax with `${ expr }`,
+matching JavaScript/TypeScript and Kotlin (Swift's `\(expr)` is the other
+mainstream spelling but is not brace-delimited and does not fit Sailfin's
+existing lexer shape as cleanly). The parser will accept both forms during a
+deprecation window — mirroring the `TypeSep` dual-accept strategy of
+SFEP-0005 — with `{{ }}` emitting a deprecation diagnostic, until the
+compiler's own sources and the ecosystem are migrated and `{{ }}` is removed
+before 1.0.
+
+## 2. Motivation
+
+Sailfin's current interpolation syntax is documented in
+`site/src/content/docs/docs/reference/spec/09-strings.md`:
+
+```sfn
+let name = "Sailfin";
+let greeting = "Hello, {{ name }}!";         // "Hello, Sailfin!"
+```
+
+`docs/status.md:176` lists this as **Shipped**, with the note "`${ }`
+migration planned pre-1.0 (see Known Design Issues)". `docs/status.md:347-349`
+records the problem explicitly, under "Known Design Issues (Pre-1.0 Syntax
+Reform)":
+
+> **String interpolation (`{{ }}` vs `${ }`)** — open. `{{ }}` means the
+> opposite of its meaning in every mainstream template language; LLMs
+> systematically generate wrong code. `${ }` migration is planned pre-1.0.
+
+`CLAUDE.md`'s Pre-1.0 Syntax Reform list carries the same item (#2):
+
+> **String interpolation: `${ }` not `{{ }}`** — parser change pending; keep
+> `{{ }}` until updated.
+
+Two independent forces make this load-bearing rather than cosmetic:
+
+1. **Boring syntax wins** (`CLAUDE.md` Design Decision Framework). Every
+   mainstream language with string interpolation that a working developer is
+   likely to know — JavaScript/TypeScript, Kotlin, Bash (`${var}` for
+   parameter expansion), PHP, Groovy — uses `${ }` (or the unbraced `$var`)
+   for interpolation, and reserves double braces for template-engine
+   *literal-escape* conventions (Jinja2/Handlebars/Mustache use `{{ }}` to
+   mean "substitute a template variable into otherwise-literal text", the
+   inverse framing from Sailfin's "substitute inside a language string
+   literal"). `{{ }}` is not merely unfamiliar in Sailfin — it actively
+   primes an experienced reader toward a *different* mental model.
+2. **AI agents are users** (`CLAUDE.md`, same framework). LLMs have zero
+   `.sfn` training data (per the project's stated tenet) and default to their
+   training distribution — overwhelmingly `${ }` — when asked to write a
+   Sailfin string literal with interpolation. This is not a hypothetical: the
+   Design Decision Framework calls out `${ }` vs `{{ }}` by name as a
+   systematic LLM-generation failure mode, and `docs/status.md:347-349` uses
+   the same "LLMs systematically generate wrong code" language for this exact
+   item. Every LLM-authored `.sfn` file that reaches for `${name}` compiles
+   silently to a *literal* string containing `${name}` today — no parse
+   error, no diagnostic, just wrong runtime output. That silent-wrongness is
+   worse than a hard parse error would be.
+
+This SFEP is the design record CLAUDE.md item 2 refers to as "pending" — it
+did not previously exist as a numbered proposal, only as a roadmap bullet and
+a `docs/status.md` note. It also fills the same procedural role SFEP-0005
+filled for the colon-annotation reform: a concrete, citable plan the
+implementer can execute directly, with a self-hosting-safe migration.
+
+## 3. Design
+
+### 3.1 Syntax
+
+```sfn
+let name = "Sailfin";
+let greeting = "Hello, ${name}!";           // "Hello, Sailfin!"
+let math = "2 + 2 = ${ 2 + 2 }";            // "2 + 2 = 4"
+let nested = "User: ${ user.name.trim() }"; // arbitrary expressions
+```
+
+- `${` opens an interpolation segment; the matching `}` (see §3.3 for nesting)
+  closes it.
+- Whitespace immediately inside the braces is insignificant: `${name}` and
+  `${ name }` are equivalent, matching the existing `{{ }}` rule ("Whitespace
+  at the edges is ignored") in `09-strings.md`.
+- A bare `$` not followed by `{` is an ordinary character with no special
+  meaning — `"Total: $5"` is the literal string `Total: $5`. This matches how
+  every language with `${ }` interpolation treats a lone `$` (JS template
+  literals, Kotlin), and keeps prices/shell-ish text unaffected.
+- **Escaping a literal `${`:** `\${` (backslash-escape, consistent with
+  Sailfin's existing `\"`/`\\`/`\n` escape family recognized by the lexer's
+  string-literal scanner) produces the two literal characters `${` with no
+  interpolation. This is the same shape Kotlin uses (`\${`). JS's alternative
+  convention of doubling (`$${`) is rejected as the primary form because it
+  overloads `$` with a second meaning ("escape the next `$`") that has no
+  precedent elsewhere in Sailfin's escape table — `\` is already the one and
+  only escape introducer in `09-strings.md`'s (implicit, via the lexer)
+  escape set. `\${` composes with zero new lexer rules: it is exactly one
+  more two-character entry in the same escape-sequence table that already
+  recognizes `\"`, `\\`, `\n`, `\r`, `\t`.
+
+### 3.2 Grammar for the embedded expression
+
+The embedded expression is **any Sailfin expression** — the existing
+`{{ }}` implementation already supports "arbitrary expressions" per
+`09-strings.md`'s own example (`user.name.trim()`), and nothing about moving
+the delimiter changes that scope. Concretely, at minimum:
+
+- Identifiers (`${name}`)
+- Field/method access chains (`${user.name.trim()}`)
+- Calls, including nested calls and argument lists (`${format(x, y)}`)
+- Arithmetic/comparison/logical expressions (`${2 + 2}`, `${a > b}`)
+- Any expression `lower_expression` (the existing LLVM-lowering expression
+  evaluator) already accepts, since the design in §3.3 routes the extracted
+  text through that same function unchanged.
+
+No new expression grammar is introduced by this proposal — the deliverable
+is exclusively the delimiter change and where recognition happens (see
+§3.3). Interpolated segments are not permitted to contain statements
+(`let`, `if`-as-statement, loops); this matches the current `{{ }}` behavior,
+which only ever hands the extracted text to the *expression* lowerer.
+
+### 3.3 Where recognition moves: lexer/parser vs. current lowering-time re-scan
+
+This is the most consequential architectural decision in this proposal, so it
+is stated explicitly rather than left implicit.
+
+**Current state (verified by reading the source):** Sailfin's lexer
+(`compiler/src/lexer.sfn`, string-literal branch starting at the
+`is_double_quote(ch)` check around line 140) treats a `"..."` literal as
+fully opaque — it scans forward to the matching unescaped `"` and emits one
+`TokenKind.StringLiteral` token carrying the *raw, unprocessed* lexeme. There
+is no interpolation awareness anywhere in the lexer, the parser
+(`compiler/src/parser/`), the AST (`compiler/src/ast.sfn` — confirmed no
+`Interpolat*` node exists), or the type checker. Interpolation is recognized
+**only** during LLVM lowering, in
+`compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn`
+(`try_lower_interpolated_string_literal`, line 1917) and
+`.../native/core_text.sfn` (`parse_interpolated_template`, line 487): the
+already-unescaped literal text is re-scanned with a `find_substring_from`
+search for the literal substrings `"{{"`/`"}}"`, split into a `parts[]` /
+`expressions[]` pair, and each extracted expression's *text* is re-fed
+through `lower_expression` (the general expression-lowering entry point,
+also used for ordinary expression statements) as if it were freshly
+re-parsed source.
+
+**This SFEP recommends keeping that architecture** — i.e., **not** promoting
+interpolation to a first-class AST node (no `InterpolatedString` variant
+added to `ast.sfn`, no parser change to `parser/expressions.sfn`'s string
+handling) — for three concrete reasons:
+
+1. **Zero pipeline stages need to change except the delimiter recognized in
+   two functions.** `parse_interpolated_template` in `core_text.sfn` is a
+   ~35-line self-contained scanner; the change is `find_substring_from(...,
+   "{{", ...)` / `"}}"` → the `${`/`}` scan described below, plus the
+   `try_lower_interpolated_string_literal` guard at
+   `core_literals_lowering.sfn:1919-1920` (`find_substring_from(content,
+   "{{", 0)` / `"}}"`). Type checking, effect checking, and native-IR
+   emission (`emit_native.sfn`) are already fully agnostic to interpolation
+   today — they see one opaque `StringLiteral` — and stay that way.
+2. **The re-scan-at-lowering design is exactly why the dual-accept migration
+   in §5 is cheap.** Because recognition is late and localized to two
+   functions in one file, supporting both delimiters simultaneously is a
+   matter of trying `${`/`}` first, then falling back to `{{`/`}}`, in that
+   single scanner — not threading a new token kind through the lexer, parser,
+   and every AST consumer.
+3. **Promoting to an AST node would be strictly more invasive for equal
+   benefit.** An `InterpolatedStringLiteral` AST node would require lexer
+   changes (recognizing `${` inside a string scan and emitting segment
+   tokens), parser changes (building the node), and updates to every AST
+   walker that currently treats a string literal as a single opaque token —
+   the type checker's literal-type inference, the effect checker's
+   AST-shape assumptions, and the Sailfin-source emitter
+   (`emitter_sailfin_expr.sfn`/`emitter_sailfin.sfn`, used by `sfn fmt` and
+   any AST-based tooling) all currently pass string literals through
+   untouched. None of that investment is needed to fix the delimiter, and
+   `docs/status.md`'s own framing of the feature as "Shipped" already
+   presumes the current re-scan architecture is the shipped design — this
+   proposal only changes what the scanner looks for, not when or how deeply
+   it looks. (A future SFEP could still promote interpolation to a real AST
+   node for other reasons — e.g. enabling `sfn fmt` to reformat the
+   *interior* of an interpolation expression, which the current opaque-token
+   design cannot do — but that is out of scope here; see §6.)
+
+**Grammar for the scanner** (replaces `parse_interpolated_template`'s body):
+scan the unescaped literal content left to right; on encountering `$`
+immediately followed by `{`, treat everything up to the next unescaped `}`
+as an embedded-expression segment (unbalanced brace nesting inside the
+segment, e.g. `${ f({a: 1}) }`, must be brace-depth-tracked rather than
+matched via a naive `find_substring_from(..., "}", ...)`, since the current
+`{{ }}` scanner's `"}}"} `-substring search has no such nesting problem but a
+single-`}` delimiter does — this is a real behavioral difference from the
+current implementation that the implementer must account for, not merely a
+delimiter swap). A `$` not followed by `{`, or an escaped `\${`, is emitted
+as a literal character and does not open a segment.
+
+### 3.4 Worked example: dual-accept period
+
+```sfn
+// Both compile identically during the deprecation window:
+let a = "Hello, {{ name }}!";   // accepted; emits E-string-interp-deprecated
+let b = "Hello, ${ name }!";    // accepted; no warning
+```
+
+### 3.5 What does *not* change
+
+- String literals without any interpolation marker are unaffected.
+- The escape table for ordinary characters (`\"`, `\\`, `\n`, `\r`, `\t`) is
+  unaffected; `\${` is a new addition to that table, not a replacement.
+- `.sfn-asm` / native IR format: string literals are emitted as opaque
+  literal text today (interpolation is resolved to a segment-concatenation
+  expression *before* IR emission, per §3.3); this proposal introduces no new
+  IR shape, matching how SFEP-0005 needed no IR change for the annotation
+  separator.
+
+## 4. Effect & capability impact
+
+None. String interpolation lowers to the same segment-concatenation +
+`lower_expression` calls it does today (`try_lower_interpolated_string_literal`
+in `core_literals_lowering.sfn`); the effect checker already treats an
+interpolated literal exactly as it treats the desugared expression sequence
+it becomes (a `+`-chain of string coercions and the embedded expression's own
+effects, e.g. `"${io.read_line()}"` requires `![io]` because the embedded
+call does — this is existing, unchanged behavior). Changing the delimiter
+recognized by the scanner does not add, remove, or reorder any effect
+requirement. `docs/status.md`'s effect rows for `sfn/strings` and the core
+language are unaffected.
+
+## 5. Self-hosting impact
+
+**Which passes change:** exactly two functions in one file,
+`compiler/src/llvm/expression_lowering/native/core_text.sfn`
+(`parse_interpolated_template`) and the interpolation-detection guard in
+`compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn`
+(`try_lower_interpolated_string_literal`, lines 1919-1920). No changes to
+`compiler/src/lexer.sfn`, `compiler/src/parser/`, `compiler/src/ast.sfn`,
+`compiler/src/typecheck.sfn`, or `compiler/src/effect_checker.sfn` — all of
+which already treat string literals as opaque and stay that way (§3.3).
+
+**Why this is a breaking change requiring a migration path** (per
+`.claude/rules/selfhost-invariant.md` and the `CLAUDE.md` self-hosting
+constraints): the compiler's own sources use `{{ }}` today. A grep-verified
+example: `examples/basics/structs.sfn:8` —
+`return "Hello, {{self.name}}!";` — and 64 files across
+`compiler/src/`, `runtime/`, `examples/`, and `capsules/` contain at least
+one `{{ ... }}` interpolation literal as of this writing. If `${`/`}` were
+made the *only* accepted form in one step, every one of those 64 files would
+need to be migrated **atomically with** the scanner change, in the same
+commit that changes `parse_interpolated_template` — and the *pinned seed*
+(the released binary `make compile` bootstraps from, per `.seed-version`)
+would need to already accept `${ }` before that commit could self-host,
+which it does not. This is exactly the bootstrapping hazard
+`CLAUDE.md`'s Self-Hosting Constraints section describes: "you can't change
+syntax the compiler uses without a strategy for bootstrapping through the
+transition."
+
+**The migration strategy — dual-accept, then narrow, mirroring SFEP-0005:**
+SFEP-0005 (`0005-colon-type-annotations.md`) solved the structurally
+identical problem — a syntax reform touching thousands of occurrences across
+the compiler's own source — by making the parser accept both the old and new
+separator simultaneously (`TypeSep = "->" | ":"`), migrating all source
+trees while both were legal, and only then splitting the acceptor into
+two strict single-form functions (`consume_annotation_separator` /
+`consume_return_type_separator`, SFEP-0005 "Phase 6"). This proposal follows
+the same shape:
+
+1. **Phase 1 — dual-accept scanner.** `parse_interpolated_template` tries
+   `${ ... }` first; if no `${` is found, it falls back to scanning for
+   `{{ ... }}` exactly as today. Both forms lower identically (same segment
+   + expression-list result shape) — there is no AST or IR difference between
+   the two spellings, only which delimiter the scanner recognized. This
+   phase alone makes the *new* form legal without touching any of the 64
+   existing occurrences. `make compile` self-hosts unchanged (the old seed's
+   compiler binary does not need to understand `${ }` — the scanner change
+   lives in `compiler/src/`, and `core_text.sfn` is `.sfn` source compiled
+   *by* the seed, not consumed *as* seed capability; see the bundling note
+   below).
+2. **Phase 2 — deprecation diagnostic on `{{ }}`.** Once `${ }` round-trips
+   (Phase 1 verified via `make compile` + `make test`), add a
+   non-fatal deprecation diagnostic when the scanner falls back to the
+   `{{ }}` branch, analogous to how a deprecated construct is flagged
+   elsewhere in the checker (informational severity — this must not fail
+   `sfn check`/`make check` yet, only surface a warning, since 64 in-tree
+   files still use the old form at this point).
+3. **Phase 3 — migrate compiler source, tests, runtime, examples, capsules.**
+   Rewrite all 64 in-tree occurrences from `{{ expr }}` to `${ expr }`
+   (a one-time mechanical script in the spirit of SFEP-0005's now-deleted
+   `scripts/migrate_colon_annotations.py` — a fresh single-use script per
+   SFEP-0005's own "Lessons Learned" note that such scripts are not kept in
+   tree). Unlike SFEP-0005's context-sensitive `->`-vs-`->`-that-means-something-else
+   ambiguity, this migration is comparatively low-risk: `{{` inside a string
+   literal is unambiguous (no ordinary Sailfin string content collides with
+   `{{`/`}}` as literal text in the existing corpus, since brace pairs are
+   rare in prose/log-message literals — the script must still skip
+   already-escaped or non-literal occurrences, e.g. `{{` appearing in a
+   *comment* rather than a string literal, the same category of care
+   SFEP-0005's script took for `->` inside comments/strings). Run
+   `make compile && make test` after the rewrite. `sfn fmt --write` on every
+   touched file per the standard change-discipline gate.
+4. **Phase 4 — narrow the scanner to `${ }` only; drop `{{ }}` and its
+   deprecation path.** Once no in-tree source uses `{{ }}` (Phase 3 complete)
+   and the ecosystem has had a deprecation window to migrate (tracked via the
+   roadmap/issue, not blocking this SFEP), remove the `{{`/`}}` fallback
+   branch from `parse_interpolated_template` and the deprecation-diagnostic
+   code from Phase 2. `{{ }}` becomes a plain (non-interpolated) literal
+   string again — i.e. a stray `{{name}}` in a string literal is no longer
+   special-cased and passes through as literal text, matching how an
+   unmatched `${` with no `${` present behaves today. This is the "drop the
+   old form after a new seed is cut" step `CLAUDE.md` describes, and — as
+   with SFEP-0005 Phase 6 — is a candidate for landing as its own PR once
+   Phase 3 has been in the pinned seed for at least one release cycle, so
+   that no in-flight external capsule relying on `{{ }}` breaks without
+   warning.
+
+**Bundling note (per `.claude/rules/seed-dependency.md`):** Phases 1-3 do
+**not** require a seed cut. `parse_interpolated_template` and
+`try_lower_interpolated_string_literal` are ordinary `compiler/src/*.sfn`
+functions; `make compile` builds the *new* compiler (with the updated
+scanner) using the *old, pinned* seed exactly as it does for any other
+`compiler/src/` change, and that freshly-built new compiler is what then
+needs to accept `${ }` in the migrated Phase 3 source tree — which it does,
+having been built from the Phase 1/2 source. Phases 1-3 should land as a
+single PR (capability + its migration are one cohesive change with one
+"consumer" — the compiler's own tree) rather than split across multiple
+seed cuts, consistent with the default in `.claude/rules/seed-dependency.md`
+("bundle a capability with its single consumer"). Only Phase 4 (dropping
+`{{ }}` entirely) is a candidate for a later, separate PR, since its
+correctness depends on an external fact (no remaining `{{ }}` usage anywhere
+that will be built against this compiler) rather than on anything internal
+to this repository — that PR is the one that should be sequenced against a
+release/deprecation-window boundary, not against a seed cut per se.
+
+## 6. Alternatives considered
+
+- **`\( expr )` (Swift-style).** Rejected as the primary form. It is
+  familiar to Swift developers but far less broadly recognized than `${ }`
+  across the languages Sailfin's target audience (and LLM training data) is
+  drawn from — JS/TS and Kotlin dominate both human familiarity and LLM
+  training-data volume relative to Swift. It also introduces a lexer
+  ambiguity with escaped parentheses and with Sailfin's existing lambda
+  syntax (`fn(x) => expr`, SFEP-0029) that `${ }` does not have, since `${`
+  is not a valid start of any other current Sailfin construct.
+- **Bare `$name` (no braces, PHP/Bash-heartbeat style) with `${ expr }` only
+  for non-trivial expressions.** Rejected: it adds a second grammar (bare
+  identifier interpolation vs. braced expression interpolation) for marginal
+  typing savings, and Sailfin's own precedent (`{{ name }}` today) already
+  requires braces even for a bare identifier — keeping "always braced" is
+  the smaller diff from current behavior and avoids ambiguity with `$` used
+  adjacent to identifier-like text in prose literals (e.g. `"Price: $5 for
+  item"` must never be misread as attempting interpolation of a variable
+  named `5`).
+- **Keep `{{ }}` permanently, treat the LLM-generation mismatch as a
+  documentation/tooling problem (e.g. teach `sfn fix`/linters to rewrite
+  `${ }` typos into `{{ }}`).** Rejected. This treats the symptom, not the
+  cause, and only mitigates the *authoring* failure mode (an LLM or human
+  typing `${ }` out of habit) while leaving the *reading* failure mode
+  unaddressed (an LLM reading existing `{{ }}`-based Sailfin code and
+  misinterpreting its semantics by analogy to Jinja2/Handlebars, where
+  `{{ }}` denotes literal-into-template substitution — the inverse framing).
+  It also does nothing for the stated design tenet ("Boring syntax wins") —
+  keeping deliberately unusual syntax because tooling can paper over it
+  contradicts the principle rather than satisfying it.
+- **Promote interpolation to a first-class AST node now, as part of this
+  change.** Rejected for *this* proposal — see §3.3 point 3. The delimiter
+  swap does not need it, it substantially increases blast radius (lexer,
+  parser, AST, every AST walker) for a change whose entire value is "which
+  two characters open a segment," and it would entangle a mechanical
+  syntax-reform PR with an unrelated representational upgrade. A future SFEP
+  can propose the AST-node promotion independently (motivated by, e.g.,
+  wanting `sfn fmt` to reformat interpolation interiors, or wanting the type
+  checker to type-check embedded expressions before lowering instead of at
+  lowering time) without needing to revisit the delimiter question this
+  SFEP settles.
+- **Skip the dual-accept window; do a single flag-day rewrite of all 64
+  in-tree files plus the scanner in one commit, with no deprecation
+  period at all.** Rejected as riskier with no offsetting benefit: it is
+  the same total diff as Phases 1+3 combined, but removes the independently
+  verifiable checkpoint ("`${ }` works, `{{ }}` still works, `make compile`
+  is green") that the dual-accept phase gives for free, and forecloses any
+  external-ecosystem grace period matching what SFEP-0005 gave the
+  annotation-separator migration.
+
+## 7. Stage1 readiness mapping
+
+- [ ] Parses — Phase 1 (dual-accept scanner in `core_text.sfn`)
+- [ ] Type-checks / effect-checks — no change required; already agnostic to
+      interpolation delimiter (§4)
+- [ ] Emits valid `.sfn-asm` — no change required; interpolation is resolved
+      to ordinary segment-concatenation expressions before IR emission
+- [ ] Lowers to LLVM IR — Phase 1 (`try_lower_interpolated_string_literal`
+      guard update)
+- [ ] Regression coverage — see §8
+- [ ] Self-hosts — Phase 3 (compiler's own `{{ }}` occurrences migrated;
+      `make compile` gate)
+- [ ] `sfn fmt --check` clean — run on every file touched in Phase 3
+- [ ] Documented in `docs/status.md` + spec — flip `docs/status.md:176`/
+      `:347-349` and rewrite `site/src/content/docs/docs/reference/spec/09-strings.md`
+      once Phase 3 lands; Phase 4 removes the "migration planned" language
+      entirely
+
+This SFEP stays `Draft` until the design gate is passed; it moves to
+`Accepted` when cleared for implementation, and to `Implemented` only once
+Phase 3 has landed, self-hosted, and the spec/status docs reflect `${ }` as
+the sole documented form (per SFEP-0001 §4, "parsed but not enforced/
+documented" does not qualify as `Implemented` — here the equivalent bar is
+"accepted but the compiler's own source still emits deprecation warnings on
+itself" not qualifying either).
+
+## 8. Test plan
+
+New/updated regression tests, following the existing pattern for
+interpolation coverage (none of the below require new AST/typecheck test
+scaffolding, since the feature stays a lowering-time concern per §3.3):
+
+- **`compiler/tests/unit/`** — a lowering-focused unit test (co-located with
+  or adjacent to wherever the current `{{ }}` lowering behavior is covered
+  today — confirm via `Grep` for existing interpolation-lowering tests
+  before adding) asserting: `parse_interpolated_template` correctly splits
+  `"Hello, ${ name }!"` into `parts = ["Hello, ", "!"]`,
+  `expressions = ["name"]`; a bare `$` not followed by `{` is left as
+  literal text; `\${` produces the literal two characters `${`; nested
+  braces inside a segment (`"${ f({a: 1}) }"`) are matched by depth, not by
+  the first `}`.
+- **`compiler/tests/integration/`** — an end-to-end compile+run test
+  (`assert_compiles`/`assert_does_not_compile` from `sfn/test`, per
+  `.claude/rules/no-bash-e2e.md`) verifying `${ name }` interpolation
+  produces the expected runtime string output, matching an existing `{{ }}`
+  integration test's shape if one exists (grep for one before writing a
+  parallel case) so the two forms have symmetric coverage during the
+  dual-accept window.
+- **`compiler/tests/e2e/`** — a deprecation-diagnostic test (Phase 2)
+  asserting that compiling a fixture containing `{{ name }}` produces the
+  deprecation diagnostic on stderr/`--json` envelope, and that compiling a
+  fixture containing `${ name }` produces no such diagnostic — using
+  `assert_compiles`/`sfn check --json` per the `sfn/test` conventions in
+  `.claude/rules/no-bash-e2e.md`, not a bash script.
+- **Self-hosting gate (Phase 3):** `make compile` after the in-tree rewrite,
+  then `make check` before declaring Phase 3 done, per
+  `.claude/rules/selfhost-invariant.md`.
+- **Formatting gate:** `sfn fmt --check` over every file touched in Phase 3
+  (`compiler/src/`, `runtime/`, `examples/`, `capsules/`, and any touched
+  `compiler/tests/*.sfn`), per `.claude/rules/formatting.md`.
+- **Removal gate (Phase 4):** a negative test confirming `{{ name }}` no
+  longer interpolates (compiles to the literal string `{{ name }}` in the
+  output) once the fallback branch and deprecation diagnostic are removed.
+
+## 9. References
+
+- `docs/status.md:176` — current "Shipped" status row for `{{ }}` with the
+  `${ }` migration note.
+- `docs/status.md:347-349` — "Known Design Issues (Pre-1.0 Syntax Reform)",
+  the `{{ }}` vs `${ }` problem statement this SFEP formalizes into a plan.
+- `CLAUDE.md`, "Pre-1.0 Syntax Reform (Active)" item 2 — the standing
+  intent this SFEP is the design record for.
+- `CLAUDE.md`, "Design Decision Framework" — "Boring syntax wins", "AI agents
+  are users" — the two tenets motivating this change.
+- [SFEP-0005 — Colon Type Annotations](./0005-colon-type-annotations.md) —
+  the directly analogous prior syntax-reform migration (dual-accept →
+  migrate → narrow-the-parser), whose phase structure this proposal mirrors.
+- `site/src/content/docs/docs/reference/spec/09-strings.md` — the spec
+  chapter this SFEP's `graduates-to` target rewrites once `${ }` ships as the
+  sole form.
+- `compiler/src/lexer.sfn` (string-literal branch, ~line 140) — confirms
+  string literals are lexed as opaque tokens today, with no interpolation
+  awareness at the lexer stage.
+- `compiler/src/llvm/expression_lowering/native/core_text.sfn`
+  (`parse_interpolated_template`, line 487) and
+  `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn`
+  (`try_lower_interpolated_string_literal`, line 1917) — the two functions
+  this proposal's Phase 1 changes.
+- `examples/basics/structs.sfn:8` — a representative in-tree `{{ }}`
+  occurrence requiring Phase 3 migration.
+- `.claude/rules/selfhost-invariant.md`, `.claude/rules/seed-dependency.md`
+  — the self-hosting and seed-bundling constraints this proposal's Phase
+  1-3 bundling recommendation follows.

--- a/docs/proposals/draft-string-interpolation-dollar.md
+++ b/docs/proposals/draft-string-interpolation-dollar.md
@@ -200,7 +200,7 @@ immediately followed by `{`, treat everything up to the next unescaped `}`
 as an embedded-expression segment (unbalanced brace nesting inside the
 segment, e.g. `${ f({a: 1}) }`, must be brace-depth-tracked rather than
 matched via a naive `find_substring_from(..., "}", ...)`, since the current
-`{{ }}` scanner's `"}}"} `-substring search has no such nesting problem but a
+`{{ }}` scanner's `"}}"`-substring search has no such nesting problem but a
 single-`}` delimiter does — this is a real behavioral difference from the
 current implementation that the implementer must account for, not merely a
 delimiter swap). A `$` not followed by `{`, or an escaped `\${`, is emitted


### PR DESCRIPTION
## Summary

Design records only — **8 new SFEP drafts** plus a `CLAUDE.md` refresh. No code, no issues filed, no seed changes. This is the output of a 2026-07 grammar / object-model audit of the language surface (how "classes" work — they don't; `struct` + `enum` + `interface`, no inheritance — and where Sailfin lags Go/Rust/Swift/TS).

Per SFEP-0001 §2, drafts keep their `draft-<slug>.md` name and `sfep: TBD` front-matter until merge, when they claim `max + 1` and get an Index row. They're listed in a new **"Drafts under review"** section of the proposals registry.

## New SFEP drafts (`docs/proposals/draft-*.md`)

| Draft | Gap it closes |
|---|---|
| **generic-constraints** | `TypeParameter.bound` parses but nothing enforces it; no monomorphization pass. **Root foundation** — unblocks collections, typed HOFs, `Result` `From<E>`, derive. |
| **generic-collections** | No map/set/tuple type or literal exists; `StrMap` is a hardcoded string→string stopgap. |
| **sized-integer-types** | Only `i64`-class ints; `u*` widths collapse to signed twins → the live `255u8 as u64 == -1` miscompile. Adds `i8..u64`, overflow semantics, `as` rules. |
| **interface-signature-conformance** | Conformance is checked by method **name only**, not signature — a wrong-typed method still fills the vtable slot (soundness hole). |
| **exhaustive-match** | `match` exhaustiveness is a runtime trap, not a compile-time check. |
| **derive** | Decorators are inert; no `derive`/macros. Adds `@derive(Eq, Hash, Debug, Clone, Ord)`. |
| **string-interpolation-dollar** | `{{ }}` is backwards vs every mainstream language and a documented LLM-generation failure mode; migrate to `${ }` (dual-accept, SFEP-0005 precedent). |
| **nullable-access-operators** | `T?` exists but has no `?.`/`??`; adds them, disambiguated from the Result `?` (`TryOperator`). |

Already covered, so **not** re-drafted: `&mut` exclusivity → SFEP-0018; `Result`/`?` → SFEP-0012 (shipped).

Draft diagnostic codes are pre-deconflicted across the slate: `E0303`; `E0711`–`E0715`; `E0820`–`E0822`; `E0823`/`W0823`; `E0824`–`E0825`.

## CLAUDE.md refresh

Corrects stale claims (verified against `docs/status.md` + the AST):
- `int`/`float`, `Result<T,E>` + `?`, and `fn(x) => expr` marked **shipped** (were "not yet in parser" / "pending").
- Concurrency runtime line updated from "No concurrency runtime" to **"v0 works, partial"** (`routine`/`channel`/`spawn`/`await` run through a real scheduler).
- Foundation-first note repointed at generic constraints as the remaining root blocker.
- Added the registry "Drafts under review" pointer.

## Notes
- SFEPs are Markdown — not subject to `sfn fmt` or the self-host gate.
- Each draft follows the 9-section `template.md` structure and cites real `compiler/src` locations.

https://claude.ai/code/session_013QngqhsEreZXXRE69S8wpa

---
_Generated by [Claude Code](https://claude.ai/code/session_013QngqhsEreZXXRE69S8wpa)_