### PR TITLE
build(check): make stage2/stage3 self-host fixed-point diff fatal in CI

### DIFF
--- a/.github/workflows/nightly-selfhost.yml
+++ b/.github/workflows/nightly-selfhost.yml
@@ -48,12 +48,18 @@ jobs:
           - os: ubuntu-24.04
             package_label: linux-x86_64
             clang: clang-18
+            # Strict self-host gate (#1830): a stage2/stage3 fixed-point
+            # mismatch fails this leg instead of warn-and-promote. Linux is
+            # the enforced surface; macOS stays warn-only (its strict
+            # participation is a separate sub-issue).
+            selfhost_strict: "1"
           # Trialing macos-26 ahead of the 2026-06-15 `macos-latest` migration:
           # nightly is the early-warning canary for fixed-point / determinism
           # breakage on the new image before CI and release jobs adopt it.
           - os: macos-26
             package_label: macos-arm64
             clang: clang
+            selfhost_strict: "0"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
@@ -112,10 +118,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLANG: ${{ matrix.clang }}
+          # #1830: SELFHOST_STRICT=1 makes a stage2/stage3 fixed-point
+          # mismatch fatal on the Linux leg; macOS passes "0" (warn-only).
+          SELFHOST_STRICT: ${{ matrix.selfhost_strict }}
         run: |
           set -euo pipefail
           export SEED_NATIVE="build/seed/bin/sailfin"
-          make check
+          make check SELFHOST_STRICT="$SELFHOST_STRICT"
 
       - name: Surface non-empty phase_types diagnostics
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ NATIVE_BIN ?= build/native/sailfin$(EXE_EXT)
 # Which compiler binary to use for running Sailfin-native tests.
 # Default: the native compiler alias produced by `make compile`.
 
-.PHONY: help install fetch-seed test test-unit test-integration test-e2e test-capsules compile check check-fast package clean bench bench-runtime test-arena
+.PHONY: help install fetch-seed test test-unit test-integration test-e2e test-capsules compile check check-strict check-fast package clean bench bench-runtime test-arena
 
 .PHONY: ci-prepare-test-artifacts ci-package ci-package-installer
 
@@ -175,6 +175,20 @@ else
 CHECK_TEST_JOBS ?= $(TEST_JOBS)
 endif
 
+# Strict self-host gate (#1830). When SELFHOST_STRICT=1, `make check`
+# passes `--strict` to `sfn selfhost` so a stage2/stage3 fixed-point
+# mismatch is fatal (exit non-zero, no promotion) instead of the default
+# warn-and-promote. CI/nightly turns this on; local `make check` stays
+# warn-only for dev ergonomics. `make check-strict` is the convenience
+# alias. The `--strict` plumbing itself lives in
+# compiler/src/cli_selfhost.sfn (`cfg.strict`).
+SELFHOST_STRICT ?=
+ifeq ($(SELFHOST_STRICT),1)
+SELFHOST_STRICT_FLAG := --strict
+else
+SELFHOST_STRICT_FLAG :=
+endif
+
 help:
 	@echo "Common Sailfin tasks"
 	@echo ""
@@ -182,6 +196,7 @@ help:
 	@echo "  make rebuild        # Force rebuild from seed via 'sfn build -p compiler'"
 	@echo "  make install        # Install the built compiler binary into PREFIX/bin"
 	@echo "  make check          # Compile (if needed) then run the full test suite"
+	@echo "  make check-strict   # Same as check, but a stage2/stage3 fixed-point mismatch is fatal"
 	@echo "  make check-fast     # Run sfn check on compiler/src/ + runtime/ (no codegen, fast PR gate)"
 	@echo "  make test           # Run Sailfin-native unit + integration + e2e tests"
 	@echo "  make test TEST_JOBS=4 # Same, with 4 parallel test children (pick N for your RAM budget)"
@@ -528,6 +543,16 @@ compile-impl:
 check:
 	@$(AGENT_REPORT) --target check -- $(MAKE) check-impl
 
+# Strict variant of `make check` (#1830): a stage2/stage3 fixed-point
+# mismatch is fatal (non-zero exit, no promotion) instead of
+# warn-and-promote. CI/nightly (Linux leg) runs this so a compiler that
+# cannot reproduce itself byte-for-byte fails the gate. A command-line
+# SELFHOST_STRICT=1 propagates through the recursive `check` → `check-impl`
+# makes via MAKEFLAGS, so the `--strict` flag reaches the `sfn selfhost`
+# invocation.
+check-strict:
+	@$(MAKE) check SELFHOST_STRICT=1
+
 check-impl:
 	@$(MAKE) compile NATIVE_OPT="$(SELFHOST1_OPT)"
 	@seed="build/native/sailfin"; \
@@ -547,8 +572,10 @@ check-impl:
 	@# verb is internal — absent from `sfn --help`; `make check` and CI are
 	@# its only callers (Go keeps this in `cmd/dist`, Rust in `x.py`). A
 	@# non-fixed-point result warns and still promotes (parity with the
-	@# former shell, which exited 0 on `.ll` divergence); add `--strict` to
-	@# make a mismatch fatal. The driver hardcodes `-O2` for the link step,
+	@# former shell, which exited 0 on `.ll` divergence) UNLESS
+	@# SELFHOST_STRICT=1 (`make check-strict`), which passes `--strict` so a
+	@# mismatch is fatal and the binary is not promoted (#1830). The driver
+	@# hardcodes `-O2` for the link step,
 	@# so `NATIVE_OPT` overrides for stage2/stage3 are still ignored (no
 	@# regression — the prior shell had the same gap). The suite legs and
 	@# the first-pass `make compile` stay Make-driven (issue `Out:` scope).
@@ -558,7 +585,8 @@ check-impl:
 		--seedcheck-out build/native/sailfin-seedcheck \
 		--stage3-out build/native/sailfin-stage3 \
 		--promote-to $(NATIVE_BIN) \
-		--smoke-timeout 10
+		--smoke-timeout 10 \
+		$(SELFHOST_STRICT_FLAG)
 	@echo "[check] running test suite with seedcheck binary (no fallbacks, jobs=$(CHECK_TEST_JOBS))..."
 	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 


### PR DESCRIPTION
## Summary
- Add a `SELFHOST_STRICT=1` toggle (and a `make check-strict` alias) that passes `--strict` to `sfn selfhost`, so a stage2/stage3 `.ll` fixed-point mismatch becomes fatal (non-zero exit, no promotion) instead of the default warn-and-promote.
- Wire the nightly self-host workflow's **Linux** leg to the strict path via a per-matrix `selfhost_strict` field; **macOS** stays warn-only (its strict participation is a separate sub-issue).
- No compiler-source change: the `--strict` machinery already exists in `compiler/src/cli_selfhost.sfn` (`cfg.strict`, parsed at :260, honored at :376). Local `make check` stays warn-only for dev ergonomics.

Closes #1830

## Acceptance Criteria
- [x] The nightly Linux self-host leg fails (non-zero) when stage2/stage3 IR digests diverge, surfacing the existing `not yet a fixed point` diagnostic — wired via `SELFHOST_STRICT=1` → `--strict`, which returns 1 on mismatch (`cli_selfhost.sfn:376-379`).
- [x] A forced mismatch returns non-zero via the strict path; the default `make check` behavior is unchanged unless the strict toggle is set (default `SELFHOST_STRICT_FLAG` resolves empty).
- [x] No change to the promotion path when the fixed point *is* reached (strict only affects the mismatch branch; the flag is empty by default).

## Map reconciliation
None — advisory `## Files Affected` matched the tree. `compiler/src/cli_selfhost.sfn` was listed for verification only; `--strict` was confirmed already plumbed, so no change there.

## Verification
```bash
# Flag derivation (Make variable database):
$ make -pn help SELFHOST_STRICT=1 | grep '^SELFHOST_STRICT_FLAG'
SELFHOST_STRICT_FLAG := --strict
$ make -pn help              | grep '^SELFHOST_STRICT_FLAG'
SELFHOST_STRICT_FLAG :=

# `--strict` is a real, parsed, honored flag:
#   cli_selfhost.sfn:260  } else if strings_equal(arg, "--strict") { cfg.strict = true; }
#   cli_selfhost.sfn:376  if !diff.matched && cfg.strict { ... return 1; }
```
Full `make check`/nightly not run here — this fresh container has no pinned seed and no network to `make fetch-seed`. The change is build-config wiring atop the already-tested `--strict` machinery; no `.sfn` files touched, so the self-host and `sfn fmt` gates do not apply.

## Files Changed
- `Makefile` — `SELFHOST_STRICT` toggle + `SELFHOST_STRICT_FLAG` derivation, `check-strict` target, `--strict` appended to the `check-impl` `sfn selfhost` invocation, help + `.PHONY`.
- `.github/workflows/nightly-selfhost.yml` — per-matrix `selfhost_strict` (`"1"` Linux, `"0"` macOS) threaded into the `make check` step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G16fshmDk96zWkz6p7q36n)_