### PR TITLE
refactor(examples): migrate unions.sfn + #1838 fixture to nominal object model

### DIFF
--- a/compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn
+++ b/compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn
@@ -12,10 +12,9 @@
 //      rejected the module with `use of undefined value
 //      '@.runtime.field.name'`. Building this fixture at all is the guard.
 //
-// NOTE: `admin.name` reads back empty (`admin:`) because a bare struct
-// literal resolved via a type annotation (`let x: T = { ... }`) is a
-// separate, broader lowering bug (#1855) — the union field-name global
-// emission this fixture pins is orthogonal to it.
+// `admin` is a concrete `struct` constructed through the object-literal
+// path (#1855), so `admin.name` reads back `Alice`. The interfaces are
+// method-only contracts under the nominal object model (SFEP-0039).
 struct StringValue {
     value: string;
 }
@@ -24,15 +23,16 @@ struct IntValue {
     value: int;
 }
 
-interface Admin {
-    isAdmin: boolean;
+interface Named {
+    fn display_name(self) -> string;
 }
 
-interface User {
+struct AdminUser implements Named {
     name: string;
-}
+    isAdmin: boolean;
 
-type AdminUser = Admin & User;
+    fn display_name(self) -> string { return self.name; }
+}
 
 fn print_value(value: StringValue | IntValue) ![io] {
     match value {

--- a/compiler/tests/e2e/union_named_variant_match_test.sfn
+++ b/compiler/tests/e2e/union_named_variant_match_test.sfn
@@ -78,9 +78,9 @@ test "union-match: named-struct tagged union builds with valid IR and selects th
     assert find(out, "string:Sailfin", 0) >= 0;
     assert find(out, "number:42", 0) >= 0;
     // The bare `print("admin:{{admin.name}}")` statement is what emits
-    // the `@.runtime.field.name` global; its `admin:` prefix printing
-    // confirms the statement lowered to valid, runnable IR. The field
-    // value itself is empty here (a separate bare-struct-literal bug,
-    // #1855), so only the prefix is asserted.
-    assert find(out, "admin:", 0) >= 0;
+    // the `@.runtime.field.name` global; its printing confirms the
+    // statement lowered to valid, runnable IR. `admin` is a concrete
+    // struct constructed via the object-literal path (#1855), so the
+    // field reads back its value — the full `admin:Alice` is asserted.
+    assert find(out, "admin:Alice", 0) >= 0;
 }

--- a/examples/advanced/unions.sfn
+++ b/examples/advanced/unions.sfn
@@ -26,15 +26,22 @@ fn printValue(value: StringValue | IntValue) ![io] {
 //             print("It's a number: {{value}}");
 //         }
 //     }
-interface Admin {
-    isAdmin: boolean;
+// Nominal object model (SFEP-0039): interfaces are method-only contracts, and the
+// data lives on a concrete `struct` that implements them. This replaces the former
+// data-field interfaces (`interface Admin { isAdmin: boolean }`) and the
+// `type AdminUser = Admin & User` intersection — idioms the nominal backend never
+// implemented. A concrete struct constructed through the object-literal path (#1855)
+// carries the fields, so `admin.name` reads back `Alice`.
+interface Named {
+    fn display_name(self) -> string;
 }
 
-interface User {
+struct AdminUser implements Named {
     name: string;
-}
+    isAdmin: boolean;
 
-type AdminUser = Admin & User;
+    fn display_name(self) -> string { return self.name; }
+}
 
 fn main() ![io] {
     printValue(StringValue { value: "Sailfin" });


### PR DESCRIPTION
## Summary
- Rewrite `examples/advanced/unions.sfn` and the #1838 e2e fixture to the nominal object model: a method-only `interface Named` plus a concrete `struct AdminUser implements Named`, with `admin` constructed through the concrete-struct object-literal path (#1855) so `admin.name` reads back `Alice`.
- Removes all three TypeScript-shaped data idioms SFEP-0039 will reject (`E0827` data-field interface members, `E0829` `Admin & User` intersection, `E0828` bare literal against a non-struct target) from the tree **before** the enforcement diagnostics land — de-risking the enforcement PR.
- Tightens the union-match e2e assertion from the `admin:` prefix to the full `admin:Alice`, upgrading the known-wrong-value carve-out into a real value assertion.

Closes #1887

## Acceptance Criteria
- [x] `examples/advanced/unions.sfn` uses only method-only interfaces and concrete-struct construction.
- [x] The #1838 fixture is migrated; its e2e asserts `admin:Alice` (plus the existing `string:Sailfin` / `number:42` lines).
- [x] Tree audit is clean (see Map reconciliation) — no straggler required migration in this PR.
- [x] `timeout 25 build/native/sailfin run examples/advanced/unions.sfn` prints `Admin: Alice` on the third line.
- [x] `make compile` passes under the current seed.
- [ ] `make test` passes — full suite running locally in parallel with CI (targeted union-match e2e already green).

## Map reconciliation
- The advisory `## Files Affected` `compiler/tests/e2e/` "assertion flip" resolves concretely to `compiler/tests/e2e/union_named_variant_match_test.sfn` (the driver for the migrated fixture) — no path drift; the map matched the tree.
- Tree audit (`compiler/src`, `runtime`, `examples`, `compiler/tests`) for the three idioms found **`compiler/src`/`runtime` completely clean** (self-host safe). The only other bare object literal beyond the two migrated files is `examples/web/websocket-chat.sfn:6` — `websocket.serve({ port: 8080 })` — whose literal targets `serve(handler: any, config: any? = null)`'s **`any`** parameter. An `any` target is none of SFEP-0039's three enforced idioms (not an interface target, not an intersection, not an un-inferable *unannotated* binding), so it is left as-is; migrating it would require inventing an unvalidated `WebSocketConfig` public struct (new surface, out of scope). Noted here for the sibling enforcement issue.

## Verification
```bash
$ timeout 60 build/native/sailfin run examples/advanced/unions.sfn
It's a string: Sailfin
It's a number: 42
Admin: Alice

$ build/native/sailfin test compiler/tests/e2e/union_named_variant_match_test.sfn
  PASS  (all 1 tests passed)

$ build/native/sailfin fmt --check <touched files>   # FMT CLEAN
$ make compile                                        # green (no compiler/src changes)
```

## Files Changed
- `examples/advanced/unions.sfn` — nominal rewrite (concrete struct implementing a method-only interface)
- `compiler/tests/e2e/fixtures/union_named_variant_match_probe.sfn` — same nominal rewrite; stale #1855 empty-read carve-out comment removed
- `compiler/tests/e2e/union_named_variant_match_test.sfn` — assertion flipped `admin:` → `admin:Alice`


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9ss9h97odbfS4FzRJ8crG)_