### PR TITLE
feat(runtime): bridge websocket.* client to a native ws:// runtime

### DIFF
--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -252,31 +252,27 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.target == "sailfin_intrinsic_fs_get_perms" {
                 _preamble_inlined = true;
             }
-            // #1601: effect-metadata-only rows for `websocket.*` and the
-            // Call-form `serve` (registered in `runtime_helpers.sfn` so
-            // the effect checker can derive their capabilities from the
-            // registry). They are NOT bridged to a runtime symbol — the
+            // #1601 / #1876: `websocket.serve` and the Call-form `serve` stay
+            // effect-metadata-only, so they stay sentinel-skipped — their
             // descriptor `symbol`s are deliberately fake
             // (`sfn_websocket_unbridged` / `sfn_serve_unbridged`) and no
             // lowering emits a `call` against them. The source-text walker
             // (`filter_runtime_helper_targets`) can still surface these
-            // targets from a literal `serve` / `websocket.*` token in a
-            // compiled module, which would otherwise drive the loop below
-            // to emit a `declare` to an undefined symbol and break the
-            // link. Skip them here so a metadata-only row never declares.
-            // The real serve runtime declares come from the
-            // `serve_start` / `serve_handler_dispatch` rows (distinct
-            // targets, real `sfn_serve` symbol) and are unaffected.
+            // targets from a literal `serve` / `websocket.serve` token in a
+            // compiled module, which would otherwise drive the loop below to
+            // emit a `declare` to an undefined symbol and break the link. Skip
+            // them so a metadata-only row never declares. The real serve
+            // runtime declares come from the `serve_start` /
+            // `serve_handler_dispatch` rows (distinct targets, real
+            // `sfn_serve` symbol) and are unaffected.
+            //
+            // `websocket.connect`/`.send`/`.close` are NO LONGER skipped: they
+            // are bridged to real `sfn_websocket_*` symbols in
+            // `runtime/sfn/adapters/websocket.sfn` (#1876), so the normal
+            // declare path below emits a real `declare` the linker resolves
+            // against that runtime module. `websocket.serve`'s runtime bridge
+            // is tracked in #1877.
             if descriptor.target == "websocket.serve" {
-                _preamble_inlined = true;
-            }
-            if descriptor.target == "websocket.send" {
-                _preamble_inlined = true;
-            }
-            if descriptor.target == "websocket.close" {
-                _preamble_inlined = true;
-            }
-            if descriptor.target == "websocket.connect" {
                 _preamble_inlined = true;
             }
             if descriptor.target == "serve" { _preamble_inlined = true; }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -1010,36 +1010,40 @@ fn _rh_descriptors_07(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
         target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: "sfn_serve_handler_dispatch", c_abi_return_type: null
     });
 
-    // Effect-metadata-only rows (#1601, epic #1180 Phase G). These give
-    // the effect checker a registry source for `websocket.*` and the
-    // Call-form `serve` so `effects_for_callee_target` resolves them,
-    // letting the checker drop the last two hardcoded name->effect `if`
-    // chains (`websocket` Member arm, `serve` Call arm in
-    // `effect_checker.sfn`). They are NOT bridged to a runtime symbol:
-    // the `symbol`s below are deliberately fake (`sfn_*_unbridged`) and
-    // these targets are sentinel-skipped in
-    // `rendering.sfn::render_runtime_helper_declarations` so no `declare`
-    // is ever emitted for them — a metadata row must never produce a
-    // call/declare to an undefined symbol (the spurious-declare/link
-    // hazard that kept #1183 from adding them). `return_type`/
-    // `parameter_types` are placeholders; no lowering consults them.
+    // Registry rows for `websocket.*` and the Call-form `serve` (#1601,
+    // epic #1180 Phase G): the effect checker derives their capabilities
+    // from these rows via `effects_for_callee_target`, replacing the last
+    // two hardcoded name->effect `if` chains (`websocket` Member arm,
+    // `serve` Call arm in `effect_checker.sfn`).
+    //
+    // `websocket.connect`/`.send`/`.close` are BRIDGED to the Sailfin-native
+    // client runtime in `runtime/sfn/adapters/websocket.sfn` (#1876): real
+    // `sfn_websocket_*` symbols, `native_signature`, and LLVM types, so the
+    // generic member-call path lowers them to real calls (mirroring the
+    // `http.*` rows). Their sentinel-skips in
+    // `rendering.sfn::render_runtime_helper_declarations` were removed with
+    // the bridge.
+    //
+    // `websocket.serve` and the Call-form `serve` remain effect-metadata-only:
+    // their `symbol`s are deliberately fake (`sfn_*_unbridged`) and they stay
+    // sentinel-skipped so a metadata row never produces a call/declare to an
+    // undefined symbol (the spurious-declare/link hazard that kept #1183 from
+    // adding them). The `websocket.serve` runtime bridge is tracked in #1877;
+    // the Call-form `serve` lowers via its own bespoke path
+    // (`serve_start`/`serve_handler_dispatch` rows + `core.sfn`).
     //
     // `serve` carries `["io", "net"]` to match the prelude/capsule
     // `fn serve(...) ![io, net]` signatures and the
     // `serve_start`/`serve_handler_dispatch` rows above — the honest set,
-    // tighter than #1183's retained `net`-only check. One `websocket.*`
-    // row makes `effects_for_callee_target("websocket.<anything>")`
-    // resolve to `["net"]` via the namespace-union fallback; the four
-    // concrete ops document the intended op surface for the future
-    // websocket runtime bridge (gap tracked separately).
+    // tighter than #1183's retained `net`-only check.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "websocket.serve", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "websocket.send", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "websocket.send", symbol: "sfn_websocket_send", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_websocket_send", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "websocket.close", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "websocket.close", symbol: "sfn_websocket_close", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_websocket_close", c_abi_return_type: null
     });
     return descriptors;
 }
@@ -1047,7 +1051,7 @@ fn _rh_descriptors_07(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
 fn _rh_descriptors_08(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelperDescriptor[] {
     let mut descriptors = descriptors_in;
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "websocket.connect", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "websocket.connect", symbol: "sfn_websocket_connect", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_websocket_connect", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "serve", symbol: "sfn_serve_unbridged", return_type: "void", parameter_types: [], effects: ["io", "net"], native_signature: null, c_abi_return_type: null

--- a/compiler/tests/e2e/runtime_adapter_websocket_test.sfn
+++ b/compiler/tests/e2e/runtime_adapter_websocket_test.sfn
@@ -1,0 +1,200 @@
+// End-to-end test for runtime/sfn/adapters/websocket.sfn — the
+// Sailfin-native RFC 6455 `ws://` client adapter (#1876, epic #1180
+// Phase G follow-through; parent #1630).
+//
+// Pins, end-to-end, the client-bridge registry flip (#1876) that replaced
+// the effect-metadata-only `sfn_websocket_unbridged` sentinel rows (#1601)
+// with real `sfn_websocket_*` symbols:
+//   1. typecheck   — `sfn check runtime/sfn/adapters/websocket.sfn` is ok.
+//   2. fmt         — the module is fmt-canonical.
+//   3. emit shape  — the module emits a `define` for every sfn_websocket_*
+//                    client export and `declare`s the BSD-sockets libc
+//                    surface (socket/connect/send/recv/close) plus the
+//                    OpenSSL handshake surface it links (RAND_bytes,
+//                    EVP_EncodeBlock).
+//   4. routing     — `websocket.connect/.send/.close` member calls lower to
+//                    real `@sfn_websocket_*` calls and NOT the unbridged
+//                    `@sfn_websocket_unbridged` sentinel.
+//
+// OMITTED here: the behavioral loopback send/receive/close round-trip. It
+// needs a real server end (`websocket.serve`), which lands in #1877; the
+// loopback test lands with it. This test covers the client registry-flip
+// behavior (emit shape + routing) without a network, mirroring
+// `runtime_adapter_http_test.sfn`.
+//
+// NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]`, so
+// they cannot be called from an `![io]` test. For subprocess/IR-output
+// assertions use `sfn/strings` (`find` / `split` / `starts_with` /
+// `contains` / `char_at_index`).
+import {
+    find,
+    split,
+    starts_with,
+    contains,
+    char_at_index
+} from "sfn/strings";
+
+// The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
+// binary relative to the repo root the runner starts from.
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `run_capture`'s empty array is the *empty* environment; thread the
+// variables the toolchain needs. `emit` / `check` neither link nor spawn
+// clang (no PATH required), but keep the standard set for portability.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// A unique scratch dir for this test (under the runner's per-file scratch
+// when present, else /tmp).
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/sfn-runtime-websocket";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Emit LLVM IR for the module at `module_path` and return it (or
+// "EMIT_FAILED" on a non-zero exit).
+fn _emit_module(tag: string, module_path: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let outpath = dir + "/" + tag + ".ll";
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", outpath, "llvm", module_path], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return "EMIT_FAILED"; }
+    return fs.readFile(outpath);
+}
+
+// Emit LLVM IR for source written to a scratch `.sfn` file, then read it
+// back (or "EMIT_FAILED" on a non-zero exit).
+fn _emit_source(tag: string, source: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let srcpath = dir + "/" + tag + ".sfn";
+    fs.writeFile(srcpath, source);
+    return _emit_module(tag, srcpath);
+}
+
+// `^define .* @sym(` — a line that starts the symbol's definition.
+fn _has_define(ir: string, sym: string) -> boolean {
+    let lines = split(ir, "\n");
+    let mut i = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = lines[i];
+        if starts_with(line, "define ") && contains(line, "@" + sym + "(") {
+            return true;
+        }
+        i = i + 1;
+    }
+    return false;
+}
+
+// `^declare .* @sym(` — the module declares the libc/OpenSSL trampoline.
+fn _has_declare(ir: string, sym: string) -> boolean {
+    let lines = split(ir, "\n");
+    let mut i = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = lines[i];
+        if starts_with(line, "declare ") && contains(line, "@" + sym + "(") {
+            return true;
+        }
+        i = i + 1;
+    }
+    return false;
+}
+
+// Does any `call`/`invoke` line target `@sym(`?
+fn _calls(ir: string, sym: string) -> boolean {
+    let lines = split(ir, "\n");
+    let mut i = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = lines[i];
+        let is_call = contains(line, "call ") || contains(line, "invoke ");
+        if is_call && contains(line, "@" + sym + "(") { return true; }
+        i = i + 1;
+    }
+    return false;
+}
+
+test "runtime/sfn/adapters/websocket.sfn typechecks cleanly" ![io] {
+    let exit = process.run_capture([_sfn_bin(), "check", "runtime/sfn/adapters/websocket.sfn"], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    assert exit == 0;
+    assert find(out + err, "ok", 0) >= 0;
+}
+
+test "runtime/sfn/adapters/websocket.sfn is fmt-canonical" ![io] {
+    let exit = process.run_capture([_sfn_bin(), "fmt", "--check", "runtime/sfn/adapters/websocket.sfn"], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    assert exit == 0;
+}
+
+test "websocket emit: define for every sfn_websocket_* client export" ![io] {
+    let ir = _emit_module("websocket", "runtime/sfn/adapters/websocket.sfn");
+    assert ir != "EMIT_FAILED";
+    assert _has_define(ir, "sfn_websocket_connect");
+    assert _has_define(ir, "sfn_websocket_send");
+    assert _has_define(ir, "sfn_websocket_close");
+}
+
+test "websocket emit: declares the BSD-sockets libc surface" ![io] {
+    let ir = _emit_module("websocket", "runtime/sfn/adapters/websocket.sfn");
+    assert ir != "EMIT_FAILED";
+    assert _has_declare(ir, "socket");
+    assert _has_declare(ir, "connect");
+    assert _has_declare(ir, "send");
+    assert _has_declare(ir, "recv");
+    assert _has_declare(ir, "close");
+}
+
+test "websocket emit: declares the OpenSSL handshake surface it links" ![io] {
+    let ir = _emit_module("websocket", "runtime/sfn/adapters/websocket.sfn");
+    assert ir != "EMIT_FAILED";
+    // The RFC 6455 client masks every frame (RAND_bytes) and base64-encodes
+    // the Sec-WebSocket-Key (EVP_EncodeBlock) — both from libcrypto, already
+    // linked repo-wide via `-lssl -lcrypto` (runtime/capsule.toml).
+    assert _has_declare(ir, "RAND_bytes");
+    assert _has_declare(ir, "EVP_EncodeBlock");
+}
+
+test "websocket.connect/.send/.close lower to @sfn_websocket_*, not the unbridged sentinel" ![io] {
+    // `![io, net]`: `websocket.*` requires `net` from the registry rows;
+    // `websocket.send` additionally trips the effect checker's receiver-
+    // agnostic `.send(` -> `channel_send` (io) rule (a pre-existing
+    // conservative-policy collision, out of scope for the #1876 runtime
+    // bridge — the chat example's `main` declares `![io, net]` for the same
+    // reason).
+    let source = "fn main() -> int ![io, net] {\n"
+        + "    let conn = websocket.connect(\"ws://127.0.0.1:9/\");\n"
+        + "    websocket.send(conn, \"hello\");\n"
+        + "    websocket.close(conn);\n"
+        + "    return 0;\n"
+        + "}\n";
+    let ir = _emit_source("websocket_member_probe", source);
+    assert ir != "EMIT_FAILED";
+    // The flipped registry rows route through the real client symbols.
+    assert _calls(ir, "sfn_websocket_connect");
+    assert _calls(ir, "sfn_websocket_send");
+    assert _calls(ir, "sfn_websocket_close");
+    // The deliberately-fake metadata sentinel must never be called.
+    assert ! _calls(ir, "sfn_websocket_unbridged");
+}

--- a/compiler/tests/unit/runtime_helper_metadata_only_test.sfn
+++ b/compiler/tests/unit/runtime_helper_metadata_only_test.sfn
@@ -2,11 +2,18 @@
 //
 // Standing guard for #1631 (epic #1180, Phase G). The effect-metadata-only
 // descriptor rows #1601 registered — so the effect checker can derive the
-// `websocket.*` and Call-form `serve` capabilities from the registry — must
-// NEVER produce a `declare` line. Their `symbol`s are deliberately fake
+// Call-form `serve` and `websocket.serve` capabilities from the registry —
+// must NEVER produce a `declare` line. Their `symbol`s are deliberately fake
 // (`sfn_websocket_unbridged` / `sfn_serve_unbridged`): no runtime is bridged,
 // and `render_runtime_helper_declarations` sentinel-skips them in
 // `rendering.sfn` (the `_preamble_inlined` cascade).
+//
+// `websocket.connect` / `.send` / `.close` are NO LONGER in this set: they
+// were bridged to the real `sfn_websocket_*` client runtime in #1876, so
+// their sentinel-skips were removed and they now emit real declares (covered
+// by `compiler/tests/e2e/runtime_adapter_websocket_test.sfn`). Only the
+// still-unbridged `serve` and `websocket.serve` remain guarded here
+// (`websocket.serve`'s runtime bridge is tracked in #1877).
 //
 // Today the only guard is `make compile`: if a sentinel-skip is removed, the
 // source-text walker (`filter_runtime_helper_targets`) can surface the target
@@ -21,10 +28,11 @@ import { find } from "sfn/strings";
 import { render_runtime_helper_declarations } from "../../src/llvm/rendering";
 import { NativeFunction } from "../../src/native_ir";
 
-// The five effect-metadata-only targets #1601 registered (Call-form `serve`
-// plus the `websocket.*` op surface).
+// The effect-metadata-only targets that remain after the #1876 client
+// bridge: the Call-form `serve` and `websocket.serve` (the three bridged
+// `websocket.connect`/`.send`/`.close` ops are no longer metadata-only).
 fn _metadata_only_targets() -> string[] {
-    return ["serve", "websocket.serve", "websocket.send", "websocket.close", "websocket.connect"];
+    return ["serve", "websocket.serve"];
 }
 
 // True if any emitted line contains `needle` as a substring.
@@ -39,11 +47,11 @@ fn _any_line_contains(lines: string[], needle: string) -> boolean {
 }
 
 test "metadata-only rows (#1631): sentinel targets emit no declare for the unbridged symbols" {
-    // All five metadata-only targets present in `used_targets`. Each is
+    // Both remaining metadata-only targets present in `used_targets`. Each is
     // sentinel-skipped, so the fake symbols must never reach a `declare`.
-    // Removing any one of the `_preamble_inlined` skips in `rendering.sfn`
-    // makes the corresponding row emit `declare void @sfn_*_unbridged()`,
-    // tripping these assertions at unit speed instead of as a link failure.
+    // Removing either `_preamble_inlined` skip in `rendering.sfn` makes the
+    // corresponding row emit `declare void @sfn_*_unbridged()`, tripping these
+    // assertions at unit speed instead of as a link failure.
     let no_locals: NativeFunction[] = [];
     let no_imports: NativeFunction[] = [];
     let lines = render_runtime_helper_declarations(_metadata_only_targets(), no_locals, no_imports);

--- a/runtime/capsule.toml
+++ b/runtime/capsule.toml
@@ -46,7 +46,7 @@ ll-sources = []
 #   `compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh`.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["sfn/runtime_globals.sfn", "sfn/memory/arena.sfn", "sfn/memory/rc.sfn", "sfn/memory/mem.sfn", "sfn/memory/ownedbuf.sfn", "sfn/string.sfn", "sfn/array.sfn", "sfn/clock.sfn", "sfn/process.sfn", "sfn/io.sfn", "sfn/exception.sfn", "sfn/assert.sfn", "sfn/type_meta.sfn", "sfn/platform/exec.sfn", "sfn/platform/rlimit.sfn", "sfn/platform/tls.sfn", "sfn/adapters/filesystem.sfn", "sfn/adapters/http.sfn", "sfn/adapters/net.sfn", "sfn/concurrency/scheduler.sfn", "sfn/concurrency/nursery.sfn", "sfn/concurrency/future.sfn", "sfn/concurrency/channel.sfn", "sfn/concurrency/parallel.sfn", "sfn/concurrency/serve.sfn"]
+sfn-sources = ["sfn/runtime_globals.sfn", "sfn/memory/arena.sfn", "sfn/memory/rc.sfn", "sfn/memory/mem.sfn", "sfn/memory/ownedbuf.sfn", "sfn/string.sfn", "sfn/array.sfn", "sfn/clock.sfn", "sfn/process.sfn", "sfn/io.sfn", "sfn/exception.sfn", "sfn/assert.sfn", "sfn/type_meta.sfn", "sfn/platform/exec.sfn", "sfn/platform/rlimit.sfn", "sfn/platform/tls.sfn", "sfn/adapters/filesystem.sfn", "sfn/adapters/http.sfn", "sfn/adapters/websocket.sfn", "sfn/adapters/net.sfn", "sfn/concurrency/scheduler.sfn", "sfn/concurrency/nursery.sfn", "sfn/concurrency/future.sfn", "sfn/concurrency/channel.sfn", "sfn/concurrency/parallel.sfn", "sfn/concurrency/serve.sfn"]
 include-dirs = []
 # `-lssl -lcrypto`: OpenSSL, linked into every Sailfin binary for the
 # native runtime's TLS surface (`sfn/platform/tls.sfn`, SFEP-0036). The

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -299,7 +299,7 @@ fn _ws_send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
 // server that splits the `101` status line and headers across TCP
 // segments is not handled here; the drain-until-`\r\n\r\n` receive loop
 // lands with the server bridge and behavioral loopback test (#1877).
-fn _ws_recv_some(fd: i32, buf: * u8, cap: i64) -> i64 {
+fn _ws_recv_some(fd: i32, buf: * u8, cap: i64) -> i64 ![net] {
     return recv(fd, buf, cap, 0);
 }
 
@@ -464,7 +464,12 @@ fn _ws_find(haystack: * u8, needle: * u8) -> * u8 {
 // into `dst24` (24-char NUL-terminated buffer, per RFC 4648 padding)
 // via OpenSSL `EVP_EncodeBlock`.
 fn _ws_base64_16(src: * u8, dst24: * u8) -> void {
-    EVP_EncodeBlock(dst24, src, 16);
+    // EVP_EncodeBlock already NUL-terminates and returns the encoded length
+    // (24 for 16 input bytes); re-assert the terminator at that length so
+    // `strlen(dst24)` is well-defined regardless of the libcrypto build. The
+    // 25-byte buffer holds 24 chars + NUL.
+    let enc_len: i32 = EVP_EncodeBlock(dst24, src, 16);
+    memset(_ws_ptr_off(dst24, enc_len as i64), 0, 1 as usize);
 }
 
 // `_ws_sec_accept(key_b64, out28)` — compute the expected
@@ -489,7 +494,11 @@ fn _ws_sec_accept(key_b64: * u8, out28: * u8) -> void {
     }
     SHA1(concat, total as usize, digest);
     free(concat);
-    EVP_EncodeBlock(out28, digest, 20);
+    // Defensive NUL-terminate at the encoded length (28 for a 20-byte
+    // digest) so `strlen(out28)` is well-defined; the 29-byte buffer holds
+    // 28 chars + NUL.
+    let enc_len: i32 = EVP_EncodeBlock(out28, digest, 20);
+    memset(_ws_ptr_off(out28, enc_len as i64), 0, 1 as usize);
     free(digest);
 }
 

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -1,0 +1,772 @@
+// runtime/sfn/adapters/websocket.sfn
+//
+// First-wave Sailfin-native RFC 6455 `ws://` CLIENT adapter (#1876).
+// Mirrors the socket/pointer idioms of `runtime/sfn/adapters/http.sfn`
+// (TCP connect, DNS resolution, socket-timeout arming) and the
+// `_serve_`-prefix collision-avoidance convention of
+// `runtime/sfn/concurrency/serve.sfn`: the native backend gives
+// file-local runtime helpers external linkage, so every helper here
+// carries a `_ws_` prefix to avoid a duplicate-symbol link error
+// against `http.sfn`'s identically-shaped helpers.
+//
+// Scope: `ws://` only (no TLS/`wss://`), client-side only (connect,
+// send a single masked TEXT frame, close). No fragmentation, no
+// ping/pong, no receive-loop — the minimal handshake + framed send
+// needed to talk to a websocket server from Sailfin code.
+//
+// ABI. `compiler/src/llvm/runtime_helpers.sfn` points the websocket
+// registry rows at the exports below (owned by the orchestrator, not
+// this file):
+//   - `websocket.connect(url)`        -> `sfn_websocket_connect` (i8*) -> i8*
+//   - `websocket.send(handle, msg)`   -> `sfn_websocket_send`    (i8*, i8*) -> i8*
+//   - `websocket.close(handle)`       -> `sfn_websocket_close`   (i8*) -> i8*
+//
+// The handle is a `malloc(16)` cell: the connected socket fd is stored
+// as an `i32` at offset 0 (one byte at a time, matching http.sfn's
+// single-byte `memset` idiom for multi-byte fields); offsets 4..16 are
+// reserved and zeroed. `sfn_websocket_close` frees it.
+//
+// Why inline the externs rather than `import` from
+// `../platform/net.sfn` / `../platform/libc.sfn`? Same #306 rationale
+// as every other `runtime/sfn/*.sfn` module (see `http.sfn` / `filesystem.sfn`
+// headers): the seed compiler reaches the cross-module extern resolver
+// through a path #306 has not closed, so inlining keeps this module
+// self-contained for every seed. Declaring the same C symbol in two
+// modules is safe — each emits its own LLVM `declare` and the linker
+// resolves both to the single libc entrypoint.
+//
+// Decimal byte constants (no char/octal literals in the seed):
+//   47 = '/'   58 = ':'   49 = '1'   48 = '0'
+// AF_INET = 2, SOCK_STREAM = 1 (identical on Linux x86_64 and macOS
+// arm64, the two targets this runtime builds for).
+// ── libc memory + string helpers ──────────────────────────────
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+// C `int atoi(const char *)` — parses a leading decimal integer,
+// stops at the first non-digit. Declared `-> i32` to match the C
+// 32-bit return; octet / port values fit comfortably.
+extern fn atoi(s: * u8) -> i32;
+
+// ── BSD sockets (libc) ────────────────────────────────────────
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+
+extern fn connect(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn send(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn close(fd: i32) -> i32;
+
+extern fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: * u8, optlen: i32) -> i32;
+
+// ── DNS resolution (libc) ─────────────────────────────────────
+extern fn getaddrinfo(node: * u8, service: * u8, hints: * u8, res: * * u8) -> i32;
+
+extern fn freeaddrinfo(res: * u8) -> void;
+
+// ── OpenSSL (handshake crypto only — linked repo-wide, see
+// `runtime/capsule.toml` `link-libs`) ──────────────────────────
+extern fn SHA1(d: * u8, n: usize, md: * u8) -> * u8;
+
+extern fn EVP_EncodeBlock(dst: * u8, src: * u8, srclen: i32) -> i32;
+
+extern fn RAND_bytes(buf: * u8, num: i32) -> i32;
+
+// `_ws_ptr_off(p, off)` — byte-stride pointer arithmetic for a
+// variable offset. Mirrors `http.sfn`'s `_ptr_off`.
+fn _ws_ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+// `_ws_byte_at(base, off)` — read the byte at `base + off` as 0..255.
+// Mirrors `http.sfn`'s `_byte_at`.
+fn _ws_byte_at(base: * u8, off: i64) -> i64 {
+    return (sailfin_intrinsic_pointer_read_i32(_ws_ptr_off(base, off)) as i64) & 255;
+}
+
+// `_ws_first_is_digit(p)` — is the first byte at `p` an ASCII digit
+// (`'0'`..`'9'` = 48..57)? Mirrors `http.sfn`'s `_first_is_digit`.
+fn _ws_first_is_digit(p: * u8) -> bool {
+    let b: i64 = (sailfin_intrinsic_pointer_read_i32(p) as i64) & 255;
+    return b >= 48 && b <= 57;
+}
+
+// `_ws_parse_quad(host, out)` — parse `host` as a numeric dotted-quad
+// IPv4 address, writing the four octets to `out[0..4]`. Returns false
+// on anything that is not a clean `N.N.N.N`. Mirrors `http.sfn`'s
+// `_parse_quad`.
+fn _ws_parse_quad(host: * u8, out: * u8) -> bool {
+    let mut cursor: * u8 = host;
+    let mut i: i64 = 0;
+    loop {
+        if i >= 4 { break; }
+        if !_ws_first_is_digit(cursor) { return false; }
+        let octet: i64 = atoi(cursor) as i64;
+        if octet < 0 || octet > 255 { return false; }
+        memset(_ws_ptr_off(out, i), octet as i32, 1 as usize);
+        if i < 3 {
+            let dot: * u8 = _ws_strchr(cursor, 46);
+            if dot as i64 == 0 { return false; }
+            cursor = _ws_ptr_off(dot, 1);
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+// `_ws_strchr(s, c)` — find the first byte equal to `c` in the
+// NUL-terminated `s`, or null. Hand-rolled (no libc `strchr` extern
+// declared in this self-contained module) via `_ws_byte_at`.
+fn _ws_strchr(s: * u8, c: i64) -> * u8 {
+    let mut i: i64 = 0;
+    loop {
+        let b: i64 = _ws_byte_at(s, i);
+        if b == c { return _ws_ptr_off(s, i); }
+        if b == 0 { return null; }
+        i = i + 1;
+    }
+    return null;
+}
+
+// `_ws_sockaddr_octets(sa, out)` — given the address of a `sockaddr_in`
+// (`sa`, as an i64), validate it is an AF_INET address and copy its
+// four `sin_addr` octets to `out[0..4]`. Mirrors `http.sfn`'s
+// `_sockaddr_octets`.
+fn _ws_sockaddr_octets(sa: i64, out: * u8) -> bool {
+    if sa == 0 { return false; }
+    let head4: i64 = sailfin_intrinsic_pointer_read_i32(sa as * u8) as i64;
+    let b0: i64 = head4 & 255;
+    let b1: i64 = (head4 >> 8) & 255;
+    if b0 != 2 && b1 != 2 { return false; }
+    memcpy(out, (sa + 4) as * u8, 4 as usize);
+    return true;
+}
+
+// `_ws_resolve_dns(host, out)` — resolve a hostname to its first IPv4
+// (A) address via libc `getaddrinfo`, writing the four octets to
+// `out[0..4]`. Mirrors `http.sfn`'s `_resolve_dns` (v0 scope: IPv4
+// only, first A record, no caching).
+fn _ws_resolve_dns(host: * u8, out: * u8) -> bool ![net] {
+    let hints: * u8 = malloc(48 as usize);
+    if hints as i64 == 0 { return false; }
+    memset(hints, 0, 48 as usize);
+    memset(_ws_ptr_off(hints, 4), 2, 1 as usize);
+    memset(_ws_ptr_off(hints, 8), 1, 1 as usize);
+    let res: * u8 = malloc(8 as usize);
+    if res as i64 == 0 {
+        free(hints);
+        return false;
+    }
+    memset(res, 0, 8 as usize);
+    let rc: i32 = getaddrinfo(host, null, hints, res as * * u8);
+    free(hints);
+    if rc != 0 {
+        free(res);
+        return false;
+    }
+    let head: i64 = sailfin_intrinsic_pointer_read_i64(res);
+    free(res);
+    if head == 0 { return false; }
+    let cand_a: i64 = sailfin_intrinsic_pointer_read_i64((head + 24) as * u8);
+    let cand_b: i64 = sailfin_intrinsic_pointer_read_i64((head + 32) as * u8);
+    let mut ok: bool = false;
+    if _ws_sockaddr_octets(cand_a, out) { ok = true; } else {
+        if _ws_sockaddr_octets(cand_b, out) { ok = true; }
+    }
+    freeaddrinfo(head as * u8);
+    return ok;
+}
+
+// `_ws_host_ip4(host, out)` — resolve `host` to four IPv4 octets,
+// written to `out[0..4]`. Handles `localhost` and numeric dotted-quad
+// addresses directly; anything else falls through to DNS. Mirrors
+// `http.sfn`'s `_host_ip4`.
+fn _ws_host_ip4(host: * u8, out: * u8) -> bool ![net] {
+    let localhost: string = "localhost";
+    if _ws_streq(host, localhost as * u8) {
+        memset(_ws_ptr_off(out, 0), 127, 1 as usize);
+        memset(_ws_ptr_off(out, 1), 0, 1 as usize);
+        memset(_ws_ptr_off(out, 2), 0, 1 as usize);
+        memset(_ws_ptr_off(out, 3), 1, 1 as usize);
+        return true;
+    }
+    if _ws_parse_quad(host, out) { return true; }
+    return _ws_resolve_dns(host, out);
+}
+
+// `_ws_streq(a, b)` — NUL-terminated byte-for-byte equality. Hand-rolled
+// (no libc `strcmp` extern declared in this self-contained module) via
+// `_ws_byte_at`.
+fn _ws_streq(a: * u8, b: * u8) -> bool {
+    let mut i: i64 = 0;
+    loop {
+        let ba: i64 = _ws_byte_at(a, i);
+        let bb: i64 = _ws_byte_at(b, i);
+        if ba != bb { return false; }
+        if ba == 0 { return true; }
+        i = i + 1;
+    }
+    return true;
+}
+
+// `_ws_io_timeout_secs()` — the recv/send socket-timeout budget
+// (seconds). Mirrors `http.sfn`'s `_http_io_timeout_secs`.
+fn _ws_io_timeout_secs() -> i64 { return 10; }
+
+// `_ws_set_socket_timeouts(fd)` — arm SO_RCVTIMEO + SO_SNDTIMEO on a
+// socket. Mirrors `http.sfn`'s `_set_socket_timeouts`.
+fn _ws_set_socket_timeouts(fd: i32) -> void {
+    let tv: * u8 = malloc(16 as usize);
+    if tv as i64 == 0 { return; }
+    memset(tv, 0, 16 as usize);
+    memset(_ws_ptr_off(tv, 0), _ws_io_timeout_secs() as i32, 1 as usize);
+    setsockopt(fd, 1, 20, tv, 16);
+    setsockopt(fd, 1, 21, tv, 16);
+    setsockopt(fd, 65535, 4102, tv, 16);
+    setsockopt(fd, 65535, 4101, tv, 16);
+    free(tv);
+}
+
+// `_ws_connect_tcp(host, port)` — build an IPv4 `sockaddr_in`, open a
+// stream socket, and connect. Returns the connected fd, or -1 on any
+// failure. Mirrors `http.sfn`'s `_connect_tcp` (dual sockaddr_in
+// layout for Linux/macOS), minus the TLS paths — `ws://` is plaintext
+// only.
+fn _ws_connect_tcp(host: * u8, port: i64) -> i32 ![net] {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 { return 0 - 1; }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            memset(_ws_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            memset(_ws_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_ws_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        memset(_ws_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_ws_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        if _ws_host_ip4(host, _ws_ptr_off(addr, 4)) {
+            let fd: i32 = socket(2, 1, 0);
+            if fd < 0 {
+                free(addr);
+                return 0 - 1;
+            }
+            _ws_set_socket_timeouts(fd);
+            let rc: i32 = connect(fd, addr, 16);
+            free(addr);
+            if rc == 0 { return fd; }
+            close(fd);
+        } else {
+            free(addr);
+            return 0 - 1;
+        }
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+// `_ws_send_all(fd, buf, total)` — write `total` bytes over the raw
+// socket, retrying on short sends. Returns false if a write ever
+// fails. `ws://` is plaintext only, so unlike `http.sfn`'s `_send_all`
+// there is no `ssl` argument.
+fn _ws_send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
+    let mut sent: i64 = 0;
+    loop {
+        if sent >= total { break; }
+        let n: i64 = send(fd, _ws_ptr_off(buf, sent), total - sent, 0);
+        if n <= 0 { return false; }
+        sent = sent + n;
+    }
+    return true;
+}
+
+// `_ws_recv_some(fd, buf, cap)` — a single bounded `recv` into `buf`
+// (up to `cap` bytes). Returns the byte count received (0 on a clean
+// EOF), or -1 on a `recv` error. Enough to read the ~200-byte handshake
+// response in one call on a loopback/localhost peer (the v0 scope). A
+// server that splits the `101` status line and headers across TCP
+// segments is not handled here; the drain-until-`\r\n\r\n` receive loop
+// lands with the server bridge and behavioral loopback test (#1877).
+fn _ws_recv_some(fd: i32, buf: * u8, cap: i64) -> i64 {
+    return recv(fd, buf, cap, 0);
+}
+
+// `_ws_append(dst, off, src)` — copy the NUL-terminated `src` into
+// `dst` at byte offset `off`, returning the new offset. Mirrors
+// `http.sfn`'s `_append`.
+fn _ws_append(dst: * u8, off: i64, src: * u8) -> i64 {
+    let n: i64 = strlen(src) as i64;
+    memcpy(_ws_ptr_off(dst, off), src, n as usize);
+    return off + n;
+}
+
+// `_ws_ci_find(base, limit, needle, nlen)` — first index in
+// `[0, limit)` where the `nlen`-byte `needle` matches
+// case-insensitively, or -1. Mirrors `http.sfn`'s `_ci_find`.
+fn _ws_ci_find(base: * u8, limit: i64, needle: * u8, nlen: i64) -> i64 {
+    if nlen <= 0 { return 0 - 1; }
+    let mut i: i64 = 0;
+    loop {
+        if i + nlen > limit { break; }
+        let mut j: i64 = 0;
+        let mut matched: bool = true;
+        loop {
+            if j >= nlen { break; }
+            if _ws_lc(_ws_byte_at(base, i + j)) != _ws_lc(_ws_byte_at(needle, j)) {
+                matched = false;
+                break;
+            }
+            j = j + 1;
+        }
+        if matched { return i; }
+        i = i + 1;
+    }
+    return 0 - 1;
+}
+
+// `_ws_lc(b)` — ASCII-lowercase a byte value. Mirrors `http.sfn`'s `_lc`.
+fn _ws_lc(b: i64) -> i64 {
+    if b >= 65 && b <= 90 { return b + 32; }
+    return b;
+}
+
+// `_ws_handle_fd(h)` — read back the connected socket fd stored at
+// offset 0 of the handle cell (one byte at a time, little-endian).
+fn _ws_handle_fd(h: * u8) -> i32 {
+    let b0: i64 = _ws_byte_at(h, 0);
+    let b1: i64 = _ws_byte_at(h, 1);
+    let b2: i64 = _ws_byte_at(h, 2);
+    let b3: i64 = _ws_byte_at(h, 3);
+    return (b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)) as i32;
+}
+
+// `_ws_make_handle(fd)` — allocate the 16-byte handle cell, storing
+// `fd` as an `i32` at offset 0 (single-byte writes, matching
+// `http.sfn`'s per-byte field idiom) and zeroing the reserved
+// offsets 4..16. Returns null on OOM.
+fn _ws_make_handle(fd: i32) -> * u8 {
+    let h: * u8 = malloc(16 as usize);
+    if h as i64 == 0 { return null; }
+    memset(h, 0, 16 as usize);
+    let fdv: i64 = fd as i64;
+    let mut k: i64 = 0;
+    loop {
+        if k >= 4 { break; }
+        memset(_ws_ptr_off(h, k), ((fdv >> (8 * k)) & 255) as i32, 1 as usize);
+        k = k + 1;
+    }
+    return h;
+}
+
+// `_ws_parse_url(url, host_slot, path_slot, port_slot)` — parse `url`
+// ("ws://host[:port][/path]"). Strips a leading `ws://` scheme if
+// present (the whole string is treated as the authority otherwise).
+// Writes a freshly-allocated NUL-terminated host string and path string
+// (default `"/"`) and the port (default 80) back through the three
+// slots. The two string pointers are passed as their i64 bit-pattern
+// (`atomic_store` stores only `i64`, not `i8*`; the caller casts back
+// with `as * u8`). Returns false on OOM; the caller owns both allocated
+// strings on success.
+fn _ws_parse_url(url: * u8, host_slot: * i64, path_slot: * i64, port_slot: * i64) -> bool {
+    let sep: string = "://";
+    let mut host_start: * u8 = url;
+    let scheme: * u8 = _ws_find(url, sep as * u8);
+    if scheme as i64 != 0 { host_start = _ws_ptr_off(scheme, 3); }
+
+    let slash: * u8 = _ws_strchr(host_start, 47);
+    let mut authority_len: i64 = 0;
+    if slash as i64 != 0 {
+        authority_len = (slash as i64) - (host_start as i64);
+    } else { authority_len = strlen(host_start) as i64; }
+    let authority: * u8 = _ws_strdup_n(host_start, authority_len);
+    if authority as i64 == 0 { return false; }
+
+    let mut port: i64 = 80;
+    let colon: * u8 = _ws_strchr(authority, 58);
+    if colon as i64 != 0 {
+        port = atoi(_ws_ptr_off(colon, 1)) as i64;
+        memset(colon, 0, 1 as usize);
+    }
+
+    let root: string = "/";
+    let mut path: * u8 = null;
+    if slash as i64 != 0 {
+        path = _ws_strdup_n(slash, strlen(slash) as i64);
+    } else { path = _ws_strdup_n(root as * u8, 1); }
+    if path as i64 == 0 {
+        free(authority);
+        return false;
+    }
+
+    atomic_store(host_slot, authority as i64);
+    atomic_store(path_slot, path as i64);
+    atomic_store(port_slot, port);
+    return true;
+}
+
+// `_ws_strdup_n(src, n)` — copy `n` bytes from `src` into a fresh
+// `malloc`'d NUL-terminated buffer the caller owns. Returns null on
+// OOM. Mirrors `http.sfn`'s `_strdup_n`.
+fn _ws_strdup_n(src: * u8, n: i64) -> * u8 {
+    // +4, not +1 (unlike http.sfn's `_strdup_n`): this module scans its
+    // strdup'd host/path/authority buffers with `_ws_byte_at`'s 4-byte load
+    // (via `_ws_strchr` / `_ws_streq` / `_ws_find`), so the terminating NUL
+    // at offset `n` must have 3 bytes of slack for the tail load. http keeps
+    // its `_strdup_n` at `n+1` because it never applies `_byte_at` to those
+    // heap buffers (it uses libc `strchr`/`strstr` there).
+    let buf: * u8 = malloc((n + 4) as usize);
+    if buf as i64 == 0 { return null; }
+    if n > 0 { memcpy(buf, src, n as usize); }
+    memset(_ws_ptr_off(buf, n), 0, 1 as usize);
+    return buf;
+}
+
+// `_ws_find(haystack, needle)` — find the first occurrence of the
+// NUL-terminated `needle` in the NUL-terminated `haystack`, or null.
+// Hand-rolled (no libc `strstr` extern declared in this
+// self-contained module) via `_ws_byte_at`.
+fn _ws_find(haystack: * u8, needle: * u8) -> * u8 {
+    let nlen: i64 = strlen(needle) as i64;
+    if nlen == 0 { return null; }
+    let mut i: i64 = 0;
+    loop {
+        let hb: i64 = _ws_byte_at(haystack, i);
+        if hb == 0 { return null; }
+        let mut j: i64 = 0;
+        let mut matched: bool = true;
+        loop {
+            if j >= nlen { break; }
+            if _ws_byte_at(haystack, i + j) != _ws_byte_at(needle, j) {
+                matched = false;
+                break;
+            }
+            j = j + 1;
+        }
+        if matched { return _ws_ptr_off(haystack, i); }
+        i = i + 1;
+    }
+    return null;
+}
+
+// `_ws_base64_16(src, dst24)` — base64-encode exactly 16 raw bytes
+// into `dst24` (24-char NUL-terminated buffer, per RFC 4648 padding)
+// via OpenSSL `EVP_EncodeBlock`.
+fn _ws_base64_16(src: * u8, dst24: * u8) -> void {
+    EVP_EncodeBlock(dst24, src, 16);
+}
+
+// `_ws_sec_accept(key_b64, out28)` — compute the expected
+// `Sec-WebSocket-Accept` value for `key_b64`: base64(SHA1(key_b64 +
+// the RFC 6455 GUID)). Writes the 28-char base64 result (NUL-terminated)
+// into `out28`.
+fn _ws_sec_accept(key_b64: * u8, out28: * u8) -> void {
+    let guid: string = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    let key_len: i64 = strlen(key_b64) as i64;
+    let guid_len: i64 = strlen(guid as * u8) as i64;
+    let total: i64 = key_len + guid_len;
+    let concat: * u8 = malloc((total + 1) as usize);
+    if concat as i64 == 0 { return; }
+    let mut off: i64 = 0;
+    off = _ws_append(concat, off, key_b64);
+    off = _ws_append(concat, off, guid as * u8);
+    memset(_ws_ptr_off(concat, off), 0, 1 as usize);
+    let digest: * u8 = malloc(20 as usize);
+    if digest as i64 == 0 {
+        free(concat);
+        return;
+    }
+    SHA1(concat, total as usize, digest);
+    free(concat);
+    EVP_EncodeBlock(out28, digest, 20);
+    free(digest);
+}
+
+// `_ws_status_is_101(resp)` — does the response's status line contain
+// the bytes `1`,`0`,`1` (a `101 Switching Protocols` response)? Scans
+// only the first line (up to the first `\r` or `\n`).
+fn _ws_status_is_101(resp: * u8) -> bool {
+    let mut line_end: i64 = 0;
+    loop {
+        let b: i64 = _ws_byte_at(resp, line_end);
+        if b == 0 || b == 13 || b == 10 { break; }
+        line_end = line_end + 1;
+    }
+    let mut i: i64 = 0;
+    loop {
+        if i + 3 > line_end { break; }
+        if _ws_byte_at(resp, i) == 49 && _ws_byte_at(resp, i + 1) == 48
+            && _ws_byte_at(resp, i
+            + 2) == 49 { return true; }
+        i = i + 1;
+    }
+    return false;
+}
+
+// `_ws_frame_send(fd, opcode, payload, payload_len)` — assemble and
+// send a masked RFC 6455 client frame (FIN=1, client→server MUST
+// mask). Returns false on OOM or a send failure.
+fn _ws_frame_send(fd: i32, opcode: i64, payload: * u8, payload_len: i64) -> bool ![net] {
+    let byte0: i64 = 128 | (opcode & 15);
+    let mut header_len: i64 = 2;
+    if payload_len >= 126 && payload_len <= 65535 { header_len = 4; } else {
+        if payload_len > 65535 { header_len = 10; }
+    }
+    let total: i64 = header_len + 4 + payload_len;
+    let out: * u8 = malloc(total as usize);
+    if out as i64 == 0 { return false; }
+    memset(_ws_ptr_off(out, 0), byte0 as i32, 1 as usize);
+    if payload_len < 126 {
+        memset(_ws_ptr_off(out, 1), (128 | payload_len) as i32, 1 as usize);
+    } else {
+        if payload_len <= 65535 {
+            memset(_ws_ptr_off(out, 1), (128 | 126) as i32, 1 as usize);
+            memset(_ws_ptr_off(out, 2), ((payload_len >> 8) & 255) as i32, 1 as usize);
+            memset(_ws_ptr_off(out, 3), (payload_len & 255) as i32, 1 as usize);
+        } else {
+            memset(_ws_ptr_off(out, 1), (128 | 127) as i32, 1 as usize);
+            let mut k: i64 = 0;
+            loop {
+                if k >= 8 { break; }
+                let shift: i64 = 8 * (7 - k);
+                memset(_ws_ptr_off(out, 2 + k), ((payload_len >> shift) & 255) as i32, 1 as usize);
+                k = k + 1;
+            }
+        }
+    }
+    // malloc(8), not 4: the XOR loop reads mask bytes via `_ws_byte_at`,
+    // whose 4-byte `pointer_read_i32` load at `mask[3]` touches `mask[3..6]`.
+    // The extra 4 bytes keep that final load in-bounds — the same
+    // over-allocation invariant http.sfn's recv buffers hold for `_byte_at`.
+    // Only the first 4 bytes are the RFC 6455 masking key.
+    let mask: * u8 = malloc(8 as usize);
+    if mask as i64 == 0 {
+        free(out);
+        return false;
+    }
+    RAND_bytes(mask, 4);
+    memcpy(_ws_ptr_off(out, header_len), mask, 4 as usize);
+    let mut i: i64 = 0;
+    loop {
+        if i >= payload_len { break; }
+        let mb: i64 = _ws_byte_at(mask, i & 3);
+        let pb: i64 = _ws_byte_at(payload, i);
+        memset(_ws_ptr_off(out, header_len + 4 + i), (pb ^ mb) as i32, 1 as usize);
+        i = i + 1;
+    }
+    free(mask);
+    let ok: bool = _ws_send_all(fd, out, total);
+    free(out);
+    return ok;
+}
+
+// `sfn_websocket_connect(url)` — parse `url` ("ws://host[:port][/path]"),
+// TCP-connect, and perform the RFC 6455 client handshake. Returns a
+// malloc'd handle cell on success, null on any failure.
+fn sfn_websocket_connect(url: * u8) -> * u8 ![net] {
+    if url as i64 == 0 { return null; }
+    let mut host_addr: i64 = 0;
+    let mut path_addr: i64 = 0;
+    let mut port: i64 = 80;
+    if !_ws_parse_url(url, & host_addr, & path_addr, & port) { return null; }
+    let host: * u8 = host_addr as * u8;
+    let path: * u8 = path_addr as * u8;
+
+    let fd: i32 = _ws_connect_tcp(host, port);
+    if fd < 0 {
+        free(host);
+        free(path);
+        return null;
+    }
+
+    let keybuf: * u8 = malloc(16 as usize);
+    if keybuf as i64 == 0 {
+        free(host);
+        free(path);
+        close(fd);
+        return null;
+    }
+    RAND_bytes(keybuf, 16);
+    let key_b64: * u8 = malloc(25 as usize);
+    if key_b64 as i64 == 0 {
+        free(keybuf);
+        free(host);
+        free(path);
+        close(fd);
+        return null;
+    }
+    _ws_base64_16(keybuf, key_b64);
+    free(keybuf);
+
+    let verb: string = "GET ";
+    let proto: string = " HTTP/1.1\r\nHost: ";
+    let colon: string = ":";
+    let upgrade: string = "\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ";
+    let version: string = "\r\nSec-WebSocket-Version: 13\r\n\r\n";
+
+    let port_str: * u8 = _ws_uint_to_str(port);
+    if port_str as i64 == 0 {
+        free(key_b64);
+        free(host);
+        free(path);
+        close(fd);
+        return null;
+    }
+
+    let total: i64 = (strlen(verb as * u8) as i64) + (strlen(path) as i64) + (strlen(proto as * u8) as i64)
+        + (strlen(host) as i64)
+        + (strlen(colon as * u8) as i64)
+        + (strlen(port_str) as i64)
+        + (strlen(upgrade as * u8) as i64)
+        + (strlen(key_b64) as i64)
+        + (strlen(version as * u8) as i64);
+    let req: * u8 = malloc((total + 1) as usize);
+    if req as i64 == 0 {
+        free(port_str);
+        free(key_b64);
+        free(host);
+        free(path);
+        close(fd);
+        return null;
+    }
+    let mut off: i64 = 0;
+    off = _ws_append(req, off, verb as * u8);
+    off = _ws_append(req, off, path);
+    off = _ws_append(req, off, proto as * u8);
+    off = _ws_append(req, off, host);
+    off = _ws_append(req, off, colon as * u8);
+    off = _ws_append(req, off, port_str);
+    off = _ws_append(req, off, upgrade as * u8);
+    off = _ws_append(req, off, key_b64);
+    off = _ws_append(req, off, version as * u8);
+    memset(_ws_ptr_off(req, off), 0, 1 as usize);
+    free(port_str);
+    free(host);
+    free(path);
+
+    let send_ok: bool = _ws_send_all(fd, req, off);
+    free(req);
+    if !send_ok {
+        free(key_b64);
+        close(fd);
+        return null;
+    }
+
+    let resp_cap: i64 = 2048;
+    // +4, not +1: `_ws_status_is_101` / `_ws_ci_find` scan this buffer with
+    // `_ws_byte_at`'s 4-byte load, which at the final in-buffer offset
+    // touches 3 bytes past it — match http.sfn's recv over-allocation so the
+    // tail load never faults.
+    let resp: * u8 = malloc((resp_cap + 4) as usize);
+    if resp as i64 == 0 {
+        free(key_b64);
+        close(fd);
+        return null;
+    }
+    let n: i64 = _ws_recv_some(fd, resp, resp_cap);
+    if n <= 0 {
+        free(key_b64);
+        free(resp);
+        close(fd);
+        return null;
+    }
+    memset(_ws_ptr_off(resp, n), 0, 1 as usize);
+
+    if !_ws_status_is_101(resp) {
+        free(key_b64);
+        free(resp);
+        close(fd);
+        return null;
+    }
+
+    // OPTIONAL but preferred: verify Sec-WebSocket-Accept.
+    let expect: * u8 = malloc(29 as usize);
+    if expect as i64 != 0 {
+        _ws_sec_accept(key_b64, expect);
+        let expect_len: i64 = strlen(expect) as i64;
+        if _ws_ci_find(resp, n, expect, expect_len) < 0 {
+            free(expect);
+            free(key_b64);
+            free(resp);
+            close(fd);
+            return null;
+        }
+        free(expect);
+    }
+    free(key_b64);
+    free(resp);
+
+    let handle: * u8 = _ws_make_handle(fd);
+    if handle as i64 == 0 {
+        close(fd);
+        return null;
+    }
+    return handle;
+}
+
+// `_ws_uint_to_str(value)` — render a non-negative i64 as a freshly
+// allocated decimal string. Mirrors `http.sfn`'s `_uint_to_str`.
+fn _ws_uint_to_str(value: i64) -> * u8 {
+    if value <= 0 {
+        let zero: * u8 = malloc(2 as usize);
+        if zero as i64 == 0 { return null; }
+        memset(_ws_ptr_off(zero, 0), 48, 1 as usize);
+        memset(_ws_ptr_off(zero, 1), 0, 1 as usize);
+        return zero;
+    }
+    let mut count: i64 = 0;
+    let mut probe: i64 = value;
+    loop {
+        if probe == 0 { break; }
+        probe = probe / 10;
+        count = count + 1;
+    }
+    let buf: * u8 = malloc((count + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    memset(_ws_ptr_off(buf, count), 0, 1 as usize);
+    let mut remaining: i64 = value;
+    let mut idx: i64 = count - 1;
+    loop {
+        if remaining == 0 { break; }
+        let digit: i64 = remaining % 10;
+        memset(_ws_ptr_off(buf, idx), (48 + digit) as i32, 1 as usize);
+        remaining = remaining / 10;
+        idx = idx - 1;
+    }
+    return buf;
+}
+
+// `sfn_websocket_send(handle, msg)` — send `msg` as a single masked
+// TEXT frame over `handle`'s socket. Returns the handle unchanged on
+// success, null on failure (a null handle, or a send error).
+fn sfn_websocket_send(handle: * u8, msg: * u8) -> * u8 ![net] {
+    if handle as i64 == 0 { return null; }
+    if msg as i64 == 0 { return null; }
+    let fd: i32 = _ws_handle_fd(handle);
+    let ok: bool = _ws_frame_send(fd, 1, msg, strlen(msg) as i64);
+    if !ok { return null; }
+    return handle;
+}
+
+// `sfn_websocket_close(handle)` — send a masked CLOSE frame (opcode
+// 0x8, empty payload), close the socket, and free the handle cell.
+// Always returns null. Safe on a null handle.
+fn sfn_websocket_close(handle: * u8) -> * u8 ![net] {
+    if handle as i64 == 0 { return null; }
+    let fd: i32 = _ws_handle_fd(handle);
+    _ws_frame_send(fd, 8, null, 0);
+    close(fd);
+    free(handle);
+    return null;
+}


### PR DESCRIPTION
## Summary
- Replaces the effect-metadata-only `websocket.connect`/`.send`/`.close` registry rows (fake `sfn_websocket_unbridged`, #1601) with a real Sailfin-native RFC 6455 `ws://` **client** runtime, so those ops codegen, link, and self-host.
- New `runtime/sfn/adapters/websocket.sfn`: TCP connect + DNS mirroring `http.sfn`; RFC 6455 handshake (`Sec-WebSocket-Key`/`Accept` via OpenSSL `RAND_bytes`/`EVP_EncodeBlock`/`SHA1`, already linked repo-wide); masked TEXT/close frame codec. Self-contained (all externs inlined per #306) and every helper `_ws_`-prefixed to avoid external-linkage duplicate symbols with `http.sfn`.
- Flips the three client registry rows to real symbols + `native_signature` + LLVM types and removes their sentinel-skips. `websocket.serve` stays metadata-only for #1877.

Closes #1876

## Acceptance Criteria
- [x] `websocket.connect`/`.send`/`.close` lower to real runtime calls and link (no `sfn_websocket_unbridged`).
- [x] Sentinel-skips for those three targets removed from the declaration renderer.
- [x] `websocket.connect`/`.send`/`.close` still require `[net]` (rows updated, not removed).
- [x] An e2e test asserts the three ops emit real `declare`s and route to the real `sfn_websocket_*` symbols.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes.

## Map reconciliation
- `## Files Affected` listed `compiler/src/llvm/expression_lowering/...` for lowering — reconciled to **no lowering change**: `websocket.*` is member-syntax and dispatches through the generic registry-driven path (same as `http.*`, which has no bespoke lowering); flipping the registry row is the whole compiler-side change. Confirmed by tracing `resolve_call_method_target` → `find_runtime_helper` → `coerce_and_emit_call`.
- `runtime/sfn/...` → concrete `runtime/sfn/adapters/websocket.sfn` (mirrors the `adapters/http.sfn` sibling).
- Added `compiler/tests/unit/runtime_helper_metadata_only_test.sfn` (not in the advisory map): the same `In:` registry-flip unit necessarily narrows that guard's metadata-only set to `serve`/`websocket.serve` since the three client ops are now bridged.
- No effect-checker change (`[net]` derivation was already registry-driven, #1601 — `Out:`).

## Verification
```bash
make compile   # status: pass (self-hosts)
make test      # unit 189/189, integration 42/42, e2e 179/179, capsules 38/38 — all pass
build/native/sailfin test compiler/tests/e2e/runtime_adapter_websocket_test.sfn   # 6/6 pass
```
An Opus code-review pass verified RFC 6455 framing/handshake correctness, the pointer-through-i64-slot idiom in `_ws_parse_url`, and the registry ABI; its memory-safety findings (a happy-path 4-byte-load over-read on the `malloc(4)` mask buffer, plus the `resp`/strdup buffers, matching http.sfn's `+4` `_byte_at` over-allocation invariant, and an OOM fd-leak guard) were fixed in this PR.

## Files Changed
- `runtime/sfn/adapters/websocket.sfn` (new) — RFC 6455 `ws://` client runtime.
- `runtime/capsule.toml` — link the new module into every Sailfin binary.
- `compiler/src/llvm/runtime_helpers.sfn` — flip the three client rows to real symbols.
- `compiler/src/llvm/rendering.sfn` — remove the three client sentinel-skips.
- `compiler/tests/e2e/runtime_adapter_websocket_test.sfn` (new) — emit-shape/routing coverage.
- `compiler/tests/unit/runtime_helper_metadata_only_test.sfn` — narrow the metadata-only guard set.

## Follow-ups (out of scope for this slice)
- **#1877** (server bridge): `websocket.serve` runtime + behavioral loopback send/receive/close test + `docs/status.md` "shipped" flip + `examples/web/websocket-chat.sfn` runs. The single-`recv` handshake read here becomes a drain-until-`\r\n\r\n` loop there.
- Pre-existing (noted, not touched): the effect checker's receiver-agnostic `.send(` → `channel_send` (`io`) rule makes `websocket.send` require `[io, net]`; harmless (real usage declares `io`) but a candidate for a future scoping fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_013zFpXHH5BLnYDXjhnFoQuW)_