### PR TITLE
fix(captures): infer un-annotated scalar capture types (fixes quicksort miscompile)

### DIFF
--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -623,13 +623,26 @@ fn _capture_scope_primitive_type(scope: LocalBinding[], name: string) -> string 
 }
 
 // Infer a primitive array type (`int[]`) from a non-empty array literal by
-// recovering its first element's primitive type. Empty or non-primitive-first
-// literals return "" so the conservative `i8*` fallback still applies (#1839).
+// recovering a single primitive element type shared by EVERY element. Mixed,
+// empty, or non-primitive literals return "" so the conservative `i8*`
+// fallback still applies. Checking all elements (not just the first) mirrors
+// `emit_native_format.sfn::infer_array_element_type` so a heterogeneous
+// literal never yields a `type_text` hint that disagrees with the array's
+// real element layout (#1839).
 fn _capture_array_literal_type(scope: LocalBinding[], array_expr: Expression) -> string {
     if array_expr.elements.length == 0 { return ""; }
-    let elem = infer_let_initializer_type(scope, array_expr.elements[0]);
-    if is_primitive_type(elem) { return elem + "[]"; }
-    return "";
+    let mut candidate: string = "";
+    let mut index: int = 0;
+    loop {
+        if index >= array_expr.elements.length { break; }
+        let elem = infer_let_initializer_type(scope, array_expr.elements[index]);
+        if !is_primitive_type(elem) { return ""; }
+        if candidate.length == 0 { candidate = elem; } else if !strings_equal(candidate, elem) {
+            return "";
+        }
+        index += 1;
+    }
+    return candidate + "[]";
 }
 
 // Map a primitive array annotation (`int[]`) to its element type (`int`).

--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -105,7 +105,7 @@ fn analyze_lambda_captures(program: Program) -> LambdaCaptureRecord[] {
         let result = walk_top_statement(scope, stmt);
         records = append_records(records, result.records);
         if stmt.variant == "VariableDeclaration" {
-            scope = append_binding(scope, binding_from_let(stmt));
+            scope = append_binding(scope, binding_from_let(scope, stmt));
         }
         i += 1;
     }
@@ -160,7 +160,7 @@ fn walk_block(scope: LocalBinding[], block: Block) -> CaptureWalkResult {
         free = union_names(free, stmt_free);
         records = append_records(records, result.records);
         if stmt.variant == "VariableDeclaration" {
-            local = append_binding(local, binding_from_let(stmt));
+            local = append_binding(local, binding_from_let(inner_scope, stmt));
         }
         i += 1;
     }
@@ -523,7 +523,7 @@ fn binding_from_parameter(p: Parameter) -> LocalBinding {
     };
 }
 
-fn binding_from_let(stmt: Statement) -> LocalBinding {
+fn binding_from_let(scope: LocalBinding[], stmt: Statement) -> LocalBinding {
     let mut type_text = type_annotation_text(stmt.type_annotation);
     // #1610: an un-annotated `let base = 100` carries no `type_annotation`,
     // so `type_text` is empty and `closure_field_llvm_type` falls back to the
@@ -533,9 +533,11 @@ fn binding_from_let(stmt: Statement) -> LocalBinding {
     // capture lays out the same `i64`/`i1`/`i8*` field its annotated form
     // (`let base: int = 100`) already does. Non-literal initializers stay
     // empty (full type inference is out of scope) and keep the conservative
-    // i8* fallback.
+    // i8* fallback. `scope` lets the recovery resolve identifier / index
+    // initializers against the bindings visible where the `let` appears
+    // (#1839).
     if type_text.length == 0 {
-        type_text = infer_let_initializer_type(stmt.initializer);
+        type_text = infer_let_initializer_type(scope, stmt.initializer);
     }
     return LocalBinding {
         name: stmt.name,
@@ -552,7 +554,7 @@ fn binding_from_let(stmt: Statement) -> LocalBinding {
 // a typecheck -> emit module dependency. Only the literal forms are handled
 // (the cases that otherwise mis-lay-out a closure env field); anything else
 // returns the empty string and preserves the prior conservative behaviour.
-fn infer_let_initializer_type(initializer: Expression?) -> string {
+fn infer_let_initializer_type(scope: LocalBinding[], initializer: Expression?) -> string {
     if initializer == null { return ""; }
     if initializer.variant == "NumberLiteral" {
         return number_literal_kind(initializer.value);
@@ -568,6 +570,78 @@ fn infer_let_initializer_type(initializer: Expression?) -> string {
             }
         }
     }
+    // #1839: an un-annotated `let nums = [10, 7, 8]` gives `nums` a primitive
+    // array type so a later `nums[i]` capture (below) can resolve its element
+    // type — otherwise an un-annotated array literal bound to a `let` leaves
+    // the index base untyped and the capture falls back to `i8*`.
+    if initializer.variant == "Array" {
+        let arr_type = _capture_array_literal_type(scope, initializer);
+        if arr_type.length > 0 { return arr_type; }
+    }
+    // #1839: an un-annotated `let pivot = arr[0]` captured by a closure (e.g.
+    // functional quicksort's `arr.filter(fn(x) => x < pivot)`) needs the
+    // element type so its env field lays out the same scalar its annotated
+    // form (`let pivot: int = arr[0]`) already does. Without it the field
+    // falls back to `i8*` while the stored value is an `i64`, emitting
+    // `store i8* %v, i8** ...` — invalid IR that fails at link. Resolve the
+    // indexed array's element type from scope, restricted to primitive
+    // elements (aggregate captures already lay out correctly on the existing
+    // path, so the conservative `i8*` fallback still covers them).
+    if initializer.variant == "Index" {
+        let elem = _capture_indexed_element_type(scope, initializer);
+        if elem.length > 0 { return elem; }
+    }
+    // #1839: an un-annotated `let p = q` inherits `q`'s known primitive type
+    // for the same reason — a scalar capture must not fall through to `i8*`.
+    if initializer.variant == "Identifier" {
+        let inherited = _capture_scope_primitive_type(scope, initializer.name);
+        if inherited.length > 0 { return inherited; }
+    }
+    return "";
+}
+
+// Resolve `arr[i]`'s element type when `arr` is an identifier bound to a
+// primitive array (`T[]`) in scope. Returns "" for non-identifier bases,
+// unknown bindings, non-array types, or non-primitive elements — every case
+// the closure-env layout already handles without this hint (#1839).
+fn _capture_indexed_element_type(scope: LocalBinding[], index_expr: Expression) -> string {
+    let base = index_expr.sequence;
+    if base == null { return ""; }
+    if base.variant != "Identifier" { return ""; }
+    let binding = find_binding(scope, base.name);
+    if binding == null { return ""; }
+    return _primitive_array_element_type(binding.type_text);
+}
+
+// Look up a scope binding's `type_text`, returning it only when it names a
+// primitive — the scalar-capture case this hint exists for (#1839).
+fn _capture_scope_primitive_type(scope: LocalBinding[], name: string) -> string {
+    let binding = find_binding(scope, name);
+    if binding == null { return ""; }
+    if is_primitive_type(binding.type_text) { return binding.type_text; }
+    return "";
+}
+
+// Infer a primitive array type (`int[]`) from a non-empty array literal by
+// recovering its first element's primitive type. Empty or non-primitive-first
+// literals return "" so the conservative `i8*` fallback still applies (#1839).
+fn _capture_array_literal_type(scope: LocalBinding[], array_expr: Expression) -> string {
+    if array_expr.elements.length == 0 { return ""; }
+    let elem = infer_let_initializer_type(scope, array_expr.elements[0]);
+    if is_primitive_type(elem) { return elem + "[]"; }
+    return "";
+}
+
+// Map a primitive array annotation (`int[]`) to its element type (`int`).
+// Restricted to the `is_primitive_type` set so the caller only recovers the
+// scalar captures the `i8*` fallback mis-lays-out; anything else returns ""
+// (#1839).
+fn _primitive_array_element_type(type_text: string) -> string {
+    if strings_equal(type_text, "int[]") { return "int"; }
+    if strings_equal(type_text, "float[]") { return "float"; }
+    if strings_equal(type_text, "number[]") { return "number"; }
+    if strings_equal(type_text, "boolean[]") { return "boolean"; }
+    if strings_equal(type_text, "string[]") { return "string"; }
     return "";
 }
 

--- a/compiler/tests/e2e/closure_capture_inferred_pivot_test.sfn
+++ b/compiler/tests/e2e/closure_capture_inferred_pivot_test.sfn
@@ -1,0 +1,53 @@
+// End-to-end regression for #1839 — a closure that captures an un-annotated
+// `let pivot = arr[0]` must compile to valid IR and run correctly. Before the
+// fix the capture's env field fell back to the opaque `i8*` slot while the
+// stored value was an `i64`, emitting `store i8* %v, i8** ...` — invalid IR
+// the LLVM verifier rejected at link (`'%tN' defined with type 'i64' but
+// expected 'ptr'`). Functional quicksort exercises three such captures.
+//
+// Drives the compiler-under-test as a subprocess with the runtime `process.*`
+// builtins and asserts on captured stdout — the canonical e2e pattern (see
+// `.claude/rules/no-bash-e2e.md`, `array_filter_closure_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted binary
+// relative to the repo root the runner starts from. Mirrors `sfn/test`'s
+// `_resolve_sfn_bin` so CI can point the test at any compiler.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `sfn run` compiles+links+executes the fixture, so the spawned compiler
+// needs a real environment (PATH for the linker, SAILFIN_TEST_SCRATCH for
+// per-invocation build-cache isolation under the parallel pool, #1333).
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "closure capture: un-annotated pivot compiles and sorts correctly" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/closure_capture_inferred_pivot/main.sfn");
+    // Exit 0 proves the IR linked (the pre-fix bug failed here); the output
+    // proves the captured `pivot` carried the right value through each filter.
+    assert r.exit == 0;
+    assert r.out == "1\n5\n7\n8\n9\n10";
+}
+
+test "closure capture: whole un-annotated array literal captured and indexed" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/closure_capture_whole_array/main.sfn");
+    // Pins the array-literal inference arm's env field shape: `nums` is
+    // captured whole and indexed inside the predicate. [20,30,40] > 10 → 3.
+    assert r.exit == 0;
+    assert r.out == "3";
+}

--- a/compiler/tests/e2e/fixtures/closure_capture_inferred_pivot/main.sfn
+++ b/compiler/tests/e2e/fixtures/closure_capture_inferred_pivot/main.sfn
@@ -1,0 +1,27 @@
+// compiler/tests/e2e/fixtures/closure_capture_inferred_pivot/main.sfn
+//
+// #1839 — an un-annotated `let pivot = arr[0]` captured by a filter closure
+// must lay out its env field as the inferred scalar (`i64`), not the opaque
+// `i8*` fallback. The fallback emitted `store i8* %v, i8** ...` with `%v` an
+// `i64` — invalid IR the verifier rejected at link. Functional quicksort is
+// the canonical trigger: three `arr.filter(fn(x) => ... pivot)` closures each
+// capture the un-annotated `pivot`.
+fn quicksort(arr: int[]) -> int[] {
+    if arr.length <= 1 { return arr; }
+    let pivot = arr[0];
+    let less = arr.filter(fn (x) -> boolean { return x < pivot; });
+    let equal = arr.filter(fn (x) -> boolean { return x == pivot; });
+    let greater = arr.filter(fn (x) -> boolean { return x > pivot; });
+    return quicksort(less).concat(equal).concat(quicksort(greater));
+}
+
+fn main() ![io] {
+    let nums = [10, 7, 8, 9, 1, 5];
+    let sorted = quicksort(nums);
+    let mut i: int = 0;
+    loop {
+        if i >= sorted.length { break; }
+        print(sorted[i]);
+        i = i + 1;
+    }
+}

--- a/compiler/tests/e2e/fixtures/closure_capture_whole_array/main.sfn
+++ b/compiler/tests/e2e/fixtures/closure_capture_whole_array/main.sfn
@@ -1,0 +1,13 @@
+// compiler/tests/e2e/fixtures/closure_capture_whole_array/main.sfn
+//
+// #1839 — a closure capturing a whole un-annotated array literal (`let nums =
+// [...]`) and indexing it inside the body must lay out its env field as the
+// inferred array pointer (`{ i64*, i64, i64 }*`), not the opaque `i8*`
+// fallback (which stored the array pointer through an `i8**` — invalid IR).
+// The array-literal inference arm feeds both this direct capture and the
+// index-element resolution the sibling fixtures exercise.
+fn main() ![io] {
+    let nums = [10, 20, 30, 40];
+    let big = nums.filter(fn (x) -> boolean { return x > nums[0]; });
+    print(big.length);
+}

--- a/compiler/tests/e2e/fixtures/float_array_index_mutate/main.sfn
+++ b/compiler/tests/e2e/fixtures/float_array_index_mutate/main.sfn
@@ -1,0 +1,12 @@
+// compiler/tests/e2e/fixtures/float_array_index_mutate/main.sfn
+//
+// #1839 acceptance — index and mutate a `float[]`: read an element, write a
+// new value into another slot, read it back. Guards the float/double array
+// element addressing path (GEP over a `{ double*, i64, i64 }*` array).
+fn main() ![io] {
+    let mut xs: float[] = [3.5, 1.2, 2.8];
+    let a = xs[0];
+    xs[1] = 9.9;
+    let b = xs[1];
+    print("a={{a}} b={{b}}");
+}

--- a/compiler/tests/e2e/float_array_index_mutate_test.sfn
+++ b/compiler/tests/e2e/float_array_index_mutate_test.sfn
@@ -1,0 +1,35 @@
+// End-to-end regression for #1839 (acceptance criterion) — indexing and
+// mutating a `float[]` must round-trip correctly. Guards the float/double
+// array element addressing path (GEP over a `{ double*, i64, i64 }*` array),
+// the surface the issue's original diagnosis named.
+//
+// Drives the compiler-under-test as a subprocess (see
+// `.claude/rules/no-bash-e2e.md`, `array_filter_closure_test.sfn`).
+import { trim_right } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+struct RunOut {
+    exit: int;
+    out: string;
+}
+
+fn _run_fixture(path: string) -> RunOut ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", path], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return RunOut { exit: exit, out: trim_right(out) };
+}
+
+test "float array: index read and slot mutate round-trip" ![io] {
+    let r = _run_fixture("compiler/tests/e2e/fixtures/float_array_index_mutate/main.sfn");
+    assert r.exit == 0;
+    // xs[0] read as 3.5; xs[1] mutated to 9.9 and read back.
+    assert r.out == "a=3.5 b=9.9";
+}

--- a/compiler/tests/unit/typecheck_lambda_capture_test.sfn
+++ b/compiler/tests/unit/typecheck_lambda_capture_test.sfn
@@ -141,6 +141,44 @@ test "captures: un-annotated negative int initializer infers int type_text" ![io
     assert strings_equal(records[0].captures[0].type_text, "int");
 }
 
+// #1839: an un-annotated `let pivot = arr[0]` (functional quicksort's
+// `arr.filter(fn(x) => x < pivot)`) must infer its element type from the
+// indexed array's binding — otherwise the capture falls back to `i8*` while
+// the stored value is an `i64`, emitting `store i8* %v, i8** ...` (invalid IR
+// that fails at link). The array's type is recovered from an annotated
+// binding (here a literal `let`, below a `T[]` parameter).
+test "captures: un-annotated index-of-array initializer infers element type" ![io] {
+    let source = "let nums = [10, 7, 8]; let pivot = nums[0]; let f = fn() -> int { return pivot; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].name, "pivot");
+    assert strings_equal(records[0].captures[0].type_text, "int");
+    assert records[0].captures[0].by_value;
+}
+
+test "captures: un-annotated index-of-float-array infers float element" ![io] {
+    let source = "let xs = [1.5, 2.5]; let head = xs[0]; let f = fn() -> float { return head; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].type_text, "float");
+}
+
+// #1839: an un-annotated `let p = q` inherits `q`'s known primitive type so a
+// scalar capture does not fall through to the `i8*` fallback.
+test "captures: un-annotated identifier initializer inherits primitive type" ![io] {
+    let source = "let a: int = 5; let b = a; let f = fn() -> int { return b; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].name, "b");
+    assert strings_equal(records[0].captures[0].type_text, "int");
+}
+
 test "captures: mutability of the enclosing binding is recorded" ![io] {
     let source = "let mut counter: int = 0; let inc = fn() -> int { return counter; };";
     let program = parse_program(source);

--- a/examples/algorithms/quicksort.sfn
+++ b/examples/algorithms/quicksort.sfn
@@ -1,17 +1,21 @@
 // examples/algorithms/quicksort.sfn
-
 fn quicksort(arr: int[]) -> int[] {
     if arr.length <= 1 { return arr; }
 
     let pivot = arr[0];
-    let less = arr.filter(fn(x) -> boolean { return x < pivot; });
-    let equal = arr.filter(fn(x) -> boolean { return x == pivot; });
-    let greater = arr.filter(fn(x) -> boolean { return x > pivot; });
+    let less = arr.filter(fn (x) -> boolean { return x < pivot; });
+    let equal = arr.filter(fn (x) -> boolean { return x == pivot; });
+    let greater = arr.filter(fn (x) -> boolean { return x > pivot; });
 
     return quicksort(less).concat(equal).concat(quicksort(greater));
 }
 
 fn main() ![io] {
     let nums = [10, 7, 8, 9, 1, 5];
-    print("Sorted: {{quicksort(nums)}}");
+    let sorted = quicksort(nums);
+    // Render element-wise: whole-array interpolation is not yet supported
+    // (tracked separately under epic #549's string-formatting category).
+    let mut line = "Sorted:";
+    for x in sorted { line = line + " {{x}}"; }
+    print(line);
 }

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -54,7 +54,6 @@ KNOWN_FAILING=(
     "examples/concurrency/producer-consumer.sfn"       # #1835 lowering fatal fixed; run still hangs on drain (#549 await follow-up)
     "examples/concurrency/dynamic-task-scheduling.sfn" # fn-typed channel element + await (#829)
     "examples/advanced/matrix-multiplication.sfn"      # #1836 range/nested-array map still gated (#766)
-    "examples/algorithms/quicksort.sfn"                # #1839 double-array GEP i64/ptr
 )
 
 in_list() {


### PR DESCRIPTION
## Summary

- An un-annotated `let pivot = arr[0]` captured by a closure (functional quicksort's `arr.filter(fn(x) => x < pivot)`) laid out its env field as the opaque `i8*` fallback while the stored value was the real scalar (`i64`), emitting `store i8* %v, i8** %field` — invalid IR the verifier rejected at link (`'%tN' defined with type 'i64' but expected 'ptr'`).
- Extends the `#1610` un-annotated-`let` capture inference (`analyze_lambda_captures`) to be scope-aware and cover **index-of-array** (`let pivot = arr[0]`), **identifier alias** (`let p = q`), and **array literal** (`let nums = [10, 7]`) initializers, restricted to the `is_primitive_type` set. The fix populates `Capture.type_text` in capture analysis so the store side and the load prologue (which re-derives field types from the `Capture` record alone) stay in agreement.

Closes #1839

## Corrected diagnosis

The issue was groomed as "array-of-`double` GEP emits base as `i64` instead of `ptr`." That diagnosis was inaccurate: `float[]`/`double[]` index+mutate already lowers correctly and every array-index GEP site is element-type-parametric. The real defect is closure **capture-type inference** for un-annotated `let` bindings — it reproduces with plain `int`, no float involved. Confirmed with the user before proceeding.

## Acceptance Criteria

- [x] `algorithms/quicksort.sfn` runs and prints the sorted array. Compiles, links, and runs (exit 0); prints `Sorted: 1 5 7 8 9 10`. Rendered element-wise — whole-array `{{}}` interpolation is a *separate* unshipped gap (epic #549 string-formatting category), tracked as follow-up, not this defect.
- [x] e2e test: index and mutate a `float[]` (`float_array_index_mutate_test.sfn`).
- [x] Self-hosts (`make compile`).

## Map reconciliation

The advisory `## Files Affected` map pointed at `compiler/src/llvm/lowering/*` (array element GEP for float/double). Reconciled at pickup: the actual fix lives in `compiler/src/typecheck_captures.sfn` (closure capture-type inference) — a different subsystem than the map named, because the groomed root-cause was wrong. Surfaced to the user (scope divergence) and approved before implementing. The GEP lowering path named in the map is correct as-is and unchanged.

## Verification

```bash
make compile                                                    # self-hosts (pass)
build/native/sailfin run examples/algorithms/quicksort.sfn      # Sorted: 1 5 7 8 9 10
build/native/sailfin test compiler/tests/unit/typecheck_lambda_capture_test.sfn         # 25/25
build/native/sailfin test compiler/tests/e2e/closure_capture_inferred_pivot_test.sfn    # 2/2
build/native/sailfin test compiler/tests/e2e/float_array_index_mutate_test.sfn          # 1/1
build/native/sailfin test compiler/tests/e2e/array_filter_closure_test.sfn              # 1/1 (no regression)
build/native/sailfin test compiler/tests/e2e/closure_capture_test.sfn                   # 7/7 (no regression)
```

## Files Changed

- `compiler/src/typecheck_captures.sfn` — scope-aware capture-type inference (index / identifier / array-literal initializers).
- `compiler/tests/unit/typecheck_lambda_capture_test.sfn` — 3 unit tests pinning the new inference arms.
- `compiler/tests/e2e/closure_capture_inferred_pivot_test.sfn` (+ fixtures) — quicksort-style closure-capture regression + whole-array-capture coverage.
- `compiler/tests/e2e/float_array_index_mutate_test.sfn` (+ fixture) — `float[]` index/mutate round-trip.
- `examples/algorithms/quicksort.sfn` — prints the sorted array element-wise.

---
_Generated by [Claude Code](https://claude.ai/code/session_012obL9hEJV5SN9wnhFoKYf2)_