### PR TITLE
feat(typecheck): unify ternary then/else branch types in a Conditional

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -52,6 +52,8 @@ import {
     is_identifier_char,
     make_await_non_future_diagnostic,
     make_channel_send_mismatch_diagnostic,
+    make_conditional_branch_mismatch_diagnostic,
+    make_conditional_non_boolean_condition_diagnostic,
     make_fn_value_position_diagnostic,
     make_main_signature_param_count_diagnostic,
     make_main_signature_param_type_diagnostic,
@@ -1047,6 +1049,13 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         let mut diagnostics = walk_expression(expression.condition, bindings, imports);
         diagnostics = diagnostics.concat(walk_expression(expression.then_value, bindings, imports));
         diagnostics = diagnostics.concat(walk_expression(expression.else_value, bindings, imports));
+        // #1715: constrain the condition to boolean and unify the two branch
+        // types. Types are literal-inferred (#829 has no live inferencer), so
+        // an un-inferable branch/condition is left unconstrained.
+        let condition_type = _conditional_branch_type(expression.condition);
+        let then_type = _conditional_branch_type(expression.then_value);
+        let else_type = _conditional_branch_type(expression.else_value);
+        diagnostics = diagnostics.concat(check_conditional_types(condition_type, then_type, else_type, expression.span));
         return diagnostics;
     }
     if expression.variant == "Assignment" {
@@ -1218,6 +1227,90 @@ fn check_try_operator(operand_type: string, enclosing_return_type: string?, span
 fn try_operator_result_type(operand_type: string) -> string? {
     if !type_is_result(operand_type) { return null; }
     return result_type_arguments(operand_type)[0];
+}
+
+// === Ternary `Conditional` type rules — issue #1715, epic #1180 ===
+//
+// A ternary `cond ? then : else` (#1690's `Expression.Conditional`) must have a
+// boolean condition and two branches that unify. The checker has no expression-
+// type inferencer (#829), so branch/condition types are inferred only for the
+// literal forms in `_conditional_branch_type` and left "" (unknown) otherwise;
+// an unknown type is never reported, so a valid ternary the checker cannot yet
+// type is passed through rather than rejected. The rules run both live (the
+// `Conditional` arm of `walk_expression`) and directly under
+// `conditional_typecheck_test.sfn`.
+// The literal-inferred type of a ternary branch/condition, as a plain type
+// string. Mirrors the emitter's `infer_expression_type`
+// (`emit_native_format.sfn`) for the literal forms: number -> "int"/"float"
+// (dot detection), string -> "string", boolean -> "boolean", null -> "null".
+// A signed numeric literal parses as `Unary { -, NumberLiteral }`, so it is
+// unwrapped to its numeric kind. Any other form yields "" (not inferable).
+fn _conditional_branch_type(expression: Expression?) -> string {
+    if expression == null { return ""; }
+    if expression.variant == "NumberLiteral" {
+        return _conditional_number_kind(expression.value);
+    }
+    if expression.variant == "StringLiteral" { return "string"; }
+    if expression.variant == "BooleanLiteral" { return "boolean"; }
+    if expression.variant == "NullLiteral" { return "null"; }
+    if expression.variant == "Unary" {
+        if expression.operand.variant == "NumberLiteral" {
+            return _conditional_number_kind(expression.operand.value);
+        }
+        return "";
+    }
+    return "";
+}
+
+// "float" if the numeric literal text carries a decimal point, else "int"
+// (mirrors `_number_literal_kind` in `emit_native_format.sfn`).
+fn _conditional_number_kind(value: string) -> string {
+    let mut i: int = 0;
+    loop {
+        if i >= value.length { break; }
+        if value[i] == "." { return "float"; }
+        i += 1;
+    }
+    return "int";
+}
+
+// Unify two ternary branch types under exact/null-compatible rules (#1715). A
+// "null" branch unifies with the other branch's type; two known non-null types
+// unify only when equal. Returns "" when either side is unknown or the two are
+// incompatible — the single source of truth for the branch rule, consumed by
+// `check_conditional_types`. Coercion beyond this is deferred (#1715 Out).
+fn conditional_result_type(then_type: string, else_type: string) -> string {
+    if then_type.length == 0 { return ""; }
+    if else_type.length == 0 { return ""; }
+    if strings_equal(then_type, "null") { return else_type; }
+    if strings_equal(else_type, "null") { return then_type; }
+    if strings_equal(then_type, else_type) { return then_type; }
+    return "";
+}
+
+// Type rules for a ternary `Conditional`, driven by the literal-inferred
+// condition/branch type strings. Reports E0305 when the condition is a known
+// non-boolean type, and E0304 when both branches are known but do not unify
+// (via `conditional_result_type`, so the rule has one implementation). Unknown
+// ("") types are left unconstrained.
+fn check_conditional_types(condition_type: string, then_type: string, else_type: string, span: SourceSpan?) -> Diagnostic[] {
+    let mut diagnostics: Diagnostic[] = [];
+
+    if condition_type.length > 0 {
+        if !strings_equal(condition_type, "boolean") {
+            diagnostics.push(make_conditional_non_boolean_condition_diagnostic(condition_type, span));
+        }
+    }
+
+    // Both branches known but no unified type -> an incompatible pair. A "null"
+    // branch unifies (non-empty result), so it never reaches this diagnostic.
+    if then_type.length > 0 && else_type.length > 0 {
+        if conditional_result_type(then_type, else_type).length == 0 {
+            diagnostics.push(make_conditional_branch_mismatch_diagnostic(then_type, else_type, span));
+        }
+    }
+
+    return diagnostics;
 }
 
 // Concurrency type rules — issue #1082, epic #965 (M4, decision B). Like the

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -1254,7 +1254,10 @@ fn _conditional_branch_type(expression: Expression?) -> string {
     if expression.variant == "BooleanLiteral" { return "boolean"; }
     if expression.variant == "NullLiteral" { return "null"; }
     if expression.variant == "Unary" {
-        if expression.operand.variant == "NumberLiteral" {
+        // Only a signed numeric literal (`Unary { "-", NumberLiteral }`) carries
+        // a numeric kind; other prefix operators (`!`, `*`, `&`) do not, so
+        // gate on `-` to avoid classifying `!5` / `*42` / `&0` as int/float.
+        if strings_equal(expression.operator, "-") && expression.operand.variant == "NumberLiteral" {
             return _conditional_number_kind(expression.operand.value);
         }
         return "";

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -438,6 +438,49 @@ fn make_try_error_type_mismatch_diagnostic(operand_error: string, fn_error: stri
 }
 
 // =============================================================================
+// Ternary `Conditional` type rules (issue #1715, epic #1180)
+// =============================================================================
+// A ternary `cond ? then : else` (#1690's `Expression.Conditional`) requires a
+// boolean condition and two branches that unify to one type. Types are plain
+// strings throughout the checker (no expression-type inferencer — #829), so
+// these operate on the literal-inferred type strings produced by
+// `_conditional_branch_type` (`typecheck.sfn`); a branch or condition whose type
+// cannot be inferred is left unconstrained rather than reported, so no valid
+// program is rejected on a type the checker cannot yet see. Unification is
+// exact/null-compatible only — branch coercion beyond that is deferred (#1715
+// Out). The rule orchestration lives in `typecheck.sfn`
+// (`check_conditional_types`).
+// E0304 — a ternary's two branches have incompatible (non-unifiable) types.
+fn make_conditional_branch_mismatch_diagnostic(then_type: string, else_type: string, span: SourceSpan?) -> Diagnostic {
+    return Diagnostic {
+        code: "E0304",
+        severity: "error",
+        message: "ternary branches have incompatible types: the `then` branch is `"
+            + trim_text(then_type)
+            + "` but the `else` branch is `"
+            + trim_text(else_type)
+            + "`. Both branches of a `?:` must produce the same type.",
+        file_path: "",
+        primary: token_from_name("?", span),
+        suggestion: null
+    };
+}
+
+// E0305 — a ternary's condition is not a boolean.
+fn make_conditional_non_boolean_condition_diagnostic(condition_type: string, span: SourceSpan?) -> Diagnostic {
+    return Diagnostic {
+        code: "E0305",
+        severity: "error",
+        message: "ternary condition must be `boolean`, but has type `"
+            + trim_text(condition_type)
+            + "`. The condition of a `?:` must be a boolean expression.",
+        file_path: "",
+        primary: token_from_name("?", span),
+        suggestion: null
+    };
+}
+
+// =============================================================================
 // Concurrency kind resolution (issue #1082, epic #965, M4 — decision B)
 // =============================================================================
 // Types are monomorphized into SIX future/channel kinds: void, number, int,

--- a/compiler/tests/unit/conditional_typecheck_test.sfn
+++ b/compiler/tests/unit/conditional_typecheck_test.sfn
@@ -112,3 +112,15 @@ test "conditional: `true ? 1 : 2` is clean end-to-end" ![io] {
 test "conditional: `true ? 1 : null` is clean end-to-end" ![io] {
     assert _codes_for("fn main() { true ? 1 : null; }", "E0304") == 0;
 }
+
+test "conditional: a signed numeric literal branch unifies as its kind" ![io] {
+    // `-1` is `Unary { "-", NumberLiteral }` -> `int`, so it mismatches a string.
+    assert _codes_for("fn main() { true ? -1 : \"s\"; }", "E0304") == 1;
+}
+
+test "conditional: a non-`-` unary branch is not misclassified" ![io] {
+    // `!5` is `Unary { "!", NumberLiteral }` — not a signed numeric literal, so
+    // it is left un-inferable ("") rather than typed `int`, and the string
+    // branch has nothing to mismatch against. Guards the operator-gate fix.
+    assert _codes_for("fn main() { true ? !5 : \"s\"; }", "E0304") == 0;
+}

--- a/compiler/tests/unit/conditional_typecheck_test.sfn
+++ b/compiler/tests/unit/conditional_typecheck_test.sfn
@@ -1,0 +1,114 @@
+// Unit tests for the ternary `Conditional` type rules — issue #1715, epic
+// #1180. A ternary `cond ? then : else` (#1690's `Expression.Conditional`)
+// requires a boolean condition (E0305) and two branches that unify under
+// exact/null-compatible rules (E0304). Types are plain type-annotation strings
+// throughout the checker (no expression-type inferencer — #829), so the pure
+// rule (`check_conditional_types`) is driven against explicit type strings the
+// way `result_question_typecheck_test.sfn` drives the `?`-operator rules, and
+// the end-to-end tests confirm the `walk_expression` `Conditional` arm fires
+// the same diagnostics through `typecheck_diagnostics`.
+import { parse_program } from "../../src/parser/mod";
+import {
+    check_conditional_types,
+    conditional_result_type,
+    typecheck_diagnostics
+} from "../../src/typecheck";
+import { Diagnostic } from "../../src/typecheck_types";
+
+fn _count_code(diagnostics: Diagnostic[], code: string) -> int {
+    let mut count: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= diagnostics.length { break; }
+        if strings_equal(diagnostics[i].code, code) { count += 1; }
+        i += 1;
+    }
+    return count;
+}
+
+fn _codes_for(source: string, code: string) -> int ![io] {
+    let program = parse_program(source);
+    return _count_code(typecheck_diagnostics(program), code);
+}
+
+// --- Pure rule: branch unification (E0304) ---------------------------------
+test "conditional: incompatible branch types emit E0304" {
+    let diags = check_conditional_types("boolean", "int", "string", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0304");
+}
+
+test "conditional: identical branch types type-check" {
+    let diags = check_conditional_types("boolean", "int", "int", null);
+    assert diags.length == 0;
+}
+
+test "conditional: a null branch unifies with the other branch" {
+    // `cond ? 1 : null` and `cond ? null : "s"` are both well-typed.
+    assert check_conditional_types("boolean", "int", "null", null).length == 0;
+    assert check_conditional_types("boolean", "null", "string", null).length == 0;
+}
+
+test "conditional: an un-inferable branch is left unconstrained" {
+    // "" is the not-inferable sentinel — no branch diagnostic either way.
+    assert check_conditional_types("boolean", "", "string", null).length == 0;
+    assert check_conditional_types("boolean", "int", "", null).length == 0;
+}
+
+test "conditional: int and float branches do not unify (coercion deferred)" {
+    // Exact unification only — `cond ? 1 : 2.5` is `int`/`float` and mismatches
+    // (#1715 Out: coercion is a later refinement). Pins the intended floor so a
+    // future coercion change is a visible test flip, not a silent one.
+    let diags = check_conditional_types("boolean", "int", "float", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0304");
+}
+
+// --- Pure rule: condition boolean constraint (E0305) -----------------------
+test "conditional: a non-boolean condition emits E0305" {
+    let diags = check_conditional_types("int", "int", "int", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0305");
+}
+
+test "conditional: an un-inferable condition is left unconstrained" {
+    let diags = check_conditional_types("", "int", "int", null);
+    assert diags.length == 0;
+}
+
+test "conditional: a bad condition and bad branches both fire" {
+    let diags = check_conditional_types("string", "int", "boolean", null);
+    assert diags.length == 2;
+    assert strings_equal(diags[0].code, "E0305");
+    assert strings_equal(diags[1].code, "E0304");
+}
+
+// --- Result-type unification ------------------------------------------------
+test "conditional: result_type unifies equal and null-compatible branches" {
+    assert strings_equal(conditional_result_type("int", "int"), "int");
+    assert strings_equal(conditional_result_type("int", "null"), "int");
+    assert strings_equal(conditional_result_type("null", "string"), "string");
+}
+
+test "conditional: result_type is empty for mismatched or unknown branches" {
+    assert strings_equal(conditional_result_type("int", "string"), "");
+    assert strings_equal(conditional_result_type("", "int"), "");
+}
+
+// --- End-to-end through typecheck_diagnostics ------------------------------
+test "conditional: `true ? 1 : \"s\"` fires E0304 end-to-end" ![io] {
+    assert _codes_for("fn main() { true ? 1 : \"s\"; }", "E0304") == 1;
+}
+
+test "conditional: `5 ? 1 : 2` fires E0305 end-to-end" ![io] {
+    assert _codes_for("fn main() { 5 ? 1 : 2; }", "E0305") == 1;
+}
+
+test "conditional: `true ? 1 : 2` is clean end-to-end" ![io] {
+    assert _codes_for("fn main() { true ? 1 : 2; }", "E0304") == 0;
+    assert _codes_for("fn main() { true ? 1 : 2; }", "E0305") == 0;
+}
+
+test "conditional: `true ? 1 : null` is clean end-to-end" ![io] {
+    assert _codes_for("fn main() { true ? 1 : null; }", "E0304") == 0;
+}


### PR DESCRIPTION
## Summary
- Constrain a ternary's condition to `boolean` and unify its `then`/`else` branch types in `typecheck.sfn`'s `walk_expression` `Conditional` arm, so `cond ? 1 : "s"` (and a non-boolean condition like `5 ? a : b`) no longer type-checks.
- Two new diagnostics — **E0304** (incompatible branch types) and **E0305** (non-boolean condition) — in the E03xx "type conflicts" band; `conditional_result_type` is the single source of truth for the branch rule, which `check_conditional_types` routes through.
- Conservative by design: types are literal-inferred (the checker has no live expression-type inferencer — #829), so an un-inferable branch/condition is left unconstrained and no valid program is rejected. Unification is exact/null-compatible only; branch coercion is deferred (#1715 Out).

Closes #1715

## Acceptance Criteria
- [x] `cond ? 1 : "s"` → branch-type-mismatch diagnostic (E0304).
- [x] `cond ? 1 : 2` and `flag ? a : b` (same type / un-inferable) → clean.
- [x] A non-boolean condition (`5 ? a : b`) → diagnostic (E0305).
- [x] `make compile` self-hosts; `make check` green (38/38 capsules).

## Map reconciliation
`## Files Affected` listed `compiler/src/typecheck.sfn`, `compiler/src/typecheck_types.sfn`, `compiler/tests/unit/` — all matched the tree. The diagnostic split across the two source files as anticipated (rule logic in `typecheck.sfn`, factories in `typecheck_types.sfn`).

**E-code reconciliation:** the issue suggested `E04xx`, but per `docs/style-guide.md` that band is *effect violations*; E03xx is "type conflicts" in `typecheck*.sfn`. E0303 is pre-reserved in `docs/proposals/README.md` for the interface-signature-conformance draft, so the codes step past it to **E0304/E0305** (both verified free in code and registry).

## Verification
```bash
make check   # → {"target":"check","status":"pass"}; 38/38 capsules passed
build/native/sailfin test compiler/tests/unit/conditional_typecheck_test.sfn  # → PASS (14 tests)
```
The 14 unit tests cover pure-rule mismatch/match/null/unknown/int-vs-float for both codes, the both-fire ordering, `conditional_result_type` directly, and four end-to-end cases through `typecheck_diagnostics`.

## Files Changed
- `compiler/src/typecheck.sfn` — `_conditional_branch_type`, `_conditional_number_kind`, `conditional_result_type`, `check_conditional_types`, and `Conditional`-arm wiring.
- `compiler/src/typecheck_types.sfn` — `make_conditional_branch_mismatch_diagnostic` (E0304), `make_conditional_non_boolean_condition_diagnostic` (E0305).
- `compiler/tests/unit/conditional_typecheck_test.sfn` — new, 14 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFRxqdGUBXE92kXsxipzTH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFRxqdGUBXE92kXsxipzTH)_