### PR TITLE
docs(sfep-0036): link #1820 grooming issues into tracking

### DIFF
--- a/docs/proposals/0036-tls-runtime.md
+++ b/docs/proposals/0036-tls-runtime.md
@@ -4,9 +4,9 @@ title: "TLS termination + upstream TLS for the native runtime (OpenSSL)"
 status: Accepted
 type: runtime
 created: 2026-06-29
-updated: 2026-06-29
+updated: 2026-07-02
 author: "agent:compiler-architect; human review"
-tracking: "#1540"
+tracking: "#1540, #1820, #1821, #1822"
 supersedes:
 superseded-by:
 graduates-to:


### PR DESCRIPTION
Groomed #1820 (harden + document cross-platform OpenSSL link integration) into two `claude-ready` sub-issues and recorded them in the SFEP-0036 design record's `tracking:` front-matter so the brief points at its implementers.

- #1821 — `refactor(build)`: harden OpenSSL keg detection (pkg-config fallback for non-Homebrew installs) + formalize/document `SAILFIN_OPENSSL_PREFIX` (M)
- #1822 — `test(build)`: guard runtime `link_libs` parity across both backend link-argv builders (S)

Metadata-only doc change (`updated:` bump + `tracking:` list). No `.sfn` touched, no code change, no self-host impact.