### PR TITLE
feat(llvm): resolve bound interface-method calls to concrete methods in specializations

### DIFF
--- a/compiler/src/llvm/monomorphize.sfn
+++ b/compiler/src/llvm/monomorphize.sfn
@@ -197,7 +197,13 @@ fn _mono_split_top_level(text: string) -> string[] {
     return parts;
 }
 
-// Parse `.meta generics <T, U>` into ["T", "U"].
+// Parse `.meta generics <T, U>` into ["T", "U"]. A bounded parameter such as
+// `<T : Comparable>` keeps only the bare name (`T`), truncating at the first
+// `:` bound separator — otherwise `_mono_unify`/`enum_inst_resolve_token`
+// exact-match the whole `"T : Comparable"` string and never recognize the bare
+// `T` token in `.param`/`.let` lines, so no binding is discovered and the
+// bounded generic is dropped without a specialization (SFEP-0038 §3.3). Mirrors
+// `parse_enum_header_type_parameters` in native_ir_parser_defs.sfn.
 fn _mono_parse_generics_meta(line: string) -> string[] {
     let open = index_of(line, "<");
     if open < 0 { return []; }
@@ -221,7 +227,20 @@ fn _mono_parse_generics_meta(line: string) -> string[] {
         } else { inner = inner + ch; }
         index += 1;
     }
-    return _mono_split_top_level(inner);
+    let raw_entries = _mono_split_top_level(inner);
+    let mut names: string[] = [];
+    let mut entry_index: int = 0;
+    loop {
+        if entry_index >= raw_entries.length { break; }
+        let mut entry = trim_text(raw_entries[entry_index]);
+        let bound_index = index_of(entry, ":");
+        if bound_index >= 0 {
+            entry = trim_text(substring(entry, 0, bound_index));
+        }
+        if entry.length > 0 { names = names.push(entry); }
+        entry_index += 1;
+    }
+    return names;
 }
 
 // True for a fn-pointer annotation in either spelling the emitter/formatter

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -109,7 +109,15 @@ fn check_struct_implements_interfaces(statement: Statement, interfaces: Statemen
         if _ai >= statement.implements_types.length { break; }
         let annotation = statement.implements_types[_ai];
         let interface_definition = resolve_interface_annotation(annotation, interfaces);
-        if interface_definition == null { continue; }
+        // An interface not visible on this path (e.g. a prelude interface not
+        // loaded for a standalone `sfn check`) is silently trusted, matching
+        // the "trusted when not visible" conformance doctrine. Advance the
+        // index before continuing — skipping it spins the loop forever, which
+        // exhausts the memory cap and aborts with no diagnostic.
+        if interface_definition == null {
+            _ai += 1;
+            continue;
+        }
         let interface_name = interface_definition.name;
         let _via_diags = validate_interface_annotation(statement.name, interface_definition, annotation);
         let mut _ci: int = 0;

--- a/compiler/tests/e2e/fixtures/mono_generic_sort.sfn
+++ b/compiler/tests/e2e/fixtures/mono_generic_sort.sfn
@@ -1,0 +1,59 @@
+// Fixture for bounded generic-method resolution (#1872, SFEP-0038 §3.3 step 3).
+// `sort<T: Comparable>` calls the bounded interface method `a.compare(b)` on a
+// `T`-typed receiver. In the specialized copy at T=Widget that call must resolve
+// to the concrete `Widget.compare` — a direct static call, not dynamic vtable
+// dispatch. Before the monomorphizer stripped the `: Comparable` bound from the
+// parsed `.meta generics` param name, the whole bounded generic was dropped with
+// no specialization emitted; correctly ordered output proves the resolution.
+//
+// `Comparable` comes from the prelude (SFEP-0038 §3.4). The exit code encodes
+// the final order (ranks 1,2,3 -> 1*100 + 2*10 + 3 = 123), so a mis-ordered or
+// unresolved dispatch produces a different code.
+//
+// `compare` takes `other: Widget` rather than the interface's `other: Self`
+// spelling: a `Self`-typed non-receiver parameter is not yet resolved to the
+// enclosing struct type at lowering (it lowers to an opaque pointer, corrupting
+// field access) — a separate, pre-existing gap outside this issue's dispatch
+// scope. `other: Widget` satisfies `Comparable` conformance identically and
+// keeps this fixture focused on the bound-method resolution under test.
+struct Widget implements Comparable {
+    rank: int;
+
+    fn compare(self, other: Widget) -> int { return self.rank - other.rank; }
+}
+
+fn sort < T: Comparable > (items: T[]) -> T[] {
+    let mut out: T[] = items;
+    let n = out.length;
+    let mut i = 0;
+    loop {
+        if i >= n { break; }
+        let mut j = 0;
+        loop {
+            if j + 1 >= n { break; }
+            let a: T = out[j];
+            let b: T = out[j + 1];
+            if a.compare(b) > 0 {
+                out[j] = b;
+                out[j + 1] = a;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    return out;
+}
+
+fn main() -> int ![io] {
+    let widgets: Widget[] = [Widget { rank: 3 }, Widget { rank: 1 }, Widget {
+        rank: 2
+    },];
+    let sorted = sort(widgets);
+    let mut line = "sorted:";
+    for w in sorted {
+        let r = w.rank;
+        line = line + " {{ r }}";
+    }
+    print(line);
+    return sorted[0].rank * 100 + sorted[1].rank * 10 + sorted[2].rank;
+}

--- a/compiler/tests/e2e/generic_sort_run_test.sfn
+++ b/compiler/tests/e2e/generic_sort_run_test.sfn
@@ -1,0 +1,97 @@
+// End-to-end coverage for bounded generic-method resolution (#1872,
+// SFEP-0038 §3.3 step 3). Drives the production `sfn build` / `sfn emit llvm`
+// paths as subprocesses over `fixtures/mono_generic_sort.sfn`, a
+// `sort<T: Comparable>` that calls the bounded interface method `a.compare(b)`
+// on a `T`-typed receiver.
+//
+// The acceptance pins two things:
+//   1. The bounded generic actually monomorphizes and runs — a `Widget[]` is
+//      sorted to ascending order. (Before the monomorphizer stripped the
+//      `: Comparable` bound from the parsed `.meta generics` param name, the
+//      whole bounded generic was dropped with no specialization emitted.)
+//   2. In the specialized copy at T=Widget the bounded call resolves to a
+//      DIRECT static call to the concrete `Widget.compare` (not a dynamic
+//      vtable / `trait_dispatch__` fat-pointer dispatch) — the payoff of
+//      interface *bounds* over interface *values*.
+//
+// Matchers note: the `sfn/test` `expect_*` matchers are `![pure]` and cannot be
+// called from an `![io]` test; assert on captured output / IR text with
+// `sfn/strings` predicates instead (#842). Build/emit isolation follows
+// `.claude/rules/no-bash-e2e.md`: the full parent environment is threaded (PATH
+// for clang/ld, SAILFIN_TEST_SCRATCH for per-invocation build-cache isolation
+// under the parallel pool).
+import { contains, find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Emit the fixture's LLVM IR and return its text (or "" on failure).
+fn _emit_ir(fixture: string, tag: string) -> string ![io] {
+    let dir = _scratch_dir();
+    let ll = dir + "/sfn-sort-" + tag + ".ll";
+    if fs.exists(ll) { fs.deleteFile(ll); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", ll, "llvm", fixture], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    if !fs.exists(ll) { return ""; }
+    let ir = fs.readFile(ll);
+    fs.deleteFile(ll);
+    return ir;
+}
+
+// Build the fixture to a unique path and run it; stash stdout to `marker` and
+// return the run's exit code, or -100 if the build itself failed.
+fn _build_and_run(fixture: string, tag: string, marker: string) -> int ![io] {
+    let dir = _scratch_dir();
+    let bin = dir + "/sfn-sort-bin-" + tag;
+    if fs.exists(bin) { fs.deleteFile(bin); }
+    let build_exit = process.run_capture([_sfn_bin(), "build", "-o", bin, fixture], _child_env());
+    let _bo = process.capture_take_stdout();
+    let _be = process.capture_take_stderr();
+    if build_exit != 0 { return -100; }
+    let run_exit = process.run_capture([bin], _child_env());
+    let out = process.capture_take_stdout();
+    let _re = process.capture_take_stderr();
+    fs.writeFile(marker, out);
+    fs.deleteFile(bin);
+    return run_exit;
+}
+
+test "generic sort e2e: bounded sort<T: Comparable> runs and orders a Widget[]" ![io] {
+    let dir = _scratch_dir();
+    let marker = dir + "/sfn-sort-run.out";
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    let exit = _build_and_run("compiler/tests/e2e/fixtures/mono_generic_sort.sfn", "run", marker);
+    // Exit code encodes the final order: ranks 1,2,3 -> 1*100 + 2*10 + 3.
+    assert exit == 123;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // Ascending order of the shuffled 3,1,2 input.
+    assert find(out, "1 2 3", 0) >= 0;
+}
+
+test "generic sort e2e: bound call resolves to a direct concrete method, not vtable" ![io] {
+    let ir = _emit_ir("compiler/tests/e2e/fixtures/mono_generic_sort.sfn", "ir");
+    assert ir.length > 0;
+    // The bounded generic monomorphized: a `sort$Widget` specialization exists.
+    assert contains(ir, "sort__");
+    assert contains(ir, "$Widget");
+    // The bounded `a.compare(b)` lowered to a DIRECT static call to the
+    // concrete `Widget.compare` symbol...
+    assert contains(ir, "call i64 @Widgetcompare");
+    // ...and NOT through the dynamic interface-value dispatch path.
+    assert ! contains(ir, "trait_dispatch");
+}

--- a/compiler/tests/unit/struct_implements_unresolved_interface_test.sfn
+++ b/compiler/tests/unit/struct_implements_unresolved_interface_test.sfn
@@ -20,6 +20,9 @@ test "conformance: struct implementing an unresolved interface terminates" ![io]
     let program = parse_program(source);
     let diags: Diagnostic[] = typecheck_diagnostics(program);
     // An unseen interface is trusted (skipped), so no conformance diagnostic is
-    // raised for it; the walk simply returns.
-    assert diags.length >= 0;
+    // raised for it: the fully-valid struct type-checks with zero diagnostics.
+    // Reaching this assertion also proves the walk terminated (a hang would time
+    // out); the exact-count check additionally pins the silently-skipped
+    // behavior the fix restores.
+    assert diags.length == 0;
 }

--- a/compiler/tests/unit/struct_implements_unresolved_interface_test.sfn
+++ b/compiler/tests/unit/struct_implements_unresolved_interface_test.sfn
@@ -1,0 +1,25 @@
+// Regression for the conformance-walk termination bug bundled with #1872
+// (SFEP-0038). An `implements` clause naming an interface not visible in the
+// current typecheck scope — a prelude interface not loaded on a standalone
+// `sfn check`, or a genuinely undeclared name — resolves to null in
+// `check_struct_implements_interfaces`. The null branch must advance the loop
+// index and continue (silently trusting the unseen interface); the #1870 E0820
+// work skipped the increment, so the walk spun forever, exhausted the memory
+// cap, and aborted with no diagnostic. This asserts the walk terminates.
+import { parse_program } from "../../src/parser/mod";
+import { typecheck_diagnostics } from "../../src/typecheck";
+import { Diagnostic } from "../../src/typecheck_types";
+
+test "conformance: struct implementing an unresolved interface terminates" ![io] {
+    // `Comparable` is neither declared here nor loaded from the prelude on this
+    // path, so it resolves to null in the conformance walk. Reaching the
+    // assertion at all proves the walk terminated instead of looping.
+    let source = "struct Widget implements Comparable {\n" + "    rank: int;\n"
+        + "    fn compare(self, other: Widget) -> int { return self.rank - other.rank; }\n"
+        + "}\n";
+    let program = parse_program(source);
+    let diags: Diagnostic[] = typecheck_diagnostics(program);
+    // An unseen interface is trusted (skipped), so no conformance diagnostic is
+    // raised for it; the walk simply returns.
+    assert diags.length >= 0;
+}


### PR DESCRIPTION
## Summary
- In a bounded generic (`sort<T: Comparable>`), a `T`-receiver method call `a.compare(b)` now lowers, in the specialized copy at `T = Widget`, to a **direct static call** to the concrete `Widget.compare` — not a dynamic vtable/`trait_dispatch` fat-pointer dispatch. Interface *bounds* (compile-time) vs interface *values* (dynamic, unchanged).
- Root cause was in the monomorphizer: `_mono_parse_generics_meta` split `.meta generics <T : Comparable>` on top-level commas only, storing the param name as `"T : Comparable"` instead of the bare `"T"`. Downstream exact-string matching then never recognized the `T` token, so **no binding was discovered, no specialization emitted, and the bounded generic was dropped entirely** — it silently vanished from output. Fix strips each entry at its first `:`, mirroring `parse_enum_header_type_parameters` (native_ir_parser_defs.sfn). The dispatch itself needed no new code — the existing struct-method resolution routes the substituted `Widget` receiver to the direct call automatically.
- **Bundled crash fix** (approved): `check_struct_implements_interfaces` (typecheck_types.sfn) skipped its loop-index increment when an `implements` clause named an interface not visible on the current path (a prelude interface absent on standalone `sfn check`), spinning forever until the 8 GiB memory cap aborted the process with no diagnostic (regressed in #1870). One line advances the index before continuing. This blocked writing the acceptance test.

Closes #1872

## Acceptance Criteria
- [x] `sort` over a `Widget[]` compiles to a binary and runs, producing correctly ordered output (proves `a.compare(b)` resolved to the concrete method). → builds, runs `sorted: 1 2 3`, exit 123; IR shows `define @sort__…$Widget`, direct `call i64 @Widgetcompare(%Widget*, %Widget*)`, and **no** `trait_dispatch`.
- [x] Dynamic interface-value dispatch is unaffected (existing trait-dispatch tests stay green). → `interface_dispatch_test`, `interface_vtable_consumer_declares_test` green.
- [x] `make compile` self-hosts; `make check` passes. → self-hosts (3×); full suite: unit 195/195, integration 42/42, capsules 38/38, e2e 185/186. The one miss (`work_dir_parity_test`, the suite's heaviest test — a double compiler self-host build) was a **load-induced timeout** and **passes 2/2 in isolation**; it is structurally unrelated to this diff (builds `-p compiler`, which has no bounded generics).

## Map reconciliation
Advisory `## Files Affected` named `monomorphize.sfn` / expression-lowering; the actual in-scope fix landed entirely in `monomorphize.sfn` (`_mono_parse_generics_meta`) — the downstream dispatch path (`core_call_resolution.sfn`) already routed a substituted concrete receiver to the direct call and needed no change. `typecheck_types.sfn` was added to the diff to fix the bundled pre-existing crash (see below), which the advisory map did not anticipate.

## Notes / follow-up
- The fixture's `Widget.compare` uses `other: Widget` rather than the interface's canonical `other: Self`: a `Self`-typed **non-receiver parameter** is a *separate* pre-existing lowering gap (lowers to an opaque `i8*`, corrupting field access → `sub i8*` LLVM error), independent of generics/bounds. `other: Widget` satisfies `Comparable` conformance identically and keeps this PR focused on dispatch. Tracked as **#1898**.

## Verification
```bash
build/native/sailfin build -o /tmp/s compiler/tests/e2e/fixtures/mono_generic_sort.sfn && /tmp/s   # → "sorted: 1 2 3", exit 123
build/native/sailfin test compiler/tests/e2e/generic_sort_run_test.sfn                             # → 2/2 PASS
build/native/sailfin test compiler/tests/unit/struct_implements_unresolved_interface_test.sfn      # → PASS (termination regression)
# regression: interface_dispatch_test, interface_vtable_consumer_declares_test,
#             generic_fn_monomorphization_test, generic_struct_monomorphization_test,
#             generic_bound_satisfaction_test (6), generic_bound_declaration_test (7)  → all green
make compile   # self-hosts
```

## Files Changed
- `compiler/src/llvm/monomorphize.sfn` — strip `: Bound` from parsed `.meta generics` param names (the fix).
- `compiler/src/typecheck_types.sfn` — advance loop index on unresolved-interface skip (bundled crash fix).
- `compiler/tests/e2e/fixtures/mono_generic_sort.sfn` — bounded-sort fixture (new).
- `compiler/tests/e2e/generic_sort_run_test.sfn` — build+run and direct-dispatch IR assertions (new).
- `compiler/tests/unit/struct_implements_unresolved_interface_test.sfn` — conformance-walk termination regression (new).

---
_Generated by [Claude Code](https://claude.ai/code/session_012SciPcAmvcr2KWU1H9mnHv)_