### PR TITLE
test(e2e): de-collide socket_recv_timeout port to stop flaky SIGABRT

### DIFF
--- a/compiler/tests/e2e/socket_recv_timeout_test.sfn
+++ b/compiler/tests/e2e/socket_recv_timeout_test.sfn
@@ -51,14 +51,37 @@ extern fn close(fd: i32) -> i32;
 
 extern fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: * u8, optlen: i32) -> i32;
 
-// Fixed loopback port for this test. High + uncommon, distinct from
-// `serve_loopback_test.sfn`'s 18790 so the two cannot collide under
-// `--jobs N`.
-fn _st_port() -> i64 { return 18793; }
+// Fixed loopback port for this test. High + uncommon, and — critically —
+// distinct from every other server-binding e2e test so the parallel
+// `--jobs N` pool cannot collide on it: 18790 serve_loopback, 18791
+// serve_reuseaddr, 18792 serve_keepalive, 18793 the long-lived ASAN-serve
+// server (`concurrency_ownedbuf_asan_interleave_test.sfn`), 18795+ the TLS
+// tests. This test previously shared 18793 with that ASAN-serve test; under
+// the pool its `serve()` server held 18793 for its ~60s lifetime, so this
+// test's raw `bind` lost the race with EADDRINUSE and `assert lfd >= 0`
+// aborted (SIGABRT / exit 134, #1862). 18794 is unshared.
+fn _st_port() -> i64 { return 18794; }
 
 fn _st_ptr_off(p: * u8, off: i64) -> * u8 {
     let addr: i64 = (p as i64) + off;
     return addr as * u8;
+}
+
+// Arm SO_REUSEADDR on the listening socket before `bind`, mirroring the
+// shipped `serve.sfn::_serve_set_reuseaddr` (#1583). The port de-collision
+// above is the primary #1862 fix; this hardens the raw `bind` against a
+// lingering TIME_WAIT socket on a repeated run (e.g. the `make check`
+// triple self-host pass rebinding inside the 60s TIME_WAIT window). 4-byte
+// int optval = 1; both platforms armed (Linux SOL_SOCKET=1/SO_REUSEADDR=2,
+// macOS 65535/4), the wrong-platform call failing harmlessly.
+fn _st_set_reuseaddr(fd: i32) -> void {
+    let optval: * u8 = malloc(4 as usize);
+    if optval as i64 == 0 { return; }
+    memset(optval, 0, 4 as usize);
+    memset(_st_ptr_off(optval, 0), 1, 1 as usize);
+    setsockopt(fd, 1, 2, optval, 4);
+    setsockopt(fd, 65535, 4, optval, 4);
+    free(optval);
 }
 
 // Open a stream socket bound to `0.0.0.0:port` and listen. Tries both
@@ -71,6 +94,7 @@ fn _st_bind_listen(port: i64) -> i32 {
         if attempt >= 2 { break; }
         let fd: i32 = socket(2, 1, 0);
         if fd < 0 { return 0 - 1; }
+        _st_set_reuseaddr(fd);
         let addr: * u8 = malloc(16 as usize);
         if addr as i64 == 0 {
             close(fd);


### PR DESCRIPTION
## Summary
- **Root cause:** `socket_recv_timeout_test.sfn` and `concurrency_ownedbuf_asan_interleave_test.sfn` both bound the **same fixed port 18793**. Under `sailfin test --jobs N` (each file runs as its own process), the ASAN-serve test stands up a long-lived `serve()` HTTP server on 18793 for ~60s; while it held the port, this test's raw `bind` got `EADDRINUSE` → `_st_bind_listen` returned -1 → `assert lfd >= 0` fired → `sfn_raise_value_error` → libc `abort()` → **SIGABRT / exit 134**. Exit 134 is **not** in the runner's retry set (only 137/139 retry), so it surfaced as a hard `linux-x86_64 / e2e-b` shard failure on unrelated PRs (e.g. #1861).
- **Fix:** move this test to the unshared port **18794**, and arm `SO_REUSEADDR` before `bind` (mirroring the shipped `serve.sfn::_serve_set_reuseaddr`, #1583) to harden the raw bind against a lingering `TIME_WAIT` socket across `make check`'s triple self-host pass.

The OpenSSL-link suspects (#1848 / #1857 / #1814) were ruled out: OpenSSL is linked into every binary but carries no repo-authored `abort`/ctor/signal path — the abort source is the assertion, not TLS init.

Closes #1862

## Acceptance Criteria
- [x] Root cause identified (aborting frame / race). Traced end-to-end (`assert lfd >= 0` → `abort()` → 134) and reproduced **deterministically** by occupying the port with a live external listener — the test aborts at `socket_recv_timeout_test.sfn:192:5` with exit 134.
- [x] `socket_recv_timeout_test.sfn` passes deterministically under the parallel `e2e` pool — **30/30 green** under `--jobs 4`.
- [x] `make check` green (validated locally).

## Verification
```bash
# Deterministic repro of the mechanism (occupy the port → bind EADDRINUSE → assert → 134):
python3 -c "import socket,time;s=socket.socket();s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);s.bind(('0.0.0.0',18794));s.listen();time.sleep(45)" &
build/native/sailfin test compiler/tests/e2e/socket_recv_timeout_test.sfn
# → exit 134, "assertion failed" at socket_recv_timeout_test.sfn:192:5 (assert lfd >= 0)

# With the port free (the fix):
for i in $(seq 1 30); do build/native/sailfin test compiler/tests/e2e/socket_recv_timeout_test.sfn --jobs 4; done
# → PASS 30 / FAIL 0

build/native/sailfin fmt --check compiler/tests/e2e/socket_recv_timeout_test.sfn   # clean
make compile   # self-hosts (test-only change; no compiler/src impact)
make check     # green
```

## Files Changed
- `compiler/tests/e2e/socket_recv_timeout_test.sfn` — port 18793 → 18794; add `_st_set_reuseaddr` and arm it before `bind` in `_st_bind_listen`.

## Map reconciliation
Advisory `## Files Affected` also listed `runtime/sfn/adapters/http.sfn` and `runtime/sfn/concurrency/serve.sfn` "if the fault is in the real path" — it wasn't; the real `SO_*TIMEO`/`SO_REUSEADDR` runtime code is correct and needs no change. The fault was confined to the test's fixed-port choice, so only the test file changed (in scope: "the test itself — port selection, error paths").

## Note for future grooming
The port ledger comment in `serve_keepalive_test.sfn:55` still groups 18793 as "socket/concurrency"; now that this test moved to 18794, that line is slightly stale. Left untouched to keep this PR scoped to `socket_recv_timeout_test.sfn` — worth a one-line ledger correction in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWGjeRL8pJJXqjRHBUzBu6)_