### PR TITLE
fix(lowering): emit field-name global for bare expression statements

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -352,6 +352,14 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
     let consumption = ownership_analysis.consumption;
 
     let _lowered = lower_expression(expression, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
+    // Issue #1838: propagate the expression's string constants (e.g. the
+    // `@.runtime.field.*` field-name globals a dynamic member access emits
+    // for an interpolated `{{admin.name}}`). A bare call statement like
+    // `print("{{admin.name}}")` references the getelementptr into the
+    // global but, without this, the constant was dropped — the assignment
+    // and return paths already capture it (see the simple-assignment branch
+    // and `lower_return_instruction`).
+    string_constants = _lowered.string_constants;
     // Issue #631: a bare expression statement (e.g. a void-returning call
     // like `spawn(...)`) can surface a `[fatal]` lowering diagnostic when
     // the callee's return type cannot be resolved. Collect those into the

--- a/compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn
+++ b/compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn
@@ -34,7 +34,7 @@ interface User {
 
 type AdminUser = Admin & User;
 
-fn printValue(value: StringValue | IntValue) ![io] {
+fn print_value(value: StringValue | IntValue) ![io] {
     match value {
         StringValue { value } => print("string:{{value}}"),
         IntValue { value } => print("number:{{value}}")
@@ -42,8 +42,8 @@ fn printValue(value: StringValue | IntValue) ![io] {
 }
 
 fn main() ![io] {
-    printValue(StringValue { value: "Sailfin" });
-    printValue(IntValue { value: 42 });
+    print_value(StringValue { value: "Sailfin" });
+    print_value(IntValue { value: 42 });
     let admin: AdminUser = {
         name: "Alice",
         isAdmin: true

--- a/compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn
+++ b/compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn
@@ -1,0 +1,52 @@
+// Fixture for compiler/tests/e2e/union_named_variant_match_test.sfn (#1838).
+//
+// Faithful reduction of examples/advanced/unions.sfn. Two constructs:
+//
+//   1. Tagged-union (`A | B`) matching over named struct variants — the
+//      criterion-2 surface. Each arm prints its interpolated field.
+//   2. A bare `print("...{{admin.name}}...")` whose dynamic member access
+//      emits an `@.runtime.field.name` string global. This is the #1838
+//      regression: the bare expression-statement lowering path dropped
+//      the member access's `string_constants`, so the global was
+//      referenced by a `getelementptr` but never defined and LLVM
+//      rejected the module with `use of undefined value
+//      '@.runtime.field.name'`. Building this fixture at all is the guard.
+//
+// NOTE: `admin.name` reads back empty (`admin:`) because a bare struct
+// literal resolved via a type annotation (`let x: T = { ... }`) is a
+// separate, broader lowering bug (#1855) — the union field-name global
+// emission this fixture pins is orthogonal to it.
+struct StringValue {
+    value: string;
+}
+
+struct IntValue {
+    value: int;
+}
+
+interface Admin {
+    isAdmin: boolean;
+}
+
+interface User {
+    name: string;
+}
+
+type AdminUser = Admin & User;
+
+fn printValue(value: StringValue | IntValue) ![io] {
+    match value {
+        StringValue { value } => print("string:{{value}}"),
+        IntValue { value } => print("number:{{value}}")
+    }
+}
+
+fn main() ![io] {
+    printValue(StringValue { value: "Sailfin" });
+    printValue(IntValue { value: 42 });
+    let admin: AdminUser = {
+        name: "Alice",
+        isAdmin: true
+    };
+    print("admin:{{admin.name}}");
+}

--- a/compiler/tests/e2e/union_named_variant_match_test.sfn
+++ b/compiler/tests/e2e/union_named_variant_match_test.sfn
@@ -1,0 +1,86 @@
+// End-to-end regression for tagged-union matching over named struct
+// variants (#1838).
+//
+// Root cause guarded here: the bare expression-statement lowering path
+// (`lower_expression_statement` in
+// `compiler/src/llvm/expression_lowering/native/statement.sfn`) dropped
+// the `string_constants` produced by a dynamic member access, so the
+// `@.runtime.field.*` field-name globals a `match`/interpolation emits
+// were referenced by a `getelementptr` but never defined. LLVM rejected
+// the module with `use of undefined value '@.runtime.field.name'`.
+//
+// `sfn check` cannot catch this — it models no codegen or link, so the
+// undefined-global surfaces only when the IR is verified/linked. This
+// test therefore BUILDS the fixture to a binary and runs it: pre-fix the
+// build fails outright (the undefined global), so a clean exit-0 build
+// AND run is itself the guard, on top of asserting the union arms fire.
+//
+// Build-and-run isolation follows the sibling `sailfin_main_entry_test`
+// pattern: the fixture is written into a fresh `with_tmp_dir` and the
+// nested `sfn build` inherits the parent environment (PATH for
+// clang/linker, SAILFIN_TEST_SCRATCH for per-invocation build-cache
+// isolation under the parallel pool). See `.claude/rules/no-bash-e2e.md`.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _fixture_src() -> string ![io] {
+    return fs.readFile("compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn");
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-union-match-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// Build the fixture in a temp dir and run it. Stashes the run's captured
+// stdout to `out_marker` and returns the run's exit code, or `-100` if
+// the build itself failed (the undefined-global regression is a build
+// failure, so `-100` is the pre-fix signal this test pins).
+fn _build_and_run(out_marker: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, _fixture_src());
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], []);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+test "union-match: named-struct tagged union builds with valid IR and selects the right arm" ![io] {
+    let marker = _marker("arms");
+    let exit = _build_and_run(marker);
+    // `-100` == build failure (the undefined `@.runtime.field.name`
+    // global regression). A clean build+run exits 0.
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // The StringValue arm and the IntValue arm each fired, selected by
+    // the union tag, printing their interpolated destructured field.
+    assert find(out, "string:Sailfin", 0) >= 0;
+    assert find(out, "number:42", 0) >= 0;
+    // The bare `print("admin:{{admin.name}}")` statement is what emits
+    // the `@.runtime.field.name` global; its `admin:` prefix printing
+    // confirms the statement lowered to valid, runnable IR. The field
+    // value itself is empty here (a separate bare-struct-literal bug,
+    // #1855), so only the prefix is asserted.
+    assert find(out, "admin:", 0) >= 0;
+}

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -54,7 +54,6 @@ KNOWN_FAILING=(
     "examples/concurrency/producer-consumer.sfn"       # #1835 lowering fatal fixed; run still hangs on drain (#549 await follow-up)
     "examples/concurrency/dynamic-task-scheduling.sfn" # fn-typed channel element + await (#829)
     "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map still gated (#766)
-    "examples/advanced/unions.sfn"                      # #1838 @.runtime.field.name global
     "examples/algorithms/quicksort.sfn"                # #1839 double-array GEP i64/ptr
 )
 


### PR DESCRIPTION
## Summary

- `lower_expression_statement`'s bare (non-assignment) expression-statement path dropped the `string_constants` produced while lowering its expression. A dynamic member access inside a bare `print("...{{obj.field}}...")` emits a `getelementptr` into an `@.runtime.field.<field>` string global but never defined it, so LLVM rejected the module with `use of undefined value '@.runtime.field.name'`.
- Fix: capture `_lowered.string_constants` on that path (one line), mirroring the simple-assignment path and `lower_return_instruction`. `merge_string_constants` dedups by name, so no duplicate-global risk.
- Adds an e2e **build-and-run** regression (`sfn check` can't catch this — it models no codegen/link) over a named-struct tagged-union match plus the field-global-emitting statement.

Closes #1838

## Acceptance Criteria

- [x] `advanced/unions.sfn` runs and prints `It's a string: Sailfin` / `It's a number: 42`. Third line prints `Admin: ` (empty) — the `admin.name` field value is a **separate, broader lowering bug** (bare struct literal via type annotation → `zeroinitializer`), split out as **#1855**. The union field-name global emission this issue targets is fixed.
- [x] e2e test: match over a named-struct tagged union (`compiler/tests/e2e/union_named_variant_match_test.sfn`).
- [x] Self-hosts (`make compile`).

## Map reconciliation

Advisory map pointed at `compiler/src/llvm/lowering/*` (union tag / field-name global emission). Reconciled to the actual root cause in the same `In:` unit (dynamic member access → field-name global): the drop was in `compiler/src/llvm/expression_lowering/native/statement.sfn` (bare expression-statement path), not the union-tag lowering itself — the union match with destructured bindings emits no field globals; the undefined global came from a bare `print("{{admin.name}}")`.

## Verification

```bash
# before: link failed — use of undefined value '@.runtime.field.name'
# after:
timeout 25 build/native/sailfin run examples/advanced/unions.sfn
#   It's a string: Sailfin
#   It's a number: 42
#   Admin:            <- empty, blocked by #1855

make compile                                                    # PASS (self-hosts)
build/native/sailfin test compiler/tests/e2e/union_named_variant_match_test.sfn   # PASS
make test                                                       # running — will confirm green
```

Opus `code-reviewer` gate: **Approve** — no correctness / self-host / effect concerns; the `=` (not merge) is correct because nothing else writes `string_constants` on this path, and `merge_string_constants` dedups downstream.

## Files Changed

- `compiler/src/llvm/expression_lowering/native/statement.sfn` — propagate `_lowered.string_constants` on the bare expression-statement path
- `compiler/tests/e2e/union_named_variant_match_test.sfn` — new e2e build-and-run regression
- `compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn` — fixture

## Notes

Fixing this revealed the separate `admin.name` empty-field bug; rather than bundle two unrelated fixes into one PR, it's filed as #1855 (bare struct literal via type annotation lowers to `zeroinitializer`). The fixture asserts only the `admin:` prefix pending that fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_013Eh4Emam5EKNEWU5Vqu63a)_