### PR TITLE
perf: native emitter — pairwise-merge join to cut per-module peak RSS

### DIFF
--- a/compiler/src/emit_native_state.sfn
+++ b/compiler/src/emit_native_state.sfn
@@ -294,14 +294,33 @@ fn append_string(values: string[], value: string) -> string[] {
 fn join_with_separator(values: string[], separator: string) -> string {
     if values == null { return ""; }
     if values.length == 0 { return ""; }
-    let mut result: string = values[0];
-    let mut index: int = 1;
+    if values.length == 1 { return values[0]; }
+    // Pair-wise merge: each pass halves the working array. O(N log N) memory
+    // total instead of the O(N^2) accumulation of `result = result + line`
+    // in a loop — under the zero-GC arena every intermediate prefix copy
+    // stays resident, so the naive join dominated per-module peak RSS when
+    // `builder_to_string` materialized the whole `.sfn-asm` text (same fix
+    // as `_join_llvm_lines_linear` in llvm/lowering/lowering_helpers_mangling.sfn).
+    //
+    // Bonus: each `current[i] + separator + current[i+1]` is a
+    // left-associative chain whose second concat sees a fresh-concat LHS,
+    // so the compiler's string_append peephole (b3b6dad) reuses the buffer
+    // in place.
+    let mut current = values;
     loop {
-        if index >= values.length { break; }
-        result = result + separator + values[index];
-        index += 1;
+        if current.length <= 1 { break; }
+        let mut next: string[] = [];
+        let mut i: int = 0;
+        loop {
+            if i >= current.length { break; }
+            if i + 1 < current.length {
+                next.push(current[i] + separator + current[i + 1]);
+            } else { next.push(current[i]); }
+            i += 2;
+        }
+        current = next;
     }
-    return result;
+    return current[0];
 }
 
 fn join_type_annotations(values: TypeAnnotation[]) -> string {

--- a/compiler/src/emitter_sailfin_utils.sfn
+++ b/compiler/src/emitter_sailfin_utils.sfn
@@ -166,14 +166,25 @@ fn trim_right(value: string) -> string {
 
 fn join_with_separator(values: string[], separator: string) -> string {
     if values.length == 0 { return ""; }
-    let mut result: string = values[0];
-    let mut index: int = 1;
+    if values.length == 1 { return values[0]; }
+    // Pair-wise merge — O(N log N) memory instead of the O(N^2)
+    // accumulation of `result = result + line` under the zero-GC arena.
+    // Same fix as emit_native_state.sfn / lowering_helpers_mangling.sfn.
+    let mut current = values;
     loop {
-        if index >= values.length { break; }
-        result = result + separator + values[index];
-        index += 1;
+        if current.length <= 1 { break; }
+        let mut next: string[] = [];
+        let mut i: int = 0;
+        loop {
+            if i >= current.length { break; }
+            if i + 1 < current.length {
+                next.push(current[i] + separator + current[i + 1]);
+            } else { next.push(current[i]); }
+            i += 2;
+        }
+        current = next;
     }
-    return result;
+    return current[0];
 }
 
 fn trim_text(value: string) -> string {


### PR DESCRIPTION
## Root cause

`emit_native_state.sfn::join_with_separator` — called by `builder_to_string`, which materializes the **entire `.sfn-asm` text for every module** — was the naive `result = result + sep + line` loop. Under the zero-GC bump arena, every intermediate prefix copy stays resident until process exit, so per-module peak RSS was **quadratic in emitted line count**. The LLVM side fixed this class years ago (`_join_llvm_lines_linear` in `lowering_helpers_mangling.sfn`, balanced join in `llvm/utils.sfn`) but the fix was never backported to the native emitter.

## Fix

Port the pairwise merge (each pass halves the working array → O(N log N) total allocation) into `emit_native_state.sfn` and the duplicate copy in `emitter_sailfin_utils.sfn`. Output is byte-identical — separator join is associative — and each `a + sep + b` keeps the left-associative shape the `string_append` peephole (b3b6dad) reuses in place.

## Numbers

`make bench` — 189 modules, isolated cold `emit llvm`, Linux x86_64, same methodology before/after:

| Metric | Before | After | Δ |
|---|---|---|---|
| Heaviest module peak RSS (`llvm/…/native/core`) | 1,761 MB | 1,422 MB | **−19.3%** |
| `capsule_resolver` peak RSS | 1,710 MB | 1,196 MB | **−30.1%** |
| `…native/core_operands` peak RSS | 1,576 MB | 1,193 MB | **−24.3%** |
| Σ per-module peak RSS (all 189) | 77,171 MB | 70,133 MB | **−9.1%** |
| Mean per-module peak RSS | 408 MB | 371 MB | −9.1% |
| Total bench wall clock | 454.6 s | 452.3 s | −0.5% |
| Modules regressed >5% RSS | — | **0** | |

## Verification

- `sfn check` clean; `sfn fmt --write` + `--check` round-trip clean on both files
- `make compile` — self-hosts
- Full suite: **185 unit / 42 integration / 170 e2e / 38 capsules — 0 failed**

## Follow-ups (filed, not in this PR)

- #1817 — stream native text as lines end-to-end (eliminate the join→split round-trip)
- #1818 — shrink import-context residency (stop holding full native texts of direct imports)

https://claude.ai/code/session_01UnQvUjUjSccHZhUC4jiCjw