### PR TITLE
refactor(cli): remove sailfin_cli_main_legacy; v2 is the sole dispatch (SFEP-0027 Phase C)

### DIFF
--- a/compiler/src/cli/commands/run.sfn
+++ b/compiler/src/cli/commands/run.sfn
@@ -18,8 +18,9 @@
 // `compiler/tests/e2e/runtime_implicit_capsule_link_test.sfn`).
 //
 // Bare-file dispatch (`sfn foo.sfn`) re-invokes `["run", foo.sfn]` from
-// `sailfin_cli_main_legacy`, which routes back through `sailfin_cli_main_v2`
-// to this command — so the bare-file path shares this exact body.
+// `sailfin_cli_main_v2`'s fallthrough (SFEP-0027 Phase C, #1797), which
+// routes back through `sailfin_cli_main_v2` to this command — so the
+// bare-file path shares this exact body.
 //
 // The `runtime_root` empty→"runtime" bundle fallback is reproduced from the
 // legacy caller (it is a filesystem probe, not argv parsing, so

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -3,16 +3,16 @@
 // Compiler CLI skeleton — `sailfin_cli_main_v2` (CLI modularization
 // epic #351, Issue 2.3 — proposal §5 Phase 2, §7 Issue 2.3, Risk R2).
 //
-// v2 builds a root `Command` via `sfn/cli`, registers ONLY the
-// `version` subcommand (from `commands/version.sfn`), and parses with
-// `sfn/cli`'s pure, non-exiting `parse()`. It dispatches `version` /
-// `--version` / `-V` to `version.run` — which prints the version and
-// returns a canonical `EXIT_*` code — and falls through to the verbatim
-// legacy dispatch (`sailfin_cli_main_legacy`) for every other
-// subcommand. As of Issue 2.4 the root is composed from
-// `version.command_def()` and the handler is `version.run`, establishing
-// the per-subcommand `command_def()` + `run()` pattern that all of
-// Phase 3 follows.
+// v2 builds a root `Command` via `sfn/cli` from every subcommand's
+// `command_def()`, parses with `sfn/cli`'s pure, non-exiting `parse()`,
+// and dispatches each command to its `run` — the per-subcommand
+// `command_def()` + `run()` pattern `version.sfn` established. As of
+// SFEP-0027 Phase C (#1797) `sailfin_cli_main_v2` is the *sole* command
+// dispatch: the four residual behaviors the former
+// `sailfin_cli_main_legacy` shim owned — root `-h`/`--help`, the
+// internal `selfhost` validator, bare-`.sfn`-file dispatch, and the
+// unknown-command fallback — are handled inline at the fallthrough
+// below, so no path routes through a legacy dispatcher.
 //
 // Risk R2 (proposal §8): `sfn/cli`'s `run()` calls `process.exit()` on
 // --help/--version/parse errors, which would terminate the process out
@@ -36,7 +36,10 @@ import {
     with_subcommand
 } from "sfn/cli";
 
-import { sailfin_cli_main_legacy } from "../cli_main";
+import { _ends_with } from "../build/paths";
+import { _runtime_bundle_exists } from "../build/runtime_objs";
+import { _usage, sailfin_cli_main_with_paths } from "../cli_main";
+import { handle_selfhost_command } from "../cli_selfhost";
 import { ice_set_binary_dir } from "../ice";
 import { number_to_string } from "../num_format";
 import { command_def as add_command_def, run as add_run } from "./commands/add";
@@ -56,14 +59,12 @@ import { command_def as test_command_def, run as test_run } from "./commands/tes
 import { command_def as version_command_def, run as version_run } from "./commands/version";
 import { CliContext, driver_prefix_length, parse_driver_prefix } from "./context";
 
-// Cold-path `SAILFIN_TRACE_ARGV` trace, byte-identical to the block at
-// the top of `sailfin_cli_main_legacy`. v2 owns the `version` paths now,
-// so it must reproduce this trace for the argv it acts on — otherwise
-// `version` / `--version` / `-V` (which never reach legacy) would emit no
-// argv trace under the toggle, regressing
-// `test_compiler_debug_toggle_env_vars.sh`. Fall-through commands trace
-// in legacy as before (no duplication: this only fires on the paths v2
-// handles itself).
+// Cold-path `SAILFIN_TRACE_ARGV` trace. v2 is the sole dispatch, so it
+// reproduces this trace for the argv each path acts on — every matched
+// subcommand block and the fallthrough call it under `ctx.trace_argv`,
+// so `version` / `--version` / `-V` and the help/selfhost/bare-file/
+// unknown paths all emit the argv trace under the toggle (pinned by
+// `compiler/tests/e2e/compiler_debug_toggle_env_vars_test.sfn`).
 fn _v2_trace_argv(argv: string[]) ![io] {
     print.err("cli: argv.len=" + number_to_string(argv.length));
     let mut trace_index: int = 0;
@@ -403,9 +404,58 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         return 2;
     }
 
-    // Every other subcommand (and help, parse errors, the bare
-    // invocation) falls through to the verbatim legacy dispatch, which
-    // re-parses the driver prefix off the original argv itself — so the
-    // full, unsliced `argv` is forwarded unchanged.
-    return sailfin_cli_main_legacy(argv);
+    // Fallthrough — every path the registered subcommands above did not
+    // claim. SFEP-0027 Phase C (#1797) folded the former
+    // `sailfin_cli_main_legacy` shim in here so v2 is the sole dispatch;
+    // `ctx` / `args` are the driver prefix and user args already parsed
+    // at the top, so no argv re-parse is needed. The four residual
+    // behaviors, in the legacy order: empty-args usage, root help,
+    // `selfhost`, bare-file dispatch, unknown-command.
+    if ctx.trace_argv { _v2_trace_argv(argv); }
+
+    // Bare invocation (no user args after the driver prefix, or empty
+    // argv): print usage, exit 2 — matching the legacy `args.length == 0`
+    // guard.
+    if args.length == 0 {
+        print(_usage());
+        return 2;
+    }
+
+    let cmd: string = args[0];
+
+    // Root `-h` / `--help` (no subcommand): print usage, exit 0.
+    let mut is_help: boolean = false;
+    if strings_equal(cmd, "-h") { is_help = true; }
+    if strings_equal(cmd, "--help") { is_help = true; }
+    if is_help {
+        print(_usage());
+        return 0;
+    }
+
+    // `selfhost` — internal self-host fixed-point validator (#1502).
+    // Intentionally absent from `_usage()`: driven by `make check` / CI,
+    // not end users.
+    if strings_equal(cmd, "selfhost") {
+        return handle_selfhost_command(args, ctx.binary_dir);
+    }
+
+    // Bare-file dispatch: `sfn <file.sfn>` (a single `.sfn` positional,
+    // no subcommand) compiles and runs the file, matching the
+    // `python script.py` / `node script.js` convention. Re-enters as
+    // `["run", <file>]` through `sailfin_cli_main_with_paths` → this
+    // dispatch, so `cli/commands/run.sfn` owns the build-then-exec body.
+    // The empty `runtime_root` → "runtime" bundle fallback is a
+    // filesystem probe (not argv parsing), reproduced from the legacy
+    // caller.
+    if args.length == 1 && _ends_with(cmd, ".sfn") {
+        let mut runtime_root: string = ctx.runtime_root;
+        if runtime_root.length == 0 {
+            if _runtime_bundle_exists("runtime") { runtime_root = "runtime"; }
+        }
+        return sailfin_cli_main_with_paths(["run", cmd], runtime_root, ctx.binary_dir);
+    }
+
+    print("unknown command: " + cmd);
+    print(_usage());
+    return 2;
 }

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -3,92 +3,7 @@
 // Sailfin-native CLI entrypoint invoked by the native C shim.
 import { bold } from "sfn/cli";
 
-import { LlvmTextBackend } from "./backend";
-import {
-    _CapsuleBuildSpec,
-    _emit_build_report,
-    _emit_capsule_artifact_sidecar,
-    _print_cache_summary,
-    _resolve_capsule_build_spec,
-    _resolve_sailfin_cache_dir_for_work
-} from "./build/cache";
-import { _do_determinism_check } from "./build/determinism";
-import { _atomic_rename_into_place, _mktemp_sibling_cmd } from "./build/fs";
-import { LinkResult, _clang_link_multi } from "./build/link";
-import {
-    _dirname,
-    _ends_with,
-    _ensure_dir,
-    _path_basename,
-    _path_join
-} from "./build/paths";
-import { _runtime_bundle_exists } from "./build/runtime_objs";
-import {
-    BuildCacheConfig,
-    CacheKey,
-    CacheStats,
-    cache_compiler_identity,
-    cache_copy_artifact_to,
-    cache_lookup_artifact,
-    cache_root,
-    cache_stats_is_empty,
-    cache_store_artifact,
-    merge_cache_stats,
-    resolve_build_cache_config,
-    runtime_object_cache_key,
-    runtime_object_cache_key_with_identity,
-    runtime_object_entry_key_from_str
-} from "./build_cache";
-import { _env_flag, _legacy_flag_file } from "./build_flags";
-import {
-    BuildReport,
-    DeterminismDiff,
-    build_report_to_json,
-    empty_build_report,
-    empty_determinism_snapshot
-} from "./build_report";
-import { emit_compiler_build_stamp_if_applicable } from "./build_stamp";
-import {
-    CapsuleArtifactManifest,
-    CapsuleArtifactModule,
-    ScopeName,
-    capsule_artifact_bin_path,
-    capsule_artifact_dir,
-    capsule_artifact_manifest_path,
-    capsule_artifact_manifest_to_json,
-    capsule_artifact_obj_path,
-    capsule_default_bin_name,
-    empty_capsule_artifact_manifest,
-    is_safe_scope_name,
-    make_capsule_artifact_module,
-    parse_scope_name
-} from "./capsule_artifact";
-import {
-    ModuleCacheEvent,
-    ProjectCapsuleResult,
-    ResolverConsumer,
-    empty_resolver_consumer,
-    prepare_project_capsules
-} from "./capsule_resolver";
-import { CliContext, driver_prefix_length, parse_driver_prefix } from "./cli/context";
 import { sailfin_cli_main_v2 } from "./cli/main";
-import { handle_selfhost_command } from "./cli_selfhost";
-import { resolve_import_module_slug_for_module } from "./llvm/imports";
-import {
-    compile_to_llvm_file_with_module,
-    compile_to_llvm_with_module,
-    module_name_from_path,
-    number_to_string
-} from "./main";
-import { parse_native_imports_for_import } from "./native_ir_api";
-import { runtime_capsule_from_root } from "./runtime_capsule_resolver";
-import {
-    toml_get_build_kind,
-    toml_get_entry,
-    toml_get_name,
-    toml_get_version
-} from "./toml_parser";
-import { resolve_compiler_version } from "./version";
 
 // M5.5 (#473) entry-point dependencies. `fn main` below resolves the
 // running binary's path and the runtime bundle root directly via the
@@ -193,158 +108,14 @@ fn _usage() -> string {
     return out;
 }
 
-// Strip the last `.<ext>` from a path's basename. `"foo.c"` →
-// `"foo"`; `"foo.tar.gz"` → `"foo.tar"` (last extension only).
-// Returns the input unchanged when there's no `.`.
-fn _path_strip_ext(name: string) -> string {
-    let mut last_dot: int = -1;
-    let mut i: int = 0;
-    loop {
-        if i >= name.length { break; }
-        if name[i] == "." { last_dot = i; }
-        i += 1;
-    }
-    if last_dot < 0 { return name; }
-    return substring(name, 0, last_dot);
-}
-
-// Historical C ABI boundary — the now-retired C driver called
-// `sailfin_cli_main__cli_main` with an `int64_t` return type.
-// After M5.5 (#473) the only callers are `sailfin_cli_main_v2`
-// (the `sfn/cli`-based dispatcher in `cli/main.sfn`, which falls
-// through here for every subcommand it does not own) and, transitively,
-// `sailfin_cli_main_with_paths` (driven from `fn main`). The `int`
-// return type keeps the ABI shape stable in case any embedder still
-// binds the symbol externally.
-//
-// CLI modularization epic #351, Issue 2.3: renamed from
-// `sailfin_cli_main` to `sailfin_cli_main_legacy` and kept verbatim;
-// v2 (`cli/main.sfn`) is the new front door and delegates here.
-fn sailfin_cli_main_legacy(argv: string[]) -> int ![io, clock] {
-    // Issue 2.2 (#1160): the driver-injected `--runtime-root` /
-    // `--binary-dir` prefix is parsed by `cli/context.sfn` into a
-    // CliContext; this body only consumes the result.
-    let ctx: CliContext = parse_driver_prefix(argv);
-    let trace_argv = ctx.trace_argv;
-    if trace_argv {
-        print.err("cli: argv.len=" + number_to_string(argv.length));
-        let mut trace_index: int = 0;
-        loop {
-            if trace_index >= argv.length { break; }
-            print.err("cli: argv[" + number_to_string(trace_index) + "]=" + argv[trace_index]);
-            trace_index += 1;
-        }
-    }
-    if argv.length == 0 {
-        print(_usage());
-        return 2;
-    }
-
-    let mut runtime_root: string = ctx.runtime_root;
-    let binary_dir: string = ctx.binary_dir;
-    let start_index: int = driver_prefix_length(argv);
-    if trace_argv {
-        print.err("cli: runtime_root=" + runtime_root);
-        print.err("cli: binary_dir=" + binary_dir);
-        print.err("cli: start_index=" + number_to_string(start_index));
-    }
-    if runtime_root.length == 0 {
-        if _runtime_bundle_exists("runtime") { runtime_root = "runtime"; }
-    }
-
-    let mut args: string[] = [];
-    let mut arg_index: int = start_index;
-    loop {
-        if arg_index >= argv.length { break; }
-        args.push(argv[arg_index]);
-        arg_index += 1;
-    }
-    if args.length == 0 {
-        print(_usage());
-        return 2;
-    }
-    if trace_argv {
-        print.err("cli: args.len=" + number_to_string(args.length));
-        let mut arg_index_trace: int = 0;
-        loop {
-            if arg_index_trace >= args.length { break; }
-            print.err("cli: args[" + number_to_string(arg_index_trace) + "]="
-                + args[arg_index_trace]);
-            arg_index_trace += 1;
-        }
-    }
-
-    // Pre-compute command checks to avoid patterns the compiler drops
-    // (&&-chained .length checks with function calls get dropped from IR)
-    // `emit` / `--emit` migrated to `sfn/cli` (epic #1671, Phase B) — handled
-    // by `sailfin_cli_main_v2` before reaching this legacy dispatch.
-    let cmd = args[0];
-    let mut _let10: boolean = false;
-    if strings_equal(cmd, "-h") { _let10 = true; }
-    if strings_equal(cmd, "--help") { _let10 = true; }
-    let is_help = _let10;
-    // #1502: internal self-host validator. Intentionally absent from
-    // `_usage()` — driven by `make check` / CI, not end users.
-    let is_selfhost = strings_equal(cmd, "selfhost");
-
-    // `sfn run` migrated to `sfn/cli` (epic #1671, Phase B) — handled by
-    // `sailfin_cli_main_v2` before reaching this legacy dispatch. Bare-file
-    // dispatch (`sfn foo.sfn`) re-enters as `["run", foo.sfn]` and routes
-    // through v2 to `cli/commands/run.sfn`.
-    // `sfn test` migrated to `sfn/cli` (epic #351, Issue 3.8) — handled
-    // by `sailfin_cli_main_v2` before reaching this legacy dispatch.
-    if is_help {
-        print(_usage());
-        return 0;
-    }
-
-    // ---- Package management commands ----
-    // `sfn init` migrated to `sfn/cli` (epic #351, Issue 3.1) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn publish` migrated to `sfn/cli` (epic #351, Issue 3.9) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn package` migrated to `sfn/cli` (epic #1671, Phase B) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn lock` migrated to `sfn/cli` (epic #1671, Phase B) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn login` migrated to `sfn/cli` (epic #351, Issue 3.2) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn config` migrated to `sfn/cli` (epic #1671, Phase B) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn fmt` migrated to `sfn/cli` (epic #351, Issue 3.4) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // `sfn check` migrated to `sfn/cli` (epic #1671, Phase B) — handled
-    // by `sailfin_cli_main_v2` before reaching the legacy dispatch.
-    // #1502: internal self-host fixed-point validator (undocumented).
-    if is_selfhost { return handle_selfhost_command(args, binary_dir); }
-
-    // Bare-file dispatch: `sailfin <file.sfn>` (no subcommand) compiles
-    // and runs the file, matching the convention `python script.py` /
-    // `node script.js` set. Replaces the legacy C-driver fallback that
-    // called `compile_to_sailfin` / `compile_to_llvm` directly
-    // (retired in M5.4 / #472).
-    if args.length == 1 && _ends_with(cmd, ".sfn") {
-        return sailfin_cli_main_with_paths(["run", cmd], runtime_root, binary_dir);
-    }
-
-    print("unknown command: " + cmd);
-    print(_usage());
-
-    return 2;
-}
-
-// M5.3 (#471): direct-params facade over `sailfin_cli_main`. After
-// M5.5 (#473) retired the C driver, this helper is the route from
-// the synthesized `@main(argc, argv)` prologue (`fn main` below)
-// into the legacy `sailfin_cli_main` dispatch — runtime_root and
-// binary_dir are resolved as Sailfin strings via
-// `runtime/sfn/platform/exec.sfn` rather than injected as
-// `--runtime-root` / `--binary-dir` argv flags by the prior C
-// driver.
-// Today it reconstructs the legacy argv shape and delegates so the
-// 700-line dispatch in `sailfin_cli_main` remains a single source of
-// truth; a follow-up PR can flip the direction (move the body here,
-// leave `sailfin_cli_main` as a back-compat shim).
+// Direct-params facade over `sailfin_cli_main_v2` (M5.3 / #471). This
+// is the route from the synthesized `@main(argc, argv)` prologue
+// (`fn main` below) into the CLI dispatch: `runtime_root` and
+// `binary_dir` are resolved as Sailfin strings via
+// `runtime/sfn/platform/exec.sfn`, then re-encoded as the
+// `--runtime-root` / `--binary-dir` driver prefix that
+// `cli/context.sfn::parse_driver_prefix` consumes — the shape the
+// retired C driver injected as argv flags.
 fn sailfin_cli_main_with_paths(argv: string[], runtime_root: string, binary_dir: string) -> int ![io, clock] {
     let mut composed: string[] = [];
     if runtime_root.length > 0 {
@@ -389,12 +160,11 @@ fn native_cli_main(argv: string[]) -> int ![io, clock] {
 // The body mirrors what the retired C driver used to do, in pure
 // Sailfin: resolve the binary's path, derive the binary directory,
 // walk upward for a runtime bundle, then hand control to
-// `sailfin_cli_main_with_paths`. The legacy `--runtime-root` /
+// `sailfin_cli_main_with_paths`. The `--runtime-root` /
 // `--binary-dir` argv-flag injection is preserved through that
-// helper so the existing argv-parsing branch in `sailfin_cli_main`
-// stays the single source of truth — flipping the direction (move
-// the body into `sailfin_cli_main_with_paths`, leave
-// `sailfin_cli_main` as a shim) is a separate cleanup.
+// helper so `cli/context.sfn::parse_driver_prefix` — consumed by
+// `sailfin_cli_main_v2` — stays the single source of truth for the
+// driver prefix.
 //
 // Platform coverage tracks `runtime/sfn/platform/exec.sfn`:
 //   - Linux x86_64: full coverage (readlink /proc/self/exe).
@@ -488,8 +258,8 @@ fn main(argv: string[]) -> int ![io, clock] {
     // future-ABI flip to `{i8*, i64}` (M1.A.2 — see the
     // `runtime/sfn/platform/exec.sfn` module header) is what the
     // "cast-quirk" note in that file anticipates; downstream
-    // consumers (`_runtime_bundle_exists`, the argv-flag re-parse in
-    // `sailfin_cli_main`) read NUL-terminated bytes off the pointer
+    // consumers (`_runtime_bundle_exists`, the driver-prefix re-parse
+    // in `cli/context.sfn`) read NUL-terminated bytes off the pointer
     // either way, so the pinned semantics here survive the future
     // shape change without source edits.
     //
@@ -501,8 +271,8 @@ fn main(argv: string[]) -> int ![io, clock] {
     // fallback is preserved below to give the runtime-root walk a
     // directory to start from. argv[0] is not guaranteed to be canonical (a bare
     // `$PATH` name fails the walk on its own), but `_runtime_bundle_exists`
-    // in `sailfin_cli_main` provides the final CWD-relative
-    // `runtime` fallback either way.
+    // in `sailfin_cli_main_v2`'s bare-file dispatch provides the final
+    // CWD-relative `runtime` fallback either way.
     let exe_raw: * u8 = exe_path();
     let mut exe_str: string = exe_raw as string;
     if exe_str.length == 0 {
@@ -545,4 +315,4 @@ fn main(argv: string[]) -> int ![io, clock] {
     // returns its exit code up through here rather than calling `exit()`.
     sfn_arena_telemetry_dump(label as * u8);
     return exit_code;
-}  // Issue #940: `cli_main` is the `@main` entrypoint root AND now an  // imported module — the `sfn test` link path in  // `cli/commands/test.sfn` imports the runtime-link assembly from here,  // forming an import cycle (the v2 CLI root imports `cli/commands/test.sfn`). Sailfin resolves function/struct-level  // import cycles (e.g. parser `statements` <-> `declarations`), so these  // edges are safe.
+}  // `cli_main` is the `@main` entrypoint root and imports  // `sailfin_cli_main_v2` from `cli/main.sfn`, which in turn imports  // `_usage` / `sailfin_cli_main_with_paths` back from here — a  // two-function mutual import between exactly these two modules. Sailfin  // resolves function/struct-level import cycles (e.g. parser  // `statements` <-> `declarations`), so this edge is safe.

--- a/compiler/tests/e2e/cli_v2_exit_codes_test.sfn
+++ b/compiler/tests/e2e/cli_v2_exit_codes_test.sfn
@@ -5,9 +5,12 @@
 // Native replacement for the former `test_cli_v2_exit_codes.sh`
 // (test-infra Phase 3, epic #842; ratchet #1327). v2 is the new front
 // door for the compiler CLI: it builds a root `Command` via `sfn/cli`,
-// registers only `version`, parses with the pure, non-exiting `parse()`,
-// prints help/version itself, and falls through to the verbatim legacy
-// dispatch (`sailfin_cli_main_legacy`) for every other subcommand.
+// registers every subcommand, parses with the pure, non-exiting
+// `parse()`, dispatches each command to its `run`, and handles the
+// residual help / `selfhost` / bare-file / unknown-command paths inline
+// at the fallthrough (SFEP-0027 Phase C, #1797 — `sailfin_cli_main_v2`
+// is the sole dispatch; the former `sailfin_cli_main_legacy` shim is
+// gone).
 //
 // This pins the Issue 2.3 acceptance contract end-to-end against the
 // real binary — i.e. through the synthesized `@main` →
@@ -77,11 +80,11 @@ test "cli-v2: version short flag routes through v2 exit zero prints version" ![i
 }
 
 // `not-a-known-subcommand` is not `version`, does not end in `.sfn`, and
-// is unknown to the legacy dispatch — which prints "unknown command" and
-// returns EXIT_USAGE (2). The point of the pin: the legacy exit code is
-// OBSERVED by the v2 caller, proving v2 forwarded to legacy without a
-// `process.exit` terminating the process first.
-test "cli-v2: legacy fallthrough exit code is observed by the v2 caller (no process.exit)" ![io] {
+// no subcommand claims it — so v2's inline fallthrough prints "unknown
+// command" and returns EXIT_USAGE (2). The point of the pin: that exit
+// code is OBSERVED by the caller, proving `parse()` never fired a
+// `process.exit` out from under the `int`-returning contract (Risk R2).
+test "cli-v2: fallthrough exit code is observed by the caller (no process.exit)" ![io] {
     let exit = process.run_capture([_sfn_bin(), "not-a-known-subcommand"], []);
     let out = process.capture_take_stdout();
     let err = process.capture_take_stderr();

--- a/compiler/tests/unit/cli_main_line_budget_test.sfn
+++ b/compiler/tests/unit/cli_main_line_budget_test.sfn
@@ -1,30 +1,34 @@
 // Line-budget sentinel for `compiler/src/cli_main.sfn` — the cheap
-// regression guard for SFEP-0027 Phase A's per-worker RSS lever.
+// regression guard for SFEP-0027's per-worker RSS lever.
 //
 // Phase A carved the build-driver orchestration out of `cli_main.sfn`
 // into `compiler/src/build/{runtime_objs,link,determinism,cache}.sfn`
-// (#1730–#1733) and shattered the 937-line `sailfin_cli_main_legacy`
-// into per-command `_legacy_dispatch_<cmd>` helpers (#1734). That took
-// `cli_main.sfn` from 3,067 lines to ~1,409 and dropped its isolated
-// per-module emit peak RSS from ~2,415 MB to ~1,065 MB
-// (docs/proposals/0006-build-architecture.md, "post-Phase-A CLI deltas").
+// (#1730–#1733); Phase B migrated the 7 remaining commands into
+// `cli/commands/`; Phase C (#1797) deleted the residual
+// `sailfin_cli_main_legacy` shim, folding its help / `selfhost` /
+// bare-file / unknown-command paths into `cli/main.sfn`. That took
+// `cli_main.sfn` from 3,067 lines to ~324 — the entry shims plus
+// `_usage` — and dropped its isolated per-module emit peak RSS far below
+// the pre-Phase-A ~2,415 MB (docs/proposals/0006-build-architecture.md,
+// "post-Phase-A CLI deltas").
 //
 // Because per-module working set is what bounds parallel `--jobs`
 // (SFEP-0027 §2.1), `cli_main.sfn` must not silently re-balloon back
 // toward the pre-Phase-A monolith. This sentinel fails the build if the
-// module regrows past a budget with modest headroom over the current
-// Phase-A size.
+// module regrows past a budget with modest headroom over its current
+// entry-shim size.
 //
-// Budget rationale: SFEP-0027 §8 names `< 1,200` as the *Phase-B-era*
-// target (reached once the 7 remaining commands migrate out into
-// `cli/commands/`). The current Phase-A floor is ~1,409 lines (the
-// `_legacy_dispatch_<cmd>` helpers still live here until Phase B), so the
-// Phase-A budget is 1,500 — enough headroom for routine maintenance,
-// tight enough to flag build-driver code creeping back. Tighten to 1,200
-// when Phase B empties the legacy dispatch arms.
+// Budget rationale: SFEP-0027 §8 named `< 1,200` as the Phase-B target.
+// Phase C (#1797) went further — it deleted `sailfin_cli_main_legacy`
+// (folded into `cli/main.sfn`) and slimmed the module to the entry shims
+// (`main`, `native_cli_main`, `sailfin_cli_main_with_paths`,
+// `_arena_telemetry_*`) plus `_usage`, landing at ~324 lines. The budget
+// is tightened to 600 — comfortable headroom for routine maintenance,
+// tight enough to flag any dispatch/build-driver code creeping back into
+// what is now a pure entry-shim module.
 import { find_char_local } from "../../src/string_utils";
 
-let CLI_MAIN_LINE_BUDGET: int = 1500;
+let CLI_MAIN_LINE_BUDGET: int = 600;
 
 // Count newlines, matching `wc -l` semantics (a trailing newline is not
 // double-counted). Cheap single linear scan via `find_char_local`.
@@ -40,7 +44,7 @@ fn _count_newlines(source: string) -> int {
     return count;
 }
 
-test "cli_main.sfn stays under the SFEP-0027 Phase A line budget" ![io] {
+test "cli_main.sfn stays under the SFEP-0027 entry-shim line budget" ![io] {
     let source = fs.readFile("compiler/src/cli_main.sfn");
     let lines = _count_newlines(source);
     // A non-empty read is a precondition — guards against a path typo

--- a/docs/proposals/0027-cli-rss-modularization.md
+++ b/docs/proposals/0027-cli-rss-modularization.md
@@ -14,6 +14,15 @@ graduates-to: docs/status.md
 
 # SFEP-0027 — CLI Modularization: Per-Worker RSS Relief First, Then Migration
 
+> **Status: Implemented (Phases A–C landed; Phase C in #1797).** This proposal
+> is a design record: the inventories and line counts in §1 and §3 describe the
+> **pre-implementation** starting state (a 3,067-line `cli_main.sfn` with the
+> 937-line `sailfin_cli_main_legacy` and dead helpers like `_path_strip_ext`)
+> — they are the *motivation*, not current-state guidance. For the delivered
+> post-Phase-C structure (`sailfin_cli_main_v2` as the sole router;
+> `cli_main.sfn` = entry shims + `_usage`; `cli_commands*.sfn` deleted) see
+> `docs/status.md` "Toolchain" and the §7 Stage1 mapping below.
+
 > Supersedes SFEP-0009 (`0009-cli-modularization-epic.md`). 0009 was written
 > 2026-05-06, **before** the runtime migration (#822) dumped the entire
 > build/link orchestration into `cli_main.sfn`. Its inventory (`cli_main.sfn`

--- a/docs/proposals/0027-cli-rss-modularization.md
+++ b/docs/proposals/0027-cli-rss-modularization.md
@@ -1,15 +1,15 @@
 ---
 sfep: 27
 title: CLI Modularization — Per-Worker RSS Relief First, Then Migration
-status: Accepted
+status: Implemented
 type: tooling
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-03
 author: "agent:compiler-architect; human review"
 tracking: "#1671"
 supersedes: 9
 superseded-by:
-graduates-to:
+graduates-to: docs/status.md
 ---
 
 # SFEP-0027 — CLI Modularization: Per-Worker RSS Relief First, Then Migration
@@ -350,10 +350,13 @@ This is a structural refactor, not a language feature; the checklist maps to
   lever guarded by the line-budget sentinel
   `compiler/tests/unit/cli_main_line_budget_test.sfn` (§8, #1735). (Phase B/C
   command-migration coverage still pending.)
-- [ ] Self-hosts — `make compile` per step; `make check` per structural step.
-- [ ] `sfn fmt --check` clean — every touched `.sfn`.
-- [ ] Documented — update `docs/status.md` (CLI module map) and cross-ref
-  SFEP-0020; flip this SFEP to `Implemented` when Phase C lands.
+- [x] Self-hosts — `make compile` self-hosts per step; `make clean-build &&
+  make check` green on the Phase C structural change (#1797).
+- [x] `sfn fmt --check` clean — every touched `.sfn`.
+- [x] Documented — `docs/status.md` "Toolchain" section carries the post-Phase-C
+  CLI dispatch map (v2 sole router; `cli_main.sfn` = entry shims + `_usage`),
+  cross-referencing SFEP-0020 for the deferred `compiler-common` boundary; this
+  SFEP is `Implemented` (Phase C landed in #1797).
 
 ## 8. Test plan
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -49,7 +49,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0024](./0024-model-engines-and-training.md) | Model Engines, Adapters, Tensors, Training | Draft | informational |
 | [0025](./0025-native-runtime-architecture.md) | Native Runtime Architecture | Accepted | runtime |
 | [0026](./0026-delivery-process.md) | Delivery Process — Drift-Tolerant Issues, Seed Discovery, Release Cadence | Accepted | process |
-| [0027](./0027-cli-rss-modularization.md) | CLI Modularization — Per-Worker RSS Relief First, Then Migration | Accepted | tooling |
+| [0027](./0027-cli-rss-modularization.md) | CLI Modularization — Per-Worker RSS Relief First, Then Migration | Implemented | tooling |
 | [0028](./0028-typed-array-higher-order-fns.md) | Typed / Generic-Element Array Higher-Order Functions (map / filter / reduce) | Draft | language |
 | [0029](./0029-lambda-syntax.md) | Lambda expression syntax for 1.0 — keep, reform, or defer | Implemented | language |
 | [0030](./0030-first-class-function-values.md) | First-Class Function Values | Accepted | language |

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,21 @@ here.
   (`compiler/src/cli_main.sfn` + `capsule_resolver.sfn` — pure orchestration,
   no fixups). The `scripts/build.sh` orchestrator (Stage E PR7, #383) and the
   Python fixup script `selfhost_native.py` are retired.
+- **CLI dispatch.** `sailfin_cli_main_v2` (`compiler/src/cli/main.sfn`) is the
+  sole command router: it builds a root `Command` via the `sfn/cli` capsule
+  from each subcommand's `command_def()` and dispatches to per-command
+  `cli/commands/<name>.sfn` `run` handlers, handling the residual
+  help / `selfhost` / bare-`.sfn`-file / unknown-command paths inline. As of
+  SFEP-0027 Phase C (#1797) the former `sailfin_cli_main_legacy` shim is gone;
+  `cli_main.sfn` retains only the `@main` entry shims (`main`,
+  `native_cli_main`, `sailfin_cli_main_with_paths`, `_arena_telemetry_*`) plus
+  `_usage`. The former `cli_commands.sfn` / `cli_commands_utils.sfn` emitters
+  were deleted, their bodies relocated by consumer (backend-shared helpers to
+  `compiler/src/build/`; the `compiler-common` boundary is deferred to
+  SFEP-0020 / #345). Per-worker peak RSS drop drove the sequencing
+  (SFEP-0027 §2.1); a line-budget sentinel
+  (`compiler/tests/unit/cli_main_line_budget_test.sfn`) guards against
+  re-ballooning.
 - **Deterministic self-hosting.** The compiler is a verified fixed point —
   stage2 and stage3 produce byte-identical LLVM IR across all modules;
   `make check` enforces this. The triple-pass validation (stage2 + stage3


### PR DESCRIPTION
## Summary
- Finishes **SFEP-0027 Phase C**: deletes the vestigial `sailfin_cli_main_legacy` shim from `compiler/src/cli_main.sfn` and folds its four residual behaviors — root `-h`/`--help`, the internal `selfhost` validator, bare-`.sfn`-file dispatch, and the unknown-command fallback — into the fallthrough of `sailfin_cli_main_v2` (`compiler/src/cli/main.sfn`), so **v2 is the sole command router**. The fold reuses v2's already-parsed `ctx`/`args` instead of re-parsing the driver prefix.
- Slims `cli_main.sfn` to the entry shims (`main`, `native_cli_main`, `sailfin_cli_main_with_paths`, `_arena_telemetry_*`) plus `_usage` (549 → ~324 lines): removes dead `_path_strip_ext` and the ~85-line residual import block left by earlier phases; corrects stale comments (incl. the already-severed `cli/commands/test.sfn` import-cycle note, resolved by #1701).
- Tightens the line-budget sentinel (1500 → 600) and updates docs; flips SFEP-0027 → `Implemented`.

Closes #1797

## Acceptance Criteria
- [x] `sailfin_cli_main_legacy` is deleted; `cli/main.sfn` (v2) is the sole command dispatch, including help/`selfhost`/bare-file/unknown-fallback paths.
- [x] `cli_main.sfn` contains only the entry shims (`main`, `native_cli_main`, `sailfin_cli_main_with_paths`, `_arena_telemetry_*`) and `_usage`.
- [x] The bare-file-dispatch and `selfhost` e2e peers pass unchanged (behavior parity) — verified byte-for-byte against the deleted body and via `cli_bare_file_dispatch_test`, `cli_v2_exit_codes_test`, `compiler_debug_toggle_env_vars_test` (24/24 sub-tests green).
- [x] `docs/status.md` reflects the post-Phase-C CLI module map.
- [x] SFEP-0027 is `Implemented` with an updated registry row; `docs/proposals/README.md` matches.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make clean-build && make check` passes (structural change) — self-host proven by `make compile`; the full `make check` gate was run and confirmed green.

## Map reconciliation
The advisory `## Files Affected` map drifted from the tree (blockers #1795/#1796 landed just before pickup); reconciled within the `cli_main.sfn` / `cli/main.sfn` In: units:
- The `cli_main.sfn ↔ cli/commands/test.sfn` runtime-link import cycle the issue asked to fix **was already severed** by #1701 (its `link_test_objects` workaround import removed); only the stale trailing comment in `cli_main.sfn` remained — corrected, not re-plumbed.
- `_path_strip_ext` — grepped tree-wide: **zero callers**, deleted (issue asked to "relocate or delete").
- Removed ~85 lines of now-dead imports in `cli_main.sfn` (residue from Phase A/B build-driver + command relocation); only `bold` (sfn/cli link gate) and `sailfin_cli_main_v2` remain, the two the entry shims actually use.
- Cross-imports fixed: `cli/main.sfn` swaps `sailfin_cli_main_legacy` for `_usage` + `sailfin_cli_main_with_paths` (`../cli_main`), `_ends_with` (`../build/paths`), `_runtime_bundle_exists` (`../build/runtime_objs`), `handle_selfhost_command` (`../cli_selfhost`). The remaining `cli_main.sfn ↔ cli/main.sfn` mutual import is function-level and Sailfin-safe (documented).
- Line-budget sentinel tightened 1500 → 600 (SFEP-0027 §8 called for post-migration tightening; file is now ~324 lines).

## Verification
```bash
make compile                                             # self-hosts (status: pass)
build/native/sailfin --help    # exit 0, prints usage
build/native/sailfin not-a-cmd # exit 2, "unknown command"
build/native/sailfin           # exit 2, prints usage
build/native/sailfin version   # exit 0
build/native/sailfin examples/basics/hello-world.sfn     # bare-file: exit 0, "Hello, Sailfin!"
build/native/sailfin test compiler/tests/e2e/cli_bare_file_dispatch_test.sfn          # 3/3
build/native/sailfin test compiler/tests/e2e/cli_v2_exit_codes_test.sfn               # 4/4
build/native/sailfin test compiler/tests/e2e/compiler_debug_toggle_env_vars_test.sfn  # 16/16
build/native/sailfin test compiler/tests/unit/cli_main_line_budget_test.sfn           # 1/1
make clean-build && make check                           # full structural gate
```

## Files Changed
- `compiler/src/cli/main.sfn` — fold the four residual dispatch paths into v2's fallthrough; swap imports.
- `compiler/src/cli_main.sfn` — delete `sailfin_cli_main_legacy` + `_path_strip_ext`; slim imports to entry-shim needs; fix stale comments.
- `compiler/src/cli/commands/run.sfn` — update bare-file re-entry comment.
- `compiler/tests/e2e/cli_v2_exit_codes_test.sfn` — refresh comments/test name for the inline fallthrough.
- `compiler/tests/unit/cli_main_line_budget_test.sfn` — tighten budget to 600, refresh narration.
- `docs/status.md`, `docs/proposals/0027-cli-rss-modularization.md`, `docs/proposals/README.md` — CLI dispatch map; SFEP → Implemented.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcYKymGyz67t7eniasH3Kt)_