### PR TITLE
Allow sailfin MCP tools through the auto-mode classifier

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,7 +104,8 @@
     "allow": [
       "$defaults",
       "Project build, test, and formatting commands are safe: make compile, make rebuild, make check, make test (and its make test-* variants), make bench, make fetch-seed, make clean, make clean-build, sfn, and build/native/sailfin invocations. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts, never files outside the repo, so treat them as routine, not destructive. This does not extend to make install, which writes to PREFIX/bin outside the repo.",
-      "Scheduling and session-management tools from the Claude_Code_Remote MCP server (send_later, create_trigger, and the other trigger tools) are safe."
+      "Scheduling and session-management tools from the Claude_Code_Remote MCP server (send_later, create_trigger, and the other trigger tools) are safe.",
+      "All tools from the sailfin MCP server (mcp__sailfin__*: sailfin_check, sailfin_diagnostics, sailfin_fmt_check, sailfin_fmt_write, sailfin_build, sailfin_test, sailfin_emit_native, sailfin_emit_llvm, sailfin_version) are safe. They are the project's own in-repo developer tooling — each is a pure passthrough to a single `sailfin` subcommand, path-restricted to the workspace root, and exists specifically for agents to use during development. Never prompt for them."
     ]
   },
   "env": {


### PR DESCRIPTION
## Problem

Running with auto mode on, the in-repo `sailfin` MCP tools kept raising approval prompts during development — the exact opposite of why the server exists (agent tooling for working in the repo).

## Root cause

Two independent permission gates were in play, and the sailfin server was only on one:

- **`permissions.allow`** (static) — already had `mcp__sailfin`, so the tools were cleared in normal permission modes.
- **`autoMode.allow`** (the auto-mode classifier) — did **not** cover sailfin. In auto mode the classifier is the effective gate, and it re-judges side-effecting tools (`sailfin_build`, `sailfin_test`, `sailfin_fmt_write`), so it kept prompting.

The `Claude_Code_Remote` server was already handled with a bespoke `autoMode.allow` rule; sailfin had simply never gotten the parallel entry.

## Change

Add one `autoMode.allow` rule to `.claude/settings.json` clearing all `mcp__sailfin__*` tools (`sailfin_check`, `sailfin_diagnostics`, `sailfin_fmt_check`, `sailfin_fmt_write`, `sailfin_build`, `sailfin_test`, `sailfin_emit_native`, `sailfin_emit_llvm`, `sailfin_version`), noting they are pure passthroughs to a single `sailfin` subcommand, path-restricted to the workspace root.

Checked in (not `settings.local.json`) so the behavior applies for every agent working the repo.

## Verification

- `.claude/settings.json` parses as valid JSON (a malformed file would silently disable *all* settings from it).
- `autoMode.allow` now has 4 entries; `mcp__sailfin` remains in `permissions.allow`.
- No compiler source touched — no self-host / fmt gate applies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XgGtmpdNAgZKDgyC9sycw4)_