### PR TITLE
chore(claude): stop appending Claude attribution + session links to PRs

### DIFF
--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -418,8 +418,6 @@ git commit -m "$(cat <<'EOF'
 <body if needed — link issue with "Closes #N">
 
 Closes #<N>
-
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
@@ -451,8 +449,6 @@ e.g. "`old/path.sfn` → `new/path.sfn` (renamed); added sibling `x.sfn` (same I
 
 ## Files Changed
 <short list>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```

--- a/.claude/commands/pin-seed.md
+++ b/.claude/commands/pin-seed.md
@@ -169,8 +169,6 @@ https://github.com/SailfinIO/sailfin/compare/v<current>...v<target>
 - [ ] `make fetch-seed` succeeded locally
 - [ ] CI green on this PR
 - [ ] (optional) `make compile` succeeds against the new seed locally
-
-https://claude.ai/code/session_<session-id>
 ```
 
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -94,6 +94,9 @@
   "agent": "Sailbot",
   "outputStyle": "Compiler Engineer",
   "includeCoAuthoredBy": false,
+  "attribution": {
+    "sessionUrl": false
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Agent-authored PRs carried redundant "Generated by Claude" footers and a `claude.ai` session link that add noise without signal — the work is already traceable via the linked issue and the archived session. This turns them off at both sources.

- **`.claude/settings.json`** — `attribution.sessionUrl: false` disables Claude Code's built-in `Claude-Session:` commit trailer **and** the PR-body session link (one setting gates both; verified against the CLI's own schema description).
- **`.claude/commands/pickup.md`** — removed the hardcoded `🤖 Generated with [Claude Code]` PR-body footer and the `Co-Authored-By: Claude …` commit trailer (the latter was silently overriding the existing `includeCoAuthoredBy: false`).
- **`.claude/commands/pin-seed.md`** — removed the hardcoded `claude.ai/code/session_…` line from its PR-body template.

Attribution is unchanged in spirit — usage is already obvious from the in-repo Claude app and `claude/*` branch names; this just drops the duplicated boilerplate.

## Verification

- `python3 -m json.tool .claude/settings.json` — valid JSON.
- `attribution.sessionUrl` confirmed as the correct key against the installed CLI (v2.1.197): schema describes it as *"Set to false to omit the Claude-Session trailer and PR-body link."*
- Repo-wide effect (also applies to the autonomous GitHub agent pipeline).

## Files Changed

- `.claude/settings.json`
- `.claude/commands/pickup.md`
- `.claude/commands/pin-seed.md`