### PR TITLE
feat(runtime): link OpenSSL + tls.sfn extern surface + HTTPS client (outbound)

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -160,16 +160,20 @@ runs:
 
     # OpenSSL link path (macOS only). The native runtime now links
     # `-lssl -lcrypto` (TLS, SFEP-0036 #1782), so every Sailfin binary —
-    # incl. the compiler — links OpenSSL. On Linux `libssl-dev` is on the
-    # default search path; on macOS Homebrew's `openssl@3` is keg-only
-    # (not symlinked into a default `-l` search dir), so clang reports
-    # `ld: library 'ssl' not found`. Export the keg's lib dir via
-    # `LIBRARY_PATH` (clang honours it for `-l` resolution) and
-    # `DYLD_FALLBACK_LIBRARY_PATH` (so the built binary loads the dylib at
-    # run time) into $GITHUB_ENV so the build + test steps inherit it.
+    # incl. the compiler AND each per-test binary the suite links — pulls
+    # OpenSSL. On Linux `libssl-dev` is on the default search path; on
+    # macOS Homebrew's `openssl@3` is keg-only (not symlinked into a
+    # default `-l` search dir), so clang reports `ld: library 'ssl' not
+    # found`. Export the keg's lib dir via `LIBRARY_PATH` (clang honours it
+    # for `-l` resolution) and `DYLD_FALLBACK_LIBRARY_PATH` (so the linked
+    # binary loads the dylib at run time) into $GITHUB_ENV so every later
+    # step inherits it. Runs on ALL macOS modes — NOT gated on
+    # `mode != 'skip-build'`: the test-shard jobs use `skip-build` (they
+    # download the prebuilt compiler) yet still compile + link per-test
+    # binaries, which need `-lssl` resolved just as much as the build job.
     # macOS-gated: Linux/Windows legs are byte-identical.
     - name: Provision OpenSSL link path (macOS)
-      if: ${{ inputs.mode != 'skip-build' && inputs.target == 'macos-arm64' }}
+      if: ${{ inputs.target == 'macos-arm64' }}
       shell: bash {0}
       run: |
         set -euo pipefail

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -158,6 +158,30 @@ runs:
           sailfin-testbin-${{ inputs.target }}-${{ inputs.seed_version }}-
           sailfin-testbin-${{ inputs.target }}-
 
+    # OpenSSL link path (macOS only). The native runtime now links
+    # `-lssl -lcrypto` (TLS, SFEP-0036 #1782), so every Sailfin binary —
+    # incl. the compiler — links OpenSSL. On Linux `libssl-dev` is on the
+    # default search path; on macOS Homebrew's `openssl@3` is keg-only
+    # (not symlinked into a default `-l` search dir), so clang reports
+    # `ld: library 'ssl' not found`. Export the keg's lib dir via
+    # `LIBRARY_PATH` (clang honours it for `-l` resolution) and
+    # `DYLD_FALLBACK_LIBRARY_PATH` (so the built binary loads the dylib at
+    # run time) into $GITHUB_ENV so the build + test steps inherit it.
+    # macOS-gated: Linux/Windows legs are byte-identical.
+    - name: Provision OpenSSL link path (macOS)
+      if: ${{ inputs.mode != 'skip-build' && inputs.target == 'macos-arm64' }}
+      shell: bash {0}
+      run: |
+        set -euo pipefail
+        prefix="$(brew --prefix openssl@3 2>/dev/null || true)"
+        if [ -z "$prefix" ] || [ ! -d "$prefix/lib" ]; then
+          brew install openssl@3
+          prefix="$(brew --prefix openssl@3)"
+        fi
+        echo "LIBRARY_PATH=${prefix}/lib:${LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+        echo "DYLD_FALLBACK_LIBRARY_PATH=${prefix}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-/usr/local/lib:/usr/lib}" >> "$GITHUB_ENV"
+        echo "[ci] macOS OpenSSL link path: ${prefix}/lib"
+
     - name: Build native compiler (selfhost from released seed)
       if: ${{ inputs.mode != 'skip-build' }}
       shell: bash {0}

--- a/compiler/src/build/link.sfn
+++ b/compiler/src/build/link.sfn
@@ -27,6 +27,29 @@ fn _dead_strip_link_flag() -> string ![io] {
     return "-Wl,--gc-sections";
 }
 
+// OpenSSL link-search path (Darwin only, #1782 / SFEP-0036). The native
+// runtime links `-lssl -lcrypto` (TLS), so every Sailfin binary — incl.
+// the compiler — pulls OpenSSL at link. On Linux `libssl-dev` sits on
+// clang's default search path; on macOS Homebrew's `openssl@3` is
+// keg-only (not symlinked into a default `-l` dir), so the link fails
+// with `ld: library 'ssl' not found`. The build driver adds the keg's
+// lib dir itself — rather than relying on a caller's `LIBRARY_PATH` — so
+// EVERY `sfn build` on macOS resolves `-lssl`: the compiler self-host,
+// nested test builds that spawn with a curated env, and real user
+// builds alike. Honours `SAILFIN_OPENSSL_PREFIX`, else probes `brew` and
+// the standard keg locations; emits nothing on Linux (default path) or a
+// macOS without a discoverable keg (there the default path / an external
+// `-L` is expected). Darwin-only, so Linux argv stays byte-identical
+// (#1112). Mirrors the `uname -s` probe `_dead_strip_link_flag` uses.
+fn _openssl_link_search_flags() -> string[] ![io] {
+    let os = _shell_read_cmd("uname -s");
+    if !strings_equal(os, "Darwin") { return []; }
+    let probe = "for d in \"${SAILFIN_OPENSSL_PREFIX:-}/lib\" \"$(brew --prefix openssl@3 2>/dev/null)/lib\" /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$d\" ] && { printf %s \"$d\"; break; }; done";
+    let dir = _shell_read_cmd(probe);
+    if dir.length == 0 { return []; }
+    return ["-L" + dir];
+}
+
 // Force-retain the runtime provider surface as link-GC roots (#1047).
 // `--gc-sections` would otherwise strip every runtime helper the *current*
 // program never statically references — including the compiler's own
@@ -175,6 +198,15 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         if rfi >= retain_flags.length { break; }
         link_flags.push(retain_flags[rfi]);
         rfi += 1;
+    }
+    // Darwin-only OpenSSL keg search path so `-lssl -lcrypto` resolve
+    // (#1782). No-op on Linux — argv stays byte-identical there (#1112).
+    let ssl_search = _openssl_link_search_flags();
+    let mut ssi: int = 0;
+    loop {
+        if ssi >= ssl_search.length { break; }
+        link_flags.push(ssl_search[ssi]);
+        ssi += 1;
     }
     let backend = LlvmTextBackend { };
     let plan = LinkPlan {

--- a/compiler/src/build/link.sfn
+++ b/compiler/src/build/link.sfn
@@ -27,29 +27,6 @@ fn _dead_strip_link_flag() -> string ![io] {
     return "-Wl,--gc-sections";
 }
 
-// OpenSSL link-search path (Darwin only, #1782 / SFEP-0036). The native
-// runtime links `-lssl -lcrypto` (TLS), so every Sailfin binary — incl.
-// the compiler — pulls OpenSSL at link. On Linux `libssl-dev` sits on
-// clang's default search path; on macOS Homebrew's `openssl@3` is
-// keg-only (not symlinked into a default `-l` dir), so the link fails
-// with `ld: library 'ssl' not found`. The build driver adds the keg's
-// lib dir itself — rather than relying on a caller's `LIBRARY_PATH` — so
-// EVERY `sfn build` on macOS resolves `-lssl`: the compiler self-host,
-// nested test builds that spawn with a curated env, and real user
-// builds alike. Honours `SAILFIN_OPENSSL_PREFIX`, else probes `brew` and
-// the standard keg locations; emits nothing on Linux (default path) or a
-// macOS without a discoverable keg (there the default path / an external
-// `-L` is expected). Darwin-only, so Linux argv stays byte-identical
-// (#1112). Mirrors the `uname -s` probe `_dead_strip_link_flag` uses.
-fn _openssl_link_search_flags() -> string[] ![io] {
-    let os = _shell_read_cmd("uname -s");
-    if !strings_equal(os, "Darwin") { return []; }
-    let probe = "for d in \"${SAILFIN_OPENSSL_PREFIX:-}/lib\" \"$(brew --prefix openssl@3 2>/dev/null)/lib\" /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$d\" ] && { printf %s \"$d\"; break; }; done";
-    let dir = _shell_read_cmd(probe);
-    if dir.length == 0 { return []; }
-    return ["-L" + dir];
-}
-
 // Force-retain the runtime provider surface as link-GC roots (#1047).
 // `--gc-sections` would otherwise strip every runtime helper the *current*
 // program never statically references — including the compiler's own
@@ -198,15 +175,6 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         if rfi >= retain_flags.length { break; }
         link_flags.push(retain_flags[rfi]);
         rfi += 1;
-    }
-    // Darwin-only OpenSSL keg search path so `-lssl -lcrypto` resolve
-    // (#1782). No-op on Linux — argv stays byte-identical there (#1112).
-    let ssl_search = _openssl_link_search_flags();
-    let mut ssi: int = 0;
-    loop {
-        if ssi >= ssl_search.length { break; }
-        link_flags.push(ssl_search[ssi]);
-        ssi += 1;
     }
     let backend = LlvmTextBackend { };
     let plan = LinkPlan {

--- a/compiler/src/build/runtime_objs.sfn
+++ b/compiler/src/build/runtime_objs.sfn
@@ -21,6 +21,7 @@ import {
     _env_flag,
     _mktemp_sibling_cmd,
     _sha256_of_file_cmd,
+    _shell_read_cmd,
     _shell_single_quote_arg
 } from "../cli_commands_utils";
 import { resolve_import_module_slug_for_module } from "../llvm/imports";
@@ -708,11 +709,51 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
 // (`cli_commands.sfn::_clang_link_test_cmd_with_deps`, which imports
 // this through the `cli_main <-> cli_commands` cycle) so the two
 // paths resolve the runtime identically.
+// OpenSSL link-search path (Darwin only, #1782 / SFEP-0036). The native
+// runtime links `-lssl -lcrypto` (TLS), so every Sailfin binary — incl.
+// the compiler — pulls OpenSSL at link. On Linux `libssl-dev` sits on
+// clang's default search path; on macOS Homebrew's `openssl@3` is
+// keg-only (not symlinked into a default `-l` dir), so the link fails
+// with `ld: library 'ssl' not found`. The build driver adds the keg's
+// lib dir itself — rather than relying on a caller's `LIBRARY_PATH` — so
+// EVERY link path resolves `-lssl`: `sfn build`/`run` (the program link)
+// AND `sfn test`'s per-binary link (a separate argv builder that emits
+// `plan.libs` but NOT `link_flags`), for the compiler self-host, nested
+// test builds spawned with a curated env, and real user builds alike.
+// Injected into the shared runtime `link_libs` (consumed by both argv
+// builders as `plan.libs`) so it can't be missed by one path. The `-L`
+// precedes `-lssl`/`-lcrypto`, so it applies. Honours
+// `SAILFIN_OPENSSL_PREFIX`, else probes `brew` and the standard keg
+// locations; emits nothing on Linux (default path). Darwin-gated via the
+// same `uname -s` probe `_dead_strip_link_flag` uses, so Linux argv stays
+// byte-identical (#1112).
+fn _openssl_link_search_flags() -> string[] ![io] {
+    let os = _shell_read_cmd("uname -s");
+    if !strings_equal(os, "Darwin") { return []; }
+    // Try the instant `[ -d ]` checks (env override, then the standard
+    // arm64 / Intel keg dirs) FIRST, and only shell out to `brew --prefix`
+    // when none exist — command substitution in a `for` list would run
+    // `brew` unconditionally (~100-300ms), and this probe fires on every
+    // link (incl. each `sfn test` per-binary link).
+    let probe = "d=\"\"; for c in \"${SAILFIN_OPENSSL_PREFIX:-}/lib\" /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; printf %s \"$d\"";
+    let dir = _shell_read_cmd(probe);
+    if dir.length == 0 { return []; }
+    return ["-L" + dir];
+}
+
 fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string, shared_cache_root: string) -> RuntimeLinkInputs ![io] {
     let inputs = _clang_compile_runtime_capsule_objects(runtime_capsules, out_dir, opt_flag, shared_cache_root);
     if !inputs.success { return _failed_runtime_link_inputs(); }
     let mut objects: string[] = inputs.object_paths;
-    let link_libs: string[] = inputs.link_libs;
+    // Prepend the Darwin OpenSSL keg `-L` (if any) so `-lssl`/`-lcrypto`
+    // resolve on macOS across every link path (#1782). No-op on Linux.
+    let mut link_libs: string[] = _openssl_link_search_flags();
+    let mut lli: int = 0;
+    loop {
+        if lli >= inputs.link_libs.length { break; }
+        link_libs.push(inputs.link_libs[lli]);
+        lli += 1;
+    }
     // Fold the c-source / ll-source layer's cache stats; the
     // sfn-source and prelude-entry layers merge in below (#915).
     let mut stats = inputs.stats;

--- a/compiler/tests/e2e/cross_windows_runtime_modules_test.sfn
+++ b/compiler/tests/e2e/cross_windows_runtime_modules_test.sfn
@@ -61,6 +61,13 @@ test "cross-windows RUNTIME_MODS / manifest per-module contracts" ![io] {
     assert contains(manifest, "\"sfn/platform/rlimit.sfn\"");
     assert ! contains(makefile, "runtime/sfn/platform/rlimit.sfn");
 
+    // tls.sfn (#1782): in the manifest, excluded from RUNTIME_MODS — it
+    // pulls the OpenSSL externs, which cannot resolve in a static mingw
+    // link (Windows TLS is #1485 M10). http.sfn forward-declares its
+    // @tls_* symbols, resolved to the windows_stubs.ll no-op stubs.
+    assert contains(manifest, "\"sfn/platform/tls.sfn\"");
+    assert ! contains(makefile, "runtime/sfn/platform/tls.sfn");
+
     // assert.sfn: in the manifest, excluded from RUNTIME_MODS.
     assert contains(manifest, "\"sfn/assert.sfn\"");
     assert ! contains(makefile, "runtime/sfn/assert.sfn");
@@ -89,6 +96,14 @@ test "cross-windows windows_stubs.ll defines the required Windows stubs" ![io] {
     assert contains(stubs, "@realpath");
     assert contains(stubs, "@runtime_assert_fail_fn");
     assert contains(stubs, "@sailfin_assert_fail");
+
+    // TLS client wrappers (#1782): tls.sfn is excluded from RUNTIME_MODS, so
+    // http.o's forward-declared @tls_* symbols resolve to these Windows
+    // no-op stubs (https:// degrades to a clean null; Windows TLS is M10).
+    assert contains(stubs, "define i8* @tls_client_ctx");
+    assert contains(stubs, "define i8* @tls_connect_fd");
+    assert contains(stubs, "define i64 @tls_read");
+    assert contains(stubs, "define i64 @tls_write");
 
     // windows_stubs.ll is a cross-windows-only object: NOT in the manifest
     // (its `ll-sources` is empty — adding windows_stubs would duplicate the

--- a/compiler/tests/e2e/runtime_tls_https_client_test.sfn
+++ b/compiler/tests/e2e/runtime_tls_https_client_test.sfn
@@ -1,0 +1,296 @@
+// Outbound HTTPS round-trip e2e for the native runtime's TLS surface
+// (SFEP-0036 gap B1, #1782). Drives the real `https://` client path
+// (`runtime/sfn/adapters/http.sfn` -> `runtime/sfn/platform/tls.sfn`,
+// OpenSSL) against a local `openssl s_server` on loopback and asserts the
+// response body arrives — proving the handshake, peer-chain verification,
+// TLS read/write, and body extraction all work end-to-end.
+//
+// Shape (the no-bash-e2e pattern, `.claude/rules/no-bash-e2e.md`): the
+// `openssl` CLI generates a self-signed cert (CN=localhost) and runs the
+// TLS server (`s_server -www`, an HTTP status page). A generated Sailfin
+// fixture `http.download`s the `https://` URL to a file; the test then
+// reads that file. `http.download` writes the file ONLY on a successful
+// round-trip (a failed connect/handshake/verify returns null before the
+// file is opened), so a non-empty file is proof the TLS GET succeeded —
+// and it sidesteps printing a possibly-null body string from the fixture.
+//
+// Trust: the fixture runs with `SAILFIN_TLS_CAFILE` pointed at the
+// generated self-signed cert, so `tls_client_ctx`'s verify-on default
+// (SSL_VERIFY_PEER + polled SSL_get_verify_result) accepts it. This
+// exercises basic verify-on without the full trust-store / hostname
+// hardening (deferred to #3).
+//
+// Skips cleanly (`assert true`, mirroring the tool-absent SKIP precedent)
+// when `openssl` is missing (no TLS peer) or no `timeout`/`gtimeout` is
+// available to reap the blocking `s_server` (no process-kill primitive).
+// CI runners (Linux + coreutils + libssl) have both.
+//
+// Matchers note (#842): `sfn/test`'s `expect_*` matchers are `![pure]` and
+// cannot be called from an `![io]` test; assert on captured text with
+// `sfn/strings::contains` instead.
+import { contains } from "sfn/strings";
+
+// ── file-local raw loopback readiness probe ──────────────────────
+// Prefixed `_tlp_` so these never collide with the external-linkage
+// runtime helpers of the same shape in `http.sfn` (not linked into this
+// test binary, but the prefix keeps that independent of link order). The
+// libc socket externs carry no effect annotation, so the effect checker
+// infers no `net` requirement for these direct callers — they are left
+// un-annotated (the same rationale as `serve_loopback_test.sfn`), while
+// the test body keeps `![io]` for its `process.*` / `fs.*` calls.
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+
+extern fn connect(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn close(fd: i32) -> i32;
+
+fn _tlp_ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+// The listening port — fixed, high, and distinct from the other native
+// loopback tests (serve_loopback uses 18790) so the pool's `--jobs N` does
+// not collide.
+fn _tls_port() -> i64 { return 18795; }
+
+fn _tls_port_str() -> string { return "18795"; }
+
+// Connect a stream socket to `127.0.0.1:port`; returns the fd or -1. Tries
+// both `sockaddr_in` byte layouts (Linux u16 sin_family at 0; macOS/BSD u8
+// sin_len at 0 + u8 sin_family at 1), first success wins — the inlined
+// `http.sfn::_connect_tcp` idiom. Used only to detect that `s_server` is
+// accepting before the fixture runs.
+fn _tlp_connect(port: i64) -> i32 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 { return 0 - 1; }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            memset(_tlp_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            memset(_tlp_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_tlp_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        memset(_tlp_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_tlp_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        memset(_tlp_ptr_off(addr, 4), 127, 1 as usize);
+        memset(_tlp_ptr_off(addr, 7), 1, 1 as usize);
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 {
+            free(addr);
+            return 0 - 1;
+        }
+        let rc: i32 = connect(fd, addr, 16);
+        free(addr);
+        if rc == 0 { return fd; }
+        close(fd);
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Full parent environment for the build + server + client subprocesses
+// (`run_capture`/`spawn_with_env`'s empty env is EMPTY, not "inherit"):
+// the nested build links a binary (clang + ld, now also `-lssl -lcrypto`),
+// and SAILFIN_TEST_SCRATCH (already present) keeps the build cache
+// per-invocation under the parallel pool.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// The client run-env plus `SAILFIN_TLS_CAFILE` pointed at the generated
+// self-signed cert so the client trusts it (verify stays on).
+fn _client_env(cert_path: string) -> string[] ![io] {
+    let mut e = process.environ();
+    e.push("SAILFIN_TLS_CAFILE=" + cert_path);
+    return e;
+}
+
+fn _has_cmd(name: string) -> boolean ![io] {
+    let probe = process.run(["sh", "-c", "command -v " + name
+        + " >/dev/null 2>&1"]);
+    return probe == 0;
+}
+
+// Resolve a wall-clock timeout command to reap the blocking `s_server`;
+// empty if none found.
+fn _timeout_cmd() -> string ![io] {
+    if _has_cmd("timeout") { return "timeout"; }
+    if _has_cmd("gtimeout") { return "gtimeout"; }
+    return "";
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/sfn-tls-https-e2e";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Generate a self-signed cert+key (CN=localhost) for the TLS server.
+// Returns true on success.
+fn _gen_cert(dir: string) -> boolean ![io] {
+    let exit = process.run_capture(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", dir
+        + "/key.pem", "-out", dir
+        + "/cert.pem", "-days", "1", "-nodes", "-subj", "/CN=localhost"], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    return exit == 0;
+}
+
+// Spawn `openssl s_server -www` (an HTTP status-page server) in the
+// background, wrapped in a wall-clock timeout so it self-reaps (there is
+// no process-kill primitive; s_server blocks forever). Returns the spawn
+// handle (unused for teardown — the timeout owns the lifetime).
+fn _spawn_server(dir: string, tcmd: string) -> i64 ![io] {
+    let mut argv: string[] = [];
+    argv.push(tcmd);
+    argv.push("60");
+    argv.push("openssl");
+    argv.push("s_server");
+    argv.push("-accept");
+    argv.push(_tls_port_str());
+    argv.push("-cert");
+    argv.push(dir + "/cert.pem");
+    argv.push("-key");
+    argv.push(dir + "/key.pem");
+    argv.push("-www");
+    argv.push("-quiet");
+    return process.spawn_with_env(argv, _child_env());
+}
+
+// Poll a raw TCP connect until `s_server` is accepting (or the budget
+// elapses). ~30s budget (60 attempts x ~0.5s) stays under the 60s server
+// timeout. Returns true once the port accepts a connection.
+fn _await_listening(port: i64) -> boolean ![io] {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 60 { break; }
+        let fd: i32 = _tlp_connect(port);
+        if fd >= 0 {
+            close(fd);
+            return true;
+        }
+        let _ = process.run(["sleep", "0.5"]);
+        attempt = attempt + 1;
+    }
+    return false;
+}
+
+// Write a fixture capsule whose `main` downloads `https://localhost:PORT/`
+// to `out_path`. `http.download` writes the file only on a successful
+// round-trip, so its presence + content is the round-trip proof.
+fn _write_client(dir: string, out_path: string) -> string ![io] {
+    let root = dir + "/client";
+    fs.createDirectory(root + "/src", true);
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"sfn/tls-https-e2e-client\"\n"
+        + "version = \"0.0.1\"\n"
+        + "description = \"outbound https e2e client\"\n"
+        + "\n"
+        + "[capabilities]\n"
+        + "required = [\"io\", \"net\"]\n"
+        + "\n"
+        + "[build]\n"
+        + "entry = \"src/main.sfn\"\n"
+        + "kind = \"library\"\n");
+    fs.writeFile(root + "/src/main.sfn", "fn main() -> int ![net, io] {\n"
+        + "    let _ = http.download(\"https://localhost:"
+        + _tls_port_str()
+        + "/\", \""
+        + out_path
+        + "\");\n"
+        + "    return 0;\n"
+        + "}\n");
+    return root + "/src/main.sfn";
+}
+
+fn _build_bin(main_path: string, bin: string) -> string ![io] {
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", bin, main_path], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    return bin;
+}
+
+test "runtime tls: https GET round-trips against a local openssl s_server" ![io] {
+    // Need the openssl CLI (TLS peer + cert gen) and a timeout to reap the
+    // blocking server. Skip cleanly otherwise — the plain suite still
+    // covers the surface via the unit skeleton test + `make compile`.
+    if !_has_cmd("openssl") {
+        print.info("[tls-https] SKIP: openssl CLI not available");
+        assert true;
+        return;
+    }
+    let tcmd = _timeout_cmd();
+    if tcmd.length == 0 {
+        print.info("[tls-https] SKIP: no timeout/gtimeout to reap the blocking s_server");
+        assert true;
+        return;
+    }
+
+    let dir = _scratch_dir();
+    let cert_ok = _gen_cert(dir);
+    assert cert_ok;
+
+    // Build the client fixture up front (cold build once, links -lssl).
+    let out_path = dir + "/body.out";
+    let _rm = process.run(["rm", "-f", out_path]);
+    let main_path = _write_client(dir, out_path);
+    let client_bin = _build_bin(main_path, dir + "/client-bin");
+    assert client_bin.length > 0;
+
+    // Start the TLS server and wait for it to accept.
+    let _handle = _spawn_server(dir, tcmd);
+    let up = _await_listening(_tls_port());
+    assert up;
+
+    // Run the client (with SAILFIN_TLS_CAFILE trusting the self-signed
+    // cert), retrying briefly to absorb any residual startup latency. A
+    // non-empty output file proves the https round-trip succeeded.
+    let cenv = _client_env(dir + "/cert.pem");
+    let mut body = "";
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 20 { break; }
+        let _rm2 = process.run(["rm", "-f", out_path]);
+        let cexit = process.run_capture([client_bin], cenv);
+        let _co = process.capture_take_stdout();
+        let _ce = process.capture_take_stderr();
+        if cexit == 0 {
+            if fs.exists(out_path) {
+                let content = fs.readFile(out_path);
+                if content.length > 0 {
+                    body = content;
+                    break;
+                }
+            }
+        }
+        let _ = process.run(["sleep", "0.5"]);
+        attempt = attempt + 1;
+    }
+
+    print.info("[tls-https] body length: received");
+    // Round-trip proof: a non-empty body came back over TLS. `s_server
+    // -www` returns an HTML status page listing the negotiated ciphers.
+    assert body.length > 0;
+    assert contains(body, "Ciphers");
+
+    // Best-effort cleanup (the timeout reaps the server process).
+    let _rmd = process.run(["rm", "-rf", dir + "/client"]);
+    let _rmo = process.run(["rm", "-f", out_path]);
+}

--- a/compiler/tests/e2e/runtime_tls_https_client_test.sfn
+++ b/compiler/tests/e2e/runtime_tls_https_client_test.sfn
@@ -15,10 +15,11 @@
 // and it sidesteps printing a possibly-null body string from the fixture.
 //
 // Trust: the fixture runs with `SAILFIN_TLS_CAFILE` pointed at the
-// generated self-signed cert, so `tls_client_ctx`'s verify-on default
-// (SSL_VERIFY_PEER + polled SSL_get_verify_result) accepts it. This
-// exercises basic verify-on without the full trust-store / hostname
-// hardening (deferred to #3).
+// generated self-signed cert (which carries a `DNS:localhost` SAN), so
+// `tls_client_ctx`'s verify-on default (SSL_VERIFY_PEER + polled
+// SSL_get_verify_result) plus the RFC-6125 hostname check (SSL_set1_host,
+// host = "localhost") both accept it. System trust-store discovery
+// hardening + the verify-failure regression are #3.
 //
 // Skips cleanly (`assert true`, mirroring the tool-absent SKIP precedent)
 // when `openssl` is missing (no TLS peer) or no `timeout`/`gtimeout` is
@@ -141,12 +142,14 @@ fn _scratch_dir() -> string ![io] {
     return dir;
 }
 
-// Generate a self-signed cert+key (CN=localhost) for the TLS server.
-// Returns true on success.
+// Generate a self-signed cert+key (CN=localhost) for the TLS server. The
+// `subjectAltName=DNS:localhost` SAN is required: the client now enforces
+// RFC-6125 hostname verification (SSL_set1_host), and modern OpenSSL checks
+// the SAN (not the CN) when a SAN is present. Returns true on success.
 fn _gen_cert(dir: string) -> boolean ![io] {
     let exit = process.run_capture(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", dir
         + "/key.pem", "-out", dir
-        + "/cert.pem", "-days", "1", "-nodes", "-subj", "/CN=localhost"], _child_env());
+        + "/cert.pem", "-days", "1", "-nodes", "-subj", "/CN=localhost", "-addext", "subjectAltName=DNS:localhost"], _child_env());
     let _o = process.capture_take_stdout();
     let _e = process.capture_take_stderr();
     return exit == 0;

--- a/compiler/tests/unit/runtime_tls_skeleton_test.sfn
+++ b/compiler/tests/unit/runtime_tls_skeleton_test.sfn
@@ -29,13 +29,17 @@ test "lowering: runtime/sfn/platform/tls.sfn emits a declare for every OpenSSL e
     // Context / handshake surface.
     assert _contains(ir, "@TLS_client_method(");
     assert _contains(ir, "@SSL_CTX_new(");
+    assert _contains(ir, "@SSL_CTX_free(");
     assert _contains(ir, "@SSL_CTX_set_verify(");
     assert _contains(ir, "@SSL_CTX_set_default_verify_paths(");
     assert _contains(ir, "@SSL_CTX_load_verify_locations(");
     assert _contains(ir, "@SSL_new(");
+    assert _contains(ir, "@SSL_free(");
     assert _contains(ir, "@SSL_set_fd(");
-    // SNI rides the SSL_ctrl ABI symbol (the set_tlsext_host_name macro).
+    // SNI rides the SSL_ctrl ABI symbol (the set_tlsext_host_name macro);
+    // SSL_set1_host binds the RFC-6125 hostname check.
     assert _contains(ir, "@SSL_ctrl(");
+    assert _contains(ir, "@SSL_set1_host(");
     assert _contains(ir, "@SSL_connect(");
     // I/O + verify-poll + teardown surface.
     assert _contains(ir, "@SSL_read(");

--- a/compiler/tests/unit/runtime_tls_skeleton_test.sfn
+++ b/compiler/tests/unit/runtime_tls_skeleton_test.sfn
@@ -1,0 +1,60 @@
+// Golden-IR test for the `runtime/sfn/platform/tls.sfn` OpenSSL surface —
+// the client-side TLS externs + wrappers behind the HTTP client's
+// `https://` path (SFEP-0036 gap B1, #1782). Mirrors
+// `runtime_net_skeleton_test.sfn`: pins the `declare` emitted for every
+// `SSL_*` extern (so the callback-free opaque-`* u8`-handle surface stays
+// lowerable) plus a `define` for the exported client wrappers.
+//
+// Strategy: ONE `lower_to_llvm_ir_from_text` call over the REAL module
+// (read via `fs.readFile`). `tls.sfn` has no imports, so single-module
+// lowering resolves every symbol it declares (the typecheck / fmt / link
+// halves are covered by `make compile` + the `fmt --check` CI gate + the
+// loopback e2e in `runtime_tls_https_client_test.sfn`).
+import { emit_native_text_with_module_name } from "../../src/emit_native";
+import { lower_to_llvm_ir_from_text } from "../../src/llvm/lowering/entrypoints";
+import { parse_program } from "../../src/parser/mod";
+import { index_of } from "../../src/string_utils";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+test "lowering: runtime/sfn/platform/tls.sfn emits a declare for every OpenSSL extern" ![io] {
+    let source = fs.readFile("runtime/sfn/platform/tls.sfn");
+    let program = parse_program(source);
+    let native = emit_native_text_with_module_name(program, "runtime/sfn/platform/tls");
+    let ir = lower_to_llvm_ir_from_text(native, "runtime/sfn/platform/tls");
+
+    assert _contains(ir, "declare ");
+    // Context / handshake surface.
+    assert _contains(ir, "@TLS_client_method(");
+    assert _contains(ir, "@SSL_CTX_new(");
+    assert _contains(ir, "@SSL_CTX_set_verify(");
+    assert _contains(ir, "@SSL_CTX_set_default_verify_paths(");
+    assert _contains(ir, "@SSL_CTX_load_verify_locations(");
+    assert _contains(ir, "@SSL_new(");
+    assert _contains(ir, "@SSL_set_fd(");
+    // SNI rides the SSL_ctrl ABI symbol (the set_tlsext_host_name macro).
+    assert _contains(ir, "@SSL_ctrl(");
+    assert _contains(ir, "@SSL_connect(");
+    // I/O + verify-poll + teardown surface.
+    assert _contains(ir, "@SSL_read(");
+    assert _contains(ir, "@SSL_write(");
+    assert _contains(ir, "@SSL_shutdown(");
+    assert _contains(ir, "@SSL_get_error(");
+    assert _contains(ir, "@SSL_get_verify_result(");
+}
+
+test "lowering: runtime/sfn/platform/tls.sfn defines the exported client wrappers" ![io] {
+    let source = fs.readFile("runtime/sfn/platform/tls.sfn");
+    let program = parse_program(source);
+    let native = emit_native_text_with_module_name(program, "runtime/sfn/platform/tls");
+    let ir = lower_to_llvm_ir_from_text(native, "runtime/sfn/platform/tls");
+
+    assert _contains(ir, "@tls_client_ctx(");
+    assert _contains(ir, "@tls_ctx_free(");
+    assert _contains(ir, "@tls_connect_fd(");
+    assert _contains(ir, "@tls_read(");
+    assert _contains(ir, "@tls_write(");
+    assert _contains(ir, "@tls_shutdown_free(");
+}

--- a/runtime/capsule.toml
+++ b/runtime/capsule.toml
@@ -46,9 +46,17 @@ ll-sources = []
 #   `compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh`.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["sfn/runtime_globals.sfn", "sfn/memory/arena.sfn", "sfn/memory/rc.sfn", "sfn/memory/mem.sfn", "sfn/memory/ownedbuf.sfn", "sfn/string.sfn", "sfn/array.sfn", "sfn/clock.sfn", "sfn/process.sfn", "sfn/io.sfn", "sfn/exception.sfn", "sfn/assert.sfn", "sfn/type_meta.sfn", "sfn/platform/exec.sfn", "sfn/platform/rlimit.sfn", "sfn/adapters/filesystem.sfn", "sfn/adapters/http.sfn", "sfn/adapters/net.sfn", "sfn/concurrency/scheduler.sfn", "sfn/concurrency/nursery.sfn", "sfn/concurrency/future.sfn", "sfn/concurrency/channel.sfn", "sfn/concurrency/parallel.sfn", "sfn/concurrency/serve.sfn"]
+sfn-sources = ["sfn/runtime_globals.sfn", "sfn/memory/arena.sfn", "sfn/memory/rc.sfn", "sfn/memory/mem.sfn", "sfn/memory/ownedbuf.sfn", "sfn/string.sfn", "sfn/array.sfn", "sfn/clock.sfn", "sfn/process.sfn", "sfn/io.sfn", "sfn/exception.sfn", "sfn/assert.sfn", "sfn/type_meta.sfn", "sfn/platform/exec.sfn", "sfn/platform/rlimit.sfn", "sfn/platform/tls.sfn", "sfn/adapters/filesystem.sfn", "sfn/adapters/http.sfn", "sfn/adapters/net.sfn", "sfn/concurrency/scheduler.sfn", "sfn/concurrency/nursery.sfn", "sfn/concurrency/future.sfn", "sfn/concurrency/channel.sfn", "sfn/concurrency/parallel.sfn", "sfn/concurrency/serve.sfn"]
 include-dirs = []
-link-libs = ["-lm", "-lpthread"]
+# `-lssl -lcrypto`: OpenSSL, linked into every Sailfin binary for the
+# native runtime's TLS surface (`sfn/platform/tls.sfn`, SFEP-0036). The
+# runtime capsule is the only `kind` whose `link-libs` reaches the link
+# (SFEP-0036 §3.2), so the TLS body must live here. Build/CI hosts must
+# have `libssl`-dev available. `--gc-sections` (link.sfn) dead-strips the
+# unreferenced `SSL_*` symbols from binaries that never call TLS (e.g. the
+# compiler), but the libraries are still linked, so their presence on the
+# link host is mandatory — same dependency class as `-lm` / `-lpthread`.
+link-libs = ["-lm", "-lpthread", "-lssl", "-lcrypto"]
 
 # The prelude (`runtime/prelude.sfn`) is emitted from source on the same
 # child-compiler path as `sfn-sources` and linked into every compiler

--- a/runtime/ir/windows_stubs.ll
+++ b/runtime/ir/windows_stubs.ll
@@ -80,3 +80,35 @@ define void @sailfin_assert_fail(i8* %file, i64 %line, i64 %col, i8* %msg) {
   call void @abort()
   unreachable
 }
+
+; TLS client wrappers (SFEP-0036, #1782). `runtime/sfn/platform/tls.sfn` is
+; excluded from RUNTIME_MODS — it pulls the OpenSSL (`libssl`/`libcrypto`)
+; externs, which do not resolve in a static mingw link (Windows native TLS
+; is deferred to #1485 M10, which reuses this same OS-independent extern
+; surface). `runtime/sfn/adapters/http.sfn`'s `https://` path forward-
+; declares these `@tls_*` symbols, so the standalone-emitted `http.o` needs
+; them defined at the Windows link. No-op stubs are the correct degraded
+; behavior: `tls_client_ctx` / `tls_connect_fd` return null → `_http_send`
+; surfaces a clean null (https unsupported on Windows for now, never a
+; silent downgrade); the read/write/free helpers are unreachable once the
+; ctx is null but are defined for completeness. Plaintext `http://` is
+; unaffected. Sync pinned by
+; compiler/tests/e2e/cross_windows_runtime_modules_test.sfn.
+define i8* @tls_client_ctx() {
+  ret i8* null
+}
+define void @tls_ctx_free(i8* %ctx) {
+  ret void
+}
+define i8* @tls_connect_fd(i8* %ctx, i32 %fd, i8* %host) {
+  ret i8* null
+}
+define i64 @tls_read(i8* %ssl, i8* %buf, i64 %n) {
+  ret i64 -1
+}
+define i64 @tls_write(i8* %ssl, i8* %buf, i64 %n) {
+  ret i64 -1
+}
+define void @tls_shutdown_free(i8* %ssl) {
+  ret void
+}

--- a/runtime/sfn/adapters/http.sfn
+++ b/runtime/sfn/adapters/http.sfn
@@ -12,8 +12,9 @@
 // Scope: HTTP and outbound HTTPS. The `https://` path (get / post /
 // download, via `_http_send`) TLS-wraps its connected socket through
 // `../platform/tls.sfn` (OpenSSL, SFEP-0036 gap B1 / #1782): default port
-// 443, SNI = host, peer chain verified (basic verify-on; trust-store /
-// hostname hardening is #3). The raw-request and keep-alive helpers
+// 443, SNI = host, peer chain verified AND hostname checked (RFC 6125);
+// system trust-store discovery hardening is #3. The raw-request and
+// keep-alive helpers
 // (`sfn_http_request_raw`, `sfn_http_conn_*`) remain HTTP-only for now
 // and still reject `https://` (a follow-up wave routes them through TLS).
 //
@@ -92,18 +93,32 @@
 // routing probe + a behavioral round-trip against a localhost
 // listener).
 // TLS client wrappers (SFEP-0036, gap B1): the `https://` path wraps its
-// connected socket via these helpers from `../platform/tls.sfn`. Imported
-// (not inlined) because they are Sailfin fn bodies, not externs — the same
-// cross-module import shape `string.sfn` uses for `owned_buf_new` (the #306
-// inline-extern workaround does not apply to imported fn bodies).
-import {
-    tls_client_ctx,
-    tls_ctx_free,
-    tls_connect_fd,
-    tls_read,
-    tls_write,
-    tls_shutdown_free
-} from "../platform/tls";
+// connected socket via these helpers, whose bodies live in
+// `../platform/tls.sfn`. Declared here as `extern fn` FORWARD-DECLARATIONS
+// rather than `import`ed for the SAME #306 reason the libc externs below
+// are inlined: a cross-module `import` is resolved from a staged
+// import-context that the standalone per-module runtime emit (the
+// `ci-cross-windows` bridge, which emits `http.sfn` in isolation) does not
+// stage, so lowering fails with "callee signature is not known". A forward
+// declaration makes this module self-contained for every emit path; the
+// linker resolves each `@tls_*` symbol to `tls.sfn`'s definition in the
+// full runtime link (unmangled external linkage, same as the `sfn_http_*`
+// exports). On the Windows cross-build — where `tls.sfn` is excluded (it
+// pulls OpenSSL, deferred to #1485 M10) — they resolve to the no-op stubs
+// in `runtime/ir/windows_stubs.ll`, so `https://` degrades to a clean null
+// there. (The runtime effect is identical to the prior `import`; only the
+// resolution mechanism changes.)
+extern fn tls_client_ctx() -> * u8;
+
+extern fn tls_ctx_free(ctx: * u8) -> void;
+
+extern fn tls_connect_fd(ctx: * u8, fd: i32, host: * u8) -> * u8;
+
+extern fn tls_read(ssl: * u8, buf: * u8, n: i64) -> i64;
+
+extern fn tls_write(ssl: * u8, buf: * u8, n: i64) -> i64;
+
+extern fn tls_shutdown_free(ssl: * u8) -> void;
 
 // ── libc memory + string helpers ──────────────────────────────
 extern fn malloc(size: usize) -> * u8;

--- a/runtime/sfn/adapters/http.sfn
+++ b/runtime/sfn/adapters/http.sfn
@@ -9,9 +9,13 @@
 // Mirrors the migration shape of `runtime/sfn/adapters/filesystem.sfn`
 // (M3.1, #814/#815) and `runtime/sfn/process.sfn` (M2.9).
 //
-// Scope: HTTP only — NO TLS for v0 (Option A per the epic). An
-// `https://` URL is rejected (returns null); capsules needing
-// HTTPS stay on the legacy curl path until a 1.1 TLS story lands.
+// Scope: HTTP and outbound HTTPS. The `https://` path (get / post /
+// download, via `_http_send`) TLS-wraps its connected socket through
+// `../platform/tls.sfn` (OpenSSL, SFEP-0036 gap B1 / #1782): default port
+// 443, SNI = host, peer chain verified (basic verify-on; trust-store /
+// hostname hardening is #3). The raw-request and keep-alive helpers
+// (`sfn_http_request_raw`, `sfn_http_conn_*`) remain HTTP-only for now
+// and still reject `https://` (a follow-up wave routes them through TLS).
 //
 // ABI. `compiler/src/llvm/runtime_helpers.sfn` flips the curl
 // registry rows by setting `native_signature` to the symbols
@@ -87,6 +91,20 @@
 // (typecheck + fmt + emit-define shape over the exports + an IR
 // routing probe + a behavioral round-trip against a localhost
 // listener).
+// TLS client wrappers (SFEP-0036, gap B1): the `https://` path wraps its
+// connected socket via these helpers from `../platform/tls.sfn`. Imported
+// (not inlined) because they are Sailfin fn bodies, not externs — the same
+// cross-module import shape `string.sfn` uses for `owned_buf_new` (the #306
+// inline-extern workaround does not apply to imported fn bodies).
+import {
+    tls_client_ctx,
+    tls_ctx_free,
+    tls_connect_fd,
+    tls_read,
+    tls_write,
+    tls_shutdown_free
+} from "../platform/tls";
+
 // ── libc memory + string helpers ──────────────────────────────
 extern fn malloc(size: usize) -> * u8;
 
@@ -433,20 +451,27 @@ fn _connect_tcp(host: * u8, port: i64) -> i32 ![net] {
     return 0 - 1;
 }
 
-// `_send_all(fd, buf, total)` — write `total` bytes, retrying on
-// short sends. Returns false if `send` ever fails.
-fn _send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
+// `_send_all(fd, ssl, buf, total)` — write `total` bytes, retrying on
+// short sends. When `ssl` is non-null the bytes go through `tls_write`
+// (TLS record layer); otherwise raw `send` on `fd`. Returns false if a
+// write ever fails.
+fn _send_all(fd: i32, ssl: * u8, buf: * u8, total: i64) -> bool ![net] {
     let mut sent: i64 = 0;
     loop {
         if sent >= total { break; }
-        let n: i64 = send(fd, _ptr_off(buf, sent), total - sent, 0);
+        let mut n: i64 = 0;
+        if ssl as i64 != 0 {
+            n = tls_write(ssl, _ptr_off(buf, sent), total - sent);
+        } else {
+            n = send(fd, _ptr_off(buf, sent), total - sent, 0);
+        }
         if n <= 0 { return false; }
         sent = sent + n;
     }
     return true;
 }
 
-// `_recv_all(fd, len_slot)` — drain the socket into a growing libc
+// `_recv_all(fd, ssl, len_slot)` — drain the socket into a growing libc
 // buffer (doubling like `filesystem.sfn`'s slurp), NUL-terminated
 // and caller-owned, writing the exact byte count received through
 // `len_slot` (so binary bodies with embedded NULs are length-known,
@@ -461,7 +486,7 @@ fn _send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
 // the 4-byte `sailfin_intrinsic_pointer_read_i32` load masked to its
 // low byte — never fault on a 4-byte load issued at the final in-body
 // offset (`off <= len`, load touches `off..off+3 <= len+3`).
-fn _recv_all(fd: i32, len_slot: * i64) -> * u8 ![net] {
+fn _recv_all(fd: i32, ssl: * u8, len_slot: * i64) -> * u8 ![net] {
     let mut capacity: i64 = 8192;
     let mut len: i64 = 0;
     let mut buf: * u8 = malloc((capacity + 4) as usize);
@@ -478,7 +503,12 @@ fn _recv_all(fd: i32, len_slot: * i64) -> * u8 ![net] {
             buf = new_buf;
             capacity = new_cap;
         }
-        let n: i64 = recv(fd, _ptr_off(buf, len), chunk, 0);
+        let mut n: i64 = 0;
+        if ssl as i64 != 0 {
+            n = tls_read(ssl, _ptr_off(buf, len), chunk);
+        } else {
+            n = recv(fd, _ptr_off(buf, len), chunk, 0);
+        }
         // Distinguish a socket error from a clean close: a partial
         // buffer from an errored socket must not look like success.
         if n < 0 {
@@ -694,6 +724,16 @@ fn _extract_body(resp: * u8, total_len: i64, body_len_slot: * i64) -> * u8 {
     return body;
 }
 
+// `_tls_teardown(ssl, ctx)` — shut down and free a client `SSL*` handle
+// and its `SSL_CTX*`. Both may be null (the plaintext-http path), making
+// this a no-op there, so it can be called unconditionally on every
+// post-handshake exit of a TLS-capable request. `tls_shutdown_free`
+// writes a close_notify over the fd, so this must run before `close(fd)`.
+fn _tls_teardown(ssl: * u8, ctx: * u8) -> void ![net] {
+    if ssl as i64 != 0 { tls_shutdown_free(ssl); }
+    if ctx as i64 != 0 { tls_ctx_free(ctx); }
+}
+
 // `_http_send(url, is_post, body, auth_header)` — the shared
 // request/response core. Parses `url` (scheme/host/port/path),
 // connects, writes the request head (plus body for POST), drains
@@ -701,9 +741,9 @@ fn _extract_body(resp: * u8, total_len: i64, body_len_slot: * i64) -> * u8 {
 // failure). `auth_header`, when non-null and non-empty, is emitted
 // as an `Authorization:` header (POST only).
 fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_slot: * i64) -> * u8 ![net] {
-    // Reject TLS — no HTTPS in v0.
+    // Detect the `https://` scheme — TLS-wrap the connection below.
     let https: string = "https://";
-    if (strstr(url, https as * u8) as i64) == (url as i64) { return null; }
+    let is_https: bool = (strstr(url, https as * u8) as i64) == (url as i64);
 
     // Locate the authority: skip past "scheme://" if present.
     let sep: string = "://";
@@ -720,8 +760,10 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
     let authority: * u8 = _strdup_n(host_start, authority_len);
     if authority as i64 == 0 { return null; }
 
-    // Split host:port (terminate host in place at the colon).
+    // Split host:port (terminate host in place at the colon). Default
+    // port is 443 for https, 80 for http; an explicit `:port` overrides.
     let mut port: i64 = 80;
+    if is_https { port = 443; }
     let colon: * u8 = strchr(authority, 58);
     if colon as i64 != 0 {
         port = atoi(_ptr_off(colon, 1)) as i64;
@@ -738,6 +780,30 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
         return null;
     }
 
+    // For https, TLS-wrap the connected socket: build a client ctx and
+    // handshake (SNI = host, peer chain verified). `ssl`/`tls_ctx` stay
+    // null for plaintext http, so the single `_send_all`/`_recv_all` path
+    // below routes bytes through TLS or raw sockets accordingly. Every
+    // post-handshake exit runs `_tls_teardown(ssl, tls_ctx)` (a no-op on
+    // http) before `close(fd)`.
+    let mut ssl: * u8 = null;
+    let mut tls_ctx: * u8 = null;
+    if is_https {
+        tls_ctx = tls_client_ctx();
+        if tls_ctx as i64 == 0 {
+            free(authority);
+            close(fd);
+            return null;
+        }
+        ssl = tls_connect_fd(tls_ctx, fd, authority);
+        if ssl as i64 == 0 {
+            tls_ctx_free(tls_ctx);
+            free(authority);
+            close(fd);
+            return null;
+        }
+    }
+
     // ── Build and send the request head ──
     let host_line: string = " HTTP/1.1\r\nHost: ";
     let tail: string = "\r\nConnection: close\r\n\r\n";
@@ -750,6 +816,7 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
         let body_len: i64 = strlen(body) as i64;
         let clen: * u8 = _uint_to_str(body_len);
         if clen as i64 == 0 {
+            _tls_teardown(ssl, tls_ctx);
             free(authority);
             close(fd);
             return null;
@@ -772,6 +839,7 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
         }
         let head: * u8 = malloc((total + 1) as usize);
         if head as i64 == 0 {
+            _tls_teardown(ssl, tls_ctx);
             free(clen);
             free(authority);
             close(fd);
@@ -792,17 +860,19 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
         memset(_ptr_off(head, off), 0, 1 as usize);
         free(clen);
 
-        let head_ok: bool = _send_all(fd, head, off);
+        let head_ok: bool = _send_all(fd, ssl, head, off);
         free(head);
         if head_ok {
-            if _send_all(fd, body, body_len) {
+            if _send_all(fd, ssl, body, body_len) {
                 // fall through to recv
             } else {
+                _tls_teardown(ssl, tls_ctx);
                 free(authority);
                 close(fd);
                 return null;
             }
         } else {
+            _tls_teardown(ssl, tls_ctx);
             free(authority);
             close(fd);
             return null;
@@ -814,6 +884,7 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
             + (strlen(tail as * u8) as i64);
         let head: * u8 = malloc((total + 1) as usize);
         if head as i64 == 0 {
+            _tls_teardown(ssl, tls_ctx);
             free(authority);
             close(fd);
             return null;
@@ -826,11 +897,12 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
         off = _append(head, off, tail as * u8);
         memset(_ptr_off(head, off), 0, 1 as usize);
 
-        let head_ok: bool = _send_all(fd, head, off);
+        let head_ok: bool = _send_all(fd, ssl, head, off);
         free(head);
         if head_ok {
             // fall through to recv
         } else {
+            _tls_teardown(ssl, tls_ctx);
             free(authority);
             close(fd);
             return null;
@@ -839,7 +911,8 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_
 
     free(authority);
     let mut total_len: i64 = 0;
-    let resp: * u8 = _recv_all(fd, & total_len);
+    let resp: * u8 = _recv_all(fd, ssl, & total_len);
+    _tls_teardown(ssl, tls_ctx);
     close(fd);
     let result: * u8 = _extract_body(resp, total_len, body_len_slot);
     if resp as i64 != 0 { free(resp); }
@@ -1005,7 +1078,7 @@ fn sfn_http_request_raw(method: * u8, url: * u8, headers: * u8, body: * u8) -> *
     memset(_ptr_off(head, off), 0, 1 as usize);
     if clen as i64 != 0 { free(clen); }
 
-    let head_ok: bool = _send_all(fd, head, off);
+    let head_ok: bool = _send_all(fd, null, head, off);
     free(head);
     if !head_ok {
         free(authority);
@@ -1013,7 +1086,7 @@ fn sfn_http_request_raw(method: * u8, url: * u8, headers: * u8, body: * u8) -> *
         return null;
     }
     if body_len > 0 {
-        if !_send_all(fd, body, body_len) {
+        if !_send_all(fd, null, body, body_len) {
             free(authority);
             close(fd);
             return null;
@@ -1022,7 +1095,7 @@ fn sfn_http_request_raw(method: * u8, url: * u8, headers: * u8, body: * u8) -> *
 
     free(authority);
     let mut total_len: i64 = 0;
-    let resp: * u8 = _recv_all(fd, & total_len);
+    let resp: * u8 = _recv_all(fd, null, & total_len);
     close(fd);
     // Return the full raw response verbatim — the capsule parses the
     // status code and headers out of it. `_recv_all` NUL-terminates the
@@ -1296,11 +1369,11 @@ fn sfn_http_conn_send(fd: i64, method: * u8, url: * u8, headers: * u8, body: * u
     if clen as i64 != 0 { free(clen); }
     free(authority);
 
-    let head_ok: bool = _send_all(fd as i32, head, off);
+    let head_ok: bool = _send_all(fd as i32, null, head, off);
     free(head);
     if !head_ok { return null; }
     if body_len > 0 {
-        if !_send_all(fd as i32, body, body_len) { return null; }
+        if !_send_all(fd as i32, null, body, body_len) { return null; }
     }
 
     let mut total_len: i64 = 0;

--- a/runtime/sfn/platform/tls.sfn
+++ b/runtime/sfn/platform/tls.sfn
@@ -7,9 +7,11 @@
 // an already-connected socket `fd`, wrapped by a small set of Sailfin
 // helpers the HTTP client (`../adapters/http.sfn`) uses for its
 // `https://` path. Inbound TLS termination in `serve` is a follow-up
-// (#2); trust-store / hostname hardening + the verify-failure e2e are
-// #3 — here verification is basic-on (peer chain checked, result
-// polled), enough to round-trip an `https://` GET.
+// (#2). Verification is on: the peer chain is verified (SSL_VERIFY_PEER,
+// result polled) AND the hostname is checked (SSL_set1_host, RFC 6125), so
+// an `https://` GET both round-trips and rejects a wrong-host cert. The
+// system CA trust-store discovery / macOS-Windows CA paths + the
+// verify-failure regression e2e remain #3.
 //
 // Callback-free by construction (SFEP-0036 §3.2): the verify callback
 // arg to `SSL_CTX_set_verify` is always `null` and the result is polled
@@ -63,6 +65,13 @@ extern fn SSL_set_fd(ssl: * u8, fd: i32) -> i32;
 // (SNI) macro. `long SSL_ctrl(SSL *, int cmd, long larg, void *parg)`.
 extern fn SSL_ctrl(ssl: * u8, cmd: i32, larg: i64, parg: * u8) -> i64;
 
+// `SSL_set1_host` — set the expected DNS hostname for OpenSSL's built-in
+// certificate hostname verification (RFC 6125). A real exported symbol
+// (not a macro), callback-free. `int SSL_set1_host(SSL *, const char *)`
+// returns 1 on success. Once set, `SSL_VERIFY_PEER` makes the handshake
+// fail on a hostname mismatch, so no Sailfin fn is address-taken.
+extern fn SSL_set1_host(ssl: * u8, host: * u8) -> i32;
+
 extern fn SSL_connect(ssl: * u8) -> i32;
 
 extern fn SSL_read(ssl: * u8, buf: * u8, num: i32) -> i32;
@@ -90,8 +99,9 @@ extern fn strlen(s: * u8) -> usize;
 // analogous to `curl`'s `CURL_CA_BUNDLE` / Node's `NODE_EXTRA_CA_CERTS`;
 // used by the loopback e2e to trust a generated self-signed cert).
 // Verification is turned ON (`SSL_VERIFY_PEER`, callback arg `null`); the
-// result is polled after the handshake in `tls_connect_fd`. Returns null
-// on allocation failure. Full trust-store / hostname hardening is #3.
+// result is polled after the handshake in `tls_connect_fd`, and the
+// hostname is bound there via SSL_set1_host. Returns null on allocation
+// failure. System trust-store discovery hardening is #3.
 fn tls_client_ctx() -> * u8 {
     let method: * u8 = TLS_client_method();
     if method as i64 == 0 { return null; }
@@ -124,7 +134,10 @@ fn tls_ctx_free(ctx: * u8) -> void {
 // result. Returns the handshaken `SSL*`, or null on any failure (freeing
 // the partial `SSL*` first) so the caller surfaces a typed failure — a
 // failed verify is never a silent downgrade. `host` (a C string) is used
-// for SNI only; strict hostname-match verification is #3.
+// for BOTH the SNI extension and the RFC-6125 hostname check
+// (SSL_set1_host); it must be the bare host (no port). An IP-literal host
+// is checked as a DNS name (IP-SAN certs are uncommon) — real hostnames
+// are the supported outbound case.
 fn tls_connect_fd(ctx: * u8, fd: i32, host: * u8) -> * u8 ![net] {
     if ctx as i64 == 0 { return null; }
     let ssl: * u8 = SSL_new(ctx);
@@ -134,16 +147,32 @@ fn tls_connect_fd(ctx: * u8, fd: i32, host: * u8) -> * u8 ![net] {
         SSL_free(ssl);
         return null;
     }
-    // SNI: SSL_set_tlsext_host_name(ssl, host) -> SSL_ctrl(ssl, 55, 0, host).
     if host as i64 != 0 {
-        SSL_ctrl(ssl, 55, 0, host);
+        // SNI: SSL_set_tlsext_host_name(ssl, host) -> SSL_ctrl(ssl, 55, 0,
+        // host). Returns 1 on success; a failure (e.g. OOM) means we would
+        // hand-shake against the wrong / a default vhost, so fail hard.
+        if SSL_ctrl(ssl, 55, 0, host) != 1 {
+            SSL_free(ssl);
+            return null;
+        }
+        // Hostname verification: bind the expected DNS name so
+        // SSL_VERIFY_PEER enforces cert<->host matching during the
+        // handshake (RFC 6125). Without this, a valid cert for ANY host
+        // would pass chain verification — an MITM hole. Callback-free.
+        if SSL_set1_host(ssl, host) != 1 {
+            SSL_free(ssl);
+            return null;
+        }
     }
-    // Blocking handshake (bounded by the socket's SO_*TIMEO).
+    // Blocking handshake (bounded by the socket's SO_*TIMEO). With
+    // SSL_set1_host + SSL_VERIFY_PEER, a chain OR hostname mismatch fails
+    // the handshake here.
     if SSL_connect(ssl) != 1 {
         SSL_free(ssl);
         return null;
     }
-    // Poll the verification result (X509_V_OK == 0).
+    // Belt-and-suspenders: poll the verification result (X509_V_OK == 0).
+    // A hostname mismatch surfaces here as X509_V_ERR_HOSTNAME_MISMATCH.
     if SSL_get_verify_result(ssl) != 0 {
         SSL_free(ssl);
         return null;

--- a/runtime/sfn/platform/tls.sfn
+++ b/runtime/sfn/platform/tls.sfn
@@ -1,0 +1,194 @@
+// runtime/sfn/platform/tls.sfn
+//
+// TLS extern surface + outbound (client) wrappers for the native
+// runtime (SFEP-0036, gap B1 of epic #1540). This is the first slice:
+// link OpenSSL (`-lssl -lcrypto`, declared in `runtime/capsule.toml`)
+// and expose a minimal, callback-free `SSL_CTX_*`/`SSL_*` surface over
+// an already-connected socket `fd`, wrapped by a small set of Sailfin
+// helpers the HTTP client (`../adapters/http.sfn`) uses for its
+// `https://` path. Inbound TLS termination in `serve` is a follow-up
+// (#2); trust-store / hostname hardening + the verify-failure e2e are
+// #3 — here verification is basic-on (peer chain checked, result
+// polled), enough to round-trip an `https://` GET.
+//
+// Callback-free by construction (SFEP-0036 §3.2): the verify callback
+// arg to `SSL_CTX_set_verify` is always `null` and the result is polled
+// imperatively with `SSL_get_verify_result` after the handshake, so no
+// Sailfin fn is ever address-taken for OpenSSL (the #1088 callback gap
+// is avoided entirely). OpenSSL drives blocking `read(2)`/`write(2)` on
+// our already-connected, already-timeout-armed (`SO_RCVTIMEO` /
+// `SO_SNDTIMEO`, #1581) fd via the default socket BIO (`SSL_set_fd`) —
+// no custom `BIO_METHOD` table (which would need C function pointers).
+//
+// Opaque-handle policy: every `SSL_CTX*` / `SSL*` is spelled `* u8`,
+// mirroring the socket-extern pattern in `../adapters/http.sfn` /
+// `../platform/net.sfn` (family-specific structs cast through `* u8` at
+// the boundary — no struct-by-value at the extern edge). Extern fns
+// carry no effect surface (E0804); enforcement rides the enclosing
+// `![net]` Sailfin fns, exactly as the socket externs do.
+//
+// Symbols confirmed exported by `libssl.so.3` (`nm -D`). OpenSSL >= 1.1
+// auto-initializes the library on first `SSL_CTX_new`, so no explicit
+// `OPENSSL_init_ssl` call is needed. `SSL_set_tlsext_host_name` (SNI) is
+// a header macro that resolves to `SSL_ctrl(ssl, 55 /*SET_TLSEXT_
+// HOSTNAME*/, 0 /*host_name*/, name)` at the ABI — declared here as the
+// real `SSL_ctrl` symbol.
+//
+// Decimal constants used below:
+//   SSL_VERIFY_PEER            = 1
+//   SSL_CTRL_SET_TLSEXT_HOSTNAME = 55, TLSEXT_NAMETYPE_host_name = 0
+//   X509_V_OK                  = 0   (SSL_get_verify_result success)
+//   SSL_ERROR_ZERO_RETURN      = 6   (clean close_notify)
+//   SSL_ERROR_SYSCALL          = 5   (peer TCP close w/o close_notify)
+// ── OpenSSL extern surface (libssl / libcrypto) ───────────────────
+extern fn TLS_client_method() -> * u8;
+
+extern fn SSL_CTX_new(method: * u8) -> * u8;
+
+extern fn SSL_CTX_free(ctx: * u8) -> void;
+
+extern fn SSL_CTX_set_verify(ctx: * u8, mode: i32, cb: * u8) -> void;
+
+extern fn SSL_CTX_set_default_verify_paths(ctx: * u8) -> i32;
+
+extern fn SSL_CTX_load_verify_locations(ctx: * u8, cafile: * u8, capath: * u8) -> i32;
+
+extern fn SSL_new(ctx: * u8) -> * u8;
+
+extern fn SSL_free(ssl: * u8) -> void;
+
+extern fn SSL_set_fd(ssl: * u8, fd: i32) -> i32;
+
+// `SSL_ctrl` — the ABI symbol behind the `SSL_set_tlsext_host_name`
+// (SNI) macro. `long SSL_ctrl(SSL *, int cmd, long larg, void *parg)`.
+extern fn SSL_ctrl(ssl: * u8, cmd: i32, larg: i64, parg: * u8) -> i64;
+
+extern fn SSL_connect(ssl: * u8) -> i32;
+
+extern fn SSL_read(ssl: * u8, buf: * u8, num: i32) -> i32;
+
+extern fn SSL_write(ssl: * u8, buf: * u8, num: i32) -> i32;
+
+extern fn SSL_shutdown(ssl: * u8) -> i32;
+
+extern fn SSL_get_error(ssl: * u8, ret: i32) -> i32;
+
+extern fn SSL_get_verify_result(ssl: * u8) -> i64;
+
+// ── libc helpers (optional extra CA bundle) ───────────────────────
+// Declared inline (redeclaring a C symbol across runtime modules is
+// safe — each emits its own LLVM `declare` and the linker resolves both
+// to the single libc entrypoint; see the `http.sfn` symbol note).
+extern fn getenv(name: * u8) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+// `tls_client_ctx()` — build a client `SSL_CTX` with the system trust
+// store loaded (`SSL_CTX_set_default_verify_paths`, e.g.
+// `/etc/ssl/certs`) plus an optional extra CA bundle from the
+// `SAILFIN_TLS_CAFILE` environment variable (loaded additively —
+// analogous to `curl`'s `CURL_CA_BUNDLE` / Node's `NODE_EXTRA_CA_CERTS`;
+// used by the loopback e2e to trust a generated self-signed cert).
+// Verification is turned ON (`SSL_VERIFY_PEER`, callback arg `null`); the
+// result is polled after the handshake in `tls_connect_fd`. Returns null
+// on allocation failure. Full trust-store / hostname hardening is #3.
+fn tls_client_ctx() -> * u8 {
+    let method: * u8 = TLS_client_method();
+    if method as i64 == 0 { return null; }
+    let ctx: * u8 = SSL_CTX_new(method);
+    if ctx as i64 == 0 { return null; }
+    // System default trust store.
+    SSL_CTX_set_default_verify_paths(ctx);
+    // Optional additional CA bundle (custom / test trust).
+    let ca_env: string = "SAILFIN_TLS_CAFILE";
+    let ca: * u8 = getenv(ca_env as * u8);
+    if ca as i64 != 0 {
+        if (strlen(ca) as i64) > 0 {
+            SSL_CTX_load_verify_locations(ctx, ca, null);
+        }
+    }
+    // Verify the peer chain; result polled via SSL_get_verify_result.
+    // The callback arg is null — no Sailfin fn is address-taken.
+    SSL_CTX_set_verify(ctx, 1, null);
+    return ctx;
+}
+
+// `tls_ctx_free(ctx)` — free a client ctx (no-op on null).
+fn tls_ctx_free(ctx: * u8) -> void {
+    if ctx as i64 != 0 { SSL_CTX_free(ctx); }
+}
+
+// `tls_connect_fd(ctx, fd, host)` — wrap an already-connected socket
+// `fd` into a client `SSL*`: attach the fd (blocking BIO), set the SNI
+// host name, drive the blocking handshake, and poll the verification
+// result. Returns the handshaken `SSL*`, or null on any failure (freeing
+// the partial `SSL*` first) so the caller surfaces a typed failure — a
+// failed verify is never a silent downgrade. `host` (a C string) is used
+// for SNI only; strict hostname-match verification is #3.
+fn tls_connect_fd(ctx: * u8, fd: i32, host: * u8) -> * u8 ![net] {
+    if ctx as i64 == 0 { return null; }
+    let ssl: * u8 = SSL_new(ctx);
+    if ssl as i64 == 0 { return null; }
+    // Attach the connected, timeout-armed socket.
+    if SSL_set_fd(ssl, fd) != 1 {
+        SSL_free(ssl);
+        return null;
+    }
+    // SNI: SSL_set_tlsext_host_name(ssl, host) -> SSL_ctrl(ssl, 55, 0, host).
+    if host as i64 != 0 {
+        SSL_ctrl(ssl, 55, 0, host);
+    }
+    // Blocking handshake (bounded by the socket's SO_*TIMEO).
+    if SSL_connect(ssl) != 1 {
+        SSL_free(ssl);
+        return null;
+    }
+    // Poll the verification result (X509_V_OK == 0).
+    if SSL_get_verify_result(ssl) != 0 {
+        SSL_free(ssl);
+        return null;
+    }
+    return ssl;
+}
+
+// `tls_write(ssl, buf, n)` — write up to `n` bytes; returns the count
+// written (> 0), or <= 0 on failure. Mirrors `send`'s contract so the
+// `_send_all` retry loop treats it identically. `n` is bounded by the
+// caller's request size (< 2 GiB), so the i32 cast is safe.
+fn tls_write(ssl: * u8, buf: * u8, n: i64) -> i64 ![net] {
+    if ssl as i64 == 0 { return 0 - 1; }
+    let r: i32 = SSL_write(ssl, buf, n as i32);
+    return r as i64;
+}
+
+// `tls_read(ssl, buf, n)` — read up to `n` bytes; returns the count read
+// (> 0), 0 at end-of-stream, or -1 on a genuine error. Mirrors `recv`'s
+// contract so `_recv_all` treats it identically. On a non-positive
+// `SSL_read`, the error is classified: ZERO_RETURN (clean close_notify)
+// and SYSCALL-with-0 (peer TCP close without close_notify, common for
+// `Connection: close` servers and `openssl s_server`) are both EOF;
+// anything else is a real error.
+fn tls_read(ssl: * u8, buf: * u8, n: i64) -> i64 ![net] {
+    if ssl as i64 == 0 { return 0 - 1; }
+    let r: i32 = SSL_read(ssl, buf, n as i32);
+    if r > 0 { return r as i64; }
+    let err: i32 = SSL_get_error(ssl, r);
+    // ZERO_RETURN (6) is a clean close_notify. SYSCALL (5) is EOF ONLY when
+    // `SSL_read` returned 0 (peer TCP close without close_notify). A SYSCALL
+    // with `r < 0` is EAGAIN / a recv timeout (`SO_RCVTIMEO`, #1581) / reset
+    // — a genuine error that must fail to -1, NOT a truncated body reported
+    // as a clean EOF. This keeps the TLS read contract identical to the raw
+    // `recv` path (which returns -1 on the same timeout).
+    if err == 6 { return 0; }
+    if err == 5 && r == 0 { return 0; }
+    return 0 - 1;
+}
+
+// `tls_shutdown_free(ssl)` — best-effort `SSL_shutdown` (sends
+// close_notify over the fd) then `SSL_free`. No-op on null. Must run
+// before the caller `close`s the underlying fd.
+fn tls_shutdown_free(ssl: * u8) -> void ![net] {
+    if ssl as i64 == 0 { return; }
+    SSL_shutdown(ssl);
+    SSL_free(ssl);
+}


### PR DESCRIPTION
## Summary
- Link OpenSSL (`-lssl -lcrypto`) into the native runtime and add a **callback-free** `SSL_CTX_*`/`SSL_*` extern surface (`runtime/sfn/platform/tls.sfn`) over the existing connected-`fd` socket layer.
- Route the HTTP client's `https://` path (`get` / `post` / `download`, via `_http_send`) through TLS read/write instead of raw `send`/`recv` — default port 443, SNI, peer-chain verification.
- The compiler self-hosts unchanged (runtime-only; it links but never calls TLS). First slice of SFEP-0036 (gap B1 of epic #1540).

Closes #1782

## Design
SFEP-0036 (`docs/proposals/0036-tls-runtime.md`) — outbound-client slice (§3.2 callback-free integration, §3.3 runtime-capsule linking, §3.4 outbound client). Inbound serve TLS (#2) and trust-store/hostname hardening (#3) are **out of scope**; the SFEP stays `Accepted` (slice 1 of 5).

## Acceptance Criteria
- [x] An `https://` GET round-trips against a local OpenSSL server (loopback) — `runtime_tls_https_client_test.sfn` drives `openssl s_server -www` over loopback and asserts the body arrives.
- [x] The TLS extern surface checks and emits cleanly (opaque `* u8` handles; no Sailfin→C callback — the verify result is polled via `SSL_get_verify_result`, callback arg `null`).
- [x] Build/CI hosts have `libssl`-dev available; the link resolves `-lssl -lcrypto` on a clean build (the self-hosted `build/native/sailfin` now `NEEDED`s `libssl.so.3` / `libcrypto.so.3`).
- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `make compile` passes
- [x] `make check` passes

## Design notes
- **Callback-free (SFEP-0036 §3.2):** `SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, null)` + a post-handshake `SSL_get_verify_result` poll — no Sailfin fn is ever address-taken for OpenSSL (the #1088 callback gap is avoided entirely). SNI rides the `SSL_ctrl(ssl, 55, 0, host)` ABI symbol behind the `SSL_set_tlsext_host_name` macro.
- **Single I/O path:** `_send_all`/`_recv_all` gained a nullable `ssl: * u8` param (null = plaintext `send`/`recv`, non-null = `tls_write`/`tls_read`), so plaintext http and https share one code path. `_tls_teardown` runs on every post-handshake exit of `_http_send`, before `close(fd)`.
- **Timeout parity (from review):** `tls_read` treats `SSL_ERROR_ZERO_RETURN` and a `SSL_ERROR_SYSCALL` with `ret == 0` as clean EOF, but a `SSL_ERROR_SYSCALL` with `ret < 0` (an `SO_RCVTIMEO` recv timeout, #1581) as a real error — matching the raw `recv` contract so a stalled TLS server can't silently truncate the body.
- **Trust config:** `tls_client_ctx` loads the system default trust store plus an optional `SAILFIN_TLS_CAFILE` extra-CA override (additive; analogous to `curl`'s `CURL_CA_BUNDLE` / Node's `NODE_EXTRA_CA_CERTS`) — the mechanism the loopback e2e uses to trust its generated self-signed cert while keeping verify on.

## Map reconciliation
Advisory `## Files Affected` matched the tree — the three named files were all touched. Two additions beyond the map, both in-scope:
- `compiler/tests/unit/runtime_tls_skeleton_test.sfn` + `compiler/tests/e2e/runtime_tls_https_client_test.sfn` — the regression coverage the issue's Acceptance/Verification imply (SFEP-0036 §8).
- `SAILFIN_TLS_CAFILE` env knob in `tls_client_ctx` — documented CA-bundle override needed to make the loopback verify-on round-trip testable; standard TLS-client config surface, not a new language/CLI surface.

## Verification
```bash
make compile   # pass (self-hosts; compiler NEEDEDs libssl.so.3 / libcrypto.so.3)
make check     # pass — unit ok, integration 42/42, e2e 171/171, capsules 38/38
build/native/sailfin test compiler/tests/unit/runtime_tls_skeleton_test.sfn   # PASS (2/2)
build/native/sailfin test compiler/tests/e2e/runtime_tls_https_client_test.sfn # PASS (1/1)
sfn fmt --check runtime/sfn/platform/tls.sfn runtime/sfn/adapters/http.sfn ... # clean
```

## Files Changed
- `runtime/capsule.toml` — `link-libs` += `-lssl -lcrypto`; `sfn-sources` += `sfn/platform/tls.sfn`
- `runtime/sfn/platform/tls.sfn` — **new**: OpenSSL extern surface + client wrappers
- `runtime/sfn/adapters/http.sfn` — `https://` routing through TLS
- `compiler/tests/unit/runtime_tls_skeleton_test.sfn` — **new**: extern-surface skeleton
- `compiler/tests/e2e/runtime_tls_https_client_test.sfn` — **new**: loopback round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZjDc4kxFmAhGprTpkQCPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZjDc4kxFmAhGprTpkQCPP)_