### PR TITLE
Fix higher-order-functions example to canonical fn(...) spelling

### DIFF
--- a/compiler/tests/e2e/fixtures/higher_order_named_fn/apply_named.sfn
+++ b/compiler/tests/e2e/fixtures/higher_order_named_fn/apply_named.sfn
@@ -1,0 +1,11 @@
+// #1837 — a user higher-order function whose parameter is declared
+// `fn(int) -> int`, invoked with a lambda that wraps a named function
+// call. Exercises indirect-call return-type resolution through a
+// function-typed parameter: `apply(5, fn(x) => double(x))` = 10.
+fn apply(value: int, transformer: fn (int) -> int) -> int {
+    return transformer(value);
+}
+
+fn double(x: int) -> int { return x * 2; }
+
+fn main() ![io] { print(apply(5, fn (x) => double(x))); }

--- a/compiler/tests/e2e/higher_order_named_fn_callback_test.sfn
+++ b/compiler/tests/e2e/higher_order_named_fn_callback_test.sfn
@@ -1,0 +1,45 @@
+// End-to-end: an indirect call through a `fn(int) -> int` parameter lowers
+// and returns the correct value (#1837). The callee is a plain parameter
+// identifier, not a method on a receiver, so its return type must come from
+// the parameter's declared function type. The canonical `fn(int) -> int`
+// spelling maps the parameter to the `{i8*, i8*}` closure pair and dispatches
+// through the closure seam; the non-canonical bare `(int) -> int` spelling
+// instead mapped it to an opaque `i8*` and silently produced the wrong result
+// (`Result: 0`), which is why the shipped example was rewritten to the
+// canonical spelling.
+//
+// Drives the compiler-under-test as a subprocess and asserts on captured
+// stdout — the canonical e2e pattern (`.claude/rules/no-bash-e2e.md`,
+// `untyped_lambda_callback_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, plus SAILFIN_TEST_SCRATCH
+// for per-invocation build-cache isolation under the parallel pool, #1333).
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _run(path: string) -> string ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    assert exit == 0;
+    return trim_right(out);
+}
+
+test "hof: fn(int)->int param invoked with a named-fn lambda returns 10" ![io] {
+    let out = _run("compiler/tests/e2e/fixtures/higher_order_named_fn/apply_named.sfn");
+    assert out == "10";
+}
+
+test "hof: shipped higher-order-functions example prints Result: 10" ![io] {
+    let out = _run("examples/functional/higher-order-functions.sfn");
+    assert out == "Result: 10";
+}

--- a/examples/functional/higher-order-functions.sfn
+++ b/examples/functional/higher-order-functions.sfn
@@ -1,14 +1,11 @@
 // examples/functional/higher-order-functions.sfn
-
-fn apply(value: int, transformer: (int) -> int) -> int {
+fn apply(value: int, transformer: fn (int) -> int) -> int {
     return transformer(value);
 }
 
-fn double(x: int) -> int {
-    return x * 2;
-}
+fn double(x: int) -> int { return x * 2; }
 
 fn main() ![io] {
-    let result = apply(5, double);
+    let result = apply(5, fn (x) => double(x));
     print("Result: {{result}}");
 }

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -54,7 +54,6 @@ KNOWN_FAILING=(
     "examples/concurrency/producer-consumer.sfn"       # #1835 lowering fatal fixed; run still hangs on drain (#549 await follow-up)
     "examples/concurrency/dynamic-task-scheduling.sfn" # fn-typed channel element + await (#829)
     "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map still gated (#766)
-    "examples/functional/higher-order-functions.sfn"   # #1837 indirect call through fn-typed param
     "examples/advanced/unions.sfn"                      # #1838 @.runtime.field.name global
     "examples/algorithms/quicksort.sfn"                # #1839 double-array GEP i64/ptr
 )


### PR DESCRIPTION
## Summary
- `examples/functional/higher-order-functions.sfn` used the non-canonical bare `(int) -> int` callback-parameter spelling and passed a bare named function `double`. Both failed: the bare named function is rejected by E0808 (named-function-as-value is SFEP-0030 item 1, **not yet shipped**), and the bare `(int) -> int` annotation maps to an opaque `i8*` instead of the `{i8*, i8*}` closure pair, so `apply`'s signature was wrong and the indirect call through the parameter silently produced `Result: 0` (surfacing as the `cannot resolve return type for call to \`transformer\`` lowering fatal).
- Rewrote the example to the canonical, documented spelling (spec §5, SFEP-0030): `transformer: fn(int) -> int` invoked with the lambda short form `apply(5, fn(x) => double(x))`. This dispatches through the already-shipped closure seam (`core_call_emission.sfn`) and prints `Result: 10`.
- Added an e2e regression test + fixture covering a user-defined HOF with a `fn(int) -> int` parameter invoked by a lambda that wraps a named-function call, plus a guard that the shipped example prints `Result: 10`.

**Decision (per the issue's "decide E0808 vs lambda" clause):** the canonical `fn(...) -> R` spelling with a lambda callback is the supported form. Bare named-function-as-value (`apply(5, double)`) stays E0808 pending SFEP-0030 item 1. No compiler-source change was needed — the closure-through-`fn(...)`-param path (SFEP-0030 item 2) already works end-to-end.

Closes #1837

## Acceptance Criteria
- [x] `functional/higher-order-functions.sfn` runs and prints `Result: 10`.
- [x] e2e test: user-defined HOF taking a `fn(int) -> int` parameter and invoking it.
- [x] Self-hosts (`make compile`).

## Map reconciliation
The issue's advisory `## Files Affected` listed `core_call_resolution.sfn`, `typecheck*.sfn`, and `compiler/tests/e2e/`. Reconciled to the semantic Goal ("calling a value of function type held in a parameter must lower"): the canonical `fn(...)` path already lowers correctly, so no compiler-source edit was required — the deliverable is the example correction (to the shipped spelling) + the e2e regression coverage the map anticipated. No new acceptance criterion or public surface introduced.

## Verification
```bash
$ build/native/sailfin run examples/functional/higher-order-functions.sfn
Result: 10

$ build/native/sailfin test compiler/tests/e2e/higher_order_named_fn_callback_test.sfn
  PASS  (all 2 tests passed)

$ build/native/sailfin fmt --check <touched .sfn files>   # clean
$ make compile                                            # status: pass
```

## Files Changed
- `examples/functional/higher-order-functions.sfn` — canonical `fn(int) -> int` param + lambda callback.
- `compiler/tests/e2e/higher_order_named_fn_callback_test.sfn` — new e2e regression test.
- `compiler/tests/e2e/fixtures/higher_order_named_fn/apply_named.sfn` — fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZyeASvVkVdXnR4RFm71M1)_