### PR TITLE
Lower array .map/.filter/.reduce over inferred map-result chains

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn
@@ -366,6 +366,38 @@ fn declared_binding_type(type_annotation: TypeAnnotation?, initializer: Expressi
     return "";
 }
 
+// #1836: the result type of an inferred `let sq = arr.map(...)` /
+// `arr.filter(...)`. `declared_binding_type` yields "" for it (the
+// initializer is a `Call`, not an `Array` literal), so `sq` never enters the
+// binding table and a follow-on `sq.reduce(...)` / `sq.map(...)` cannot
+// backfill its untyped callback params (they default to the wrong width and
+// segfault, the exact gap #1683 closed for the direct-receiver case). The
+// shipped map/filter helpers are i64-only and preserve/produce an `int`
+// element, so when the receiver resolves to an int array the result is
+// `int[]`. Mirrors the runtime gate in `array_builtin_expected_fn_type`. The
+// receiver is resolved against the partial table built so far, which already
+// holds any earlier `let` in the same block — so chained `a.map(...).map(...)`
+// via intermediate lets resolves left-to-right.
+fn _map_filter_result_type(initializer: Expression?, bindings: BindingEntry[]) -> string {
+    if initializer != null {
+        let init = initializer;
+        if init.variant == "Call" {
+            let callee = init.callee;
+            if callee.variant == "Member" {
+                let mut is_map_filter: boolean = false;
+                if callee.member == "map" { is_map_filter = true; }
+                if callee.member == "filter" { is_map_filter = true; }
+                if is_map_filter {
+                    if receiver_element_type(callee.object, bindings) == "int" {
+                        return "int[]";
+                    }
+                }
+            }
+        }
+    }
+    return "";
+}
+
 // Build the program-wide binding table ONCE (immutable, like the signature
 // table). A per-walk *mutable* scope re-stored into the threaded `LiftContext`
 // corrupts the struct string fields under the seed compiler; the static table
@@ -430,7 +462,15 @@ fn _collect_statement_bindings(table: BindingEntry[], statement: Statement) -> B
     let mut out: BindingEntry[] = table;
     if statement.variant == "VariableDeclaration" {
         if statement.name.length > 0 {
-            let type_text = declared_binding_type(statement.type_annotation, statement.initializer);
+            let mut type_text = declared_binding_type(statement.type_annotation, statement.initializer);
+            // #1836: recover `int[]` for an inferred `let sq = arr.map(...)` /
+            // `arr.filter(...)` (no annotation, non-`Array` initializer) so a
+            // follow-on reduce/map/filter backfills its untyped callback.
+            if type_text.length == 0 {
+                if statement.type_annotation == null {
+                    type_text = _map_filter_result_type(statement.initializer, out);
+                }
+            }
             if type_text.length > 0 {
                 out.push(BindingEntry {
                     name: statement.name, type_text: type_text

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -3,6 +3,7 @@
 // Let binding instruction lowering.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { index_of } from "../../string_utils";
+import { array_pointer_element_type } from "../expression_lowering/arrays";
 import { analyze_value_ownership, detect_borrow_conflicts, lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
 import {
@@ -10,10 +11,10 @@ import {
     mark_last_local_consumed,
     promote_escaping_locals_for_boundaries
 } from "../expression_lowering/native/core_scopes";
-import { is_heap_type } from "../expression_lowering/native/core_type_mapping";
+import { is_heap_type, map_array_pointer_type } from "../expression_lowering/native/core_type_mapping";
 import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
 import { map_local_type } from "../expression_lowering/native/statement_type_mapping";
-import { find_local_binding, mark_parameter_consumed } from "../expressions_bindings";
+import { find_local_binding, find_parameter_binding, mark_parameter_consumed } from "../expressions_bindings";
 import { default_return_literal, format_local_pointer_name } from "../expressions_helpers";
 import {
     append_lifetime_region,
@@ -110,6 +111,64 @@ fn _extract_leading_call_target(expression: string) -> string {
     return substring(trimmed, 0, index);
 }
 
+// Detect an array higher-order-method initializer `<base>.map(...)` /
+// `<base>.filter(...)` and return the `<base>` identifier, else "". The
+// runtime array-HOF helpers return an opaque `i8*` (runtime_helpers.sfn),
+// so an inferred `let sq = arr.map(...)` records no resolvable array
+// annotation and a follow-on `sq.reduce(...)` / `sq.map(...)` cannot
+// recover the `i64` element type the routing needs
+// (core_call_resolution.sfn:563-676). #1836.
+fn _array_hof_result_base(expression: string) -> string {
+    let trimmed = trim_text(expression);
+    if trimmed.length == 0 { return ""; }
+    let first = substring(trimmed, 0, 1);
+    if !is_identifier_start_char(first) { return ""; }
+    let mut index: int = 1;
+    loop {
+        if index >= trimmed.length { break; }
+        let ch = substring(trimmed, index, index + 1);
+        if !is_identifier_part_char(ch) { break; }
+        index += 1;
+    }
+    let base = substring(trimmed, 0, index);
+    if base.length == 0 { return ""; }
+    let rest = substring(trimmed, index, trimmed.length);
+    if starts_with(rest, ".map(") { return base; }
+    if starts_with(rest, ".filter(") { return base; }
+    return "";
+}
+
+// Recover the source array element type for a base identifier binding,
+// mirroring the receiver-element resolution in
+// core_call_resolution.sfn:563-588 (the binding's llvm_type first, then
+// the source annotation via `map_array_pointer_type`). Returns "" when the
+// base is not a resolvable array. #1836.
+fn _base_array_element_type(base: string, locals: LocalBinding[], bindings: ParameterBinding[], context: TypeContext) -> string {
+    let mut ltype: string = "";
+    let mut ann: string = "";
+    let local = find_local_binding(locals, base);
+    if local != null {
+        ltype = local.llvm_type;
+        ann = local.type_annotation;
+    } else {
+        let param = find_parameter_binding(bindings, base);
+        if param != null {
+            ltype = param.llvm_type;
+            ann = param.type_annotation;
+        }
+    }
+    let mut elem = array_pointer_element_type(ltype);
+    if elem.length == 0 {
+        if ann.length > 0 {
+            let derived = map_array_pointer_type(context, ann);
+            if derived.length > 0 {
+                elem = array_pointer_element_type(derived);
+            }
+        }
+    }
+    return elem;
+}
+
 fn lower_let_instruction(function: NativeFunction, instruction: NativeInstruction, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> LetLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
@@ -153,10 +212,36 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         }
     }
 
-    let trimmed_annotation = trim_text(instruction.type_annotation);
+    // #1836: derive an effective source annotation for the binding before
+    // the LLVM type is computed. An inferred `let sq = arr.map(...)` /
+    // `arr.filter(...)` otherwise binds the runtime-helper result as an
+    // opaque `i8*`, losing the array element type that BOTH the array-HOF
+    // routing (core_call_resolution.sfn:563-676) and the closure-parameter
+    // inference need from the receiver — a follow-on `sq.reduce(...)` /
+    // `sq.map(...)` then fatals at lowering or miscompiles its untyped
+    // closure params to `i8*`. The shipped map/filter helpers are i64-only,
+    // so when the base resolves to an i64 array, treat the binding as
+    // `int[]` — the same annotation a typed `let sq: int[] = ...` carries —
+    // so the result becomes a first-class array local (llvm_type
+    // `{i64*, i64, i64}*`, the i8* result coerced on store) with the element
+    // type recoverable everywhere downstream. Gated on an empty source
+    // annotation so an explicit `let sq: int[] = ...` is untouched; non-i64
+    // element maps never route to the helper (they fatal earlier), so only
+    // genuinely-i64 results are enriched.
+    let mut effective_annotation: string = instruction.type_annotation;
+    if trim_text(instruction.type_annotation).length == 0 {
+        let hof_base = _array_hof_result_base(instruction.value);
+        if hof_base.length > 0 {
+            if _base_array_element_type(hof_base, current_locals, current_bindings, context) == "i64" {
+                effective_annotation = "int[]";
+            }
+        }
+    }
+
+    let trimmed_annotation = trim_text(effective_annotation);
     let mut llvm_type: string = "";
     if trimmed_annotation.length > 0 {
-        llvm_type = map_local_type(context, instruction.type_annotation);
+        llvm_type = map_local_type(context, effective_annotation);
         if llvm_type.length == 0 {
             diagnostics.push("llvm lowering: unsupported local type for `"
                 + instruction.name
@@ -542,7 +627,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     // imported / mangled callees — the unique `target + "__"` suffix, so we
     // reach the same `NativeFunction.return_type` the file-IPC channel used
     // to carry for both local and imported async functions.
-    let mut local_type_annotation: string = instruction.type_annotation;
+    let mut local_type_annotation: string = effective_annotation;
     // Issue #689: enrich the bare `__closure__` sentinel with the
     // lifted lambda's symbol so call-site dispatch can recover the
     // function signature without a side-channel. The AST-level

--- a/compiler/tests/e2e/array_map_reduce_chain_test.sfn
+++ b/compiler/tests/e2e/array_map_reduce_chain_test.sfn
@@ -1,0 +1,51 @@
+// End-to-end test for a `.map(...).reduce(...)` chain over an `int[]` where
+// the intermediate `.map` result is bound to an inferred `let` (#1836).
+//
+// `numbers.map(...)` routes to `runtime_array_map_fn`, returning the mapped
+// array as an opaque `i8*`. The `squares` binding therefore carries no
+// resolvable array annotation; the follow-on `squares.reduce(0, ...)` must
+// recover the `i64` element type from the map-result binding to route to
+// `runtime_array_reduce_fn`. Before #1836 the reduce routing no-op'd and the
+// build fataled at lowering.
+//
+// Drives the compiler-under-test as a subprocess with the runtime `process.*`
+// builtins and asserts on captured stdout — the canonical e2e pattern (see
+// `.claude/rules/no-bash-e2e.md`, `array_reduce_closure_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from. Mirrors
+// `sfn/test`'s `_resolve_sfn_bin` so CI can point the test at any compiler.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, plus SAILFIN_TEST_SCRATCH
+// for per-invocation build-cache isolation under the parallel pool, #1333).
+// Inherit the full parent environment — mirrors array_reduce_closure_test.sfn.
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+// Compile+run a fixture and return its exit code plus the trailing-
+// newline-normalized stdout.
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "array map->reduce chain: inferred-let map result reduces to 55" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/array_map_reduce_chain/main.sfn");
+    assert r.exit == 0;
+    // [1,2,3,4,5].map(x*x) = [1,4,9,16,25]; reduce(0, +) = 55.
+    // A no-op'd reduce (or a build fatal) would not print 55.
+    assert r.out == "55";
+}

--- a/compiler/tests/e2e/fixtures/array_map_reduce_chain/main.sfn
+++ b/compiler/tests/e2e/fixtures/array_map_reduce_chain/main.sfn
@@ -1,0 +1,17 @@
+// compiler/tests/e2e/fixtures/array_map_reduce_chain/main.sfn
+//
+// Issue #1836 acceptance — a `.map(...).reduce(...)` chain over an `int[]`
+// where the intermediate `.map` result is bound to an *inferred* `let`
+// (no explicit `: int[]` annotation). The map result is an opaque `i8*`
+// from the `runtime_array_map_fn` helper; the follow-on `.reduce` must
+// still recover an `i64` element type from the map-result binding so it
+// routes to `runtime_array_reduce_fn` instead of fataling at lowering.
+//
+// [1,2,3,4,5].map(x => x*x) = [1,4,9,16,25]; reduce(0, +) = 55.
+// (Before #1836 the inferred-let reduce no-op'd and the build fataled.)
+fn main() ![io] {
+    let numbers = [1, 2, 3, 4, 5];
+    let squares = numbers.map(fn (x) -> int { return x * x; });
+    let sum = squares.reduce(0, fn (acc, x) -> int { return acc + x; });
+    print(sum);
+}

--- a/compiler/tests/unit/lambda_param_inference_test.sfn
+++ b/compiler/tests/unit/lambda_param_inference_test.sfn
@@ -3,7 +3,12 @@
 // no-op-on-typed-lambda guarantee that keeps typed lambdas (the no-regression
 // surface) untouched.
 import { Expression } from "../../src/ast";
-import { backfill_lambda_from_fn_type, parse_fn_type_text } from "../../src/llvm/expression_lowering/native/lambda_param_inference";
+import {
+    backfill_lambda_from_fn_type,
+    build_binding_table,
+    lookup_binding_type,
+    parse_fn_type_text
+} from "../../src/llvm/expression_lowering/native/lambda_param_inference";
 import { parse_program } from "../../src/parser/mod";
 
 // The lambda bound by the first top-level `let f = <lambda>;`.
@@ -109,4 +114,25 @@ test "backfill: arity mismatch is a no-op" ![io] {
     let filled = backfill_lambda_from_fn_type(lam, "fn(int, int) -> int");
     let p0 = filled.parameters[0].type_annotation;
     assert p0 == null;
+}
+
+// -------------------------------------------------------------------
+// build_binding_table — inferred map/filter-result recovery (#1836).
+// An inferred `let sq = arr.map(...)` has no annotation and a `Call`
+// (not `Array`) initializer, so it must still enter the binding table as
+// `int[]` for a follow-on reduce/map/filter to backfill its untyped
+// callback params.
+// -------------------------------------------------------------------
+test "binding table: inferred map result binds int[] (#1836)" ![io] {
+    let source = "fn host() { let numbers = [1, 2, 3]; let squares = numbers.map(fn (x) -> int { return x * x; }); }";
+    let table = build_binding_table(parse_program(source));
+    assert lookup_binding_type(table, "numbers") == "int[]";
+    assert lookup_binding_type(table, "squares") == "int[]";
+}
+
+test "binding table: chained filter->map results bind int[] (#1836)" ![io] {
+    let source = "fn host() { let numbers = [1, 2, 3, 4]; let evens = numbers.filter(fn (x) -> bool { return x > 1; }); let doubled = evens.map(fn (x) -> int { return x * 2; }); }";
+    let table = build_binding_table(parse_program(source));
+    assert lookup_binding_type(table, "evens") == "int[]";
+    assert lookup_binding_type(table, "doubled") == "int[]";
 }

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -53,8 +53,7 @@ KNOWN_FAILING=(
     "examples/advanced/generic-structures.sfn"         # #766 generic-struct method monomorphization
     "examples/concurrency/producer-consumer.sfn"       # #1835 lowering fatal fixed; run still hangs on drain (#549 await follow-up)
     "examples/concurrency/dynamic-task-scheduling.sfn" # fn-typed channel element + await (#829)
-    "examples/functional/map-reduce.sfn"               # #1836 array-HOF map->reduce chain
-    "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map (#766)
+    "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map still gated (#766)
     "examples/functional/higher-order-functions.sfn"   # #1837 indirect call through fn-typed param
     "examples/advanced/unions.sfn"                      # #1838 @.runtime.field.name global
     "examples/algorithms/quicksort.sfn"                # #1839 double-array GEP i64/ptr


### PR DESCRIPTION
## Summary

- Array `.map`/`.filter`/`.reduce` routing was simple-identifier + i64-only. An inferred `let sq = arr.map(...)` bound the runtime-helper result as an opaque `i8*` with no source annotation, so a follow-on `sq.reduce(...)` **fataled at lowering** (`callee signature is not known`) or — with an untyped reducer closure — defaulted its params to `i8*` and **segfaulted**.
- Two complementary fixes for the shipped i64 element path:
  - **`instructions_let.sfn`** — when an un-annotated `let` initializer is a `<i64-array>.map(...)`/`.filter(...)`, derive an effective `int[]` annotation *before* the LLVM type is computed, so the result is a first-class array local (`{i64*,i64,i64}*`, the i8* result coerced on store) — identical to an explicit `let sq: int[] = ...`. Both the array-HOF routing (`core_call_resolution.sfn`) and the closure-param inference then recover the `i64` element type.
  - **`lambda_param_inference.sfn`** — enter an inferred map/filter-result `let` into the #1683 backfill binding table as `int[]`, so an untyped reducer/mapper callback (`fn(acc, x)`) backfills its params to `int` instead of `i8*`. The receiver is resolved against the partial table, so chained intermediate lets resolve left-to-right.

Closes #1836

## Acceptance Criteria

- [x] `functional/map-reduce.sfn` runs and prints `Sum of squares: 55`.
- [x] e2e test for a `.map(...).reduce(...)` chain over an `int[]` (`compiler/tests/e2e/array_map_reduce_chain_test.sfn`).
- [x] Self-hosts (`make compile`).

## Scope

- **In:** the inferred map-result chain over the shipped `i64` element path (the `map-reduce.sfn` failure).
- **Out (unchanged):** non-`i64` element types and nested `int[][]` stay gated on generics (#766). Range receivers (`(0..n).map(...)`) are *not* addressed here — `matrix-multiplication.sfn` (range + nested arrays) remains in the examples ratchet.
- **Known pre-existing limitation (documented, deferred to #766):** both fixes — like the existing routing in `core_call_resolution.sfn` — gate on the **receiver** element being `i64`, not the map's **result** element. So `numbers.map(fn(x) -> string {...})` would be annotated `int[]`, but that program is already miscompiled today by the i64-only routing, so no new hazard is introduced. Element-transforming maps are correctly out of scope.

## Map reconciliation

None — `## Files Affected` matched the tree. The fix also touches `compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn` (the #1683 untyped-closure backfill), reconciled as an in-`In:`-unit sibling of the array-HOF lowering (the second, segfault-causing gate the traced root cause missed).

## Verification

```bash
make compile        # self-hosts (pass)
make test           # full unit + integration + e2e suite: status=pass, 0 failed (capsules 38/38)

build/native/sailfin run examples/functional/map-reduce.sfn   # -> "Sum of squares: 55"
build/native/sailfin test compiler/tests/e2e/array_map_reduce_chain_test.sfn   # PASS (1/1)
build/native/sailfin test compiler/tests/unit/lambda_param_inference_test.sfn  # PASS (12/12)

# Regression spot-checks
#  filter->map->reduce chain over inferred lets, untyped closures -> 24
#  direct reduce on a literal int[], untyped closure            -> 15
#  matrix-multiplication.sfn still fatals (range receiver, #766) -> stays KNOWN_FAILING
```

## Files Changed

- `compiler/src/llvm/lowering/instructions_let.sfn` — effective `int[]` annotation for inferred map/filter results
- `compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn` — map/filter results enter the backfill binding table as `int[]`
- `compiler/tests/e2e/array_map_reduce_chain_test.sfn` + `compiler/tests/e2e/fixtures/array_map_reduce_chain/main.sfn` — new e2e chain test
- `compiler/tests/unit/lambda_param_inference_test.sfn` — unit coverage for the binding-table recovery
- `scripts/check-examples.sh` — remove `map-reduce.sfn` from `KNOWN_FAILING` (matrix-multiplication retained, still gated on #766)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEXAK33UVP22J5rUaFdptr)_