### PR TITLE
feat(cli): print a uniform ICE banner on compiler panic + add ICE template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -1,0 +1,54 @@
+---
+name: Internal Compiler Error (ICE)
+about: The compiler panicked instead of emitting a diagnostic — every ICE is a bug
+title: "ICE: <one-line summary from the banner message>"
+labels: ["type:bug", "area:compiler"]
+assignees: []
+---
+
+<!--
+The Sailfin compiler is not supposed to panic. Any internal compiler error
+(the `internal compiler error (ICE)` banner on stderr) is a bug by
+definition — a pass hit a state it should have diagnosed or handled. File
+it here so /triage can dedupe it by banner content (SFEP-0037 §3.2).
+
+Paste the banner verbatim — its version, stage, and source lines are what
+dedupe keys on. Do not hand-edit them.
+-->
+
+## ICE banner
+
+<!-- Paste the full `internal compiler error (ICE): ...` block from stderr,
+     including the version / stage / source / file-a-report lines. -->
+
+```text
+
+```
+
+## Repro command
+
+<!-- The exact command that produced the ICE. -->
+
+```bash
+
+```
+
+## Input source
+
+<!-- The `.sfn` source (or a link/attachment) that triggers the panic. Keep
+     it as small as you can; a minimized repro goes in the next section. -->
+
+```sfn
+
+```
+
+## Minimized repro
+
+<!-- Optional today; `sfn reduce` (SFEP-0037 §3.5, a future SFEP) will fill
+     this automatically once it exists. Until then, leave blank or paste a
+     hand-reduced version if you have one. -->
+
+## Environment
+
+- Compiler version (from the banner's `version:` line):
+- OS / arch:

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -37,6 +37,7 @@ import {
 } from "sfn/cli";
 
 import { sailfin_cli_main_legacy } from "../cli_main";
+import { ice_set_binary_dir } from "../ice";
 import { number_to_string } from "../num_format";
 import { command_def as add_command_def, run as add_run } from "./commands/add";
 import { command_def as build_command_def, run as build_run } from "./commands/build";
@@ -78,6 +79,14 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // (Issue 2.2) so `binary_dir` is available for version resolution
     // and the user-visible args can be sliced off the front.
     let ctx: CliContext = parse_driver_prefix(argv);
+    // Stash `binary_dir` for the ICE banner (SFEP-0037 §3.2, #1807): an
+    // uncaught pipeline `throw` — which the `@main` wrapper prints as the ICE
+    // banner — resolves the version from this lazily, so the banner carries
+    // the `.build-stamp` dev hash even though the throw site cannot reach
+    // `binary_dir`. No panic boundary is installed here on purpose: a nested
+    // source-level `try/catch` frame corrupts the exception chain under the
+    // arena allocator (see `ice.sfn` header).
+    ice_set_binary_dir(ctx.binary_dir);
     let start_index: int = driver_prefix_length(argv);
 
     let mut args: string[] = [];

--- a/compiler/src/ice.sfn
+++ b/compiler/src/ice.sfn
@@ -1,0 +1,99 @@
+// compiler/src/ice.sfn
+//
+// Internal-compiler-error (ICE) support (SFEP-0037 §3.2, #1807). Prior art:
+// rustc's ICE contract — every compiler panic on a non-user-error path is a
+// reportable bug, and the crash output carries enough structure that filing
+// and deduping are mechanical.
+//
+// The top-level panic boundary is the synthesized `@main` wrapper
+// (`llvm/lowering/emission.sfn`), which already `setjmp`s once per process
+// and prints an uncaught `throw`'s message to stderr before exiting non-zero.
+// This module makes that message a *uniform banner* rather than raw text: a
+// panic throws `format_ice_banner(...)`, so the existing wrapper prints the
+// banner with no extra machinery. A deliberate design choice: adding a second
+// source-level `try/catch` frame here corrupts the exception chain under the
+// arena allocator (`SAILFIN_USE_ARENA=1`) — the nested frame is reclaimed at
+// arena reset and the wrapper's own `pop` then walks a stale `prev`, faulting
+// in `sfn_exception_pop_frame`. Formatting at throw time keeps the process in
+// the known-good single-frame regime.
+//
+// The banner needs context the throw site lacks: the compiler's `binary_dir`
+// (only known at the CLI entry — it resolves the version, incl. the
+// `.build-stamp` dev hash) and the active pipeline stage / source (only known
+// deep in the passes). All are stashed in process-wide markers, then read by
+// the formatter when a panic fires. `binary_dir` is stashed (not the resolved
+// version) so the version's filesystem read is paid lazily, only on an actual
+// panic, not on every CLI invocation.
+import { resolve_compiler_version } from "./version";
+
+// New-issue URL prefilled with the ICE template. Kept grep-stable: /triage
+// dedupes ICE issues by banner content, so the banner's shape is contract.
+let ICE_ISSUE_URL: string = "https://github.com/SailfinIO/sailfin/issues/new?template=ice.md";
+
+// Process-wide banner context. Same module-mutable-state pattern as
+// `test_runner_state.sfn` / `llvm/lowering_debug_state.sfn`; the constant
+// initializers keep them out of the runtime-evaluated-global class (#1386).
+//
+// Stage/source semantics are forward-only: stages advance them, nothing
+// resets them. A `throw` that reaches the banner *after* a compile function
+// has returned (e.g. driver/link orchestration between modules) would render
+// the last stage/source seen, not the true panic site. Harmless today — those
+// paths return exit codes rather than `throw` — but the banner's stage/source
+// is best-effort context, not a guaranteed panic location.
+let mut _ice_stage: string = "";
+let mut _ice_source: string = "";
+let mut _ice_binary_dir: string = "";
+
+// Stash the compiler's `binary_dir` at the CLI entry, where it is known. The
+// version is resolved from it lazily at throw time (so the banner carries the
+// `.build-stamp` dev hash) — paying the filesystem read only on an actual
+// panic, not on every invocation.
+fn ice_set_binary_dir(binary_dir: string) { _ice_binary_dir = binary_dir; }
+
+// Record the current pipeline stage and, when the debug hook is armed, force
+// a panic in it. Called at the entry of each stage in the compile driver so a
+// panic anywhere downstream reports the stage that raised it.
+fn ice_enter_stage(stage: string) ![io] {
+    _ice_stage = stage;
+    _ice_check_force_panic(stage);
+}
+
+// Record the source (module) currently being compiled so the banner can name
+// it. Set once per compile entry; pure (no env read).
+fn ice_set_source(source: string) { _ice_source = source; }
+
+// Debug-only forced panic (SFEP-0037 §8 test hook). When
+// `SAILFIN_DEBUG_FORCE_PANIC` names the current stage (or "all" / "1"), throw
+// the uniform banner so the ICE path is exercised deterministically without
+// depending on a real compiler bug. The `@main` wrapper prints the thrown
+// message (the banner) to stderr and exits non-zero. A no-op unless the env
+// var is set, so ordinary compiles pay only one env read per stage.
+fn _ice_check_force_panic(stage: string) ![io] {
+    let want = env.get("SAILFIN_DEBUG_FORCE_PANIC");
+    if want.length == 0 { return; }
+    if strings_equal(want, stage) || strings_equal(want, "all") || strings_equal(want, "1") {
+        let reason = "forced panic (SAILFIN_DEBUG_FORCE_PANIC) in stage '"
+            + stage
+            + "'";
+        let version = resolve_compiler_version(_ice_binary_dir);
+        throw format_ice_banner(version, _ice_stage, _ice_source, reason);
+    }
+}
+
+// Format the uniform ICE banner. Grep-stable lines — `internal compiler
+// error`, `version:`, `stage:`, `file a report:` — are contract for /triage's
+// ICE dedupe. `source:` is emitted only when a source was recorded; an unset
+// stage renders as `<unknown>` rather than blank.
+fn format_ice_banner(version: string, stage: string, source: string, message: string) -> string {
+    let mut banner: string = "error: internal compiler error (ICE): " + message
+        + "\n";
+    banner = banner
+        + "note: the compiler unexpectedly panicked — this is a bug\n";
+    banner = banner + "note: version: " + version + "\n";
+    let mut stage_line: string = stage;
+    if stage_line.length == 0 { stage_line = "<unknown>"; }
+    banner = banner + "note: stage: " + stage_line + "\n";
+    if source.length > 0 { banner = banner + "note: source: " + source + "\n"; }
+    banner = banner + "note: file a report: " + ICE_ISSUE_URL + "\n";
+    return banner;
+}

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -18,6 +18,7 @@ import {
     report_reexport_violations
 } from "./emit_native";
 import { emit_program } from "./emitter_sailfin";
+import { ice_enter_stage, ice_set_source } from "./ice";
 import {
     lower_to_llvm_ir,
     lower_to_llvm_ir_from_text,
@@ -274,10 +275,13 @@ fn print_llvm_with_module(source: string, module_name: string) -> boolean ![io] 
 }
 
 fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![io] {
+    ice_set_source(module_name);
+    ice_enter_stage("parse");
     let program: Program = parse_program(source);
     let prelude_globals = load_prelude_global_names(runtime_helper_call_names());
     let skip_typecheck = _env_flag("SAILFIN_SKIP_TYPECHECK")
         || _legacy_flag_file("build/sailfin/.skip_typecheck");
+    ice_enter_stage("typecheck");
     if !skip_typecheck {
         if typecheck_has_errors_with_prelude(program, prelude_globals) {
             let diagnostics = typecheck_diagnostics_with_prelude(program, prelude_globals);
@@ -288,12 +292,15 @@ fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![
         print.err("emit-llvm: skipping typecheck (SAILFIN_SKIP_TYPECHECK set, or legacy build/sailfin/.skip_typecheck file present)");
     }
     if _reject_reexport_violations(program) { return ""; }
+    ice_enter_stage("effects");
     if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         return "";
     }
     // E4 ownership pass (#1213): dormant Phase R0 gate.
+    ice_enter_stage("ownership");
     if run_ownership_checker(program) > 0 { return ""; }
     let trace_emit = _env_flag("SAILFIN_TRACE_EMIT") || _legacy_flag_file("build/sailfin/.trace_emit");
+    ice_enter_stage("emit_native");
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
         print.err("emit-llvm: native text bytes=" + number_to_string(native_text.length));
@@ -302,6 +309,7 @@ fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![
             print.err("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
         }
     }
+    ice_enter_stage("lower_llvm");
     let mut ir: string = "";
     if native_text.length > 0 {
         ir = lower_to_llvm_ir_from_text(native_text, module_name);
@@ -324,12 +332,15 @@ fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![
 }
 
 fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> string ![io, clock] {
+    ice_set_source(module_name);
+    ice_enter_stage("parse");
     let t0 = monotonic_millis();
     let program: Program = parse_program(source);
     let prelude_globals = load_prelude_global_names(runtime_helper_call_names());
     let t_parse = _ms_since(t0);
 
     let t1 = monotonic_millis();
+    ice_enter_stage("typecheck");
     let skip_typecheck = _env_flag("SAILFIN_SKIP_TYPECHECK")
         || _legacy_flag_file("build/sailfin/.skip_typecheck");
     let mut t_typecheck: int = 0;
@@ -351,12 +362,14 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
         print.err(_timing_line(module_name, "typecheck", t_typecheck));
         return "";
     }
+    ice_enter_stage("effects");
     if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         print.err(_timing_line(module_name, "parse", t_parse));
         print.err(_timing_line(module_name, "typecheck", t_typecheck));
         return "";
     }
     // E4 ownership pass (#1213): dormant Phase R0 gate.
+    ice_enter_stage("ownership");
     if run_ownership_checker(program) > 0 {
         print.err(_timing_line(module_name, "parse", t_parse));
         print.err(_timing_line(module_name, "typecheck", t_typecheck));
@@ -364,6 +377,7 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
     }
 
     let t2 = monotonic_millis();
+    ice_enter_stage("emit_native");
     let trace_emit = _env_flag("SAILFIN_TRACE_EMIT") || _legacy_flag_file("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
@@ -376,6 +390,7 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
     let t_emit_native = _ms_since(t2);
 
     let t3 = monotonic_millis();
+    ice_enter_stage("lower_llvm");
     let mut ir = "";
     if native_text.length > 0 {
         ir = lower_to_llvm_ir_from_text(native_text, module_name);

--- a/compiler/tests/e2e/ice_banner_test.sfn
+++ b/compiler/tests/e2e/ice_banner_test.sfn
@@ -27,12 +27,30 @@ fn _valid_src() -> string {
     return "fn add(a: int, b: int) -> int {\n    return a + b;\n}\n";
 }
 
-// The full parent environment plus the forced-panic stage, so the in-process
-// compile resolves its runtime root exactly as the parent did and the hook
-// sees the flag. `run_capture`'s env array is the CHILD's entire environment
-// (empty = empty, not inherit), so the parent env must be threaded through.
+// The parent environment with any pre-existing `SAILFIN_DEBUG_FORCE_PANIC`
+// stripped, so the in-process compile resolves its runtime root exactly as
+// the parent did without inheriting a stray forced-panic flag from the
+// developer's shell. `run_capture`'s env array is the CHILD's entire
+// environment (empty = empty, not inherit), so the parent env is threaded
+// through; both the forced-panic and clean runs build on this filtered base
+// so a single caller-set flag cannot skew either.
+fn _base_env() -> string[] ![io] {
+    let raw = process.environ();
+    let mut e: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= raw.length { break; }
+        if find(raw[i], "SAILFIN_DEBUG_FORCE_PANIC=", 0) != 0 {
+            e.push(raw[i]);
+        }
+        i += 1;
+    }
+    return e;
+}
+
+// The filtered base plus exactly one forced-panic stage.
 fn _env_with_panic(stage: string) -> string[] ![io] {
-    let mut e: string[] = process.environ();
+    let mut e: string[] = _base_env();
     e.push("SAILFIN_DEBUG_FORCE_PANIC=" + stage);
     return e;
 }
@@ -46,12 +64,13 @@ test "ICE #1807: forced parse-stage panic prints the banner on stderr" ![io] {
         let err = process.capture_take_stderr();
         // Uniform banner, version line, correct stage, and the issue URL. The
         // banner is the thrown message; the `@main` wrapper prints it to
-        // stderr and exits non-zero.
+        // stderr and exits 1 (its uncaught-throw code) — asserting the exact
+        // code rejects a non-zero exit from an unrelated failure path.
         assert find(err, "internal compiler error (ICE)", 0) >= 0;
         assert find(err, "note: version:", 0) >= 0;
         assert find(err, "note: stage: parse", 0) >= 0;
         assert find(err, "issues/new?template=ice.md", 0) >= 0;
-        assert exit != 0;
+        assert exit == 1;
         return 0;
     });
     assert code == 0;
@@ -66,7 +85,7 @@ test "ICE #1807: the banner names the stage that raised (lower_llvm)" ![io] {
         let err = process.capture_take_stderr();
         assert find(err, "internal compiler error (ICE)", 0) >= 0;
         assert find(err, "note: stage: lower_llvm", 0) >= 0;
-        assert exit != 0;
+        assert exit == 1;
         return 0;
     });
     assert code == 0;
@@ -76,10 +95,11 @@ test "ICE #1807: a clean compile prints no banner and exits 0" ![io] {
     let code = with_tmp_dir(fn (dir: string) -> int {
         let src = dir + "/ice_probe.sfn";
         fs.writeFile(src, _valid_src());
-        let exit = process.run_capture([_sfn_bin(), "emit", "llvm", "--timing", src], process.environ());
+        let exit = process.run_capture([_sfn_bin(), "emit", "llvm", "--timing", src], _base_env());
         let _out = process.capture_take_stdout();
         let err = process.capture_take_stderr();
-        // No panic banner on the ordinary path.
+        // No panic banner on the ordinary path — the filtered base env cannot
+        // carry a stray `SAILFIN_DEBUG_FORCE_PANIC` from the developer's shell.
         assert find(err, "internal compiler error", 0) < 0;
         assert exit == 0;
         return 0;

--- a/compiler/tests/e2e/ice_banner_test.sfn
+++ b/compiler/tests/e2e/ice_banner_test.sfn
@@ -1,0 +1,88 @@
+// compiler/tests/e2e/ice_banner_test.sfn
+//
+// Regression for the ICE panic boundary (SFEP-0037 §3.2, #1807). A compiler
+// panic on a non-user-error path must print the uniform internal-compiler-
+// error banner (resolved version, active pipeline stage, new-issue URL) on
+// stderr and exit with the ICE exit code, while an ordinary clean compile
+// prints no banner. Driven via the debug-only `SAILFIN_DEBUG_FORCE_PANIC`
+// hook (`compiler/src/ice.sfn`), which throws in the named stage so the
+// banner path is exercised deterministically without depending on a real
+// compiler bug.
+//
+// Native e2e per `.claude/rules/no-bash-e2e.md`: drives the compiler via
+// `process.run_capture` and asserts on captured stderr with `sfn/strings`.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// A trivially valid program: it clears every pipeline stage on a clean run,
+// so a forced panic in any stage (parse … lower_llvm) is deterministically
+// reachable.
+fn _valid_src() -> string {
+    return "fn add(a: int, b: int) -> int {\n    return a + b;\n}\n";
+}
+
+// The full parent environment plus the forced-panic stage, so the in-process
+// compile resolves its runtime root exactly as the parent did and the hook
+// sees the flag. `run_capture`'s env array is the CHILD's entire environment
+// (empty = empty, not inherit), so the parent env must be threaded through.
+fn _env_with_panic(stage: string) -> string[] ![io] {
+    let mut e: string[] = process.environ();
+    e.push("SAILFIN_DEBUG_FORCE_PANIC=" + stage);
+    return e;
+}
+
+test "ICE #1807: forced parse-stage panic prints the banner on stderr" ![io] {
+    let code = with_tmp_dir(fn (dir: string) -> int {
+        let src = dir + "/ice_probe.sfn";
+        fs.writeFile(src, _valid_src());
+        let exit = process.run_capture([_sfn_bin(), "emit", "llvm", "--timing", src], _env_with_panic("parse"));
+        let _out = process.capture_take_stdout();
+        let err = process.capture_take_stderr();
+        // Uniform banner, version line, correct stage, and the issue URL. The
+        // banner is the thrown message; the `@main` wrapper prints it to
+        // stderr and exits non-zero.
+        assert find(err, "internal compiler error (ICE)", 0) >= 0;
+        assert find(err, "note: version:", 0) >= 0;
+        assert find(err, "note: stage: parse", 0) >= 0;
+        assert find(err, "issues/new?template=ice.md", 0) >= 0;
+        assert exit != 0;
+        return 0;
+    });
+    assert code == 0;
+}
+
+test "ICE #1807: the banner names the stage that raised (lower_llvm)" ![io] {
+    let code = with_tmp_dir(fn (dir: string) -> int {
+        let src = dir + "/ice_probe.sfn";
+        fs.writeFile(src, _valid_src());
+        let exit = process.run_capture([_sfn_bin(), "emit", "llvm", "--timing", src], _env_with_panic("lower_llvm"));
+        let _out = process.capture_take_stdout();
+        let err = process.capture_take_stderr();
+        assert find(err, "internal compiler error (ICE)", 0) >= 0;
+        assert find(err, "note: stage: lower_llvm", 0) >= 0;
+        assert exit != 0;
+        return 0;
+    });
+    assert code == 0;
+}
+
+test "ICE #1807: a clean compile prints no banner and exits 0" ![io] {
+    let code = with_tmp_dir(fn (dir: string) -> int {
+        let src = dir + "/ice_probe.sfn";
+        fs.writeFile(src, _valid_src());
+        let exit = process.run_capture([_sfn_bin(), "emit", "llvm", "--timing", src], process.environ());
+        let _out = process.capture_take_stdout();
+        let err = process.capture_take_stderr();
+        // No panic banner on the ordinary path.
+        assert find(err, "internal compiler error", 0) < 0;
+        assert exit == 0;
+        return 0;
+    });
+    assert code == 0;
+}


### PR DESCRIPTION
## Summary
- A compiler panic now prints a uniform **internal-compiler-error banner** on stderr — resolved version (incl. the `.build-stamp` dev hash), active pipeline stage, source when known, and a prefilled new-issue URL — instead of a bare thrown message.
- New `.github/ISSUE_TEMPLATE/ice.md` (pre-labeled `type:bug`, `area:compiler`) so agent-filed ICE issues are uniform and `/triage`-dedupable by banner content.
- Design: **SFEP-0037 §3.2** (Accepted). Prior art: rustc's ICE contract.

Closes #1807

## Design note — why no `try/catch`
The banner is emitted through the **existing synthesized `@main` wrapper**, which already `setjmp`s once per process and prints an uncaught `throw`'s message to stderr. A panic throws `format_ice_banner(...)`, so the wrapper prints the banner with no new machinery.

Adding a second source-level `try/catch` panic boundary was implemented, then **rejected**: the nested exception frame corrupts the exception chain under the arena allocator (`SAILFIN_USE_ARENA=1`) — it is reclaimed at arena reset and the wrapper's own `pop` then walks a stale `prev`, faulting in `sfn_exception_pop_frame` (surfaced as a SIGSEGV in `check_resolver_scan_memo_test.sfn`, the #1247 memory guard). Formatting at throw time keeps the process in the known-good single-frame regime. The rationale is captured in the `ice.sfn` header.

The banner's context lives in forward-only process-wide markers in the new `ice.sfn`: `binary_dir` is stashed at the CLI entry (version is resolved from it **lazily**, only on an actual panic — no per-invocation FS read); the stages in `compile_to_llvm_with_module[_timed]` advance the stage/source markers.

## Acceptance Criteria
- [x] An injected/forced panic in a pipeline stage produces the banner with the correct version string, stage name, and issue URL on stderr.
- [x] Ordinary user-source diagnostics (E0xxx) are unaffected — no banner on clean diagnostic exits.
- [x] `ice.md` template exists and renders with the `type:bug` label.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree, plus one addition in the same spirit: the stage/source markers required a small dedicated module (`compiler/src/ice.sfn`) rather than living inline in `cli_main.sfn`, since both the CLI entry and the pipeline stages consume them.

## Verification
```
make compile                                    # self-hosts (223 modules)
make test                                        # unit 185/185, integration 42/42, e2e 171/171, capsules 38/38 — pass
SAILFIN_DEBUG_FORCE_PANIC=parse sfn emit llvm --timing x.sfn   # banner on stderr, exit 1
SAILFIN_USE_ARENA=1 sfn check a.sfn b.sfn        # exit 0 — no crash (regression guarded by #1247 test)
```

Banner output:
```
error: internal compiler error (ICE): forced panic (SAILFIN_DEBUG_FORCE_PANIC) in stage 'parse'
note: the compiler unexpectedly panicked — this is a bug
note: version: 0.7.0+dev.<hash>
note: stage: parse
note: source: <module>
note: file a report: https://github.com/SailfinIO/sailfin/issues/new?template=ice.md
```

## Files Changed
- `compiler/src/ice.sfn` (new) — ICE markers, forced-panic hook, banner formatter
- `compiler/src/cli/main.sfn` — stash `binary_dir` at CLI entry
- `compiler/src/main.sfn` — stage/source markers across the compile pipeline
- `.github/ISSUE_TEMPLATE/ice.md` (new) — ICE issue template
- `compiler/tests/e2e/ice_banner_test.sfn` (new) — banner regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZBpJVSi6iQYfoZW6m5rn6)_