### PR TITLE
chore(effect-checker): retire stale text-pattern Raw-body comments; close out #1627 audit

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -57,8 +57,8 @@ struct EffectRequirement {
     // Source-token attribution for the operation that introduced
     // this requirement. Populated by `collect_effects_from_expression`
     // when the AST node carries a span (Identifier / Member). Stays
-    // null on the text-pattern (`Raw` body) path and on synthesized
-    // decorator-implied effects, where no Expression is available.
+    // null on synthesized decorator-implied effects, where no
+    // Expression is available.
     // `analyze_routine` reads the first non-null trigger from the
     // missing-requirements list to caret the diagnostic at the call
     // site rather than the function declaration.
@@ -458,9 +458,9 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
     // call-site token captured during the body walk — that's where
     // the offending operation actually lives, so the caret lands on
     // the user-actionable line. When no per-requirement trigger
-    // exists (text-pattern Raw bodies, decorator-implied effects,
-    // synthesized expressions), the trigger falls back to
-    // signature_token so diagnostics never lose source attribution.
+    // exists (decorator-implied effects, synthesized expressions),
+    // the trigger falls back to signature_token so diagnostics never
+    // lose source attribution.
     //
     // Use `signature.name` (the bare identifier) for the
     // signature_token's lexeme so the fallback caret has the right
@@ -489,9 +489,9 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
 
 // B1: pick the first per-requirement trigger token captured by the
 // body walker; fall back to the signature token if every requirement
-// came from a non-AST path (text patterns, decorator-implied effects,
-// synthesized expressions). The caller passes signature_token as the
-// fallback so the violation always carries a source location.
+// came from a non-AST path (decorator-implied effects, synthesized
+// expressions). The caller passes signature_token as the fallback so
+// the violation always carries a source location.
 fn _first_requirement_trigger(missing_requirements: EffectRequirement[], fallback: Token?) -> Token? {
     let mut i: int = 0;
     loop {

--- a/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
+++ b/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
@@ -4,7 +4,7 @@
 - **Epic:** #1180
 - **Design record extended:** SFEP-0008 (`docs/proposals/0008-effect-validation.md`)
 - **Author:** agent:compiler-architect
-- **Status:** Draft (single-issue design gate; not a new SFEP) — Parts E (E0819/#1755) and F (E0818/#1743) **implemented**; Parts A–D still pending
+- **Status:** Implemented (single-issue design gate; not a new SFEP) — all parts A–F shipped. A/B/C (casts→`Cast`, prefix `*`/`&`→`Unary`, pointer/fn-ptr/generic cast targets) in #1737; D (assignment→`Assignment`) in #1741/#1745; typed `channel:Type` in #1742; E (E0819 nested-`Unknown`) in #1755; F (blanket E0818 fail-closed `Raw`) in #1743; corpus cleanup in #1751. #1627's fail-closed criterion is met: no valid parseable construct degrades to an effect-opaque `Raw`/`Unknown` node without a diagnostic.
 - **Date:** 2026-06-26; **revised 2026-06-27** (the E0818-flip endgame — parts A–F); **annotated 2026-06-29** (Parts E+F shipped)
 - **Decision:** **Structural lift (root fix)** chosen at the design gate. The
   earlier text-anchor "floor" (`_raw_contains_effectful_anchor`) is **superseded**


### PR DESCRIPTION
## Summary

- Remove three stale comments in `effect_checker.sfn` that still described the text-pattern (`Raw` body) effect-collection path deleted in #1186 — now misleading, since the only remaining null-trigger sources are decorator-implied and synthesized effects.
- Correct the #1627 design-note status header, which still read "Parts A–D still pending" after all of A–F shipped; the fail-closed criterion is met.

This closes out the last documentation loose end of the #1627 effect-blindness audit. The substantive enforcement work landed earlier across #1737 / #1741 / #1745 / #1742 / #1755 / #1743 / #1751 (all merged); this PR is comment/record-only.

Closes #1693

## Verification — #1627 fail-closed guarantee re-confirmed live in main

The effect checker now **fails closed**: no valid parseable construct can reach codegen through an effect-opaque `Raw`/`Unknown` node without a diagnostic. Re-verified end-to-end against a fresh self-host:

```
c ? print.info(x) : 0   (ternary)     → E0400  (Conditional walked)
print.info(x) as int    (cast)        → E0400  (Cast walks operand)
a = print.info(x)       (assignment)  → E0400  (Assignment walked)
fn f() { @@@ junk }      (block junk)  → E0818  (blanket Raw backstop — fails closed)
@@@ junk (top level)                  → E0500  (no double-fire)
```

- Blanket `E0818` Raw backstop is LIVE (`typecheck.sfn:1148-1163`), with empty-Raw and match-arm-pattern exemptions intact; no feature-flag/dead-branch guard.
- Structured `Conditional` / `Cast` / `Unary` / `Assignment` nodes all carry effect-merging arms; `is`-guards structured (#1753).

## Acceptance Criteria (#1693)

- [x] No comment in `effect_checker.sfn` implies a text-pattern / `Raw`-body effect-collection path survives.
- [x] `sfn fmt --check` clean; `make compile` self-hosts (comment-only, no behavior change).
- [x] SFEP-0008 prose audited — its `collect_effects_from_text` references are accurate historical record (it documents the detector *and its #1186 deletion*), so left unchanged.

## Verification

```bash
make compile                 # self-hosts (exit 0), twice — before and after the edit
sfn fmt --check compiler/src/effect_checker.sfn   # clean
sailfin test compiler/tests/unit/effect_raw_failclosed_test.sfn \
  effect_assignment_test.sfn effect_conditional_branch_test.sfn \
  effect_cast_operand_test.sfn effect_prefix_deref_addr_test.sfn \
  effect_checker_test.sfn     # all pass (incl. 43-test effect_checker_test)
```

`make check` (full triple-pass) was not run: the change is comment/record-only and cannot alter emitted code — the self-host + targeted effect suite is sufficient.

## Files Changed

- `compiler/src/effect_checker.sfn` — three stale comment fixes (comment-only)
- `docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md` — status header correction

---
_Generated by [Claude Code](https://claude.ai/code/session_017UMHZhi7LUTSj1K4STdZmK)_