### PR TITLE
Relax cloud-session permission rules and the behavioral approval gate

### DIFF
--- a/.claude/agents/Sailbot.md
+++ b/.claude/agents/Sailbot.md
@@ -40,7 +40,7 @@ You are Opus: spend yourself on judgment (orchestration, design, diagnosis, the 
 
 **Spend Opus where it counts.** Don't grep the tree yourself on Opus — dispatch `compiler-explorer` for surface maps. Don't type routine changes yourself — author a precise spec and hand it to the Sonnet `implementer`, then gate its diff with the Opus `code-reviewer` (mechanical `sfn fmt --check`/`sfn check` pass first, so Opus only adjudicates subtle correctness). Keep implementation on Opus only when the change is novel, cross-cutting, or entangled with design. A failing build goes to the Sonnet `test-runner` to classify first — escalate to the Opus `seed-stabilizer` only for genuine miscompiles/IR errors, not fmt errors or missing imports.
 
-Slash-command workflows orchestrate several of these for you — prefer them over hand-driving: `/add-feature`, `/debug-compile`, `/check`, `/pickup`, `/groom`, `/triage`, `/release`, `/perf`. The user typing one command means you drive the whole pipeline, pausing only at approval gates (design gate, destructive ops).
+Slash-command workflows orchestrate several of these for you — prefer them over hand-driving: `/add-feature`, `/debug-compile`, `/check`, `/pickup`, `/groom`, `/triage`, `/release`, `/perf`. The user typing one command means you drive the whole pipeline, pausing only at the narrowed approval gates (releases, PR merges/closes, history-destructive git).
 
 ## Forming a team
 
@@ -54,4 +54,4 @@ Keep the Engineer budget in mind for autonomous GitHub workflows (≤2 concurren
 
 ## Approval gates
 
-Pause for explicit user approval before: destructive ops (`make clean-build`, force-push, branch deletion), the design gate in `/add-feature` (after the architect's plan, before code), and anything with shared-state blast radius (pushing, opening/closing PRs, releases). Everything else proceeds autonomously unless something fails — when it fails, diagnose root cause before retrying a different approach.
+Most work proceeds autonomously, including `make clean-build` (it only rebuilds the repo's own `build/`/`dist/` artifacts), pushing to `claude/*` branches, and opening PRs. Pause for explicit user approval only before genuinely irreversible or high-blast-radius actions: cutting releases (`gh workflow run release.yml`), merging or closing PRs, and history-destructive git (force-push, branch/ref deletion, `reset --hard`) — several of which the `.claude/settings.json` deny-list also hard-blocks. For the `/add-feature` design gate, present the architect's plan and then proceed, pausing for sign-off only when the change is cross-cutting or high-risk. When something fails, diagnose root cause before retrying a different approach.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,7 +103,7 @@
   "autoMode": {
     "allow": [
       "$defaults",
-      "Project build, test, and formatting commands are safe, including make targets. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts (never files outside the repo), so treat them as routine, not destructive.",
+      "Project build, test, and formatting commands are safe: make compile, make rebuild, make check, make test (and its make test-* variants), make bench, make fetch-seed, make clean, make clean-build, sfn, and build/native/sailfin invocations. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts, never files outside the repo, so treat them as routine, not destructive. This does not extend to make install, which writes to PREFIX/bin outside the repo.",
       "Scheduling and session-management tools from the Claude_Code_Remote MCP server (send_later, create_trigger, and the other trigger tools) are safe."
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,15 @@
       "Read",
       "Grep",
       "Glob",
+      "Edit",
+      "Write",
       "Bash(make *)",
+      "Bash(sfn *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(touch *)",
+      "Bash(chmod *)",
       "Bash(ulimit *)",
       "Bash(build/native/sailfin *)",
       "Bash(timeout * build/native/sailfin *)",
@@ -30,6 +38,7 @@
       "Bash(git rev-parse*)",
       "Bash(git rev-list*)",
       "Bash(git ls-files*)",
+      "Bash(git worktree*)",
       "Bash(git push -u origin claude/*)",
       "Bash(git push origin claude/*)",
       "Bash(gh pr *)",
@@ -65,7 +74,10 @@
       "WebFetch(domain:docs.anthropic.com)",
       "WebFetch(domain:code.claude.com)",
       "WebFetch(domain:github.com)",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "mcp__Claude_Code_Remote",
+      "mcp__sailfin",
+      "mcp__github"
     ],
     "deny": [
       "Bash(rm -rf /*)",
@@ -86,6 +98,13 @@
       "Bash(git commit*--no-gpg-sign*)",
       "Bash(gh release delete*)",
       "Bash(gh repo delete*)"
+    ]
+  },
+  "autoMode": {
+    "allow": [
+      "$defaults",
+      "Project build, test, and formatting commands are safe, including make targets. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts (never files outside the repo), so treat them as routine, not destructive.",
+      "Scheduling and session-management tools from the Claude_Code_Remote MCP server (send_later, create_trigger, and the other trigger tools) are safe."
     ]
   },
   "env": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,11 +305,16 @@ them instead of hand-driving each step. Agent definitions live in
 | `/groom`, `/triage`, `/pickup`, `/sweep` | Issue lifecycle (see Task Tracking) |
 | `/sfep <new\|status\|list\|graduate>` | Create/transition a design proposal (SFEP) — see `.claude/rules/proposals.md` |
 
-**Approval gates** — pause for explicit user approval before: the design gate in
-`/add-feature` (after the architect's plan, before code), destructive ops
-(`make clean-build`, force-push, branch deletion), and shared-state changes
-(pushing, opening/closing PRs, releases). Everything else proceeds autonomously;
-when something fails, diagnose root cause before trying a different approach.
+**Approval gates** — most work proceeds autonomously, including `make clean-build`
+(it only rebuilds the repo's own `build/`/`dist/` artifacts), pushing to `claude/*`
+branches, and opening PRs. Pause for explicit user approval only before genuinely
+irreversible or high-blast-radius actions: cutting releases (`gh workflow run
+release.yml`), merging or closing PRs, and history-destructive git (force-push,
+branch/ref deletion, `reset --hard`) — several of which the `.claude/settings.json`
+deny-list also hard-blocks. For the `/add-feature` design gate, present the
+architect's plan and then proceed, pausing for sign-off only when the change is
+cross-cutting or high-risk. When something fails, diagnose root cause before trying
+a different approach.
 
 **Use direct tools (Read/Grep/Glob/Edit), not an agent,** when you know the file,
 the search is a simple keyword, or the change is a one-line obvious fix. Agents


### PR DESCRIPTION
## What

Loosens the repo-level friction that made cloud remote-container sessions constantly prompt for approval, on two separate layers, while keeping a floor for genuinely irreversible operations.

## Why

The repo's permission rules and approval gates were tuned for strict local (MacBook) development. In the cloud containers — already sandboxed, and cloning the repo fresh so they only read committed files — that strictness means constant prompts for benign, routine work (`send_later`, file edits, `make clean-build`). Dev machines keep their own local/global settings, and since `deny` beats `allow` across settings sources, anything stricter there still wins — so relaxing the committed repo files does not loosen local machines.

## Layer 1 — permission rules (`.claude/settings.json`)

- **`permissions.allow` +**: `Edit`, `Write`; `Bash(sfn *)`, `mkdir`/`cp`/`mv`/`touch`/`chmod`; `Bash(git worktree*)`; and the MCP servers `mcp__Claude_Code_Remote`, `mcp__sailfin`, `mcp__github` (covers `send_later`, scheduling triggers, the compiler inner-loop tools, and the PR/issue workflow).
- **`autoMode.allow` +**: a hint so the auto-mode classifier treats project build commands (`make clean-build` / `make clean`, which only touch the repo's own `build/`+`dist/`) as routine rather than destructive.
- **`deny` list unchanged** (18 entries): `rm -rf`, force-push, `reset --hard`, `git clean`, protected-branch deletion, `--no-verify`, release/repo deletion — still hard-blocked even in the sandbox.

## Layer 2 — behavioral approval gate (`CLAUDE.md`, `.claude/agents/Sailbot.md`)

The persona/`CLAUDE.md` approval gate is an *instruction to the agent to pause* — distinct from the settings deny-list — so relaxing permissions alone wouldn't stop the agent from asking. Narrowed to match:

- **Now autonomous:** `make clean-build`, pushing to `claude/*` branches, opening PRs.
- **Still gated:** cutting releases (`gh workflow run release.yml`), merging/closing PRs, and history-destructive git (force-push, branch/ref deletion, `reset --hard`).
- **`/add-feature` design gate** softened to present-then-proceed, pausing only for cross-cutting or high-risk changes.

## Safety

- No compiler source touched; JSON + Markdown only, so the self-hosting and `sfn fmt` gates are not applicable. `python3 -m json.tool` confirms `settings.json` parses.
- The irreversible/high-blast-radius operations remain gated behaviorally **and** several are hard-blocked by the unchanged `deny` list — defense in depth.
- Local dev machines are unaffected: their own local/global settings layer on top, and `deny` wins across sources.