### PR TITLE
docs(proposals): accept SFEP-0037 — peer-language process adoption

### DIFF
--- a/docs/proposals/0037-peer-language-process-adoption.md
+++ b/docs/proposals/0037-peer-language-process-adoption.md
@@ -1,7 +1,7 @@
 ---
-sfep: TBD
+sfep: 0037
 title: Peer-Language Process Adoption — Merge Queue, ICE Discipline, Perf History, Corpus Runs, Reduction, Fuzzing
-status: Draft
+status: Accepted
 type: process
 created: 2026-07-01
 updated: 2026-07-01
@@ -12,7 +12,7 @@ superseded-by:
 graduates-to:
 ---
 
-# SFEP-TBD — Peer-Language Process Adoption
+# SFEP-0037 — Peer-Language Process Adoption
 
 ## 1. Summary
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -59,6 +59,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0034](./0034-is-type-guard.md) | Structured, Enforced `x is T` Type-Guard Operator | Accepted | language |
 | [0035](./0035-prelude-mirror-signature-derivation.md) | Deriving Prelude-Mirror Registry Signatures from the Prelude | Accepted | runtime |
 | [0036](./0036-tls-runtime.md) | TLS termination + upstream TLS for the native runtime (OpenSSL) | Accepted | runtime |
+| [0037](./0037-peer-language-process-adoption.md) | Peer-Language Process Adoption — Merge Queue, ICE Discipline, Perf History, Corpus Runs | Accepted | process |
 
 ## Drafts under review (numbers assigned at merge)
 


### PR DESCRIPTION
Transitions the peer-language process adoption proposal (drafted in #1805) through the design gate per `.claude/rules/proposals.md` / SFEP-0001:

- Assigns number **0037** (registry `max + 1` after 0036) and renames `draft-peer-language-process-adoption.md` → `0037-peer-language-process-adoption.md`
- Front-matter: `sfep: 0037`, `status: Accepted` (design gate passed by owner)
- Adds the registry row to `docs/proposals/README.md`

Grooming (out-of-band, no diff): the four Tier 1 execution issues from §3.13 — #1806 (merge queue trigger), #1807 (ICE banner + template), #1808 (perf history), #1809 (corpus run) — pre-existed with full issue contracts and `claude-ready`; their `## Design:` citations were updated from the draft path to `SFEP-0037`. Tier 2/3 items groom when their tier is reached, per §3.13.

Markdown-only change — no `.sfn` files touched, no self-host or fmt gate applies.

https://claude.ai/code/session_012JRpbbtGPxpuJYhUnt9i5g

---
_Generated by [Claude Code](https://claude.ai/code/session_012JRpbbtGPxpuJYhUnt9i5g)_