### PR TITLE
docs(style): expand style guide into a full coding-conventions doc

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,43 @@
+`docs/style-guide.md` is the single source of truth for coding conventions;
+this rule is the always-loaded summary of the parts agents most often get
+wrong. When in doubt, read the guide — do not improvise style.
+
+## Comments (the most-violated rules)
+
+- One syntax: `//`. There is no `///` doc-comment form; don't invent one.
+- Comments explain **why**, code explains **what**. Never narrate the line
+  below a comment.
+- **Durable references only**: cite `(#1234)`, `SFEP-NNNN`, or an RCA path.
+  Never write "this commit", "this PR", or "this change" — the reader can't
+  see your diff. Never transcribe phase/wave/milestone history into file
+  headers; link the SFEP or epic instead.
+- **No `TODO`/`FIXME`** — file an issue and cite it in the comment.
+- **No commented-out code** — delete it; git remembers.
+- File header = repo-relative path + 1–5 sentences of purpose. Not a
+  changelog, not a rollout plan (>~15 lines means it belongs in an SFEP).
+- A workaround comment states its concrete removal condition; the PR that
+  satisfies the condition deletes the workaround **and** the comment.
+
+## Naming
+
+- `snake_case` functions/locals/files; `PascalCase` types and enum variants;
+  `_underscore` prefix for module-private helpers (with a module tag in big
+  files: `_cr_*`); `SCREAMING_SNAKE_CASE` module-level constants.
+- Treat acronyms as words in new names: `LlvmOperand`, not `LLVMOperand`.
+- Test names: `test "<area>: <behavior>"` — never encode the tier.
+
+## Effects & errors
+
+- Effect lists are **alphabetical**: `![io, net]`, never `![net, io]`
+  (matches `effect_taxonomy.sfn::canonical_effects()`).
+- User-source errors → `Diagnostic` with an `E0xxx` code and span; core
+  passes never `panic()` on user input. New internal fallible code →
+  `Result<T, E>` + `?`. E-code ranges are owned — see the table in
+  `docs/style-guide.md` and grep the range before allocating a code.
+
+## Shape
+
+- `let` by default, `let mut` only when reassigned. Early returns over
+  nesting. Guard counters on input-driven loops.
+- ~1,500-line soft budget per `compiler/src` module; split into a folder +
+  `mod.sfn` (parser/ is the model). Don't grow grandfathered giants.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,8 +89,12 @@ Effect checking walks nested blocks, lambdas, and `routine` scopes. Missing effe
 
 ## Coding Style & Naming Conventions
 
-- **Python:** PEP 8, four-space indentation, `snake_case` functions, narrow passes; share helpers instead of duplicating parsing logic.
-- **Sailfin (`.sfn`):** Spell effects explicitly, keep effect lists ordered by impact, `CamelCase` for models/capsules, `snake_case` for locals, annotate future syntax as comments until the compiler supports it.
+`docs/style-guide.md` is the single source of truth for coding conventions. Headline rules:
+
+- **Formatting:** `sfn fmt --write` then `sfn fmt --check` on every touched `.sfn` file; never hand-tune what the formatter owns.
+- **Naming:** `snake_case` functions/locals/files, `PascalCase` types and enum variants, `_underscore` module-private helpers, `SCREAMING_SNAKE_CASE` module-level constants.
+- **Effects:** spelled explicitly and listed alphabetically — `![io, net]`, never `![net, io]`.
+- **Comments:** `//` only, explain *why* not *what*, cite issues/SFEPs (`(#1234)`, `SFEP-0027`) — no `TODO`s, no commented-out code, no "this commit"/"this PR" language.
 - Align terminology with the language spec at `site/src/content/docs/docs/reference/spec/` (capsule, fleet, provenance card).
 
 ## Adding a Language Feature

--- a/.github/instructions/compiler.instructions.md
+++ b/.github/instructions/compiler.instructions.md
@@ -10,7 +10,7 @@ When working in the compiler directory:
 - Follow the pipeline order: lexer → parser → AST → type check → effect check → emit → LLVM lowering.
 - Every change must preserve self-hosting: `make compile` must succeed after your edits.
 - Add regression tests in `compiler/tests/` for every change.
-- Spell effects explicitly: `fn foo() -> Bar ![io, model]`.
-- Use `CamelCase` for types, `snake_case` for functions and locals.
+- Spell effects explicitly and list them alphabetically: `fn foo() -> Bar ![io, model]`.
+- Coding conventions (naming, comments, error handling, file-size budgets) are defined in `docs/style-guide.md` — follow it; `PascalCase` types, `snake_case` functions/locals, `_underscore` private helpers.
 - Fix bugs in the compiler source, never by adding fixup passes to the build driver. (The prior `scripts/build.sh` orchestrator was retired in Stage E PR7 / #383; the same rule applies to the driver in `compiler/src/cli_main.sfn` + `compiler/src/capsule_resolver.sfn`.)
 - Reference `docs/status.md` for current feature implementation status.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 
 ## Style, Tests, and Documentation
 
-- Sailfin files spell effects explicitly (`fn foo() -> Bar ![io, model]`), keep effect lists ordered by impact, and use `CamelCase` for models/capsules while locals remain `snake_case`.
+- `docs/style-guide.md` is the single source of truth for coding conventions (naming, comments, effect-annotation style, error handling, file size budgets); `.claude/rules/code-style.md` is the always-loaded summary. Headline rules: effects spelled explicitly and listed alphabetically (`fn foo() -> Bar ![io, model]`); `snake_case` functions/locals, `PascalCase` types, `_underscore` private helpers; comments explain *why* and cite issues/SFEPs — never `TODO`s, commented-out code, or "this PR" language.
 - Align terminology with the language spec at `site/src/content/docs/docs/reference/spec/` (capsule, fleet, provenance card) and note currency or latency literals as comments until syntax support arrives.
 - Before committing touched `.sfn` files under `compiler/src/` or `runtime/`, run `sfn fmt --write <files>` and then `sfn fmt --check <files>` (or the equivalent `build/native/sailfin` commands).
 - Stage regression tests beside related coverage in `compiler/tests/`; prefer Sailfin-native tests and slim fixtures over recorded generated output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,10 +138,17 @@ Reviewers will check for:
 
 ## 6. Code Style
 
-- Sailfin (`.sfn`): explicit effect lists, `CamelCase` for models/capsules,
-  `snake_case` locals, and comment future syntax when used for illustration.
-  Follow the module and file conventions in `docs/style-guide.md` (one concern
-  per file, `mod.sfn` re-exports, mirrored `*.spec.sfn` tests).
+[`docs/style-guide.md`](docs/style-guide.md) is the single source of truth for
+coding conventions — naming, comments, effect-annotation style, error-handling
+idiom, file organization, and size budgets. Read it before your first `.sfn`
+change; the short version:
+
+- `sfn fmt --write` then `sfn fmt --check` on every touched `.sfn` file
+  (mechanics are the formatter's, everything else is the guide's).
+- `snake_case` functions/files, `PascalCase` types, `_underscore` private
+  helpers, alphabetical effect lists (`![io, net]`).
+- Comments explain *why* and cite issues/SFEPs — no `TODO`s, no
+  commented-out code, no "this PR" language.
 - Examples: keep inputs minimal, avoid generated artefacts, and annotate
   future-only constructs.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,10 @@ documentation lives on the docs site.**
 - **Native runtime architecture** → `docs/proposals/0025-native-runtime-architecture.md` (SFEP-0025)
 - **Build architecture and performance baseline** → `docs/proposals/0006-build-architecture.md` (SFEP-0006)
 - **Runtime execution perf baseline** → `docs/perf/runtime-performance.md`
-- **Repository style guide** → `docs/style-guide.md`
+- **Coding conventions & repository style guide** → `docs/style-guide.md`
+  (the single source of truth for naming, comments, effects style, error
+  handling, and file organization; narrow single-topic conventions live under
+  `docs/conventions/`)
 - **Proposals (SFEPs)** → `docs/proposals/` — numbered design records;
   index + process in [`docs/proposals/README.md`](proposals/README.md) and
   [SFEP-0001](proposals/0001-sfep-process.md)

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -71,9 +71,9 @@ Additional rules:
 
 ## Comments
 
-Sailfin has one comment syntax: `//`. There is no `///` doc-comment form and
-no `/* */` convention — the five files using block comments are historical,
-not a pattern to follow.
+Sailfin has one comment syntax: `//`. There is no `///` doc-comment form,
+and block comments (`/* */`) are not used — write `//` line comments
+exclusively.
 
 The prime directive, borrowed from Go and Rust practice: **comments explain
 *why*, code explains *what*.** A comment that restates the line below it is
@@ -207,7 +207,8 @@ Three tiers, by audience:
    guard + diagnostic over an assertion; the compiler must degrade to an
    error message, not a crash.
 
-**Error codes** are `E0xxx` strings with range ownership:
+**Error codes** are `E0xxx` strings with range ownership (Home paths are
+relative to `compiler/src/`):
 
 | Range | Domain | Home |
 |---|---|---|

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,68 +1,271 @@
 # Sailfin Style & Layout Guide
 
-This guide captures the current Sailfin repository layout and the conventions
-the compiler, runtime, and examples follow. Treat it as the source of truth
-for naming, organization, and where new work should land.
+This guide is the **single source of truth** for coding conventions in this
+repository: naming, comments, effect annotations, error handling, file
+organization, and where new work should land. Other documents
+(`CONTRIBUTING.md`, `AGENTS.md`, `.github/copilot-instructions.md`,
+`.claude/rules/code-style.md`) link here rather than restating rules — if a
+pointer disagrees with this guide, this guide wins.
+
+Sailfin's design principle is **boring syntax wins**, and the same applies to
+style: where Go or Rust already settled a convention and nothing about Sailfin
+demands otherwise, we adopt the settled answer. Contributors — human and agent
+alike — should never have to guess.
+
+Two layers of authority:
+
+1. **`sfn fmt` decides mechanics.** Indentation, brace placement, spacing,
+   blank lines, import sorting. Never hand-tune these (see below).
+2. **This guide decides everything the formatter can't.** Naming, comment
+   content, effect ordering, error-handling idiom, decomposition.
 
 ## Code Formatting
 
-All `.sfn` files in the repository are formatted with `sfn fmt` and CI enforces
-this on every pull request. There is one canonical style with no configuration.
+All `.sfn` files are formatted with `sfn fmt`; CI enforces this on every pull
+request. There is one canonical style with **no configuration**.
 
 ```bash
 sfn fmt --write compiler/src/   # format files in place
 sfn fmt --check compiler/src/   # verify formatting (CI mode)
 ```
 
-Do not manually adjust indentation, spacing, or brace placement — `sfn fmt`
-handles all of it. If you disagree with a formatting decision, file an issue
-against the formatter rather than overriding the output.
+The formatter owns (see SFEP-0007, `docs/proposals/0007-fmt-architecture.md`,
+for the full rule set): 4-space indentation, K&R braces, operator/punctuation
+spacing, blank-line normalization, import grouping and alphabetization,
+trailing whitespace, and EOF newline. It deliberately does **not** wrap long
+expressions, reorder match arms, or touch comment content — those stay the
+author's responsibility, governed by this guide.
 
-## Goals
+Do not manually adjust anything the formatter owns. If you disagree with its
+output, file an issue against the formatter rather than overriding it.
 
-- Keep one major concern per file (lexer, parser, lowering, etc.).
-- Make intent obvious from the path and filename.
-- Use `mod.sfn` to present stable public APIs within a folder.
-- Mirror source and tests so navigation and refactors stay predictable.
+## Naming
+
+| Item | Convention | Example |
+|---|---|---|
+| Functions | `snake_case` | `parse_program`, `collect_direct_function_effects` |
+| Types (struct/enum/interface) | `PascalCase` | `Program`, `SourceSpan`, `EffectViolation` |
+| Enum variants | `PascalCase` | `Identifier`, `NumberLiteral`, `TryOperator` |
+| Module-private helpers | leading underscore | `_count_newlines`, `_sfn_bin` |
+| Module-level constants | `SCREAMING_SNAKE_CASE` | `let STDOUT_FD: i32 = 1;` |
+| Locals and parameters | `snake_case` | `let mut entries: Entry[] = [];` |
+| Files | `snake_case.sfn` | `effect_checker.sfn` |
+| Effects | lowercase, alphabetical in `![...]` | `![clock, io]` |
+| Test names | `"<area>: <behavior>"` | `test "publish: too many args shows usage"` |
+
+Additional rules:
+
+- **Private means underscore.** A function or module-level value not exported
+  from the file gets a leading underscore. In large modules, add a short
+  module tag to avoid collisions across the flattened import namespace:
+  `_cr_*` in `capsule_resolver.sfn`, `_dj_*` in `diagnostics_json.sfn`.
+- **Treat acronyms as words** in new PascalCase names: `LlvmOperand`,
+  `JsonEvent`, `CliContext` — not `LLVMOperand` or `JSONEvent`. (Existing
+  all-caps names are grandfathered; do not rename them in unrelated PRs.)
+- **Booleans read as predicates.** Prefer `is_`, `has_`, `needs_` prefixes for
+  boolean-returning functions and boolean fields (`is_effectful`,
+  `has_explicit_return`).
+- **Type parameters** are single capital letters, `T` first, `E` for error
+  types — matching `Result<T, E>`. (Generic constraints are still landing;
+  this is the convention for the surface that exists.)
+
+## Comments
+
+Sailfin has one comment syntax: `//`. There is no `///` doc-comment form and
+no `/* */` convention — the five files using block comments are historical,
+not a pattern to follow.
+
+The prime directive, borrowed from Go and Rust practice: **comments explain
+*why*, code explains *what*.** A comment that restates the line below it is
+noise; a comment that explains a non-obvious invariant, a subtle ordering
+constraint, or the reason a simpler approach fails is gold.
+
+### File headers
+
+Every `.sfn` file opens with a header docblock:
+
+```sfn
+// compiler/src/effect_checker.sfn
+//
+// Effect validation for the Sailfin self-hosted compiler. Scans routine
+// bodies for constructs that require explicit `![effect]` declarations.
+```
+
+- First line: the repo-relative path.
+- Then 1–5 sentences: what the module does and, if non-obvious, why it exists
+  as a separate module.
+- **No changelog.** Phase histories ("Phase E adds…"), milestone codes,
+  rollout plans, and wave-by-wave migration narratives do **not** belong in
+  the header. That history lives in git, in the issue tracker, and in SFEPs —
+  link the SFEP or epic (`See SFEP-0026 / #1639.`) instead of transcribing it.
+  A header that needs more than ~15 lines is a design document trying to
+  escape; move it to `docs/proposals/` and cite it.
+
+### Public API comments
+
+A `//` block immediately above an exported function, struct, or enum is its
+documentation. Start with a complete sentence naming the item's behavior
+(Go style):
+
+```sfn
+// parse_program lexes and parses `source` into a Program AST. Diagnostics
+// are accumulated on the returned Program rather than raised.
+fn parse_program(source: string) -> Program ![io] { ... }
+```
+
+Field-level rationale comments inside structs (see `ast.sfn`'s `Capture`
+fields) are encouraged **when the field encodes a non-obvious invariant** —
+that is exactly the *why* comments are for.
+
+### Durable references only
+
+Comments must make sense to a reader with no knowledge of the diff that
+introduced them:
+
+- **Cite issues, SFEPs, and RCAs**: `(#1234)`, `SFEP-0027`,
+  `docs/rca/...`. These are stable and searchable.
+- **Never write "this commit", "this PR", "this change"** — the reader cannot
+  see your diff. `// Phase E (this commit) adds cross-module resolution` reads
+  as a PR description that escaped into the tree. Say what the code does now
+  and cite the issue for the history.
+- **No `TODO`/`FIXME`/`HACK` markers.** The repository convention is
+  cite-the-issue: file a GitHub issue and reference it —
+  `// Fallback until #1441 lands proper slice reuse.` An issue is triaged,
+  labeled, and visible on the board; a `TODO` is where work goes to die.
+
+### Workaround comments carry their expiry
+
+A comment marking a temporary workaround (seed miscompilation pads,
+compatibility shims) must state the **concrete removal condition**, and the PR
+that satisfies the condition **must delete both the workaround and the
+comment**:
+
+```sfn
+// Seed workaround (#998): 0.5.7 folds this allocation away. Remove when
+// .seed-version reaches >= 0.5.8.
+```
+
+If you bump the seed or complete a migration, grep for comments citing the
+thing you just retired — a workaround comment that outlives its expiry is a
+bug in the comment. (Reviewers: treat a stale expiry the same as a failing
+test.)
+
+### No commented-out code
+
+Delete it. Git remembers. Commented-out code is ambiguous (is it coming back?
+was it broken?) and rots silently. The only exception is a short illustrative
+snippet inside a *why* comment (e.g. the worked desugaring example in
+`emit_native_desugar_try.sfn`), which is prose, not parked code.
+
+### Section banners
+
+`// ==== Section Name ====` banners are fine for navigating large files
+(see `llvm/types.sfn`) — use them to group, not to decorate. If a file needs
+more than a handful of sections, that is usually a signal to split it (see
+File Size below).
+
+### Density heuristic
+
+If the prose above a function is longer than the function, ask whether it is
+documenting an invariant (keep it) or narrating history/design (move it to an
+SFEP or design note and cite it). Files at >40% comment density are almost
+always carrying design documents in disguise.
+
+## Effect Annotations
+
+- **Spell effects explicitly**: `fn fetch(id: Id) -> Order ![io, net]`.
+- **Order effect lists alphabetically.** This matches the canonical taxonomy
+  order the compiler itself uses for rendered diagnostics
+  (`compiler/src/effect_taxonomy.sfn::canonical_effects()`:
+  `clock, gpu, io, model, net, rand`). Write `![io, net]`, not `![net, io]`.
+  Alphabetical is deterministic and needs no judgment call — the previous
+  "most impactful first" rule required one, and practice diverged.
+- **Declare what the body needs, transitively.** If a helper calls an
+  effectful function, the helper declares the effect and so do its callers.
+  Do not add speculative effects a body doesn't use.
+- The canonical effect set is `clock`, `gpu`, `io`, `model`, `net`, `rand`.
+  The `pure` and `unsafe` markers seen in a few signatures are **not** part of
+  the locked taxonomy; treat them as provisional and do not spread them to new
+  code without a design ruling (file an issue if you need one).
+
+## Error Handling & Diagnostics
+
+Three tiers, by audience:
+
+1. **User-source errors → diagnostics, never panics.** Errors in the program
+   being compiled are reported as structured `Diagnostic` records with an
+   error code, a source span, and (where possible) a fix-it hint — collected
+   and rendered, not thrown. Core passes (`typecheck.sfn`,
+   `effect_checker.sfn`, lowering) must not `panic()` or bare-`assert` on user
+   input: a compiler crash on bad input is a compiler bug.
+2. **Internal fallible operations → `Result<T, E>` + `?`.** For new code,
+   fallible internal operations (I/O, resolution, parsing of tool output)
+   should return `Result` and propagate with `?` (SFEP-0012). Adoption in
+   older modules is incremental — match the module you're in, but prefer
+   `Result` when adding new fallible surface.
+3. **Impossible states → make them unrepresentable first.** Reach for a
+   guard + diagnostic over an assertion; the compiler must degrade to an
+   error message, not a crash.
+
+**Error codes** are `E0xxx` strings with range ownership:
+
+| Range | Domain | Home |
+|---|---|---|
+| `E00xx` | Names / generic resolution | `typecheck_types.sfn` |
+| `E03xx` | Duplicate symbols / type conflicts | `typecheck*.sfn` |
+| `E04xx` | Effect violations | `diagnostics_render.sfn`, `effect_checker.sfn` |
+| `E05xx`–`E06xx` | Build / check tooling | `tools/check.sfn` |
+| `E08xx` | `Result` / `?` operator | `typecheck_types.sfn` |
+| `E09xx` | Ownership / affine types | `ownership_checker.sfn` |
+
+New codes go in the matching range at the next free number; grep the range
+before allocating. Do not reuse a retired code.
+
+## Immutability & Control Flow
+
+- **Immutable by default.** `let` unless the binding is reassigned; `let mut`
+  only when it is. Do not pre-declare `mut` "just in case".
+- **Early returns over nesting.** Stack guard clauses
+  (`if bad { return ...; }` / `continue`) at the top; keep the happy path at
+  the lowest indentation.
+- **Guard counters on unbounded loops.** Loops whose termination depends on
+  input structure carry a guard counter that breaks with a loud error rather
+  than hanging (see `lexer.sfn`'s `guard`/`max_guard` idiom). A hung compiler
+  is worse than a failed one.
 
 ## Repository Layout (Current)
 
 ```
 sailfin/
 ├─ compiler/
+│  ├─ capsule.toml               # version source of truth + manifest
 │  ├─ src/                       # self-hosted compiler sources (.sfn)
 │  │  ├─ main.sfn                # compiler entry point
 │  │  ├─ lexer.sfn
-│  │  ├─ parser/                 # parser domain
-│  │  │  ├─ mod.sfn              # public parser API
-│  │  │  ├─ declarations.sfn
-│  │  │  ├─ expressions.sfn
-│  │  │  ├─ statements.sfn
-│  │  │  └─ types.sfn
+│  │  ├─ parser/                 # parser domain (mod.sfn = public API)
 │  │  ├─ llvm/                   # native backend lowering
-│  │  │  ├─ mod.sfn              # public LLVM backend API
+│  │  │  ├─ mod.sfn
 │  │  │  ├─ lowering/
 │  │  │  └─ expression_lowering/
+│  │  ├─ cli/commands/           # one file per CLI subcommand
 │  │  └─ ...                     # typecheck, effects, emitters, utilities
-│  ├─ tests/
-│  │  ├─ unit/
-│  │  ├─ integration/
-│  │  └─ e2e/
-│  ├─ build/                     # generated bootstrap artifacts (do not edit)
-│  └─ *.py                       # legacy bootstrap sources (emergency only)
+│  └─ tests/
+│     ├─ unit/
+│     ├─ integration/
+│     └─ e2e/
 ├─ runtime/
 │  ├─ prelude.sfn                # Sailfin-visible runtime surface
-│  ├─ native/                    # Supporting C runtime helpers (entry point is Sailfin; M3 retires the rest)
-│  ├─ sfn/                       # Sailfin-native runtime modules (clock, memory, process, type_meta, …)
-│  └─ (no Python shims)          # Python runtime shims removed pre-1.0
+│  ├─ sfn/                       # Sailfin-native runtime modules
+│  └─ ir/                        # runtime IR support
 ├─ docs/
 ├─ examples/
 ├─ scripts/
 └─ tools/
 ```
 
-If a subsystem grows large, give it its own folder under `compiler/src/` with a
-`mod.sfn` and keep cross-module imports going through that `mod.sfn`.
+The toolchain is pure Sailfin: there is no C runtime and no Python bootstrap.
+If a subsystem grows large, give it its own folder under `compiler/src/` with
+a `mod.sfn` and keep cross-module imports going through that `mod.sfn`.
 
 ## File Naming Conventions
 
@@ -70,85 +273,97 @@ If a subsystem grows large, give it its own folder under `compiler/src/` with a
 - Prefer name + role suffixes that match existing usage:
   - `*_utils.sfn` for helpers (`string_utils.sfn`, `token_utils.sfn`)
   - `*_checker.sfn` for validators (`effect_checker.sfn`)
-  - `*_lowering.sfn` for lowering passes (`core_ops_lowering.sfn`, `core_literals_lowering.sfn`)
+  - `*_lowering.sfn` for lowering passes (`core_ops_lowering.sfn`)
   - `*_ir.sfn` for IR definitions (`native_ir.sfn`)
   - `*_semantics.sfn` for semantic interpretation (`decorator_semantics.sfn`)
 - In multi-file domains, use neutral names like `types.sfn`, `utils.sfn`,
   `expressions.sfn`, and keep the public entry point as `mod.sfn`.
-- Test files use `_test.sfn` suffixes and live under the matching test tier.
+- Test files use the `_test.sfn` suffix and live under the matching test tier.
 
-## Module APIs (`mod.sfn`)
+## File Size & Splitting
 
-Use `mod.sfn` to re-export public APIs for a folder. Keep imports from other
-folders pointing at `mod.sfn` so internal files can move freely.
+Large files are a **memory and build-parallelism cost**, not just a
+readability one: per-module working set bounds what `--jobs` can parallelize
+(SFEP-0027). `compiler/src/cli_main.sfn` carries a hard 1,500-line regression
+budget (`compiler/tests/unit/cli_main_line_budget_test.sfn`).
+
+- Treat **~1,500 lines as the soft budget** for any `compiler/src` module.
+  Approaching it, split by concern into a folder with a `mod.sfn` — the
+  parser (`parser/{mod,types,expressions,statements,declarations}.sfn`) and
+  LLVM lowering trees are the models.
+- Existing oversized files (`capsule_resolver.sfn`) are grandfathered — do not
+  grow them further; carve pieces out when you touch them substantially.
+- Keep public exports near the top of a file; helpers follow below, grouped
+  in small sections where it improves scanability.
+- Private helpers stay in the file that uses them. Hoist to a shared
+  `*_utils.sfn` only when a second module genuinely needs them.
+
+## Module APIs (`mod.sfn`) & Imports
+
+Use `mod.sfn` to re-export the public API of a folder:
 
 ```sfn
 // compiler/src/parser/mod.sfn
 export { parse_declaration } from "./declarations";
 export { parse_expression } from "./expressions";
-export { parse_statement } from "./statements";
-export { parse_type } from "./types";
 ```
-
-```sfn
-import { parse_expression } from "./parser/mod";
-```
-
-## Source Organization
-
-- Keep public exports near the top; helpers follow below.
-- Group related helpers in small sections if it improves scanability.
-- Prefer additional files over large mixed concerns in a single file.
-
-## Imports
 
 - Use relative imports within a folder (`./utils`, `./types`).
-- When crossing a domain boundary (e.g., `parser` to `llvm`), import from that
-  folder's `mod.sfn` rather than internal files.
+- When crossing a domain boundary (e.g. `parser` → `llvm`), import from that
+  folder's `mod.sfn` rather than internal files — so internals can move
+  freely.
+- **But prefer leaf imports over barrels when pulling one or two names**:
+  barrel imports are eager and inflate the compile graph. The full rule (and
+  the regression that motivated it) is
+  [`docs/conventions/barrel-imports.md`](conventions/barrel-imports.md).
 
 ## Tests
 
-- Mirror `compiler/src/` paths under `compiler/tests/`.
-- Use `unit/`, `integration/`, and `e2e/` tiers; keep test files suffixed
-  `_test.sfn`.
-- Keep large fixtures under `compiler/tests/**/data` or `fixtures/` and keep
-  test files focused on assertions.
+- Mirror `compiler/src/` paths under `compiler/tests/`; use the `unit/`,
+  `integration/`, `e2e/` tiers.
+- Test names are `test "<area>: <behavior>" { ... }` — don't encode the tier
+  in the name; the folder already says it. Full conventions:
+  `compiler/tests/README.md`.
+- Unit tests must watch their import closure — importing a "heavy" module
+  drags in ~130 modules. See
+  [`docs/conventions/unit-test-import-envelope.md`](conventions/unit-test-import-envelope.md).
+- E2E tests are Sailfin (`*_test.sfn`), never bash — the pattern catalog
+  (subprocess driving, shims, env threading) is `.claude/rules/no-bash-e2e.md`.
+- Bare `assert <expr>;` is the house style inside tests; the `expect_*`
+  matchers from `sfn/test` are for `![pure]` tests only.
+- Keep large fixtures under `compiler/tests/**/data` or `fixtures/`; keep test
+  files focused on assertions.
 
 ## Documentation Alignment
 
 - Update `docs/status.md` first whenever behavior changes.
-- Follow up with the language spec (`site/src/content/docs/docs/reference/spec/` for shipped features, `.../reference/preview/` for planned) and the [roadmap](https://sailfin.dev/roadmap) (`site/src/pages/roadmap.astro`) as needed.
-- Add or adjust proposal docs under `docs/proposals/` for future work.
+- Follow up with the language spec
+  (`site/src/content/docs/docs/reference/spec/` for shipped features,
+  `.../reference/preview/` for planned) and the
+  [roadmap](https://sailfin.dev/roadmap) as needed.
+- Record non-trivial designs as SFEPs under `docs/proposals/`
+  (`.claude/rules/proposals.md` has the always-loaded summary).
+- Narrow, single-topic conventions (usually born from an incident) live under
+  `docs/conventions/`; broad, always-relevant style lives **here**. Don't
+  create a second general style document.
 
-## Sailfin Language Style
+## Sailfin Language Style — Syntax Reform (Pre-1.0)
 
-- Spell effects explicitly: `fn foo() -> Bar ![io, model]`.
-- Order effect lists by impact (most impactful first).
-- Use `CamelCase` for models/capsules and `snake_case` for locals.
-- Note currency or latency literals as comments until syntax lands.
+The active reforms, for code you write today (rationale:
+`docs/proposals/0005-colon-type-annotations.md` and the roadmap):
 
-### Syntax Reform (Pre-1.0)
-
-The following syntax changes are active. See `docs/proposals/0005-colon-type-annotations.md` and the [roadmap](https://sailfin.dev/roadmap) for rationale.
-
-- **Type annotations**: Use `:` (colon) for parameter, variable, and struct
-  field types. Function return types use `->`. The parser still accepts `->`
-  in annotation positions for backward compatibility, but the in-tree codebase
-  has been migrated and new code should use `:` exclusively.
+- **Type annotations use `:`** for parameters, variables, and struct fields;
+  return types use `->`. The parser still accepts `->` in annotation positions
+  for compatibility, but new code uses `:` exclusively.
 
   ```sfn
-  fn add(x: number, y: number) -> number { return x + y; }
+  fn add(x: int, y: int) -> int { return x + y; }
   let name: string = "Sailfin";
-  struct User { id: number; name: string; }
   ```
 
-- **String interpolation**: Current syntax is `{{ expr }}`. This will change to
-  `${ expr }` before 1.0. Continue using `{{ }}` until the parser change lands.
-
-- **Numeric types**: `int` and `float` will replace the single `number` type.
-  Until this lands, use `number` and add comments where integer semantics matter.
-
-## Comments and Docstrings
-
-- Use `///` doc comments for public items; keep the first sentence a summary.
-- Use inline comments only for intent or future syntax gaps.
+- **Numeric types**: `int` (i64) and `float` (f64) are shipped; `number` is an
+  alias for `float`. Use `int`/`float` in new code.
+- **String interpolation** is currently `{{ expr }}`; it will become
+  `${ expr }` before 1.0 — keep `{{ }}` until the parser change lands.
+- **Lambda short form** `fn(x) => expr` is shipped (SFEP-0029) alongside the
+  block form `fn(x) -> T { ... }`.


### PR DESCRIPTION
## Summary

Sailfin had almost no coding conventions beyond the formatter, and it shows most in comments: "this commit"/"this PR" language baked into source, ~90-line rollout-plan file headers citing files that no longer exist, and seed-workaround comments two minor versions past their own stated expiry. This PR makes `docs/style-guide.md` the **single source of truth** for coding conventions and de-duplicates the two-line style rules previously restated across five other docs.

Every rule codifies dominant existing practice (surveyed across `compiler/src`, `runtime/`, and `compiler/tests`) or issues a ruling where the tree disagrees with itself — following the project's "boring wins" principle, borrowing from Go/Rust where they already settled the question.

## What's new in `docs/style-guide.md`

- **Comment conventions** (previously ungoverned):
  - `//` only — the guide previously claimed a `///` doc-comment form that has zero uses in the tree.
  - Comments explain *why*, code explains *what*; public-API comments open Go-style ("`parse_program` lexes and parses…").
  - **Durable references only**: cite `(#1234)` / `SFEP-NNNN` / RCA paths; never "this commit"/"this PR" (real offenders: `effect_checker.sfn:20`, `effect_gate.sfn:21`, `llvm/runtime_helpers.sfn:45`).
  - File headers are path + 1–5 sentences of purpose — **no changelogs or rollout plans** (`llvm/runtime_helpers.sfn`'s 90-line header still cites the deleted `runtime/native/` C runtime and a retired `.sh` test).
  - **Workaround comments carry a concrete removal condition**, deleted by the PR that satisfies it (`parser/mod.sfn:53` says "remove once 0.5.8 lands"; the seed is 0.7.0-alpha.39).
  - No `TODO`/`FIXME` (file an issue and cite it — already the de-facto culture: 1,335 issue citations vs ~0 real TODOs), no commented-out code, section banners for grouping only, and a comment-density heuristic.
- **Naming table**: `snake_case` fns/files, `PascalCase` types/variants, `_underscore` private helpers (+ module tags like `_cr_*`), `SCREAMING_SNAKE_CASE` module constants, acronyms-as-words in new names (`LlvmOperand`, not `LLVMOperand` — the tree is currently mixed), predicate booleans, `T`/`E` type params.
- **Effect annotations**: lists are **alphabetical** (`[io, net]`), matching `effect_taxonomy.sfn::canonical_effects()` — replaces the old "order by impact" rule, which was undefined and unfollowed (the tree has both `[net, io]` and `[io, net]`, sometimes in the same file). Notes `pure`/`unsafe` markers as provisional, outside the locked taxonomy.
- **Error handling**: user-source errors → diagnostics with `E0xxx` codes + spans, never panics in core passes; new internal fallible code → `Result<T, E>` + `?` (SFEP-0012); plus the implicit `E0xxx` range-ownership table (E04xx effects, E08xx try-operator, E09xx ownership, …) made explicit with an allocation rule.
- **File size & splitting**: generalizes the SFEP-0027 rationale (per-module working set bounds `--jobs`) into a ~1,500-line soft budget with `parser/` as the split model; grandfathers `capsule_resolver.sfn` without licensing growth.
- **Immutability & control flow**: `let` by default, early returns over nesting, guard counters on input-driven loops (the `lexer.sfn` idiom).
- **Staleness fixes**: layout tree no longer shows the deleted `runtime/native/`, retired `*.py` bootstrap, or `compiler/build/`; `int`/`float` documented as shipped; `:` annotations documented as migrated; lambda short form (SFEP-0029) added.

## Supporting changes

- **`.claude/rules/code-style.md`** (new): compact always-loaded summary for agents of the rules most often violated, pointing at the guide for detail.
- **Pointer de-duplication**: `CONTRIBUTING.md` §6, `AGENTS.md`, `.github/copilot-instructions.md`, and `.github/instructions/compiler.instructions.md` now link to the guide with a short headline summary instead of independently restating (slightly different, partly stale) rules. `docs/README.md` navigation entry updated. Also drops the stale Python/PEP 8 bullet from the Copilot instructions and the stale `*.spec.sfn` reference in CONTRIBUTING.

## Scope

Docs only — no `.sfn` files touched, no build or test impact. The haywire comments cited above are *documented as anti-patterns* but not cleaned up here; pruning them (especially `llvm/runtime_helpers.sfn`'s header and the expired `parser/mod.sfn` seed workaround, which guards live code) is deliberate follow-up work for separate, groomable issues since it touches compiler source and needs the self-host gate.

## Verification

- Survey-backed: every codified rule was checked against dominant practice in `compiler/src` (186 files), `runtime/` (33 files), and `compiler/tests` before being written down; rulings on genuine inconsistencies (effect order, acronym casing) are called out as rulings.
- Cross-references verified: `effect_taxonomy.sfn::canonical_effects()` order, E-code ranges, SFEP-0007/0012/0027/0029 claims, current repo layout (`runtime/ir/` present; no `runtime/native/`, no `compiler/*.py`).

https://claude.ai/code/session_01NW3K86bX5prthfe1R9qGcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NW3K86bX5prthfe1R9qGcE)_