### PR TITLE
refactor(cli): make _string_contains_cmd a true substring search; fix stale fs.sfn comment

### DIFF
--- a/compiler/src/build/fs.sfn
+++ b/compiler/src/build/fs.sfn
@@ -84,8 +84,9 @@ fn _toml_trim_cmd(text: string) -> string {
     return substring(text, s, e);
 }
 
-// Forward declare the arena-aware popen-based capture helper added
-// in `runtime/native/src/sailfin_runtime.c`. The pre-existing
+// Forward declare the arena-aware popen-based capture helper
+// implemented in `runtime/sfn/io.sfn` (`fn sailfin_runtime_shell_capture`).
+// The pre-existing
 // implementation of `_shell_read_cmd` redirected the shell's stdout
 // through `/tmp/.sfn_shell_read_cmd_tmp` — a single fixed path that
 // raced under any cross-process concurrency (xargs-spawned emit

--- a/compiler/src/string_cmd_utils.sfn
+++ b/compiler/src/string_cmd_utils.sfn
@@ -52,12 +52,18 @@ fn _sort_strings_cmd(input: string[]) -> string[] {
     return out;
 }
 
+// True substring search: reports whether `needle` occurs anywhere in
+// `haystack`. For a single-char needle this degrades to byte membership,
+// so `_is_ident_char_cmd` (its only single-char caller) is unchanged;
+// multi-byte needles like ".." are now matched correctly (#1854).
 fn _string_contains_cmd(haystack: string, needle: string) -> boolean {
     if needle.length == 0 { return true; }
+    if needle.length > haystack.length { return false; }
+    let last = haystack.length - needle.length;
     let mut i: int = 0;
     loop {
-        if i >= haystack.length { break; }
-        if haystack[i] == needle { return true; }
+        if i > last { break; }
+        if substring(haystack, i, i + needle.length) == needle { return true; }
         i += 1;
     }
     return false;

--- a/compiler/tests/unit/string_contains_cmd_test.sfn
+++ b/compiler/tests/unit/string_contains_cmd_test.sfn
@@ -1,0 +1,39 @@
+// Regression coverage for `_string_contains_cmd` (compiler/src/string_cmd_utils.sfn)
+// and its consumer `_is_safe_capsule_version_cmd` (compiler/src/cli/commands/cmd_shared.sfn).
+//
+// `_string_contains_cmd` used to test single-byte membership only, so a
+// multi-byte needle like ".." could never match — silently no-oping the
+// traversal-defense line in `_is_safe_capsule_version_cmd` (#1854). These
+// tests pin the true-substring-search behaviour and the version validator.
+import { _is_safe_capsule_version_cmd } from "../../src/cli/commands/cmd_shared";
+import { _string_contains_cmd } from "../../src/string_cmd_utils";
+
+test "string_cmd: multi-byte needle matches substring" {
+    assert _string_contains_cmd("1.2..3", "..") == true;
+}
+
+test "string_cmd: multi-byte needle absent when bytes are non-adjacent" {
+    assert _string_contains_cmd("1.2.3", "..") == false;
+}
+
+test "string_cmd: single-char needle membership unchanged" {
+    assert _string_contains_cmd("abc", "b") == true;
+    assert _string_contains_cmd("abc", "z") == false;
+}
+
+test "string_cmd: empty needle is always contained" {
+    assert _string_contains_cmd("", "") == true;
+    assert _string_contains_cmd("abc", "") == true;
+}
+
+test "string_cmd: needle longer than haystack is absent" {
+    assert _string_contains_cmd("a", "..") == false;
+}
+
+test "cmd_shared: capsule version with `..` is rejected" {
+    assert _is_safe_capsule_version_cmd("1..2") == false;
+}
+
+test "cmd_shared: ordinary capsule version is accepted" {
+    assert _is_safe_capsule_version_cmd("1.2.3") == true;
+}


### PR DESCRIPTION
## Summary
- Rewrote `_string_contains_cmd` (`compiler/src/string_cmd_utils.sfn`) as a **true substring search** — it previously tested single-byte membership (`haystack[i] == needle`), so a multi-byte needle like `".."` could never match. Chose the "make it a real substring search" option from the issue (matches the function's name/intent). The single-char path is preserved, so its other caller `_is_ident_char_cmd` is unchanged.
- This un-noops the defense-in-depth `_string_contains_cmd(value, "..")` line in `_is_safe_capsule_version_cmd`. As the issue notes, this is a **correctness/code-quality fix, not a security fix** — real traversal needs a separator, and the earlier `/`/`\` checks already reject those.
- Fixed a stale extern comment in `compiler/src/build/fs.sfn` that referenced the deleted `runtime/native/src/sailfin_runtime.c` (removed in #822); it now points at `runtime/sfn/io.sfn` (`fn sailfin_runtime_shell_capture`).

Closes #1854

## Acceptance Criteria
- [x] `_string_contains_cmd(value, "..")` correctly detects the multi-byte substring, and `_is_ident_char_cmd` behavior is unchanged (single-char path preserved).
- [x] Regression test covers `_string_contains_cmd` with a multi-byte needle (asserts `_string_contains_cmd("1.2..3", "..")` is true and `"1.2.3"` is false), and `_is_safe_capsule_version_cmd("1..2")` returns false.
- [x] `build/fs.sfn` comment references `runtime/sfn/io.sfn`; no reference to the deleted `runtime/native/...`.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] `make compile` self-hosts; `make test` passes.

## Map reconciliation
None — advisory map matched the tree. The `cmd_shared.sfn` "only if redundant-line-removal is chosen" entry was not needed (kept the `..` check and fixed the helper instead).

## Verification
```bash
make compile   # self-hosts → status: pass
make test      # unit 189/189, integration 42/42, e2e 176/176, capsules 38/38 → status: pass
build/native/sailfin test compiler/tests/unit/string_contains_cmd_test.sfn   # 7/7 pass
build/native/sailfin fmt --check compiler/src/string_cmd_utils.sfn compiler/src/build/fs.sfn compiler/tests/unit/string_contains_cmd_test.sfn   # clean
```

## Files Changed
- `compiler/src/string_cmd_utils.sfn` — `_string_contains_cmd` → substring search
- `compiler/src/build/fs.sfn` — extern comment now cites `runtime/sfn/io.sfn`
- `compiler/tests/unit/string_contains_cmd_test.sfn` — new regression test (7 cases)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqeLKbWi2BQCon2kUYbHjL)_