### PR TITLE
feat(build): default content-addressed cache to a global XDG root

### DIFF
--- a/compiler/src/build/cache.sfn
+++ b/compiler/src/build/cache.sfn
@@ -159,7 +159,7 @@ fn _emit_build_report(input_path: string, out_path: string, kind: string, exit_c
     // `stats` is the build-wide total (`.ll` module cache folded with
     // the runtime object cache, #915), not just `capsule_result.stats`.
     report.cache = stats;
-    report.cache_root = cache_root();
+    report.cache_root = cache_root(cache_config.capsule_name);
     report.cache_enabled = cache_config.enabled;
     report.dep_ll_paths = capsule_result.ll_paths;
     print(build_report_to_json(report));

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -44,9 +44,14 @@
 //
 //   <root>/<key[0..2]>/<key>/{ir.sfn-asm, layout.manifest, mod.ll, mod.o}
 //
-// `<root>` defaults to `build/cache/v2` (in-tree) and can be
-// overridden by `$SAILFIN_BUILD_CACHE_DIR` to support shared CI
-// caches without code changes. The trailing suffix is
+// `<root>` defaults to a shared per-user directory
+// (`$XDG_CACHE_HOME/sailfin` or `$HOME/.cache/sailfin`) so identical
+// module compiles are deduplicated across projects on a machine
+// (SFEP-0040 §3.1). It can be overridden by `$SAILFIN_BUILD_CACHE_DIR`
+// (shared CI caches), falls back to in-tree `build/cache` when `$HOME`
+// is unresolvable, and is pinned in-tree for the compiler self-host
+// build so `make compile` / `make check` stay hermetic. See
+// `cache_root_from`. The trailing suffix is
 // `build_cache_schema_version()` (currently `v2`) — when the key
 // shape or layout changes, bump it and let the old `v<N>` tree age
 // out so stale entries can never poison new compilers.
@@ -61,8 +66,10 @@
 //
 // All `![io]` operations are parameterized on `root` so tests can
 // pass an arbitrary tmp directory without setting environment
-// variables. The convenience reader `cache_root()` is the
-// production-side wrapper that resolves `$SAILFIN_BUILD_CACHE_DIR`.
+// variables. The convenience reader `cache_root(capsule_name)` is the
+// production-side wrapper that resolves the root ladder from the
+// environment; the pure `cache_root_from` underneath it takes every
+// input explicitly so the precedence order is unit-testable.
 import {
     _dirname_cmd,
     _ensure_dir_recursive_cmd,
@@ -194,10 +201,23 @@ struct BuildCacheConfig {
     enabled: boolean;
     trace: boolean;
     clean: boolean;
+    // The current build's `[capsule].name`, threaded here so it
+    // reaches every `cache_root()` call site (this config already
+    // flows to all of them). Used only to pin the content-addressed
+    // cache root in-tree for the compiler self-host build
+    // (`== "sailfin"`, SFEP-0040 §3.1) so `make compile` / `make
+    // check` never read a developer's global `~/.cache/sailfin`.
+    // Empty for positional/foreign builds → global default root.
+    capsule_name: string;
 }
 
 fn empty_build_cache_config() -> BuildCacheConfig {
-    return BuildCacheConfig { enabled: true, trace: false, clean: false };
+    return BuildCacheConfig {
+        enabled: true,
+        trace: false,
+        clean: false,
+        capsule_name: ""
+    };
 }
 
 // `no_cache_flag` / `trace_flag` / `clean_flag` are the CLI
@@ -208,7 +228,8 @@ fn resolve_build_cache_config(no_cache_flag: boolean, trace_flag: boolean, clean
     return BuildCacheConfig {
         enabled: !env_disabled && !no_cache_flag,
         trace: env_trace || trace_flag,
-        clean: clean_flag
+        clean: clean_flag,
+        capsule_name: ""
     };
 }
 
@@ -216,10 +237,10 @@ fn resolve_build_cache_config(no_cache_flag: boolean, trace_flag: boolean, clean
 // success (or no-op when the directory didn't exist), false if
 // `rm` failed. Defensive: refuses to operate on an empty path.
 //
-// Note: deletes the FULL `<override>/v<N>/...` tree the cache
-// stores under. Callers should resolve `cache_root()` first and
-// pass that — wiping `$SAILFIN_BUILD_CACHE_DIR` itself would
-// nuke any sibling schema versions that future compilers might
+// Note: deletes the FULL `<root>/v<N>/...` tree the cache stores
+// under. Callers should resolve `cache_root(capsule_name)` first and
+// pass that — wiping the bare cache base (e.g. `$SAILFIN_BUILD_CACHE_DIR`)
+// would nuke any sibling schema versions that future compilers might
 // be relying on.
 fn cache_clean(root: string) -> boolean ![io] {
     if root.length == 0 { return false; }
@@ -232,21 +253,48 @@ fn cache_clean(root: string) -> boolean ![io] {
 // ----------------------------------------------------------------
 // Cache root resolution
 // ----------------------------------------------------------------
-// Pure variant — used by tests and by the production reader below.
-// `override_path` empty → in-tree default `build/cache/<version>`;
-// non-empty → `<override>/<version>`.
-fn cache_root_with_override(override_path: string) -> string {
-    if override_path.length > 0 {
-        return override_path + "/" + build_cache_schema_version();
-    }
-    return "build/cache/" + build_cache_schema_version();
+// Pure resolution ladder (SFEP-0040 §3.1). Highest precedence first:
+//   1. `explicit` ($SAILFIN_BUILD_CACHE_DIR) — CI/sandbox override.
+//   2. compiler self-host pin — in-tree `build/cache` stays hermetic
+//      so `make compile` / `make check` never read a developer's
+//      global store (explicit still wins above, so CI can redirect
+//      even the self-host cache).
+//   3. `$XDG_CACHE_HOME/sailfin` — global default when XDG is set.
+//   4. `$HOME/.cache/sailfin` — global default on Linux/macOS.
+//   5. `build/cache` — hermetic fallback when `$HOME` is unresolvable
+//      (containers, minimal CI).
+// All inputs are explicit so the ladder is unit-testable without any
+// process-global env mutation. The `<version>` schema suffix is
+// appended uniformly across every branch.
+fn cache_root_from(explicit: string, is_selfhost: boolean, xdg: string, home: string) -> string {
+    let schema = build_cache_schema_version();
+    if explicit.length > 0 { return explicit + "/" + schema; }
+    if is_selfhost { return "build/cache/" + schema; }
+    if xdg.length > 0 { return xdg + "/sailfin/" + schema; }
+    if home.length > 0 { return home + "/.cache/sailfin/" + schema; }
+    return "build/cache/" + schema;
 }
 
-// Production reader. Resolves `$SAILFIN_BUILD_CACHE_DIR` at call
-// time; callers should invoke once at the top of a build and
-// thread the result through.
-fn cache_root() -> string ![io] {
-    return cache_root_with_override(_get_env_cmd("SAILFIN_BUILD_CACHE_DIR"));
+// Pure variant — used by tests and by other callers that already hold
+// an override. `override_path` empty → in-tree default
+// `build/cache/<version>`; non-empty → `<override>/<version>`.
+// Equivalent to the non-self-host, no-XDG/HOME slice of the ladder.
+fn cache_root_with_override(override_path: string) -> string {
+    return cache_root_from(override_path, false, "", "");
+}
+
+// Production reader. Resolves the cache-root ladder from the
+// environment plus `capsule_name` (the current build's
+// `[capsule].name`); callers should invoke once at the top of a
+// build and thread the result through. `capsule_name == "sailfin"`
+// pins the in-tree root so the compiler self-host build stays
+// hermetic (SFEP-0040 §3.1).
+fn cache_root(capsule_name: string) -> string ![io] {
+    let explicit = _get_env_cmd("SAILFIN_BUILD_CACHE_DIR");
+    let is_selfhost = strings_equal(capsule_name, "sailfin");
+    let xdg = _get_env_cmd("XDG_CACHE_HOME");
+    let home = _get_env_cmd("HOME");
+    return cache_root_from(explicit, is_selfhost, xdg, home);
 }
 
 // ----------------------------------------------------------------
@@ -1016,6 +1064,7 @@ export {
     CacheStats,
     BuildCacheConfig,
     build_cache_schema_version,
+    cache_root_from,
     cache_root_with_override,
     cache_root,
     cache_artifact_path,

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1704,7 +1704,7 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
     // #984: sidecars are still written only for `sources`; only the slug
     // resolution universe is widened.
     _cr_stage_import_deps(sources, slug_universe, work_dir);
-    let cache_root_path = cache_root();
+    let cache_root_path = cache_root(config.capsule_name);
     if config.clean {
         // `--clean` is a destructive opt-in. If the wipe fails
         // (read-only fs, perms, etc.), surface a warning so the

--- a/compiler/src/cli/commands/build.sfn
+++ b/compiler/src/cli/commands/build.sfn
@@ -118,7 +118,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     // `--work-dir` unset both fall back to the legacy in-tree
     // paths so the default invocation is byte-for-byte identical.
     let sailfin_cache_dir = _resolve_sailfin_cache_dir_for_work(work_dir);
-    let cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
+    let mut cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
 
     // -p resolves the entry path + build kind from the capsule's
     // manifest. The build then proceeds as for a positional source
@@ -145,6 +145,12 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
         cap_version = cap_spec.version;
         cap_entry_relative = cap_spec.entry_relative;
     }
+    // Thread the resolved capsule name into the cache config so every
+    // downstream `cache_root(...)` call (this fn, `_emit_build_report`,
+    // `compile_capsule_modules`) pins the in-tree root for the
+    // compiler self-host build (`== "sailfin"`, SFEP-0040 §3.1). Empty
+    // for a positional build → global default root.
+    cache_config.capsule_name = cap_capsule_name;
     if input_path.length == 0 {
         print("usage: sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)");
         return 2;
@@ -393,7 +399,9 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     // `--no-cache` so the persistent store is neither read nor
     // written, matching the summary-fold gate below.
     let mut build_shared_cache_root: string = "";
-    if cache_config.enabled { build_shared_cache_root = cache_root(); }
+    if cache_config.enabled {
+        build_shared_cache_root = cache_root(cache_config.capsule_name);
+    }
     let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir, build_shared_cache_root);
     let rc = link_result.rc;
     if rc != 0 {

--- a/compiler/src/cli/commands/run.sfn
+++ b/compiler/src/cli/commands/run.sfn
@@ -154,7 +154,9 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     // Shared runtime-object cache root (#1096); empty under `--no-cache` to
     // leave the persistent store untouched.
     let mut run_shared_cache_root: string = "";
-    if run_cache_config.enabled { run_shared_cache_root = cache_root(); }
+    if run_cache_config.enabled {
+        run_shared_cache_root = cache_root(run_cache_config.capsule_name);
+    }
     let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "", run_shared_cache_root);
     let link_rc = link_result.rc;
     if link_rc != 0 {

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -36,6 +36,7 @@ import {
     cache_lookup_artifact,
     cache_lookup_complete,
     cache_paths_for,
+    cache_root_from,
     cache_root_with_override,
     cache_stats_is_empty,
     cache_store,
@@ -84,6 +85,32 @@ test "build_cache: cache_root_with_override empty -> in-tree default" {
 
 test "build_cache: cache_root_with_override non-empty -> override + version" {
     assert cache_root_with_override("/tmp/sfn-shared-cache") == "/tmp/sfn-shared-cache/v2";
+}
+
+// Cache-root ladder (SFEP-0040 §3.1). Pure inputs so precedence is
+// verified without any process-global env mutation.
+test "build_cache: cache_root_from explicit override wins over all" {
+    // Explicit ($SAILFIN_BUILD_CACHE_DIR) beats even the self-host
+    // pin, so CI can redirect the compiler's own cache.
+    assert cache_root_from("/ci/cache", true, "/xdg", "/home/dev") == "/ci/cache/v2";
+    assert cache_root_from("/ci/cache", false, "/xdg", "/home/dev") == "/ci/cache/v2";
+}
+
+test "build_cache: cache_root_from self-host pins in-tree over XDG/HOME" {
+    assert cache_root_from("", true, "/xdg", "/home/dev") == "build/cache/v2";
+}
+
+test "build_cache: cache_root_from XDG_CACHE_HOME beats HOME" {
+    assert cache_root_from("", false, "/xdg", "/home/dev") == "/xdg/sailfin/v2";
+}
+
+test "build_cache: cache_root_from HOME is the global default" {
+    assert cache_root_from("", false, "", "/home/dev") == "/home/dev/.cache/sailfin/v2";
+}
+
+test "build_cache: cache_root_from all-empty falls back in-tree" {
+    // Hermetic fallback when $HOME is unresolvable (containers, CI).
+    assert cache_root_from("", false, "", "") == "build/cache/v2";
 }
 
 // --------------------------------------------------------------

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -1059,7 +1059,10 @@ able to act on link failures.
 - Cache key per module:
   `sha256(source)` ⊕ `sha256(each resolved dep's .layout-manifest)` ⊕
   `compiler_version` ⊕ `canonical(flags)`.
-- Cache store: `build/cache/<key-prefix>/<key>.{sfn-asm,layout-manifest,ll,o}`.
+- Cache store: `<root>/<key-prefix>/<key>.{sfn-asm,layout-manifest,ll,o}`, where
+  `<root>` defaults to a shared per-user directory (`$XDG_CACHE_HOME/sailfin` or
+  `$HOME/.cache/sailfin`; `$SAILFIN_BUILD_CACHE_DIR` override; in-tree `build/cache`
+  fallback and for the compiler self-host build — SFEP-0040 §3.1).
 - Cache hits skip parse, typecheck, effect, emit, and clang. They do not
   skip link.
 - `--no-cache` disables the lookup but still writes. `--clean` wipes the

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -1059,10 +1059,12 @@ able to act on link failures.
 - Cache key per module:
   `sha256(source)` ⊕ `sha256(each resolved dep's .layout-manifest)` ⊕
   `compiler_version` ⊕ `canonical(flags)`.
-- Cache store: `<root>/<key-prefix>/<key>.{sfn-asm,layout-manifest,ll,o}`, where
-  `<root>` defaults to a shared per-user directory (`$XDG_CACHE_HOME/sailfin` or
-  `$HOME/.cache/sailfin`; `$SAILFIN_BUILD_CACHE_DIR` override; in-tree `build/cache`
-  fallback and for the compiler self-host build — SFEP-0040 §3.1).
+- Cache store: `<root>/<key[0..2]>/<key>/{ir.sfn-asm,layout.manifest,mod.ll,mod.o}`
+  — one directory per key, sharded by the 2-char key prefix. `<root>` already
+  includes the schema suffix (`.../v2`) and defaults to a shared per-user
+  directory (`$XDG_CACHE_HOME/sailfin/v2` or `$HOME/.cache/sailfin/v2`;
+  `$SAILFIN_BUILD_CACHE_DIR` override; in-tree `build/cache/v2` fallback and for
+  the compiler self-host build — SFEP-0040 §3.1).
 - Cache hits skip parse, typecheck, effect, emit, and clang. They do not
   skip link.
 - `--no-cache` disables the lookup but still writes. `--clean` wipes the

--- a/docs/status.md
+++ b/docs/status.md
@@ -54,10 +54,10 @@ here.
   is gone (Stages A–B). By-name and relative imports of a workspace capsule
   converge to one mangled symbol (#873).
 - **Build cache.** Content-addressed cache defaulting to a shared per-user root
-  (`$XDG_CACHE_HOME/sailfin` or `$HOME/.cache/sailfin`; `$SAILFIN_BUILD_CACHE_DIR`
-  override; in-tree `build/cache` fallback when `$HOME` is unresolvable and pinned
-  in-tree for the compiler self-host build — SFEP-0040 §3.1) with per-source dep
-  manifests,
+  (`$XDG_CACHE_HOME/sailfin/v2` or `$HOME/.cache/sailfin/v2`, schema-suffixed;
+  `$SAILFIN_BUILD_CACHE_DIR` override; in-tree `build/cache/v2` fallback when
+  `$HOME` is unresolvable and pinned in-tree for the compiler self-host build —
+  SFEP-0040 §3.1) with per-source dep manifests,
   `--no-cache` / `--clean` / `--cache-trace` flags, and a `[cache]` summary on
   stderr (Stage C PR1–1f, #254–#259). Runtime C/LL/sfn objects share the same
   cache across work-dirs (#915, #1096). `sfn test` content-addresses each

--- a/docs/status.md
+++ b/docs/status.md
@@ -53,8 +53,11 @@ here.
   and workspace-implicit `sfn/X` imports in one pass. Textual import inlining
   is gone (Stages A–B). By-name and relative imports of a workspace capsule
   converge to one mangled symbol (#873).
-- **Build cache.** Content-addressed cache under `build/cache/v1`
-  (`$SAILFIN_BUILD_CACHE_DIR` override) with per-source dep manifests,
+- **Build cache.** Content-addressed cache defaulting to a shared per-user root
+  (`$XDG_CACHE_HOME/sailfin` or `$HOME/.cache/sailfin`; `$SAILFIN_BUILD_CACHE_DIR`
+  override; in-tree `build/cache` fallback when `$HOME` is unresolvable and pinned
+  in-tree for the compiler self-host build — SFEP-0040 §3.1) with per-source dep
+  manifests,
   `--no-cache` / `--clean` / `--cache-trace` flags, and a `[cache]` summary on
   stderr (Stage C PR1–1f, #254–#259). Runtime C/LL/sfn objects share the same
   cache across work-dirs (#915, #1096). `sfn test` content-addresses each


### PR DESCRIPTION
## Summary
- Resolve the build-cache root through a precedence ladder (SFEP-0040 §3.1): `$SAILFIN_BUILD_CACHE_DIR` → compiler self-host in-tree pin → `$XDG_CACHE_HOME/sailfin` → `$HOME/.cache/sailfin` → in-tree `build/cache` fallback. Identical module compiles now deduplicate across projects on a machine instead of each project growing its own `build/cache`.
- The compiler self-host build (`[capsule].name == "sailfin"`) pins the root to in-tree `build/cache`, so `make compile` / `make check` never read a developer's global store and stay hermetic/reproducible.
- Only the root *location* changes — the cache key, entry layout, and atomic-publish protocol are untouched.

Closes #1892

## Design
SFEP-0040 §3.1 (`docs/proposals/0040-artifact-cache.md`). The `sfn cache` command, GC, schema-sweep, and mtime-on-hit (§3.2–3.4) are **out of scope** — they land with #1893. SFEP-0040 stays `Accepted` (this is one slice of a two-issue proposal).

## Implementation notes
- New pure `cache_root_from(explicit, is_selfhost, xdg, home)` holds the ladder with every input explicit, so precedence is unit-testable with no process-global env mutation. `cache_root_with_override` now delegates to it (behavior-identical); `cache_root()` → `cache_root(capsule_name)` reads the environment and pins when `capsule_name == "sailfin"`.
- The capsule name is threaded via a new `BuildCacheConfig.capsule_name` field. `BuildCacheConfig` already flows to **every** `cache_root()` call site (build, run, resolver's per-module `.ll` cache, and the build report), so this collapses all threading to zero call-site signature changes — the field is populated once in `build.sfn` after `-p` resolution.

## Acceptance Criteria
- [x] `cache_root()` resolves in the documented precedence order, verified by unit test under scoped (pure) inputs — 5 new `cache_root_from` cases.
- [x] A compiler self-host build resolves the in-tree `build/cache` root (never `$HOME/.cache/sailfin`) — verified end-to-end: `-p compiler` under a fake `$HOME` wrote only in-tree `build/cache`; a plain fixture build did create the global default.
- [x] Two builds of the same fixture under the same root produce a cache hit on the second — covered by `run_cache_flags_test.sfn` (cold `misses≥1/stores≥1` → warm `hits≥1/misses=0`); the root-resolution change does not alter this mechanism.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Map reconciliation
The advisory `## Files Affected` listed `compiler/src/build_cache.sfn` + `compiler/tests/unit/`. Reconciled to the current tree: the self-host pin required threading the capsule name to every `cache_root()` consumer — the same "cache-root resolution" semantic unit — so the change also touches `compiler/src/cli/commands/build.sfn`, `compiler/src/cli/commands/run.sfn`, `compiler/src/capsule_resolver.sfn`, and `compiler/src/build/cache.sfn` (all in-`In:`-unit sibling call sites, no new public surface). Docs `docs/status.md` and `docs/proposals/0006-build-architecture.md` had stale cache-root descriptions corrected (SFEP §3.1 Stage1 doc mapping). No semantic scope growth.

## Verification
```
make compile                     # self-hosts green
build/native/sailfin test compiler/tests/unit/build_cache_test.sfn   # 71/71 (incl. 5 new ladder tests)
make test  (parallel)            # unit 192/192, integration 42/42, e2e 184/184, capsules 38/38
```
Hermeticity spot-check (new binary):
- `HOME=<tmp> XDG unset  sailfin build -p compiler` → `$HOME/.cache/sailfin` **absent**, in-tree `build/cache` populated.
- `HOME=<tmp> XDG unset  sailfin build hello-world.sfn` → `$HOME/.cache/sailfin/v2` **created** (27 entries).

Note: the single serial-`--jobs 1` `make test` run reported `work_dir_parity_test.sfn` failed with `Error 124` (timeout — it does two full compiler self-host builds); a parallel re-run passed it 2/2 and the full e2e tier 184/184. The failure was a serial-run timeout artifact, not a regression — the change is byte-neutral for `-p compiler` builds (same in-tree cache root as before).

## Files Changed
- `compiler/src/build_cache.sfn` — `cache_root_from` ladder, `cache_root(capsule_name)`, `BuildCacheConfig.capsule_name`, exports + header comments.
- `compiler/src/cli/commands/build.sfn` — populate `cache_config.capsule_name`; pass it at the runtime-obj cache site.
- `compiler/src/cli/commands/run.sfn` — pass `run_cache_config.capsule_name` (always `""`).
- `compiler/src/capsule_resolver.sfn` — `cache_root(config.capsule_name)` in `compile_capsule_modules` (per-module `.ll` cache).
- `compiler/src/build/cache.sfn` — `cache_root(cache_config.capsule_name)` in `_emit_build_report`.
- `compiler/tests/unit/build_cache_test.sfn` — 5 new `cache_root_from` precedence tests.
- `docs/status.md`, `docs/proposals/0006-build-architecture.md` — cache-root description updates.

---
_Generated by [Claude Code](https://claude.ai/code/session_017kqar1nihtdggNbXzZrXBk)_