### PR TITLE
perf(emit): stream native text as lines on the emit→lower/write handoff

### DIFF
--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -58,6 +58,8 @@ import {
     builder_to_string,
     join_type_annotations,
     join_with_separator,
+    lines_to_native_text,
+    native_lines_have_text,
     state_add_diagnostic,
     state_emit_blank,
     state_emit_line,
@@ -153,8 +155,13 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
     };
 }
 
-// Emit native text without returning the NativeModule struct (avoids ABI issues in stage2).
-fn emit_native_text_with_module_name(program: Program, module_name: string) -> string {
+// Emit native text as its line array, without joining into one string
+// (avoids the join→split round-trip on the emit→lower/write handoff, #1817)
+// and without returning the NativeModule struct (avoids ABI issues in
+// stage2). Callers that need one string wrap this with
+// `lines_to_native_text`; the streaming write/parse paths consume the
+// array directly.
+fn emit_native_lines_with_module_name(program: Program, module_name: string) -> string[] {
     // Issue #686 — match the lifting in `emit_native_with_module_name`.
     let lifted = lift_non_capturing_lambdas(program);
     let lifted_program = lifted.program;
@@ -181,17 +188,24 @@ fn emit_native_text_with_module_name(program: Program, module_name: string) -> s
         }
         index += 1;
     }
-    let text = builder_to_string(state.builder);
-    if text == null { return ""; }
-    return text;
+    if state.builder.lines == null { return []; }
+    return state.builder.lines;
+}
+
+// Emit native text without returning the NativeModule struct (avoids ABI issues in stage2).
+fn emit_native_text_with_module_name(program: Program, module_name: string) -> string {
+    return lines_to_native_text(emit_native_lines_with_module_name(program, module_name));
 }
 
 // Emit native text directly to a file to avoid returning large strings across ABI boundaries.
+// Streams the emitter's line array straight to disk via `fs.writeLines`
+// (the `write_llvm_lines_chunked` pattern) rather than joining to one
+// string first — byte-identical output, one fewer full-text copy (#1817).
 fn emit_native_text_to_file_with_module_name(program: Program, module_name: string, out_path: string) -> boolean ![io] {
-    let text = emit_native_text_with_module_name(program, module_name);
-    if text.length == 0 { return false; }
+    let lines = emit_native_lines_with_module_name(program, module_name);
+    if !native_lines_have_text(lines) { return false; }
     if fs.exists(out_path) { fs.deleteFile(out_path); }
-    fs.writeFile(out_path, text);
+    fs.writeLines(out_path, lines);
     return fs.exists(out_path);
 }
 

--- a/compiler/src/emit_native_state.sfn
+++ b/compiler/src/emit_native_state.sfn
@@ -88,9 +88,33 @@ fn builder_pop_indent(builder: TextBuilder) -> TextBuilder {
 
 fn builder_to_string(builder: TextBuilder) -> string {
     if builder.lines == null { return ""; }
-    let content = join_with_separator(builder.lines, "\n");
+    return lines_to_native_text(builder.lines);
+}
+
+// Join a native-text line array into a single `.sfn-asm` string with the
+// same trailing-newline contract as `builder_to_string`. Retained for
+// callers that genuinely need one string (the lowering recovery re-parse
+// and the `NativeArtifact.contents` ABI); the emit hot path streams the
+// line array to `fs.writeLines` / a from-lines parse instead of joining
+// (#1817).
+fn lines_to_native_text(lines: string[]) -> string {
+    if lines == null { return ""; }
+    let content = join_with_separator(lines, "\n");
     if content.length == 0 { return ""; }
     return content + "\n";
+}
+
+// True iff `lines_to_native_text(lines)` would be non-empty, without
+// materializing the joined string. Equivalent to
+// `join_with_separator(lines, "\n").length > 0`: a separator makes the
+// text non-empty as soon as there is more than one line, otherwise the
+// single line must itself be non-empty. Lets the streaming write/emit
+// paths reproduce the string path's empty-output guard byte-for-byte.
+fn native_lines_have_text(lines: string[]) -> boolean {
+    if lines == null { return false; }
+    if lines.length == 0 { return false; }
+    if lines.length > 1 { return true; }
+    return lines[0].length > 0;
 }
 
 // ── State functions ──────────────────────────────────────────────────

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -99,6 +99,8 @@ import {
 } from "../utils";
 import { emit_llvm_function } from "./emission";
 import {
+    compile_native_lines_to_llvm_file,
+    compile_native_lines_to_llvm_file_with_context,
     compile_native_text_to_llvm_file,
     compile_native_text_to_llvm_file_with_context,
     has_fatal_lowering_diagnostic,
@@ -354,6 +356,17 @@ fn write_llvm_ir_from_native_text(native_text: string, module_name: string, out_
 // (`write_llvm_ir_for_tests_from_text_with_context`).
 fn write_llvm_ir_from_native_text_with_context(native_text: string, module_name: string, out_path: string, imported_native_texts: string[]) -> boolean ![io] {
     return compile_native_text_to_llvm_file_with_context(native_text, module_name, out_path, imported_native_texts);
+}
+
+// Lines-array counterparts (#1817): the per-module build driver passes the
+// emitter's line array straight through instead of joining to one string
+// that lowering would immediately re-split.
+fn write_llvm_ir_from_native_lines(native_lines: string[], module_name: string, out_path: string) -> boolean ![io] {
+    return compile_native_lines_to_llvm_file(native_lines, module_name, out_path);
+}
+
+fn write_llvm_ir_from_native_lines_with_context(native_lines: string[], module_name: string, out_path: string, imported_native_texts: string[]) -> boolean ![io] {
+    return compile_native_lines_to_llvm_file_with_context(native_lines, module_name, out_path, imported_native_texts);
 }
 
 fn lower_to_llvm_with_manifests(native_module: NativeModule, imported_manifests: LayoutManifest[]) -> LoweredLLVMResult ![io] {

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -14,6 +14,7 @@
 //   lowering_io.sfn             — string array ops, file I/O, intrinsics
 import { NativeModule } from "../../emit_native";
 import { NativeArtifact } from "../../emit_native_layout";
+import { lines_to_native_text, native_lines_have_text } from "../../emit_native_state";
 import {
     LayoutManifest,
     NativeBinding,
@@ -29,6 +30,7 @@ import {
 } from "../../native_ir";
 import {
     parse_native_artifact,
+    parse_native_artifact_from_lines,
     parse_native_bindings_from_text,
     parse_native_function_count_from_text,
     parse_native_functions_from_text
@@ -389,6 +391,12 @@ fn compile_native_text_to_llvm_file(native_text: string, module_name: string, ou
     return compile_native_text_to_llvm_file_with_context(native_text, module_name, out_path, no_texts);
 }
 
+// Lines-array counterpart of `compile_native_text_to_llvm_file` (#1817).
+fn compile_native_lines_to_llvm_file(native_lines: string[], module_name: string, out_path: string) -> boolean ![io] {
+    let no_texts: string[] = [];
+    return compile_native_lines_to_llvm_file_with_context(native_lines, module_name, out_path, no_texts);
+}
+
 // Context-carrying variant for the `-p` per-module build path (#999).
 // The build driver stages each module's direct-import `.sfn-asm` bodies
 // — including the walk-excluded entry (#984) — and loads them via
@@ -409,7 +417,32 @@ fn compile_native_text_to_llvm_file_with_context(native_text: string, module_nam
         print.err("emit-llvm: empty native text for module " + module_name);
         return false;
     }
-    let parse = parse_native_artifact(native_text);
+    return _lower_parsed_native_to_llvm_file(parse_native_artifact(native_text), native_text, module_name, out_path, imported_native_texts);
+}
+
+// Lines-array counterpart of `compile_native_text_to_llvm_file_with_context`
+// for the in-process emit→lower handoff (#1817). Parses the emitter's line
+// array directly (no join→split), reconstructing the joined text only for
+// the recovery re-parse the lowering still consumes on the happy path
+// (`recover_functions_for_lowering` cross-checks the structured parse and
+// `make_native_module_for_emit` carries it as the fallback). `recovery_text`
+// is byte-identical to the old `native_text`, so output is unchanged; the
+// win is skipping the primary `parse_native_artifact` re-split.
+fn compile_native_lines_to_llvm_file_with_context(native_lines: string[], module_name: string, out_path: string, imported_native_texts: string[]) -> boolean ![io] {
+    if !native_lines_have_text(native_lines) {
+        print.err("emit-llvm: empty native text for module " + module_name);
+        return false;
+    }
+    let recovery_text = lines_to_native_text(native_lines);
+    return _lower_parsed_native_to_llvm_file(parse_native_artifact_from_lines(native_lines), recovery_text, module_name, out_path, imported_native_texts);
+}
+
+// Shared lowering tail for the text and lines entry points above. Given the
+// parsed native artifact and the joined native text (needed by the recovery
+// re-parse / `make_native_module_for_emit` fallback), union the import
+// context, lower to LLVM lines, gate on `[fatal]` diagnostics, and write the
+// `.ll`.
+fn _lower_parsed_native_to_llvm_file(parse: ParseNativeResult, native_text: string, module_name: string, out_path: string, imported_native_texts: string[]) -> boolean ![io] {
     let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
     let mut combined_texts: string[] = import_context.native_texts;
     let mut _it: int = 0;

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -12,17 +12,21 @@ import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import {
     NativeModule,
     emit_native,
+    emit_native_lines_with_module_name,
     emit_native_text_to_file_with_module_name,
     emit_native_text_with_module_name,
     emit_native_with_module_name,
     report_reexport_violations
 } from "./emit_native";
+import { native_lines_have_text } from "./emit_native_state";
 import { emit_program } from "./emitter_sailfin";
 import {
     lower_to_llvm_ir,
     lower_to_llvm_ir_from_text,
     print_llvm_ir_from_text,
     write_llvm_ir,
+    write_llvm_ir_from_native_lines,
+    write_llvm_ir_from_native_lines_with_context,
     write_llvm_ir_from_native_text,
     write_llvm_ir_from_native_text_with_context
 } from "./llvm/lowering/entrypoints";
@@ -681,8 +685,11 @@ fn compile_to_llvm_file_with_module_imports(source: string, module_name: string,
     // E4 ownership pass (#1213): dormant Phase R0 gate.
     if run_ownership_checker(program) > 0 { return false; }
 
-    let native_text = emit_native_text_with_module_name(program, module_name);
-    if native_text.length == 0 {
+    // Stream the emitter's line array into lowering instead of joining to
+    // one full-text string that `parse_native_artifact` would immediately
+    // re-split (#1817).
+    let native_lines = emit_native_lines_with_module_name(program, module_name);
+    if !native_lines_have_text(native_lines) {
         print.err("emit-llvm-file: empty native output for module "
             + module_name);
         // Drop any stale `.ll` from a previous build so downstream tooling
@@ -696,9 +703,9 @@ fn compile_to_llvm_file_with_module_imports(source: string, module_name: string,
     // (`import_asm_paths.length == 0`) keeps routing through the
     // context-free writer — no behavior change there.
     if import_asm_paths.length > 0 {
-        return write_llvm_ir_from_native_text_with_context(native_text, module_name, out_path, imported_native_texts);
+        return write_llvm_ir_from_native_lines_with_context(native_lines, module_name, out_path, imported_native_texts);
     }
-    return write_llvm_ir_from_native_text(native_text, module_name, out_path);
+    return write_llvm_ir_from_native_lines(native_lines, module_name, out_path);
 }
 
 // Build-path typecheck diagnostic emission. Every `compile_to_*`

--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -23,7 +23,7 @@ import {
     StructLayoutFieldParse,
     StructLayoutHeaderParse
 } from "./native_ir";
-import { parse_native_artifact_impl } from "./native_ir_parser";
+import { parse_native_artifact_impl, parse_native_artifact_impl_from_lines } from "./native_ir_parser";
 import {
     parse_enum_layout_header,
     parse_enum_payload_layout,
@@ -78,6 +78,16 @@ fn select_layout_manifest_artifact(artifacts: NativeArtifact[]) -> NativeArtifac
 
 fn parse_native_artifact(text: string) -> ParseNativeResult {
     return parse_native_artifact_impl(text, true, true);
+}
+
+// From-lines variant of `parse_native_artifact`: parse the emitter's line
+// array directly, skipping the join→split round-trip on the in-process
+// emit→lower handoff (#1817). Parse result is identical to
+// `parse_native_artifact(lines_to_native_text(lines))` — the only textual
+// difference (a trailing empty line from the joined string's terminating
+// newline) is a blank line the parser already skips.
+fn parse_native_artifact_from_lines(lines: string[]) -> ParseNativeResult {
+    return parse_native_artifact_impl_from_lines(lines, true, true);
 }
 
 fn parse_native_function_count_from_text(text: string) -> int {
@@ -164,6 +174,7 @@ export {
     select_text_artifact,
     select_layout_manifest_artifact,
     parse_native_artifact,
+    parse_native_artifact_from_lines,
     parse_native_function_count_from_text,
     parse_native_functions_from_text,
     parse_native_bindings_from_text,

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -44,7 +44,14 @@ import {
 import { char_code, substring } from "./string_utils";
 
 fn parse_native_artifact_impl(text: string, include_instructions: boolean, include_top_level_bindings: boolean) -> ParseNativeResult {
-    let lines = split_lines(text);
+    return parse_native_artifact_impl_from_lines(split_lines(text), include_instructions, include_top_level_bindings);
+}
+
+// From-lines core of `parse_native_artifact_impl`. Lets the in-process
+// emit→lower handoff pass the emitter's line array straight in, instead of
+// joining to one string that this parser would immediately re-split
+// (#1817). The text entry point above is the thin `split_lines` shim.
+fn parse_native_artifact_impl_from_lines(lines: string[], include_instructions: boolean, include_top_level_bindings: boolean) -> ParseNativeResult {
     let mut diagnostics: string[] = [];
     let mut functions: NativeFunction[] = [];
     let mut imports: NativeImport[] = [];
@@ -458,4 +465,4 @@ fn binding_from_instruction(instruction: NativeInstruction) -> NativeBinding {
     };
 }
 
-export { parse_native_artifact_impl };
+export { parse_native_artifact_impl, parse_native_artifact_impl_from_lines };

--- a/compiler/tests/unit/emit_native_state_test.sfn
+++ b/compiler/tests/unit/emit_native_state_test.sfn
@@ -79,6 +79,24 @@ fn _escape_char(ch: string) -> string {
     return ch;
 }
 
+// Local mirrors of `lines_to_native_text` / `native_lines_have_text`
+// (#1817). The streaming write/emit paths use `native_lines_have_text` as a
+// materialization-free stand-in for `lines_to_native_text(lines).length > 0`
+// (the empty-output guard the old string path applied). These pin that
+// equivalence — and the join's trailing-newline contract — so a future edit
+// to either real function that breaks byte-identity is caught here.
+fn _lines_to_native_text(lines: string[]) -> string {
+    let content = _join(lines, "\n");
+    if content.length == 0 { return ""; }
+    return content + "\n";
+}
+
+fn _native_lines_have_text(lines: string[]) -> boolean {
+    if lines.length == 0 { return false; }
+    if lines.length > 1 { return true; }
+    return lines[0].length > 0;
+}
+
 // ── ends_with tests ──────────────────────────────────────────────────
 test "state: ends_with match" {
     assert _ends_with("hello.sfn", ".sfn") == true;
@@ -191,4 +209,40 @@ test "state: is_optional_annotation positive" {
 test "state: is_optional_annotation negative" {
     assert _is_optional("number") == false;
     assert _is_optional("") == false;
+}
+
+// ── lines_to_native_text / native_lines_have_text equivalence (#1817) ─
+test "state: native_lines_have_text empty array" {
+    let e: string[] = [];
+    assert _native_lines_have_text(e) == false;
+    assert(_lines_to_native_text(e).length > 0) == false;
+}
+
+test "state: native_lines_have_text single blank line" {
+    assert _native_lines_have_text([""]) == false;
+    assert(_lines_to_native_text([""]).length > 0) == false;
+}
+
+test "state: native_lines_have_text two blank lines" {
+    // join(["",""], "\n") == "\n" — non-empty, so the text guard is true.
+    assert _native_lines_have_text(["", ""]) == true;
+    assert(_lines_to_native_text(["", ""]).length > 0) == true;
+}
+
+test "state: native_lines_have_text single non-empty line" {
+    assert _native_lines_have_text(["a"]) == true;
+    assert(_lines_to_native_text(["a"]).length > 0) == true;
+}
+
+test "state: native_lines_have_text multiple lines" {
+    assert _native_lines_have_text(["a", "b"]) == true;
+    assert(_lines_to_native_text(["a", "b"]).length > 0) == true;
+}
+
+test "state: lines_to_native_text trailing newline contract" {
+    // fs.writeLines writes each line + "\n" (incl. trailing), matching
+    // builder_to_string's join + "\n" — byte-identical staged output.
+    assert _lines_to_native_text(["a", "b"]) == "a\nb\n";
+    assert _lines_to_native_text(["only"]) == "only\n";
+    assert _lines_to_native_text([""]) == "";
 }

--- a/compiler/tests/unit/emit_native_state_test.sfn
+++ b/compiler/tests/unit/emit_native_state_test.sfn
@@ -6,6 +6,13 @@
 // trim_right, number_to_string, strip_optional_suffix) require the runtime
 // prelude which isn't available in standalone test files. Those are exercised
 // indirectly through the emit_native integration test and the full test suite.
+//
+// Exception (#1817): `lines_to_native_text` / `native_lines_have_text` are
+// pure (no substring/char_code, hence no prelude dependency), so they are
+// imported directly — the equivalence tests below gate the *real*
+// implementations, not local mirrors.
+import { lines_to_native_text, native_lines_have_text } from "../../src/emit_native_state";
+
 // ── Local copies of functions under test ─────────────────────────────
 fn _ends_with(value: string, suffix: string) -> boolean {
     if suffix.length == 0 { return true; }
@@ -77,24 +84,6 @@ fn _escape_char(ch: string) -> string {
     if ch == "\r" { return "\\r"; }
     if ch == "\t" { return "\\t"; }
     return ch;
-}
-
-// Local mirrors of `lines_to_native_text` / `native_lines_have_text`
-// (#1817). The streaming write/emit paths use `native_lines_have_text` as a
-// materialization-free stand-in for `lines_to_native_text(lines).length > 0`
-// (the empty-output guard the old string path applied). These pin that
-// equivalence — and the join's trailing-newline contract — so a future edit
-// to either real function that breaks byte-identity is caught here.
-fn _lines_to_native_text(lines: string[]) -> string {
-    let content = _join(lines, "\n");
-    if content.length == 0 { return ""; }
-    return content + "\n";
-}
-
-fn _native_lines_have_text(lines: string[]) -> boolean {
-    if lines.length == 0 { return false; }
-    if lines.length > 1 { return true; }
-    return lines[0].length > 0;
 }
 
 // ── ends_with tests ──────────────────────────────────────────────────
@@ -214,35 +203,35 @@ test "state: is_optional_annotation negative" {
 // ── lines_to_native_text / native_lines_have_text equivalence (#1817) ─
 test "state: native_lines_have_text empty array" {
     let e: string[] = [];
-    assert _native_lines_have_text(e) == false;
-    assert(_lines_to_native_text(e).length > 0) == false;
+    assert native_lines_have_text(e) == false;
+    assert(lines_to_native_text(e).length > 0) == false;
 }
 
 test "state: native_lines_have_text single blank line" {
-    assert _native_lines_have_text([""]) == false;
-    assert(_lines_to_native_text([""]).length > 0) == false;
+    assert native_lines_have_text([""]) == false;
+    assert(lines_to_native_text([""]).length > 0) == false;
 }
 
 test "state: native_lines_have_text two blank lines" {
     // join(["",""], "\n") == "\n" — non-empty, so the text guard is true.
-    assert _native_lines_have_text(["", ""]) == true;
-    assert(_lines_to_native_text(["", ""]).length > 0) == true;
+    assert native_lines_have_text(["", ""]) == true;
+    assert(lines_to_native_text(["", ""]).length > 0) == true;
 }
 
 test "state: native_lines_have_text single non-empty line" {
-    assert _native_lines_have_text(["a"]) == true;
-    assert(_lines_to_native_text(["a"]).length > 0) == true;
+    assert native_lines_have_text(["a"]) == true;
+    assert(lines_to_native_text(["a"]).length > 0) == true;
 }
 
 test "state: native_lines_have_text multiple lines" {
-    assert _native_lines_have_text(["a", "b"]) == true;
-    assert(_lines_to_native_text(["a", "b"]).length > 0) == true;
+    assert native_lines_have_text(["a", "b"]) == true;
+    assert(lines_to_native_text(["a", "b"]).length > 0) == true;
 }
 
 test "state: lines_to_native_text trailing newline contract" {
     // fs.writeLines writes each line + "\n" (incl. trailing), matching
     // builder_to_string's join + "\n" — byte-identical staged output.
-    assert _lines_to_native_text(["a", "b"]) == "a\nb\n";
-    assert _lines_to_native_text(["only"]) == "only\n";
-    assert _lines_to_native_text([""]) == "";
+    assert lines_to_native_text(["a", "b"]) == "a\nb\n";
+    assert lines_to_native_text(["only"]) == "only\n";
+    assert lines_to_native_text([""]) == "";
 }


### PR DESCRIPTION
## Summary

- Streams the native emitter's `TextBuilder.lines` array end-to-end on the per-module emit→lower/write handoff instead of joining to one `.sfn-asm` string that `parse_native_artifact` immediately re-splits — mirrors the LLVM-side `write_llvm_lines_chunked` pattern.
- Staged `.sfn-asm` now written via `fs.writeLines`; the `-p` LLVM driver parses the line array directly and reconstructs the joined text only for the lowering-recovery re-parse that still consumes one string.
- **Byte-identical output**, self-hosts, full suite green.

Closes #1817

## Acceptance Criteria

- [x] Staged `.sfn-asm` and emitted `.ll` outputs are byte-identical to before — verified **189/189 emitted `.ll` identical** and **sampled staged `.sfn-asm` identical** (via the new `fs.writeLines` path, incl. the heaviest module) between the old and new binary on the same source + import-context.
- [ ] `make bench` peak RSS drops ≥5% on the top-3 heaviest modules — **not achievable by this change; criterion relaxed to no-regression + measured delta** (see below). Owner-approved.
- [x] `make compile` passes (compiler self-hosts) — including two clean `make rebuild` cycles.
- [x] `make test` passes — unit 185/185, integration 42/42, e2e 170/170, capsules 38/38, **0 failed**.

## Why the ≥5% target was relaxed

After #1816's pairwise-merge join, the native `.sfn-asm` text is tiny relative to the lowering peak: on the heaviest module (`llvm__expression_lowering__native__core`) it is **124 KB (2917 lines) = 0.009% of the 1422 MB peak** — the peak lives in the AST/parse/lowering IR structures, not the text. Eliminating the entire join→split round-trip therefore cannot move peak RSS by 5% (≈71 MB ≈ 570× the whole native text). Measured `make bench` delta on the heaviest module: **1422 MB → 1420 MB**, no module regressing. The change is delivered as the clean, byte-identical round-trip elimination it was scoped to be (matching the LLVM-side discipline), with the numeric bar relaxed to no-regression + measured delta.

An additional entanglement surfaced during pickup: stage-6 lowering's `recover_functions_for_lowering` re-parses the native text on the happy path to cross-check the structured parse, so the joined string is still needed there and is reconstructed lazily (`lines_to_native_text`, byte-identical to the old `native_text`) — recovery behavior is unchanged.

## Map reconciliation

Advisory `## Files Affected` matched the tree, with these in-unit reconciliations (same semantic units, no scope growth):
- `builder_to_string` join logic extracted to `lines_to_native_text` in `emit_native_state.sfn` (kept for the string callers that genuinely need it, per the issue's `Out:`).
- Parser from-lines intake landed in `native_ir_parser.sfn` (`parse_native_artifact_impl_from_lines`) + `native_ir_api.sfn` (`parse_native_artifact_from_lines`) — the issue named `parse_native_artifact`, which lives in `native_ir_api.sfn`.
- Lowering intake added lines-accepting siblings in `llvm/lowering/entrypoints.sfn` + `lowering_core.sfn` (`write_llvm_ir_from_native_lines*`, `compile_native_lines_to_llvm_file*`, shared tail `_lower_parsed_native_to_llvm_file`).
- Added a regression test (`compiler/tests/unit/emit_native_state_test.sfn`) pinning `native_lines_have_text(lines) == (lines_to_native_text(lines).length > 0)` and the trailing-newline contract across the `[]`, `[""]`, `["",""]`, `["a"]` edge cases (Opus review recommendation).

## Verification

```
make compile          # self-hosts (pass)
make rebuild x2       # old + new binary (pass)
make test             # unit 185/185, integration 42/42, e2e 170/170, capsules 38/38 — 0 failed
make bench            # heaviest module 1422 → 1420 MB, no regression
# byte-identical: OLD vs NEW binary, same source + import-context → 189/189 .ll identical; sampled .sfn-asm identical via fs.writeLines
```

## Files Changed

- `compiler/src/emit_native_state.sfn` — `lines_to_native_text`, `native_lines_have_text`; `builder_to_string` reuses the former.
- `compiler/src/emit_native.sfn` — `emit_native_lines_with_module_name`; string entry wraps it; file entry writes via `fs.writeLines`.
- `compiler/src/native_ir_parser.sfn` — `parse_native_artifact_impl_from_lines` core + `split_lines` shim.
- `compiler/src/native_ir_api.sfn` — `parse_native_artifact_from_lines`.
- `compiler/src/llvm/lowering/lowering_core.sfn` — lines drivers + shared `_lower_parsed_native_to_llvm_file` tail.
- `compiler/src/llvm/lowering/entrypoints.sfn` — `write_llvm_ir_from_native_lines*`.
- `compiler/src/main.sfn` — `-p` driver routes through the lines path.
- `compiler/tests/unit/emit_native_state_test.sfn` — equivalence + trailing-newline regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgyaaAB1YiHaZJbcxbrKQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgyaaAB1YiHaZJbcxbrKQ1)_