### PR TITLE
Lower interface & explicit-channel method calls through real dispatch (#1835)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -833,7 +833,28 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                     result_temp = _pre_lowered.temp_index;
                                     if _pre_lowered.operand != null {
                                         method_operand = _pre_lowered.operand;
-                                        result_target = _pre_struct + _pre_field;
+                                        // #1835: an interface-typed base is trait
+                                        // dispatch, not a struct method. Fusing
+                                        // `<Iface><field>` (e.g. `Greetergreet`)
+                                        // yields a dot-less callee that the
+                                        // downstream `parse_member_access` can't
+                                        // split, so the `trait_dispatch__` branch is
+                                        // never reached and lowering fatals with an
+                                        // unresolvable callee. Build the dispatch name
+                                        // here — the base is already lowered and
+                                        // injected as arg0 — matching the downstream
+                                        // interface path. Struct bases keep the fused
+                                        // `<Struct><field>` method name.
+                                        let _pre_iface = find_interface_info_by_name(context, _pre_struct);
+                                        if _pre_iface != null {
+                                            result_target = "trait_dispatch__"
+                                                + _pre_iface.name
+                                                + "__"
+                                                + _pre_field;
+                                        } else {
+                                            result_target = _pre_struct
+                                                + _pre_field;
+                                        }
                                         injected_argument_count = 1;
                                     }
                                 }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -29,7 +29,7 @@ import {
     find_struct_info_by_llvm_type,
     find_vtable_for_struct_interface
 } from "../type_context_queries";
-import { ends_with_pointer_suffix, numeric_type_kind } from "../type_mapping";
+import { ends_with_pointer_suffix, numeric_type_kind, strip_pointer_suffix } from "../type_mapping";
 import {
     LLVMOperand,
     LetLoweringResult,
@@ -236,7 +236,20 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                 + instruction.value);
         }
         let _pre_expr_line_count = current_lines.length;
-        let lowered = lower_expression(instruction.value, current_bindings, current_locals, current_temp, current_lines, functions, context, llvm_type);
+        // #1835: an interface-typed local boxes its concrete initializer into a
+        // trait object below (the `find_vtable_for_struct_interface` path). If
+        // the initializer is lowered with the trait type (`%trait.X`) as its
+        // expected type, the generic coercion fallback reinterpret-loads the
+        // concrete struct's bytes as the `{data, vtable}` fat pointer — the
+        // vtable slot ends up holding a field value, so dispatch jumps through
+        // garbage and segfaults. Lower it with a neutral expected type so the
+        // initializer yields its natural `%Struct*`, then box it with the real
+        // vtable below.
+        let mut init_expected_type: string = llvm_type;
+        if find_interface_info_by_name(context, instruction.type_annotation) != null {
+            init_expected_type = "";
+        }
+        let lowered = lower_expression(instruction.value, current_bindings, current_locals, current_temp, current_lines, functions, context, init_expected_type);
         if debug_lowering {
             print.err("let-lowering: post-lower_expression name=" + instruction.name);
         }
@@ -310,8 +323,12 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     let interface_info = find_interface_info_by_name(context, instruction.type_annotation);
     if interface_info != null {
         if operand != null {
-            // Target type is an interface; check if operand is a concrete struct
-            let struct_info = find_struct_info_by_llvm_type(context, operand.llvm_type);
+            // Target type is an interface; check if operand is a concrete struct.
+            // #1835: under the 0.5.8+ boxed-struct ABI the operand arrives as a
+            // `%T*` pointer (see the pointer branch below), but structs are keyed
+            // by their bare `%T` llvm_name — strip the pointer suffix so the
+            // lookup resolves and boxing is not silently skipped.
+            let struct_info = find_struct_info_by_llvm_type(context, strip_pointer_suffix(operand.llvm_type));
             if struct_info != null {
                 // Find the vtable for this struct-interface pair
                 let vtable = find_vtable_for_struct_interface(context, struct_info.name, interface_info.name);
@@ -584,7 +601,17 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     // find them. Annotating the local as `"channel"` lets the method-call
     // resolver route `.send` / `.receive` / `.close` to the `sfn_channel_*`
     // runtime helpers instead of failing closed.
-    if local_type_annotation.length == 0 {
+    //
+    // #1835: key off the *initializer*, not the annotation. An explicit
+    // `let buf: Channel<int> = channel(N)` carries a source annotation
+    // ("Channel<int>"), which skipped the old empty-annotation guard, so the
+    // binding never received the `channel` / `channel:<kind>` sentinel — and
+    // `buf.send(x)` fused into an unresolvable `Channel<int>send` callee. A
+    // `channel(...)` / `channel:...` initializer is itself proof the local is
+    // a channel (they are builtin constructors, so typecheck admits them only
+    // for channel-typed bindings), so normalize whenever the initializer is
+    // one, regardless of the source annotation's spelling.
+    {
         let trimmed_init = trim_text(instruction.value);
         if starts_with(trimmed_init, "channel(") {
             local_type_annotation = "channel";

--- a/compiler/tests/e2e/fixtures/interface_dispatch_probe.sfn
+++ b/compiler/tests/e2e/fixtures/interface_dispatch_probe.sfn
@@ -1,0 +1,30 @@
+// Fixture for interface_dispatch_test.sfn (#1835). Exercises dynamic
+// dispatch through interface-typed locals: a method call on a
+// `let x: Iface = Concrete { ... }` binding must box the concrete struct
+// into a trait object (data pointer + vtable) and dispatch through the
+// vtable, rather than fuse `<Iface><method>` into a dot-less callee that
+// no lookup resolves. Two structs implement the same interface so a
+// correct vtable dispatch must select a different method body per
+// concrete type.
+interface Greeter {
+    fn greet(self) -> string;
+}
+
+struct English {
+    name: string;
+
+    fn greet(self) -> string { return "Hello, {{self.name}}!"; }
+}
+
+struct Spanish {
+    name: string;
+
+    fn greet(self) -> string { return "Hola, {{self.name}}!"; }
+}
+
+fn main() ![io] {
+    let a: Greeter = English { name: "Alice" };
+    let b: Greeter = Spanish { name: "Bob" };
+    print(a.greet());
+    print(b.greet());
+}

--- a/compiler/tests/e2e/interface_dispatch_test.sfn
+++ b/compiler/tests/e2e/interface_dispatch_test.sfn
@@ -1,0 +1,82 @@
+// End-to-end test for dynamic dispatch through interface-typed locals
+// (#1835). Before the fix, a method call on a `let x: Iface = Concrete`
+// binding fused the receiver's raw annotation with the field name
+// (`Greetergreet`), a dot-less callee that `parse_member_access` could
+// not split — so the `trait_dispatch__` branch was never reached and
+// lowering fatally rejected the call. A companion construction bug then
+// reinterpret-loaded the concrete struct's bytes as the `{data, vtable}`
+// fat pointer, so even once dispatch resolved the vtable slot held a
+// field value and the call jumped through garbage (segfault). This
+// builds a fixture with two structs implementing one interface, runs it,
+// and asserts each interface-typed local dispatches to its own method
+// body.
+//
+// Build hygiene mirrors sailfin_main_entry_test.sfn: the fixture is
+// written into a fresh `with_tmp_dir` before building, and the nested
+// `sfn build` inherits the full environment (PATH for clang/ld,
+// SAILFIN_TEST_SCRATCH for per-invocation build-cache isolation under the
+// parallel pool — see `.claude/rules/no-bash-e2e.md`).
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _fixture_src() -> string ![io] {
+    return fs.readFile("compiler/tests/e2e/fixtures/interface_dispatch_probe.sfn");
+}
+
+// Full parent environment for the nested `sfn build` (PATH/HOME/TMPDIR
+// plus SAILFIN_TEST_SCRATCH). `process.run_capture` treats an empty array
+// as the empty environment, not "inherit".
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// A fresh marker-file path outside the `with_tmp_dir` tree so captured
+// stdout survives teardown and can be asserted after the run.
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-iface-dispatch-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// Build the fixture in a temp dir and run it, stashing captured stdout to
+// `out_marker`. Returns the run's exit code, or `-100` if the build itself
+// failed.
+fn _build_and_run(out_marker: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, _fixture_src());
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], []);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+test "interface-dispatch: method call through interface-typed local dispatches per concrete type" ![io] {
+    let marker = _marker("greet");
+    let exit = _build_and_run(marker);
+    // Reject the `-100` build-failure sentinel and any runtime crash
+    // (a segfault from the pre-fix garbage vtable would surface here as a
+    // non-zero exit) before reading the marker.
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // Distinct method bodies prove real vtable dispatch, not a single
+    // fused callee: English.greet and Spanish.greet occupy different
+    // vtable slots keyed off each local's concrete type.
+    assert find(out, "Hello, Alice!", 0) >= 0;
+    assert find(out, "Hola, Bob!", 0) >= 0;
+}

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -50,12 +50,9 @@ SKIP_RUN=(
 # Runnable examples that fail today on an open compiler bug (epic #549).
 # Each entry cites its tracking sub-issue; remove it when that issue lands.
 KNOWN_FAILING=(
-    "examples/basics/interfaces.sfn"                    # #1835 interface dynamic dispatch
-    "examples/basics/struct-composition.sfn"           # #1835 interface dynamic dispatch
-    "examples/advanced/interface-polymorphism.sfn"     # #1835 interface dynamic dispatch
-    "examples/advanced/generic-structures.sfn"         # #1835 + generics (#766)
-    "examples/concurrency/producer-consumer.sfn"       # #1835 explicit Channel<int> method dispatch
-    "examples/concurrency/dynamic-task-scheduling.sfn" # #1835 fn-typed channel + await (#829)
+    "examples/advanced/generic-structures.sfn"         # #766 generic-struct method monomorphization
+    "examples/concurrency/producer-consumer.sfn"       # #1835 lowering fatal fixed; run still hangs on drain (#549 await follow-up)
+    "examples/concurrency/dynamic-task-scheduling.sfn" # fn-typed channel element + await (#829)
     "examples/functional/map-reduce.sfn"               # #1836 array-HOF map->reduce chain
     "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map (#766)
     "examples/functional/higher-order-functions.sfn"   # #1837 indirect call through fn-typed param


### PR DESCRIPTION
## Summary

- Method calls on interface-typed and explicitly-`Channel<T>`-typed receivers passed `sfn check` but died at LLVM lowering with `cannot resolve return type for call to ...` — the resolver fused the receiver's raw source annotation with the field name into a dot-less callee (`Greetergreet`, `Channel<int>send`) that no lookup could resolve, so the real `trait_dispatch__` / channel machinery downstream was skipped.
- **Interface call-site** (`core_call_resolution.sfn`): an interface-typed base now builds `trait_dispatch__<Iface>__<field>` (base already lowered + injected as arg0), matching the downstream interface path; struct bases keep the fused `<Struct><field>` method name.
- **Explicit channel** (`instructions_let.sfn`): normalize a `channel(...)` / `channel:...` initializer to the `channel` / `channel:<kind>` sentinel off the *initializer* (not the annotation spelling), so `let buf: Channel<int> = channel(N)` routes `send`/`receive` to the runtime helpers instead of fusing `Channel<int>send`.
- **Interface value construction** (`instructions_let.sfn`): a second, latent bug surfaced once dispatch resolved — the initializer was lowered with the trait type as its expected type, so the coercion fallback reinterpret-loaded the concrete struct's bytes as the `{data, vtable}` fat pointer (segfault). Fixed by lowering interface-typed initializers with a neutral expected type (yielding the natural `%Struct*`) and stripping the `%T*` pointer suffix in the vtable-boxing struct lookup so boxing is no longer silently skipped under the boxed-struct ABI.

Closes #1835

## Acceptance Criteria

- [x] `basics/interfaces.sfn`, `basics/struct-composition.sfn`, `advanced/interface-polymorphism.sfn` run end-to-end and print the expected greeting/drive output.
- [x] `concurrency/producer-consumer.sfn` no longer fatals at lowering on `Channel<int>send` (builds + links; runtime drain is a separate follow-up).
- [x] A new e2e test covers method dispatch through an interface-typed local.
- [x] Self-hosts (`make compile`).

## Map reconciliation

The issue's `In:` scoped the fix to `resolve_call_method_target`'s call-site fusion. During implementation a **second, latent bug in interface value construction** (the reinterpret-load segfault + the boxed-struct-ABI pointer-suffix lookup miss) was found: it was masked because the call-site fatal fired first, and it must be fixed for the issue's explicit "run end-to-end and print" acceptance criteria. Both fixes live in the same lowering module (`compiler/src/llvm/lowering/instructions_let.sfn`, listed in the issue's Files Affected) and are in-unit siblings of the same "make interface dispatch work end-to-end" goal — no new acceptance criterion or public surface, so reconciled and recorded here rather than halted. `core.sfn`'s channel intercept (also listed) needed no change: with the sentinel set at the binding site, the existing `_try_lower_channel_method` path intercepts correctly.

Out-of-scope examples stay gated: `advanced/generic-structures.sfn` (generic-struct method monomorphization, #766) and `concurrency/dynamic-task-scheduling.sfn` (fn-typed channel element + `await`, #829) remain `KNOWN_FAILING`; `producer-consumer.sfn` stays failing on the runtime drain hang (#549 await follow-up) though its lowering fatal is fixed.

## Verification

```bash
make compile                                   # self-hosts ✓
build/native/sailfin run examples/basics/interfaces.sfn            # Hello, Alice! ✓
build/native/sailfin run examples/basics/struct-composition.sfn   # Driving a Subaru car. / Riding a Yamaha bike. ✓
build/native/sailfin run examples/advanced/interface-polymorphism.sfn  # (same) ✓
build/native/sailfin build examples/concurrency/producer-consumer.sfn -o /tmp/pc  # links, no lowering fatal ✓
scripts/check-examples.sh                      # 0 REGRESSION / 0 XPASS ✓
make test                                      # unit 188/188, integration 42/42, e2e 173/173, capsules 38/38 ✓
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — interface base → `trait_dispatch__` callee
- `compiler/src/llvm/lowering/instructions_let.sfn` — channel sentinel off initializer; interface init neutral expected-type + pointer-suffix strip in boxing lookup
- `scripts/check-examples.sh` — un-ratchet the 3 now-passing interface examples; update out-of-scope comments
- `compiler/tests/e2e/interface_dispatch_test.sfn` + `fixtures/interface_dispatch_probe.sfn` — new e2e regression test

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUoR2LjgPkEUjSGKoxTgGc)_