### PR TITLE
site: fix hero example to use int, not the retired number type

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@
 
 const exampleCode = `struct Config {
     host: string;
-    port: number;
+    port: int;
     verbose: boolean;
 }
 


### PR DESCRIPTION
## Summary

The marketing hero (`site/src/components/Hero.astro`) advertised a `number` type in its `Config` struct example:

```sfn
struct Config {
    host: string;
    port: number;   // ← retired type
    verbose: boolean;
}
```

The `number` type was migrated to `int`/`float` months ago (`number` now only survives as an alias for `float` in `typecheck_types.sfn`). A port is an integer, so the example now uses `int`:

```sfn
    port: int;
```

## Scope

- One-line content fix in the hero code sample. No compiler/runtime source touched, so no self-host gate applies.
- Left the `{{config.host}}` interpolation as-is — the `${ }` reform is still pending per `CLAUDE.md`.

## Verification

`.astro` markup change only; the code sample is display text (not compiled), and the rest of the example already reflects current syntax (`[io]`/`[net]` effects, `:` annotations, `-> T` returns).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br5Xs94vXToHwWviE8YvPj)_