### PR TITLE
fix(typecheck): reject non-struct object literals and intersection data types (E0828/E0829)

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -37,6 +37,8 @@ import {
     check_function_signature,
     check_generic_instantiation,
     check_interface_members,
+    check_intersection_value_type_annotation,
+    check_object_literal_target,
     check_struct_fields,
     check_struct_implements_interfaces,
     check_struct_methods,
@@ -443,9 +445,11 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
         let walk_diags = walk_expression(statement.initializer, bindings, imports);
         let annotation_diags = check_bare_fn_type_annotation(statement.type_annotation, statement.name, statement.span);
+        let intersection_diags = check_intersection_value_type_annotation(statement.type_annotation, statement.name, statement.span);
+        let object_literal_diags = check_object_literal_target(statement.initializer, statement.type_annotation, statement.name, statement.span, top_level);
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: registration.diagnostics.concat(walk_diags).concat(annotation_diags)
+            diagnostics: registration.diagnostics.concat(walk_diags).concat(annotation_diags).concat(intersection_diags).concat(object_literal_diags)
         };
     }
     if statement.variant == "FunctionDeclaration" {
@@ -693,6 +697,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             _ci += 1;
         }
         diagnostics = diagnostics.concat(check_bare_fn_type_annotation(statement.aliased_type, statement.name, statement.name_span));
+        diagnostics = diagnostics.concat(check_intersection_value_type_annotation(statement.aliased_type, statement.name, statement.name_span));
         return ScopeResult {
             bindings: registration.bindings,
             diagnostics: diagnostics
@@ -1106,6 +1111,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
             let parameter = expression.parameters[_lp];
             if lambda_span == null { lambda_span = parameter.span; }
             diagnostics = diagnostics.concat(check_bare_fn_type_annotation(parameter.type_annotation, parameter.name, parameter.span));
+            diagnostics = diagnostics.concat(check_intersection_value_type_annotation(parameter.type_annotation, parameter.name, parameter.span));
             _lp += 1;
         }
         // A param-less lambda (`fn() -> (int) -> int`) has no parameter span
@@ -1123,6 +1129,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
             }
         }
         diagnostics = diagnostics.concat(check_bare_fn_type_annotation(expression.return_type, "lambda", lambda_span));
+        diagnostics = diagnostics.concat(check_intersection_value_type_annotation(expression.return_type, "lambda", lambda_span));
         return diagnostics;
     }
     if expression.variant == "Range" {
@@ -1498,7 +1505,8 @@ fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[], imp
     if statement.variant == "VariableDeclaration" {
         let init_diags = walk_expression(statement.initializer, bindings, imports);
         let annotation_diags = check_bare_fn_type_annotation(statement.type_annotation, statement.name, statement.span);
-        return init_diags.concat(annotation_diags);
+        let intersection_diags = check_intersection_value_type_annotation(statement.type_annotation, statement.name, statement.span);
+        return init_diags.concat(annotation_diags).concat(intersection_diags);
     }
     if statement.variant == "IfStatement" {
         let mut diagnostics = walk_expression(statement.condition, bindings, imports);

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -4,6 +4,7 @@
 // Extracted from typecheck.sfn to keep file sizes manageable.
 import {
     EnumVariant,
+    Expression,
     FieldDeclaration,
     FunctionSignature,
     MethodDeclaration,
@@ -228,6 +229,152 @@ fn check_bare_fn_type_annotation(annotation: TypeAnnotation?, anchor_name: strin
     return [make_bare_fn_type_diagnostic(annotation.text, token_from_name(anchor_name, anchor_span))];
 }
 
+// -------------------------------------------------------------------
+// SFEP-0039 (#1860): nominal object model — honest rejection of the
+// TypeScript-shaped data constructs the nominal backend never
+// implemented. E0828 rejects a bare object literal without a concrete
+// `struct` target; E0829 rejects `A & B` used as a data / value type.
+// Data is only ever constructed through a concrete `struct` (the #1855
+// object-literal path). Design record:
+// docs/proposals/0039-nominal-object-model.md.
+// -------------------------------------------------------------------
+// Split a type annotation on top-level `&`, respecting `(`/`)` and
+// `<`/`>` nesting so an intersection nested inside generic arguments
+// (`Map<A & B, C>`) is not mistaken for a top-level intersection.
+// Mirrors `split_top_level_plus`; empty segments are dropped.
+fn split_top_level_ampersand(text: string) -> string[] {
+    let mut out: string[] = [];
+    let mut current: string = "";
+    let mut depth: int = 0;
+    let mut index: int = 0;
+    loop {
+        if index >= text.length { break; }
+        let ch = text[index];
+        if ch == "(" {
+            depth += 1;
+            current = current + ch;
+        } else if ch == ")" {
+            if depth > 0 { depth -= 1; }
+            current = current + ch;
+        } else if ch == "<" {
+            depth += 1;
+            current = current + ch;
+        } else if ch == ">" {
+            if depth > 0 { depth -= 1; }
+            current = current + ch;
+        } else if ch == "&" {
+            if depth == 0 {
+                let trimmed = trim_text(current);
+                if trimmed.length > 0 { out.push(trimmed); }
+                current = "";
+                index += 1;
+                continue;
+            }
+            current = current + ch;
+        } else { current = current + ch; }
+        index += 1;
+    }
+    let trimmed_last = trim_text(current);
+    if trimmed_last.length > 0 { out.push(trimmed_last); }
+    return out;
+}
+
+// A type annotation is an intersection when two or more operands are
+// joined by a top-level `&` (`A & B`, `Admin & User`). A stray leading
+// or trailing `&`, or a `&` only inside generic arguments, yields
+// fewer than two operands and is not treated as an intersection.
+fn type_annotation_is_intersection(text: string) -> boolean {
+    return split_top_level_ampersand(text).length >= 2;
+}
+
+// E0829: an intersection `A & B` used as a data / value type. The
+// fix-it steers to the two sanctioned paths — a concrete `struct`
+// implementing both interfaces, or a generic bound when the intent is
+// "a value satisfying both" (SFEP-0038 bounds are `+`-separated).
+fn make_intersection_value_type_diagnostic(type_text: string, anchor: Token?) -> Diagnostic {
+    let bare = trim_text(type_text);
+    let fix = FixSuggestion {
+        message: "declare a concrete `struct` that implements both interfaces and annotate with it; "
+            + "for a value satisfying both interfaces in a generic context, use a `+`-separated bound "
+            + "such as `<T: A + B>` (SFEP-0038)",
+        edits: []
+    };
+    return Diagnostic {
+        code: "E0829",
+        severity: "error",
+        message: "intersection type `" + bare
+            + "` is not a data type; `A & B` is reserved for generic trait bounds",
+        file_path: "",
+        primary: anchor,
+        suggestion: fix
+    };
+}
+
+// Reject an intersection `A & B` in any value / type-annotation
+// position (variable, parameter, struct/enum field, return type, and
+// the RHS of a `type X = A & B` alias). Bound position (`<T: A + B>`)
+// is resolved through `check_type_parameters`, never this helper, so
+// generic bounds are untouched (SFEP-0039 §3.3).
+fn check_intersection_value_type_annotation(annotation: TypeAnnotation?, anchor_name: string, anchor_span: SourceSpan?) -> Diagnostic[] {
+    if annotation == null { return []; }
+    if !type_annotation_is_intersection(annotation.text) { return []; }
+    return [make_intersection_value_type_diagnostic(annotation.text, token_from_name(anchor_name, anchor_span))];
+}
+
+// E0828: a bare object literal whose target is not a concrete `struct`.
+// `is_interface` selects between the interface-target and the
+// un-inferable-unannotated wording.
+fn make_object_literal_requires_struct_diagnostic(target: string, is_interface: boolean, anchor_name: string, anchor_span: SourceSpan?) -> Diagnostic {
+    let anchor = token_from_name(anchor_name, anchor_span);
+    let mut message: string = "";
+    if is_interface {
+        message = "object literal requires a concrete `struct` type; `"
+            + trim_text(target)
+            + "` is an interface, not a struct";
+    } else {
+        message = "object literal requires a concrete `struct` type annotation; "
+            + "its target type cannot be inferred";
+    }
+    let fix = FixSuggestion {
+        message: "declare a `struct` with these fields and annotate the binding with it "
+            + "(data is constructed only through concrete structs)",
+        edits: []
+    };
+    return Diagnostic {
+        code: "E0828",
+        severity: "error",
+        message: message,
+        file_path: "",
+        primary: anchor,
+        suggestion: fix
+    };
+}
+
+// Reject a bare object literal (`{ ... }`) whose target type is not a
+// registered concrete `struct`: an interface target, or an
+// un-inferable unannotated binding. A direct or aliased intersection
+// target is left to E0829, which takes precedence (SFEP-0039 §3.3); an
+// unknown / type-alias / enum target is left unflagged (conservative —
+// avoids false positives on imported or aliased names, and the
+// alias-to-intersection case is already reported at the alias
+// definition). The concrete-`struct` target is the sanctioned #1855
+// construction path and compiles unchanged.
+fn check_object_literal_target(initializer: Expression?, annotation: TypeAnnotation?, anchor_name: string, anchor_span: SourceSpan?, top_level: SymbolEntry[]) -> Diagnostic[] {
+    if initializer == null { return []; }
+    if initializer.variant != "Object" { return []; }
+    if annotation == null {
+        return [make_object_literal_requires_struct_diagnostic("", false, anchor_name, anchor_span)];
+    }
+    let text = trim_text(annotation.text);
+    if type_annotation_is_intersection(text) { return []; }
+    let target = find_symbol(top_level, text);
+    if target == null { return []; }
+    if strings_equal(target.kind, "interface") {
+        return [make_object_literal_requires_struct_diagnostic(text, true, anchor_name, anchor_span)];
+    }
+    return [];
+}
+
 fn check_struct_fields(fields: FieldDeclaration[]) -> Diagnostic[] {
     let mut seen: string[] = [];
     let mut diagnostics: Diagnostic[] = [];
@@ -241,6 +388,7 @@ fn check_struct_fields(fields: FieldDeclaration[]) -> Diagnostic[] {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "struct field", token_from_name(name, field.name_span)));
         } else { seen.push(name); }
         diagnostics = diagnostics.concat(check_bare_fn_type_annotation(field.type_annotation, name, field.name_span));
+        diagnostics = diagnostics.concat(check_intersection_value_type_annotation(field.type_annotation, name, field.name_span));
         _fi += 1;
     }
 
@@ -905,6 +1053,7 @@ fn check_enum_variants(variants: EnumVariant[]) -> Diagnostic[] {
             if _evf >= variant.fields.length { break; }
             let field = variant.fields[_evf];
             diagnostics = diagnostics.concat(check_bare_fn_type_annotation(field.type_annotation, field.name, field.name_span));
+            diagnostics = diagnostics.concat(check_intersection_value_type_annotation(field.type_annotation, field.name, field.name_span));
             _evf += 1;
         }
         _vi += 1;
@@ -945,9 +1094,11 @@ fn check_function_signature(signature: FunctionSignature, interfaces: Statement[
         if _pi >= signature.parameters.length { break; }
         let parameter = signature.parameters[_pi];
         diagnostics = diagnostics.concat(check_bare_fn_type_annotation(parameter.type_annotation, parameter.name, parameter.span));
+        diagnostics = diagnostics.concat(check_intersection_value_type_annotation(parameter.type_annotation, parameter.name, parameter.span));
         _pi += 1;
     }
     diagnostics = diagnostics.concat(check_bare_fn_type_annotation(signature.return_type, signature.name, signature.name_span));
+    diagnostics = diagnostics.concat(check_intersection_value_type_annotation(signature.return_type, signature.name, signature.name_span));
     return diagnostics;
 }
 

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -350,6 +350,22 @@ fn make_object_literal_requires_struct_diagnostic(target: string, is_interface: 
     };
 }
 
+// Head type name of a value annotation, stripping a trailing optional
+// marker (`Named?` -> `Named`) so an object literal targeting an
+// optional interface is still classified by its head type. Broader
+// wrapper normalization (array `T[]`, generic-instantiation heads) and
+// the return/parameter positions are the coverage follow-up (#1900).
+fn _object_literal_head_type(text: string) -> string {
+    let mut head = trim_text(text);
+    loop {
+        if head.length == 0 { break; }
+        if head[head.length - 1] == "?" {
+            head = trim_text(substring(head, 0, head.length - 1));
+        } else { break; }
+    }
+    return head;
+}
+
 // Reject a bare object literal (`{ ... }`) whose target type is not a
 // registered concrete `struct`: an interface target, or an
 // un-inferable unannotated binding. A direct or aliased intersection
@@ -367,10 +383,11 @@ fn check_object_literal_target(initializer: Expression?, annotation: TypeAnnotat
     }
     let text = trim_text(annotation.text);
     if type_annotation_is_intersection(text) { return []; }
-    let target = find_symbol(top_level, text);
+    let head = _object_literal_head_type(text);
+    let target = find_symbol(top_level, head);
     if target == null { return []; }
     if strings_equal(target.kind, "interface") {
-        return [make_object_literal_requires_struct_diagnostic(text, true, anchor_name, anchor_span)];
+        return [make_object_literal_requires_struct_diagnostic(head, true, anchor_name, anchor_span)];
     }
     return [];
 }

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -51,6 +51,18 @@ test "object-model: bare literal targeting a concrete struct is not E0828" ![io]
     assert ! _has_code(_diags(source), "E0828");
 }
 
+test "object-model: bare literal targeting an optional interface is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn main() ![io] { let bad: Named? = { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: bare literal targeting an optional struct is not E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn main() ![io] { let p: Person? = { name: \"Alice\" }; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
 // -------------------------------------------------------------------
 // E0829 — `A & B` in value / type-annotation position.
 // -------------------------------------------------------------------

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -1,0 +1,127 @@
+// Unit tests for the SFEP-0039 nominal-object-model diagnostics (#1860):
+//
+//   E0828 — a bare object literal `{ ... }` whose target is not a concrete
+//           `struct` (an interface target, or an un-inferable unannotated
+//           `let`). Data is constructed only through concrete structs (the
+//           #1855 object-literal path), which stays legal.
+//   E0829 — `A & B` used as a data / value type (variable, parameter,
+//           struct/enum field, return type, or the RHS of a `type X = A & B`
+//           alias). `A & B` is reserved for generic trait bounds (SFEP-0038,
+//           `+`-separated) and is NOT flagged in bound position.
+//
+// These parse a small `.sfn` source through `parse_program` and run
+// `typecheck_diagnostics` end-to-end, asserting on the `Diagnostic.code`
+// field, mirroring `typecheck_bare_fn_type_test.sfn`.
+import { parse_program } from "../../src/parser/mod";
+import { typecheck_diagnostics } from "../../src/typecheck";
+import { Diagnostic } from "../../src/typecheck_types";
+
+fn _has_code(diagnostics: Diagnostic[], code: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= diagnostics.length { break; }
+        if strings_equal(diagnostics[i].code, code) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _diags(source: string) -> Diagnostic[] ![io] {
+    let program = parse_program(source);
+    return typecheck_diagnostics(program);
+}
+
+// -------------------------------------------------------------------
+// E0828 — bare object literal without a concrete `struct` target.
+// -------------------------------------------------------------------
+test "object-model: bare literal targeting an interface is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn main() ![io] { let bad: Named = { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: unannotated bare literal is E0828" ![io] {
+    let source = "fn main() ![io] { let huh = { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: bare literal targeting a concrete struct is not E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn main() ![io] { let p: Person = { name: \"Alice\" }; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
+// -------------------------------------------------------------------
+// E0829 — `A & B` in value / type-annotation position.
+// -------------------------------------------------------------------
+test "object-model: intersection type alias is E0829 at the definition" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "type AdminUser = Admin & User;\n";
+    assert _has_code(_diags(source), "E0829");
+}
+
+test "object-model: intersection variable annotation is E0829" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "fn main() ![io] { let x: Admin & User = 0; }\n";
+    assert _has_code(_diags(source), "E0829");
+}
+
+test "object-model: intersection parameter annotation is E0829" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "fn describe(v: Admin & User) -> int { return 0; }\n";
+    assert _has_code(_diags(source), "E0829");
+}
+
+test "object-model: intersection struct field is E0829" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "struct Holder { both: Admin & User; }\n";
+    assert _has_code(_diags(source), "E0829");
+}
+
+// -------------------------------------------------------------------
+// E0829 — must NOT fire in generic bound position (SFEP-0038 territory).
+// -------------------------------------------------------------------
+test "object-model: intersection in a generic bound is not E0829" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "fn describe<T: Admin & User>(v: T) -> T { return v; }\n";
+    assert ! _has_code(_diags(source), "E0829");
+}
+
+// A `&` nested inside generic arguments is not a top-level intersection
+// and must not be mistaken for one (depth-aware scan).
+test "object-model: nested `&` inside generic args is not E0829" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "fn f(x: Box<Admin & User>) -> int { return 0; }\n";
+    assert ! _has_code(_diags(source), "E0829");
+}
+
+// -------------------------------------------------------------------
+// Precedence — a bare literal targeting an intersection alias reports
+// E0829 (the illegal annotation), never E0828 (SFEP-0039 §3.3).
+// -------------------------------------------------------------------
+test "object-model: intersection-alias literal target is E0829, not E0828" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "type AdminUser = Admin & User;\n"
+        + "fn main() ![io] { let admin: AdminUser = { name: \"Alice\", isAdmin: true }; }\n";
+    let diagnostics = _diags(source);
+    assert _has_code(diagnostics, "E0829");
+    assert ! _has_code(diagnostics, "E0828");
+}
+
+// A direct intersection annotation on a bare literal likewise reports
+// E0829, not E0828.
+test "object-model: direct-intersection literal target is E0829, not E0828" ![io] {
+    let source = "interface Admin { fn is_admin() -> boolean; }\n"
+        + "interface User { fn name() -> string; }\n"
+        + "fn main() ![io] { let admin: Admin & User = { name: \"Alice\" }; }\n";
+    let diagnostics = _diags(source);
+    assert _has_code(diagnostics, "E0829");
+    assert ! _has_code(diagnostics, "E0828");
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -181,6 +181,18 @@ here.
   signatures, variable declarations (scope- and lambda-body-local), struct
   fields, lambda parameter/return annotations, enum variant fields, and type
   aliases.
+- **Nominal object model — object literals and intersections** (`E0828`/`E0829`,
+  SFEP-0039, #1860): data is constructed only through a concrete `struct`. A
+  bare object literal `{ ... }` whose resolved target is an **interface**, or
+  an unannotated `let` the compiler cannot infer a struct for, fails typecheck
+  with `E0828`; `let p: Person = { name: "Alice" }` against a `struct Person`
+  is the sanctioned path (#1855) and is unaffected. Separately, `A & B` used as
+  a **data/value type** (variable, parameter, field, or return annotation, or
+  the RHS of a `type X = A & B` alias) fails typecheck with `E0829` — `A & B`
+  stays in the grammar but is reserved for generic trait-bound composition
+  (`<T: A + B>`, SFEP-0038) and is not diagnosed in bound position. The sibling
+  rule that interface members must be method signatures (`E0827`) is designed
+  in SFEP-0039 but **not yet enforced** — tracked separately in #1888.
 
 ## Feature Matrix
 
@@ -190,10 +202,10 @@ here.
 | `thread_local let mut` | Shipped | Top-level only; ELF TLS; immutable form rejected (`E0807`) |
 | Functions (`fn`) | Shipped | Generics, default params, decorators |
 | `async fn` | Parsed | Structural only; `spawn`/`await` on spawned tasks works end-to-end (v0, #1084 closed, #1474/#1477/#1546); `await` on `async fn` return values is not wired into the live typecheck walk (pending #829). Use `spawn fn() -> T { ... }` + `await` instead |
-| Structs | Shipped | Generic params, `implements` clause |
-| Interfaces | Shipped | Trait-style method signatures |
+| Structs | Shipped | Generic params, `implements` clause. Sole sanctioned bare-object-literal target (`E0828`, SFEP-0039, #1860) — a literal targeting an interface or an un-inferable unannotated `let` is rejected |
+| Interfaces | Shipped | Trait-style method signatures. Nominal model intent is method-only contracts (SFEP-0039); data-field-shaped members are still parsed without a diagnostic pending `E0827` enforcement (#1888) |
 | Enums / ADTs | Shipped | Payload variants; generic payloads monomorphise per instantiation (#830). >8-byte by-value payload layouts not yet emitted |
-| Type aliases | Shipped | Including generic params |
+| Type aliases | Shipped | Including generic params. `A & B` is reserved for generic trait bounds, not a data type — `type X = A & B` is rejected at the definition (`E0829`, SFEP-0039, #1860) |
 | Module exports | **Shipped** | Block form `export { name };` / `export { x } from "./m";` and inline `export <declaration>` (`export fn`/`export struct`/`export enum`/`export interface`/`export type`/`export let`/`export extern …`/`export thread_local let mut`). Inline form added in SFEP-0031 (#1681); equivalent to `<decl> export { name };` |
 | `if`/`else`, `for` | Shipped | |
 | `loop` / `break` / `continue` | Shipped | `while` is intentionally not a keyword (`E0411` with a `loop` fix-it) |

--- a/site/src/content/docs/docs/reference/spec/06-types.md
+++ b/site/src/content/docs/docs/reference/spec/06-types.md
@@ -81,7 +81,8 @@ parameter, struct/enum field, or return-type annotation, or the RHS of a
 `type X = A & B` alias — is a typecheck error (`E0829`). It is never
 decomposed into a structural record of both interfaces' members; the nominal
 object model has no such structural type. `A & B` is *reserved* for generic
-trait-bound composition and stays undiagnosed in bound position; only
+trait-bound composition — a bound is written `+`-separated (`<T: A + B>`, per
+SFEP-0038), not with `&` — and stays undiagnosed in bound position; only
 data/value-type uses are rejected. See SFEP-0039 for the full rationale.
 
 ```sfn

--- a/site/src/content/docs/docs/reference/spec/06-types.md
+++ b/site/src/content/docs/docs/reference/spec/06-types.md
@@ -55,9 +55,42 @@ boundaries — bindings, call arguments, struct fields, and arithmetic operands:
 
 **Composite types**: structs, enums, arrays (`T[]`)
 
+**Object literals require a concrete `struct` target**: data is constructed
+only through a `struct`. A bare object literal `{ ... }` resolves its shape
+against the annotation or contextual type it targets; if that target is an
+**interface**, or the binding is unannotated and no concrete struct can be
+inferred, the literal is a typecheck error (`E0828`). The sanctioned path is
+a `struct` annotation:
+
+```sfn
+struct Person { name: string; }
+interface Named { fn name() -> string; }
+
+let p: Person = { name: "Alice" };   // OK — concrete struct target
+let n: Named  = { name: "Alice" };   // E0828 — Named is an interface, not a struct
+let u         = { name: "Alice" };   // E0828 — no inferable struct target
+```
+
 **Optional types**: `T?` — the value is `T` or `null`
 
 **Union types**: `A | B` — the value is either type; matched with `match`
+
+**Intersection types (`A & B`) are not a data type**: the grammar accepts
+`A & B` as a `Type`, but using it as a **data/value type** — a variable,
+parameter, struct/enum field, or return-type annotation, or the RHS of a
+`type X = A & B` alias — is a typecheck error (`E0829`). It is never
+decomposed into a structural record of both interfaces' members; the nominal
+object model has no such structural type. `A & B` is *reserved* for generic
+trait-bound composition and stays undiagnosed in bound position; only
+data/value-type uses are rejected. See SFEP-0039 for the full rationale.
+
+```sfn
+interface Named  { fn name() -> string; }
+interface Scoped { fn is_admin() -> boolean; }
+
+type AdminUser = Named & Scoped;         // E0829 — intersection at the alias definition
+let x: Named & Scoped = get_admin();     // E0829 — intersection in annotation position
+```
 
 **Generic types**: user-declared generics (`fn first<T>(items: T[]) -> T?`).
 `Result<T, E>` is on the [roadmap](/roadmap); use union return types


### PR DESCRIPTION
## Summary
- **E0828** — a bare object literal `{ ... }` must target a concrete `struct`. A literal whose resolved target is an **interface**, or an **un-inferable unannotated `let`**, is now a typecheck error instead of a silent store of `null`/`zeroinitializer`. The concrete-struct path (`let p: Person = { ... }`, #1855) still compiles and produces correct output.
- **E0829** — `A & B` used as a **data/value type** (variable, parameter, struct/enum field, or return-type annotation, or the RHS of a `type X = A & B` alias — flagged at the definition) is now a typecheck error. `A & B` stays in the grammar, **reserved** for generic trait-bound composition, and is untouched in bound position (bounds resolve through `check_type_parameters` on `+`, a disjoint path).
- Both constructs previously type-checked clean (`sfn check` green) and silently miscompiled to empty strings / zeros — the failure mode SFEP-0039 sets out to eliminate.

Closes #1860

Design: SFEP-0039 (`docs/proposals/0039-nominal-object-model.md`), §3.2 (E0828), §3.3–§3.4 (E0829 + precedence). This PR delivers the **typecheck** slice; the sibling **parser** rule E0827 (interface members must be method signatures) is #1888. SFEP-0039 therefore stays **Accepted**, not Implemented.

## Acceptance Criteria
- [x] `E0828` and `E0829` fire at the specified sites with documented messages / fix-its.
- [x] `E0829`-over-`E0828` precedence is deterministic (test: `intersection-alias literal target is E0829, not E0828`).
- [x] `A & B` in bound position (`<T: A & B>`) is **not** flagged (test).
- [x] The #1855 concrete-struct object-literal path still compiles and produces correct output (`unions.sfn` prints `Admin: Alice`; existing `bare_struct_literal_annotation_test` green).
- [x] Regression tests in `compiler/tests/` (new `typecheck_object_model_test.sfn`, 11 cases).
- [x] `make compile` passes (self-hosts; rebuild from seed exit 0).
- [x] Suite green except one flaky pool-contention failure — see Verification.

## Design notes / reviewer conditions addressed
- **SFEP function citation reconciled (map drift).** SFEP-0039 §9 cites `resolve_struct_info_from_llvm_type` in `typecheck.sfn`/`typecheck_types.sfn` as the E0828 classification point, but that function is LLVM-lowering-stage and not `check`-visible. To make E0828 a real `sfn check` diagnostic, it is built on the AST-level `SymbolEntry` registry (`find_symbol(top_level, ...)` for struct-vs-interface classification) — same choke point, correct stage. The Goal and In/Out scope are unchanged.
- **E0829 fix-it uses `+`, not `&`.** SFEP prose writes the reserved bound as `<T: A & B>`, but the shipped SFEP-0038 bound syntax is `+`-separated. The fix-it steers to `<T: A + B>` (the syntax the parser accepts) — intentionally more correct than the SFEP prose.
- **E0828 scope is `let`-position (deliberate first cut).** E0828 fires at the primary `VariableDeclaration` site (covering the bug repro and every SFEP §3.2 example). Return-position, parameter-default, and lambda-body-local bare object literals targeting non-structs are **not** yet covered — they'd require threading `top_level`/return-type context through the expression walker. E0829 is complete at all 9 value positions. Follow-up filed: see linked issue.

## Map reconciliation
Advisory `## Files Affected` listed `compiler/src/typecheck.sfn`, `compiler/src/typecheck_types.sfn` (both touched, correct), `compiler/src/llvm/` (not needed — rejected cases never reach lowering, so the old default-store fall-through is dead for type-checked programs; no LLVM change), and `compiler/tests/{unit,integration}` (landed as a `unit` test). No path drift beyond the SFEP function-citation correction noted above.

## Verification
```bash
# E0828 / E0829 fire at check time
timeout 60 build/native/sailfin check /tmp/bare_iface_probe.sfn
#   error[E0828]: object literal requires a concrete `struct` type; `Named` is an interface, not a struct
timeout 60 build/native/sailfin check /tmp/intersection_probe.sfn
#   error[E0829]: intersection type `Admin & User` is not a data type; ... (at the `type AdminUser = ...` definition)

# #1855 concrete-struct path still correct
build/native/sailfin run examples/advanced/unions.sfn
#   It's a string: Sailfin / It's a number: 42 / Admin: Alice

# New unit test
build/native/sailfin test compiler/tests/unit/typecheck_object_model_test.sfn   # PASS (11/11)

# Self-host
make compile        # pass (rebuild from seed, exit 0)
make check          # unit 195/195, integration 42/42, e2e 184/185, capsules 38/38
```
The single `make check` e2e failure was `work_dir_parity_test.sfn`, classified `crash` under the parallel pool. It **passes cleanly in isolation** (both cases, including the nested `build -p compiler` byte-identity check) — a documented resource/timeout sensitivity (#1576), not a regression. The isolation run also exercises the stricter binary compiling the full compiler source into two work-dir roots successfully (a seedcheck-equivalent proof). This change is additive typecheck-only — no codegen/determinism impact.

## Files Changed
- `compiler/src/typecheck_types.sfn` — `split_top_level_ampersand` / `type_annotation_is_intersection` (depth-aware), `make_intersection_value_type_diagnostic` + `check_intersection_value_type_annotation` (E0829), `make_object_literal_requires_struct_diagnostic` + `check_object_literal_target` (E0828); `Expression` added to the ast import.
- `compiler/src/typecheck.sfn` — wires E0829 at the 9 value-position annotation sites and E0828 at the `let` site; imports the two new checks.
- `compiler/tests/unit/typecheck_object_model_test.sfn` — 11 regression cases (E0828 interface/unannotated/positive-struct; E0829 alias-def/annotation/param/field; bound-not-flagged; nested-generic depth; precedence ×2).
- `docs/status.md`, `site/src/content/docs/docs/reference/spec/06-types.md` — object-literal + intersection rules (E0827 noted as designed-but-not-yet-enforced, #1888).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1pbZPvcLc81QEAT1nBRXW)_