### PR TITLE
examples: restore CI regression sweep + fix drift examples (#549)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,19 @@ jobs:
           (file build/native/sailfin || true)
           build/native/sailfin version || build/native/sailfin --version || true
 
+      # Examples regression sweep (epic #549). Every runnable example under
+      # examples/ must still `check` + `run` end-to-end. The KNOWN_FAILING
+      # allowlist in the script tracks examples blocked on an open compiler
+      # bug (each tied to a #549 sub-issue); the gate fails on a NEW failure
+      # (a regression in the marketed surface) or when a listed example starts
+      # passing (remove it — the ratchet tightens). Primary leg only: it has
+      # the packaged native compiler, and runs from the repo root so runtime/
+      # resolves via CWD.
+      - name: Examples sweep (epic #549)
+        if: ${{ matrix.primary }}
+        shell: bash
+        run: scripts/check-examples.sh
+
       # Regression guard for #615 / #807: assert the effect gate
       # actually fails the build (non-zero exit + correct summary
       # integers) on both Linux x86_64 and macOS arm64. The

--- a/examples/advanced/web-server-with-concurrency.sfn
+++ b/examples/advanced/web-server-with-concurrency.sfn
@@ -1,17 +1,14 @@
 // examples/advanced/web-server-with-concurrency.sfn
-
 import { serve } from "http";
 import { sleep } from "time";
 
-fn handleRequest(req, res) {
+fn handleRequest(req, res) ![clock, io] {
     if req.path == "/compute" {
         routine {
             let result = computeHeavyTask();
             res.send("Computed result: {{result}}");
         }
-    } else {
-        res.send("Welcome to Sailfin!", 200);
-    }
+    } else { res.send("Welcome to Sailfin!", 200); }
 }
 
 fn computeHeavyTask() -> int ![clock] {
@@ -20,6 +17,8 @@ fn computeHeavyTask() -> int ![clock] {
 }
 
 fn main() ![io, net] {
-    serve(handleRequest, { port: 8080 });
+    serve(handleRequest, {
+        port: 8080
+    });
     print("Server is running on http://localhost:8080");
 }

--- a/examples/concurrency/channels.sfn
+++ b/examples/concurrency/channels.sfn
@@ -1,14 +1,14 @@
 // examples/concurrency/channels.sfn
+// Bounded channels ship as the language builtin `channel(N)` (capacity N),
+// with `.send` / `.receive` over the by-pointer element ABI. A receive target
+// annotated `int` loads the element at the right width. The typed `sync`
+// capsule wrapper (`Channel<int>`, `channel<T>()`) and `async`/`await` are not
+// yet shipped — see docs/status.md and #829.
+fn main() ![io] {
+    let messages = channel(1);
 
-import { Channel, channel } from "sync";
+    routine { messages.send(42); }
 
-async fn main() ![io] {
-    let messages: Channel<int> = channel();
-
-    routine {
-        messages.send(42);
-    }
-
-    let result: int = await messages.receive();
+    let result: int = messages.receive();
     print("Received: {{result}}");
 }

--- a/examples/web/rest-api.sfn
+++ b/examples/web/rest-api.sfn
@@ -1,16 +1,17 @@
 // examples/web/rest-api.sfn
-
 import { serve } from "http";
 
-fn handleRequest(req, res) {
+fn handleRequest(req, res) ![io] {
     match req.method {
         "GET" => res.send("You sent a GET request."),
         "POST" => res.send("You sent a POST request."),
-        _ => res.send("Unsupported method!", 405),
+        _ => res.send("Unsupported method!", 405)
     }
 }
 
 fn main() ![io, net] {
-    serve(handleRequest, { port: 3000 });
+    serve(handleRequest, {
+        port: 3000
+    });
     print("Server is running on http://localhost:3000");
 }

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -79,12 +79,25 @@ emit() { # file status detail
     else printf "  %-11s %-52s %s\n" "$2" "$1" "$3"; fi
 }
 
+# Private stderr scratch file for `run` capture — mktemp (not a predictable
+# /tmp/$$ name) avoids symlink races and cross-run collisions; cleaned on exit.
+err_tmp="$(mktemp "${TMPDIR:-/tmp}/sfn_ex_err.XXXXXX")" || {
+    echo "error: mktemp failed" >&2; exit 2; }
+trap 'rm -f "$err_tmp"' EXIT
+
+# First non-empty line of stdin, capped — the fallback when no error/fatal line
+# matched (a timeout, a missing `timeout` binary, or another wrapper failure),
+# so a regression is still actionable from CI logs.
+first_line() { grep -m1 . | head -c 160; }
+
 while IFS= read -r f; do
     known=0; in_list "$f" "${KNOWN_FAILING[@]}" && known=1
 
     check_out="$(timeout "$TIMEOUT" "$SAILFIN_BIN" check "$f" 2>&1)"
     if [ $? -ne 0 ]; then
         detail="$(printf '%s' "$check_out" | grep -m1 -E 'error|fatal' | head -c 160)"
+        [ -z "$detail" ] && detail="$(printf '%s' "$check_out" | first_line)"
+        [ -z "$detail" ] && detail="check exited non-zero with no output (timeout?)"
         if [ "$known" -eq 1 ]; then xfail=$((xfail + 1)); emit "$f" "XFAIL" "check: $detail"
         else regressions+=("$f"); emit "$f" "CHECK_FAIL" "$detail"; fi
         continue
@@ -94,14 +107,15 @@ while IFS= read -r f; do
         skipped=$((skipped + 1)); emit "$f" "SKIP_RUN" "check-only (no main / blocking server)"; continue
     fi
 
-    run_out="$(timeout "$TIMEOUT" "$SAILFIN_BIN" run "$f" 2>/tmp/ex_err.$$)"
+    run_out="$(timeout "$TIMEOUT" "$SAILFIN_BIN" run "$f" 2>"$err_tmp")"
     run_rc=$?
-    run_err="$(cat /tmp/ex_err.$$ 2>/dev/null)"; rm -f /tmp/ex_err.$$
+    run_err="$(cat "$err_tmp" 2>/dev/null)"
 
     status="PASS"; detail=""
     if [ $run_rc -ne 0 ]; then
         status="RUN_FAIL"
         detail="$(printf '%s' "$run_err" | grep -m1 -E 'error|fatal|verifier' | head -c 160)"
+        [ -z "$detail" ] && detail="$(printf '%s' "$run_err" | first_line)"
         [ -z "$detail" ] && detail="exit $run_rc"
     elif [ -z "$run_out" ]; then
         status="EMPTY_OUT"; detail="exit 0 but no stdout"

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# scripts/check-examples.sh
+#
+# Examples regression sweep (epic #549). Runs every runnable `.sfn` under
+# examples/ through `sfn check` and `sfn run`, capturing stdout/stderr/exit
+# separately so "exits 0 but prints nothing" is distinguishable from a real
+# pass. Prints a per-file table and a summary.
+#
+# CI ratchet: the KNOWN_FAILING list below enumerates runnable examples that
+# fail today because of an open compiler bug (each tied to its tracking issue).
+# The script gates CI as follows:
+#   - a NON-listed runnable example that fails  -> REGRESSION -> exit 1
+#   - a listed example that now PASSES          -> XPASS      -> exit 1
+#     (a good problem: the bug is fixed; remove it from KNOWN_FAILING)
+#   - a listed example that still fails          -> XFAIL      -> tolerated
+# This lets the marketed example surface be guarded now, while the remaining
+# compiler bugs in #549 are worked off one sub-issue at a time.
+#
+# Two files are intentionally not run:
+#   - basics/tests.sfn  — no `main`; exercised by `sfn test`.
+#   - the blocking-server web examples — `sfn run` never returns (Category 8
+#     in #549); they need a spawn/probe/kill harness, tracked separately.
+#
+# Usage:
+#   scripts/check-examples.sh            # sweep, human-readable table
+#   SAILFIN_BIN=path scripts/check-examples.sh
+#   scripts/check-examples.sh --tsv      # machine-readable TSV to stdout
+
+set -u
+
+SAILFIN_BIN="${SAILFIN_BIN:-build/native/sailfin}"
+TIMEOUT="${SAILFIN_EXAMPLES_TIMEOUT:-25}"
+TSV=0
+[ "${1:-}" = "--tsv" ] && TSV=1
+
+if [ ! -x "$SAILFIN_BIN" ]; then
+    echo "error: compiler not found at $SAILFIN_BIN (run 'make compile')" >&2
+    exit 2
+fi
+
+# Files that have no `main` or block forever — not runnable via `sfn run`.
+SKIP_RUN=(
+    "examples/basics/tests.sfn"
+    "examples/web/http-server.sfn"
+    "examples/web/rest-api.sfn"
+    "examples/web/websocket-chat.sfn"
+    "examples/advanced/web-server-with-concurrency.sfn"
+)
+
+# Runnable examples that fail today on an open compiler bug (epic #549).
+# Each entry cites its tracking sub-issue; remove it when that issue lands.
+KNOWN_FAILING=(
+    "examples/basics/interfaces.sfn"                    # #1835 interface dynamic dispatch
+    "examples/basics/struct-composition.sfn"           # #1835 interface dynamic dispatch
+    "examples/advanced/interface-polymorphism.sfn"     # #1835 interface dynamic dispatch
+    "examples/advanced/generic-structures.sfn"         # #1835 + generics (#766)
+    "examples/concurrency/producer-consumer.sfn"       # #1835 explicit Channel<int> method dispatch
+    "examples/concurrency/dynamic-task-scheduling.sfn" # #1835 fn-typed channel + await (#829)
+    "examples/functional/map-reduce.sfn"               # #1836 array-HOF map->reduce chain
+    "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map (#766)
+    "examples/functional/higher-order-functions.sfn"   # #1837 indirect call through fn-typed param
+    "examples/advanced/unions.sfn"                      # #1838 @.runtime.field.name global
+    "examples/algorithms/quicksort.sfn"                # #1839 double-array GEP i64/ptr
+)
+
+in_list() {
+    local needle="$1"; shift
+    for x in "$@"; do [ "$needle" = "$x" ] && return 0; done
+    return 1
+}
+
+pass=0 skipped=0 xfail=0
+regressions=() xpasses=()
+
+[ "$TSV" -eq 1 ] && printf "file\tstatus\tdetail\n"
+
+emit() { # file status detail
+    if [ "$TSV" -eq 1 ]; then printf "%s\t%s\t%s\n" "$1" "$2" "$3"
+    else printf "  %-11s %-52s %s\n" "$2" "$1" "$3"; fi
+}
+
+while IFS= read -r f; do
+    known=0; in_list "$f" "${KNOWN_FAILING[@]}" && known=1
+
+    check_out="$(timeout "$TIMEOUT" "$SAILFIN_BIN" check "$f" 2>&1)"
+    if [ $? -ne 0 ]; then
+        detail="$(printf '%s' "$check_out" | grep -m1 -E 'error|fatal' | head -c 160)"
+        if [ "$known" -eq 1 ]; then xfail=$((xfail + 1)); emit "$f" "XFAIL" "check: $detail"
+        else regressions+=("$f"); emit "$f" "CHECK_FAIL" "$detail"; fi
+        continue
+    fi
+
+    if in_list "$f" "${SKIP_RUN[@]}"; then
+        skipped=$((skipped + 1)); emit "$f" "SKIP_RUN" "check-only (no main / blocking server)"; continue
+    fi
+
+    run_out="$(timeout "$TIMEOUT" "$SAILFIN_BIN" run "$f" 2>/tmp/ex_err.$$)"
+    run_rc=$?
+    run_err="$(cat /tmp/ex_err.$$ 2>/dev/null)"; rm -f /tmp/ex_err.$$
+
+    status="PASS"; detail=""
+    if [ $run_rc -ne 0 ]; then
+        status="RUN_FAIL"
+        detail="$(printf '%s' "$run_err" | grep -m1 -E 'error|fatal|verifier' | head -c 160)"
+        [ -z "$detail" ] && detail="exit $run_rc"
+    elif [ -z "$run_out" ]; then
+        status="EMPTY_OUT"; detail="exit 0 but no stdout"
+    else
+        detail="$(printf '%s' "$run_out" | head -1 | head -c 60)"
+    fi
+
+    if [ "$status" = "PASS" ]; then
+        if [ "$known" -eq 1 ]; then xpasses+=("$f"); emit "$f" "XPASS" "now passes — remove from KNOWN_FAILING: $detail"
+        else pass=$((pass + 1)); emit "$f" "PASS" "$detail"; fi
+    else
+        if [ "$known" -eq 1 ]; then xfail=$((xfail + 1)); emit "$f" "XFAIL" "$detail"
+        else regressions+=("$f"); emit "$f" "$status" "$detail"; fi
+    fi
+done < <(find examples -name '*.sfn' | sort)
+
+if [ "$TSV" -eq 0 ]; then
+    echo ""
+    echo "  summary: $pass PASS / ${#regressions[@]} REGRESSION / ${#xpasses[@]} XPASS / $xfail XFAIL(known #549) / $skipped SKIP_RUN"
+fi
+
+rc=0
+if [ "${#regressions[@]}" -gt 0 ]; then
+    echo "  REGRESSION: these runnable examples newly fail — fix or add to KNOWN_FAILING with an issue:" >&2
+    for r in "${regressions[@]}"; do echo "    - $r" >&2; done
+    rc=1
+fi
+if [ "${#xpasses[@]}" -gt 0 ]; then
+    echo "  XPASS: these now pass — remove them from KNOWN_FAILING (the ratchet tightens):" >&2
+    for x in "${xpasses[@]}"; do echo "    - $x" >&2; done
+    rc=1
+fi
+exit $rc


### PR DESCRIPTION
Re-establishes the examples smoke test retired long ago (epic #549) and fixes the examples that failed purely because the language evolved. **No `compiler/src` or `runtime` changes** — the remaining failures are genuine compiler bugs, now filed as scoped sub-issues and allowlisted so CI can go green today while they're worked off one at a time.

## Fresh sweep vs. the epic's 2-month-old data

The epic's audit was `sfn 0.5.10-alpha.14` (2026-05-11); this re-sweep is `0.8.0-alpha.1+dev.19e49c2`. The compiler has already closed most of the epic's categories:

- **Category 6 (silent miscompiles)** — gone; 0 `EMPTY_OUT`. They now pass or fail loudly.
- **Category 4 (`@sailfin_runtime_clear_exception`)** — fixed; `try-catch-finally`, `encapsulation-struct` pass.
- **Category 3 (`@sailfin_intrinsic_http_get`)** — fixed; `async`, `fetch-data` run (stubbed payload).

Current state via the new script: **33 PASS / 0 REGRESSION / 11 XFAIL(known #549) / 5 SKIP**.

## What this PR does

**`scripts/check-examples.sh`** — runs every runnable example through `check` + `run`, separating a real pass from "exit 0, no output". A `KNOWN_FAILING` allowlist tracks examples blocked on an open compiler bug (each tied to a #549 sub-issue). CI fails on a **new** failure (regression in the marketed surface) or when a listed example **starts passing** (remove it — the ratchet tightens). Wired into the `build-linux` primary leg in `ci.yml`.

**Example drift fixes (language evolved, not compiler bugs):**
- `web/rest-api.sfn`, `advanced/web-server-with-concurrency.sfn` — the effect-checker now requires the effects `handleRequest` actually uses (`res.send` → `io`; `routine` compute → `clock`).
- `concurrency/channels.sfn` — migrated off the **stubbed `sync` capsule** and the unshipped typed `Channel<int>` / `async`-`await` to the shipped `channel(N)` builtin (proven to run: `Received: 42`).

## Remaining compiler bugs (filed as sub-issues of #549, allowlisted)

An explorer pass traced the dominant failure family to **2 root causes** in `core_call_resolution.sfn`, plus 3 isolated bugs:

| Issue | Bug | Examples |
|---|---|---|
| #1835 | Method-call callee names fuse without dispatch for interface / generic / explicit-`Channel<T>` receivers | interfaces, struct-composition, interface-polymorphism, generic-structures, producer-consumer, dynamic-task-scheduling |
| #1836 | `.map`/`.filter`/`.reduce` routing is i64-only + simple-identifier-only | map-reduce, matrix-multiplication |
| #1837 | Indirect call through a function-typed parameter | higher-order-functions |
| #1838 | Union field-name global `@.runtime.field.name` referenced but never emitted | unions |
| #1839 | Array-of-`double` element access emits GEP base as `i64` instead of `ptr` | quicksort |

## Verification

```
scripts/check-examples.sh   # 33 PASS / 0 REGRESSION / 0 XPASS / 11 XFAIL / 5 SKIP, exit 0
```

`sfn fmt --check` clean on all touched `.sfn`. Self-host unaffected (no compiler/runtime source touched).

Refs #549 (epic stays open until the sub-issues land).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TofnQp7SijEnmFmdTmibEG)_