### PR TITLE
fix(lowering): populate bare struct literal via type annotation

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -2563,22 +2563,40 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             let bare_parse = parse_struct_literal(bare_target.name + " "
                 + stripped);
             if bare_parse.recognized {
-                if bare_parse.success {
-                    let bare_lowered = lower_struct_literal(bare_parse, bindings, locals, temp_index, lines, functions, context, expected_type, null);
-                    let mut _ci_bare: int = 0;
+                // Fail closed on a malformed body (missing `}`, trailing
+                // content) rather than dropping the parse diagnostics and
+                // falling through to a zeroinitializer store — mirrors the
+                // explicit `T { ... }` arm's `!success` handling below so the
+                // bare form surfaces the same struct-literal diagnostics.
+                if !bare_parse.success {
+                    let mut _ci_bad: int = 0;
                     loop {
-                        if _ci_bare >= bare_lowered.diagnostics.length { break; }
-                        diagnostics.push(bare_lowered.diagnostics[_ci_bare]);
-                        _ci_bare += 1;
+                        if _ci_bad >= bare_parse.diagnostics.length { break; }
+                        diagnostics.push(bare_parse.diagnostics[_ci_bad]);
+                        _ci_bad += 1;
                     }
                     return ExpressionResult {
-                        lines: bare_lowered.lines,
-                        temp_index: bare_lowered.temp_index,
-                        operand: bare_lowered.operand,
+                        lines: lines,
+                        temp_index: temp_index,
+                        operand: null,
                         diagnostics: diagnostics,
-                        string_constants: bare_lowered.string_constants
+                        string_constants: empty_constants
                     };
                 }
+                let bare_lowered = lower_struct_literal(bare_parse, bindings, locals, temp_index, lines, functions, context, expected_type, null);
+                let mut _ci_bare: int = 0;
+                loop {
+                    if _ci_bare >= bare_lowered.diagnostics.length { break; }
+                    diagnostics.push(bare_lowered.diagnostics[_ci_bare]);
+                    _ci_bare += 1;
+                }
+                return ExpressionResult {
+                    lines: bare_lowered.lines,
+                    temp_index: bare_lowered.temp_index,
+                    operand: bare_lowered.operand,
+                    diagnostics: diagnostics,
+                    string_constants: bare_lowered.string_constants
+                };
             }
         }
     }

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -2546,6 +2546,43 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     // form (enum parse unsuccessful, or `enum_info == null`) falls through to
     // the struct dispatch below (parse_struct_literal recognizes the dotted
     // name), where the fail-closed guard catches the unresolvable type.
+    // #1855: a bare object literal `{ field: val, ... }` routed through a
+    // concrete-struct type annotation (`let p: Person = { ... }`) reaches
+    // lowering as bare `{...}` text with no leading type name, so the
+    // parse_struct_literal call below cannot recognize it (it requires a
+    // leading identifier) and it would fall through to a zeroinitializer
+    // store — the literal's fields are silently dropped. When `expected_type`
+    // resolves to a concrete struct, prepend that struct's source name so the
+    // literal routes through the same field-population path the explicit
+    // `T { ... }` form uses. Interface/intersection annotations resolve to no
+    // struct here (they lower through the dynamic runtime-object path) and are
+    // intentionally left untouched.
+    if starts_with(stripped, "{") {
+        let bare_target = resolve_struct_info_from_llvm_type(context, expected_type);
+        if bare_target != null {
+            let bare_parse = parse_struct_literal(bare_target.name + " "
+                + stripped);
+            if bare_parse.recognized {
+                if bare_parse.success {
+                    let bare_lowered = lower_struct_literal(bare_parse, bindings, locals, temp_index, lines, functions, context, expected_type, null);
+                    let mut _ci_bare: int = 0;
+                    loop {
+                        if _ci_bare >= bare_lowered.diagnostics.length { break; }
+                        diagnostics.push(bare_lowered.diagnostics[_ci_bare]);
+                        _ci_bare += 1;
+                    }
+                    return ExpressionResult {
+                        lines: bare_lowered.lines,
+                        temp_index: bare_lowered.temp_index,
+                        operand: bare_lowered.operand,
+                        diagnostics: diagnostics,
+                        string_constants: bare_lowered.string_constants
+                    };
+                }
+            }
+        }
+    }
+
     let struct_parse = parse_struct_literal(stripped);
     if struct_parse.recognized {
         if !struct_parse.success {

--- a/compiler/tests/e2e/bare_struct_literal_annotation_test.sfn
+++ b/compiler/tests/e2e/bare_struct_literal_annotation_test.sfn
@@ -1,0 +1,82 @@
+// End-to-end test for issue #1855 — a bare struct literal (`{ field: val }`)
+// assigned through a concrete struct type annotation (`let p: Person = { ... }`)
+// must populate its fields via the same path as the explicit `Person { ... }`
+// form, rather than lowering to `store %Person zeroinitializer`.
+//
+// NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]` and so
+// cannot be called from an `![io]` test like this. Assert on the captured
+// `.ll` text with `sfn/strings` predicates instead. (#842.)
+import { contains, split, trim } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Child environment for the spawned `sfn` invocations. `process.run_capture`
+// treats an empty array as the *empty* environment (not "inherit"), so PATH
+// (the nested `sfn run` build shells out to clang + a linker) and
+// SAILFIN_TEST_SCRATCH (per-invocation build-cache dir, #1333) are threaded
+// explicitly.
+fn _child_env() -> string[] ![io] {
+    // Inherit the full parent environment: PATH/HOME/TMPDIR plus the macOS
+    // SDK/toolchain vars the nested clang/ld need (a minimal set links on
+    // Linux but fails on macOS with `ld: library 'm' not found`, #1410),
+    // and SAILFIN_TEST_SCRATCH for per-invocation build-cache isolation
+    // (#1333). Mirrors serve_loopback_test.sfn / process_environ_test.sfn.
+    return process.environ();
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+fn _fixture() -> string {
+    return "compiler/tests/e2e/fixtures/bare_struct_literal_annotation.sfn";
+}
+
+fn _emit_llvm() -> string ![io] {
+    let dir = _scratch_dir();
+    let ll = dir + "/bare_struct_literal_annotation.ll";
+    if fs.exists(ll) { fs.deleteFile(ll); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", ll, "llvm", _fixture()], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    if !fs.exists(ll) { return ""; }
+    let ir = fs.readFile(ll);
+    fs.deleteFile(ll);
+    return ir;
+}
+
+// 1 — The bare literal's field assignment goes through `insertvalue %Person`
+// (field population), not a `store %Person zeroinitializer`.
+test "bare-struct-annotation: field literal populates %Person (no zeroinitializer)" ![io] {
+    let ir = _emit_llvm();
+    assert ir.length > 0;
+    let lines = split(ir, "\n");
+    let mut found = false;
+    let mut i = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = lines[i];
+        if contains(line, "insertvalue %Person") { found = true; }
+        i += 1;
+    }
+    assert found;
+    assert contains(ir, "Bob");
+}
+
+// 2 — Runtime round-trip: the populated field prints its assigned value, not
+// a zeroed/empty default.
+test "bare-struct-annotation: runtime prints populated field" ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", _fixture()], _child_env());
+    let out = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    assert exit == 0;
+    assert contains(out, "Person: Bob");
+}

--- a/compiler/tests/e2e/bare_struct_literal_annotation_test.sfn
+++ b/compiler/tests/e2e/bare_struct_literal_annotation_test.sfn
@@ -69,6 +69,8 @@ test "bare-struct-annotation: field literal populates %Person (no zeroinitialize
     }
     assert found;
     assert contains(ir, "Bob");
+    // Guard against the pre-fix lowering reappearing alongside the fixed path.
+    assert ! contains(ir, "%Person zeroinitializer");
 }
 
 // 2 — Runtime round-trip: the populated field prints its assigned value, not

--- a/compiler/tests/e2e/fixtures/bare_struct_literal_annotation.sfn
+++ b/compiler/tests/e2e/fixtures/bare_struct_literal_annotation.sfn
@@ -1,0 +1,12 @@
+// Fixture for issue #1855 — a bare struct literal assigned through a concrete
+// type annotation must populate its fields (not lower to a zero value).
+struct Person {
+    name: string;
+}
+
+fn main() ![io] {
+    let p: Person = {
+        name: "Bob"
+    };
+    print("Person: {{p.name}}");
+}


### PR DESCRIPTION
## Summary

- A bare struct literal assigned through a concrete-struct type annotation (`let p: Person = { name: "Bob" }`) lowered to `store %Person zeroinitializer` — the literal's fields were silently dropped. The explicit form (`Person { name: "Bob" }`) already worked.
- Root cause: the bare `{...}` text has no leading type name, so `parse_struct_literal` (which requires a leading identifier) never recognized it; the expression fell through to a null operand and `lower_let_instruction` stored `zeroinitializer`.
- Fix: in `lower_expression`, when the stripped text starts with `{` and `expected_type` resolves to a concrete struct, prepend the struct's source name and re-parse through the existing `lower_struct_literal` field-population path — identical to the explicit `T { ... }` form. Interface/intersection annotations resolve to no struct here and are left on their existing dynamic-object path.

Closes #1855

## Scope note

Issue #1855 originally listed three acceptance criteria, but investigation showed they span **two different lowering paths**:

- **Concrete struct** (`let p: Person = {...}`) → static `%T` aggregate via GEP/`insertvalue`. **Fixed here.**
- **Interface/intersection** (`let admin: AdminUser = {...}`, `type AdminUser = Admin & User`) → opaque dynamic runtime object (`i8*`) accessed by field-name via `sfn_mem_get_field`. Constructing a populated dynamic object from a bare literal is a separate, unimplemented mechanism (even an unannotated bare object doesn't construct one today).

Per the reporter's direction, this PR delivers the concrete-struct case and the interface/intersection case is split out to **#1860** (`needs-grooming`). The `unions.sfn` `Admin: Alice` and intersection criteria move with it.

## Acceptance Criteria (rescoped to the concrete-struct case)

- [x] `let p: Person = { name: "Bob" }; print("{{p.name}}")` prints `Bob`.
- [x] Regression test in `compiler/tests/` (IR-level + runtime).
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).
- [ ] `examples/advanced/unions.sfn` prints `Admin: Alice` → deferred to **#1860** (different lowering path).
- [ ] Intersection-type case populates fields → deferred to **#1860**.

## Map reconciliation

`## Files Affected` named `compiler/src/llvm/expression_lowering/native/` (struct-literal lowering) and `compiler/tests/` — both matched the tree. The concrete change landed in `core.sfn` (the `lower_expression` dispatch), which is the correct in-unit file. No path drift.

## Verification

```bash
# concrete struct via annotation — fixed
$ build/native/sailfin run <bare Person fixture>
Person: Bob                 # was: "Person: " (empty)

# annotated + explicit still works (unchanged)
$ build/native/sailfin run <annotated explicit fixture>
P: Carol

# interface/intersection — unchanged, still compiles & runs (deferred to #1860)
$ build/native/sailfin run examples/advanced/unions.sfn
It's a string: Sailfin
It's a number: 42
Admin:                      # unchanged; not a regression to a compile error

# gates
$ make compile              # pass (self-hosts)
$ make test                 # unit 189/189, integration 42/42, e2e 179/179, capsules 38/38
$ build/native/sailfin test compiler/tests/e2e/bare_struct_literal_annotation_test.sfn   # PASS (2/2)
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core.sfn` — new dispatch arm in `lower_expression` routing bare `{...}` + concrete-struct `expected_type` to `lower_struct_literal`.
- `compiler/tests/e2e/bare_struct_literal_annotation_test.sfn` — regression test (IR asserts `insertvalue %Person`/no `zeroinitializer`; runtime asserts `Person: Bob`).
- `compiler/tests/e2e/fixtures/bare_struct_literal_annotation.sfn` — fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9EerQJvmLgNtyGwkriky3)_