### PR TITLE
refactor(build): harden macOS OpenSSL detection + formalize SAILFIN_OPENSSL_PREFIX

### DIFF
--- a/compiler/src/build/runtime_objs.sfn
+++ b/compiler/src/build/runtime_objs.sfn
@@ -738,7 +738,11 @@ fn _openssl_link_search_flags() -> string[] ![io] {
     // arm64 / Intel keg dirs) FIRST, and only shell out to `brew --prefix`
     // when none exist — command substitution in a `for` list would run
     // `brew` unconditionally (~100-300ms), and this probe fires on every
-    // link (incl. each `sfn test` per-binary link). The `pkg-config`
+    // link (incl. each `sfn test` per-binary link). The override is guarded
+    // by `[ -n "$P" ]` so an UNSET `SAILFIN_OPENSSL_PREFIX` does not expand
+    // to the bare `/lib` candidate (which would wrongly short-circuit the
+    // keg/brew/pkg-config search on a host that happens to have a `/lib`
+    // dir); it only participates when explicitly set. The `pkg-config`
     // fallback runs LAST and only when every `[ -d ]` keg check AND
     // `brew --prefix` miss; it is guarded by `command -v pkg-config` so a
     // host without `pkg-config` (or without a registered `openssl.pc`)
@@ -748,7 +752,7 @@ fn _openssl_link_search_flags() -> string[] ![io] {
     // generally off the default `pkg-config` path — this fallback targets
     // system/registered OpenSSL, not the Homebrew case the keg/brew
     // candidates already cover.
-    let probe = "d=\"\"; for c in \"${SAILFIN_OPENSSL_PREFIX:-}/lib\" /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; [ -z \"$d\" ] && command -v pkg-config >/dev/null 2>&1 && { L=\"$(pkg-config --libs-only-L openssl 2>/dev/null)\"; L=\"${L%% *}\"; c=\"${L#-L}\"; [ -n \"$c\" ] && [ -d \"$c\" ] && d=\"$c\"; }; printf %s \"$d\"";
+    let probe = "d=\"\"; P=\"${SAILFIN_OPENSSL_PREFIX:-}\"; [ -n \"$P\" ] && [ -d \"$P/lib\" ] && d=\"$P/lib\"; [ -z \"$d\" ] && { for c in /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; }; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; [ -z \"$d\" ] && command -v pkg-config >/dev/null 2>&1 && { L=\"$(pkg-config --libs-only-L openssl 2>/dev/null)\"; L=\"${L%% *}\"; c=\"${L#-L}\"; [ -n \"$c\" ] && [ -d \"$c\" ] && d=\"$c\"; }; printf %s \"$d\"";
     let dir = _shell_read_cmd(probe);
     if dir.length == 0 { return []; }
     return ["-L" + dir];

--- a/compiler/src/build/runtime_objs.sfn
+++ b/compiler/src/build/runtime_objs.sfn
@@ -722,10 +722,14 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
 // test builds spawned with a curated env, and real user builds alike.
 // Injected into the shared runtime `link_libs` (consumed by both argv
 // builders as `plan.libs`) so it can't be missed by one path. The `-L`
-// precedes `-lssl`/`-lcrypto`, so it applies. Honours
-// `SAILFIN_OPENSSL_PREFIX`, else probes `brew` and the standard keg
-// locations; emits nothing on Linux (default path). Darwin-gated via the
-// same `uname -s` probe `_dead_strip_link_flag` uses, so Linux argv stays
+// precedes `-lssl`/`-lcrypto`, so it applies. Candidate order (first hit
+// wins, so exactly one `-L` is ever emitted): `SAILFIN_OPENSSL_PREFIX`
+// (supported public override — a valid prefix surfaces `-L<prefix>/lib`),
+// then the standard arm64 / Intel keg dirs, then `brew --prefix
+// openssl@3`, and finally a `pkg-config --libs-only-L openssl` fallback
+// for a non-Homebrew / system-registered OpenSSL (SFEP-0036 §3.1, #1821).
+// Emits nothing on Linux (default path). Darwin-gated via the same
+// `uname -s` probe `_dead_strip_link_flag` uses, so Linux argv stays
 // byte-identical (#1112).
 fn _openssl_link_search_flags() -> string[] ![io] {
     let os = _shell_read_cmd("uname -s");
@@ -734,8 +738,17 @@ fn _openssl_link_search_flags() -> string[] ![io] {
     // arm64 / Intel keg dirs) FIRST, and only shell out to `brew --prefix`
     // when none exist — command substitution in a `for` list would run
     // `brew` unconditionally (~100-300ms), and this probe fires on every
-    // link (incl. each `sfn test` per-binary link).
-    let probe = "d=\"\"; for c in \"${SAILFIN_OPENSSL_PREFIX:-}/lib\" /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; printf %s \"$d\"";
+    // link (incl. each `sfn test` per-binary link). The `pkg-config`
+    // fallback runs LAST and only when every `[ -d ]` keg check AND
+    // `brew --prefix` miss; it is guarded by `command -v pkg-config` so a
+    // host without `pkg-config` (or without a registered `openssl.pc`)
+    // yields empty output and the function returns `[]` exactly as before
+    // (#1112 keeps the fast keg-hit path free of any `brew`/`pkg-config`
+    // subshell). Homebrew's `openssl@3` is keg-only, so its `.pc` is
+    // generally off the default `pkg-config` path — this fallback targets
+    // system/registered OpenSSL, not the Homebrew case the keg/brew
+    // candidates already cover.
+    let probe = "d=\"\"; for c in \"${SAILFIN_OPENSSL_PREFIX:-}/lib\" /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; [ -z \"$d\" ] && command -v pkg-config >/dev/null 2>&1 && { L=\"$(pkg-config --libs-only-L openssl 2>/dev/null)\"; L=\"${L%% *}\"; c=\"${L#-L}\"; [ -n \"$c\" ] && [ -d \"$c\" ] && d=\"$c\"; }; printf %s \"$d\"";
     let dir = _shell_read_cmd(probe);
     if dir.length == 0 { return []; }
     return ["-L" + dir];

--- a/compiler/tests/e2e/openssl_prefix_honored_test.sfn
+++ b/compiler/tests/e2e/openssl_prefix_honored_test.sfn
@@ -72,14 +72,14 @@ fn _env_with_prefix(prefix: string) -> string[] ![io] {
     let mut i = 0;
     loop {
         if i >= base.length { break; }
-        if !contains_prefix_key(base[i]) { e.push(base[i]); }
+        if !_contains_prefix_key(base[i]) { e.push(base[i]); }
         i = i + 1;
     }
     e.push("SAILFIN_OPENSSL_PREFIX=" + prefix);
     return e;
 }
 
-fn contains_prefix_key(entry: string) -> boolean {
+fn _contains_prefix_key(entry: string) -> boolean {
     let key = "SAILFIN_OPENSSL_PREFIX=";
     if entry.length < key.length { return false; }
     return substring(entry, 0, key.length) == key;

--- a/compiler/tests/e2e/openssl_prefix_honored_test.sfn
+++ b/compiler/tests/e2e/openssl_prefix_honored_test.sfn
@@ -66,23 +66,37 @@ fn _scratch_dir() -> string ![io] {
 // parallel pool) with an explicit `SAILFIN_OPENSSL_PREFIX` appended. Any
 // ambient copy is dropped first so the child sees exactly the value under
 // test regardless of the platform's duplicate-key getenv precedence.
+//
+// It ALSO strips `LIBRARY_PATH` (and `DYLD_FALLBACK_LIBRARY_PATH`) from the
+// child so `SAILFIN_OPENSSL_PREFIX` *solely* determines where the link finds
+// OpenSSL. CI's macOS legs export `LIBRARY_PATH=<keg>/lib` (the
+// `Provision OpenSSL link path` step), which clang also searches for `-l`
+// resolution — so without stripping it, a bogus override `-L` would be
+// masked by `LIBRARY_PATH` and the negative leg's link would wrongly
+// succeed. Removing it makes both legs sound proofs of honoring, independent
+// of CI provisioning. `-lm` / `-lpthread` live on the default SDK path (not
+// `LIBRARY_PATH`), so stripping it only removes the OpenSSL keg confound.
 fn _env_with_prefix(prefix: string) -> string[] ![io] {
     let base = process.environ();
     let mut e: string[] = [];
     let mut i = 0;
     loop {
         if i >= base.length { break; }
-        if !_contains_prefix_key(base[i]) { e.push(base[i]); }
+        if !_is_stripped_env_key(base[i]) { e.push(base[i]); }
         i = i + 1;
     }
     e.push("SAILFIN_OPENSSL_PREFIX=" + prefix);
     return e;
 }
 
-fn _contains_prefix_key(entry: string) -> boolean {
-    let key = "SAILFIN_OPENSSL_PREFIX=";
+fn _has_key(entry: string, key: string) -> boolean {
     if entry.length < key.length { return false; }
     return substring(entry, 0, key.length) == key;
+}
+
+fn _is_stripped_env_key(entry: string) -> boolean {
+    return _has_key(entry, "SAILFIN_OPENSSL_PREFIX=") || _has_key(entry, "LIBRARY_PATH=")
+        || _has_key(entry, "DYLD_FALLBACK_LIBRARY_PATH=");
 }
 
 // A trivial fixture. Any Sailfin binary links `-lssl -lcrypto` (SFEP-0036
@@ -141,8 +155,11 @@ test "openssl prefix: a valid SAILFIN_OPENSSL_PREFIX links (macOS)" ![io] {
 // ---- Negative: the override is honored (suppresses keg discovery) ----
 // An existing-but-empty `lib` prefix is the first and only candidate; the
 // keg dirs are never searched, so `-lssl` is unresolvable and the link
-// fails. Sound on macOS precisely because `-lssl` is NOT on the default
-// link path (the reason `_openssl_link_search_flags` exists at all).
+// fails. Sound on macOS because `-lssl` is NOT on the default link path
+// (the reason `_openssl_link_search_flags` exists at all) AND
+// `_env_with_prefix` strips `LIBRARY_PATH` (see its note), so the empty
+// override `-L` is genuinely the sole OpenSSL search dir — no ambient
+// `LIBRARY_PATH` keg can rescue the link.
 test "openssl prefix: an empty-lib SAILFIN_OPENSSL_PREFIX suppresses the keg and fails the link (macOS)" ![io] {
     if !_is_darwin() {
         print.info("[openssl-prefix] SKIP: non-Darwin (override is inert)");

--- a/compiler/tests/e2e/openssl_prefix_honored_test.sfn
+++ b/compiler/tests/e2e/openssl_prefix_honored_test.sfn
@@ -1,0 +1,172 @@
+// Darwin-gated e2e for the `SAILFIN_OPENSSL_PREFIX` build override
+// (SFEP-0036 §3.1, §5; #1821). The native runtime links `-lssl -lcrypto`
+// on every binary, and on macOS Homebrew's `openssl@3` is keg-only, so the
+// build driver injects a `-L<openssl>/lib` link-search flag
+// (`_openssl_link_search_flags` in `compiler/src/build/runtime_objs.sfn`).
+// `SAILFIN_OPENSSL_PREFIX` is the supported public override: it is the
+// FIRST candidate and, because the probe stops at the first match, the
+// SOLE `-L` emitted when it is set to a valid prefix. That single-`-L`
+// property is what makes the override observable end-to-end here without a
+// backend argv trace (out of scope for #1821):
+//
+//   - valid prefix  → `-L<prefix>/lib` resolves `-lssl` → build SUCCEEDS.
+//   - empty-lib prefix → `-L<prefix>/lib` is the only search dir, the keg
+//     is suppressed, `-lssl` is unresolvable → build FAILS.
+//
+// The negative leg proves the override is genuinely *honored* (it wins over
+// and suppresses keg/brew discovery), not merely that a happy build worked.
+//
+// Non-Darwin: `_openssl_link_search_flags` returns `[]` (the override is
+// inert), so both legs SKIP cleanly (`assert true`), mirroring the
+// tool-absent SKIP precedent. On Darwin with no discoverable host OpenSSL
+// (no keg / brew / pkg-config hit) the tests also SKIP — there is nothing
+// to symlink a valid prefix at.
+//
+// Matchers note (#842): `sfn/test`'s `expect_*` matchers are `![pure]` and
+// cannot be called from an `![io]` test; assert on captured text / exit
+// codes directly.
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _is_darwin() -> boolean ![io] {
+    let _exit = process.run_capture(["uname", "-s"], process.environ());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return contains(out, "Darwin");
+}
+
+// Discover the host's real OpenSSL lib dir the same way the build driver
+// would (standard kegs, then `brew --prefix openssl@3`, then a
+// `pkg-config` fallback) but WITHOUT consulting `SAILFIN_OPENSSL_PREFIX` —
+// this is the ground-truth location we symlink a valid override prefix at.
+// Empty when the host has no discoverable OpenSSL.
+fn _discover_openssl_lib() -> string ![io] {
+    let probe = "d=\"\"; for c in /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; [ -z \"$d\" ] && command -v pkg-config >/dev/null 2>&1 && { L=\"$(pkg-config --libs-only-L openssl 2>/dev/null)\"; L=\"${L%% *}\"; c=\"${L#-L}\"; [ -n \"$c\" ] && [ -d \"$c\" ] && d=\"$c\"; }; printf %s \"$d\"";
+    let _exit = process.run_capture(["sh", "-c", probe], process.environ());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return out;
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/sfn-openssl-prefix-e2e";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Parent env (the nested build links clang + ld + `-lssl -lcrypto`, and
+// SAILFIN_TEST_SCRATCH keeps the build cache per-invocation under the
+// parallel pool) with an explicit `SAILFIN_OPENSSL_PREFIX` appended. Any
+// ambient copy is dropped first so the child sees exactly the value under
+// test regardless of the platform's duplicate-key getenv precedence.
+fn _env_with_prefix(prefix: string) -> string[] ![io] {
+    let base = process.environ();
+    let mut e: string[] = [];
+    let mut i = 0;
+    loop {
+        if i >= base.length { break; }
+        if !contains_prefix_key(base[i]) { e.push(base[i]); }
+        i = i + 1;
+    }
+    e.push("SAILFIN_OPENSSL_PREFIX=" + prefix);
+    return e;
+}
+
+fn contains_prefix_key(entry: string) -> boolean {
+    let key = "SAILFIN_OPENSSL_PREFIX=";
+    if entry.length < key.length { return false; }
+    return substring(entry, 0, key.length) == key;
+}
+
+// A trivial fixture. Any Sailfin binary links `-lssl -lcrypto` (SFEP-0036
+// §5), so a hello-world exercises the OpenSSL link search — no TLS call is
+// needed to make `-L` resolution load-bearing.
+fn _write_fixture(dir: string) -> string ![io] {
+    let path = dir + "/main.sfn";
+    fs.writeFile(path, "fn main() ![io] {\n    print(\"ok\");\n}\n");
+    return path;
+}
+
+struct BuildOutcome {
+    exit: int;
+    err: string;
+}
+
+fn _build_with_prefix(main_path: string, bin: string, prefix: string) -> BuildOutcome ![io] {
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", bin, main_path], _env_with_prefix(prefix));
+    let _o = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return BuildOutcome { exit: exit, err: err };
+}
+
+// ---- Positive: a valid prefix surfaces a working `-L<prefix>/lib` ----
+test "openssl prefix: a valid SAILFIN_OPENSSL_PREFIX links (macOS)" ![io] {
+    if !_is_darwin() {
+        print.info("[openssl-prefix] SKIP: non-Darwin (override is inert)");
+        assert true;
+        return;
+    }
+    let real_lib = _discover_openssl_lib();
+    if real_lib.length == 0 {
+        print.info("[openssl-prefix] SKIP: no host OpenSSL to point a valid prefix at");
+        assert true;
+        return;
+    }
+    let dir = _scratch_dir();
+    // A distinct prefix (NOT a keg dir) whose `lib` symlinks the real
+    // OpenSSL dir. Because the override is the first and only candidate,
+    // build success proves the `-L<prefix>/lib` it produced resolved
+    // `-lssl` — i.e. the override path, not the keg, drove the link.
+    let prefix = dir + "/honored";
+    fs.createDirectory(prefix, true);
+    let _rm = process.run(["rm", "-rf", prefix + "/lib"]);
+    let ln = process.run_capture(["ln", "-s", real_lib, prefix + "/lib"], process.environ());
+    let _lo = process.capture_take_stdout();
+    let _le = process.capture_take_stderr();
+    assert ln == 0;
+
+    let main_path = _write_fixture(dir);
+    let outcome = _build_with_prefix(main_path, dir + "/honored-bin", prefix);
+    assert outcome.exit == 0;
+    assert fs.exists(dir + "/honored-bin");
+}
+
+// ---- Negative: the override is honored (suppresses keg discovery) ----
+// An existing-but-empty `lib` prefix is the first and only candidate; the
+// keg dirs are never searched, so `-lssl` is unresolvable and the link
+// fails. Sound on macOS precisely because `-lssl` is NOT on the default
+// link path (the reason `_openssl_link_search_flags` exists at all).
+test "openssl prefix: an empty-lib SAILFIN_OPENSSL_PREFIX suppresses the keg and fails the link (macOS)" ![io] {
+    if !_is_darwin() {
+        print.info("[openssl-prefix] SKIP: non-Darwin (override is inert)");
+        assert true;
+        return;
+    }
+    // Only meaningful when the host actually HAS an OpenSSL keg that the
+    // override must be shown to suppress; otherwise the link would fail
+    // regardless and the assertion proves nothing.
+    let real_lib = _discover_openssl_lib();
+    if real_lib.length == 0 {
+        print.info("[openssl-prefix] SKIP: no host OpenSSL keg to suppress");
+        assert true;
+        return;
+    }
+    let dir = _scratch_dir();
+    let prefix = dir + "/empty";
+    fs.createDirectory(prefix + "/lib", true);
+
+    let main_path = _write_fixture(dir);
+    let outcome = _build_with_prefix(main_path, dir + "/empty-bin", prefix);
+    // Fail AND for the intended reason: the sole `-L<empty>/lib` leaves
+    // `-lssl` unresolvable, so clang/ld reports an ssl link error. Pinning
+    // the cause keeps the test from passing on an unrelated build failure.
+    assert outcome.exit != 0;
+    assert contains(outcome.err, "ssl");
+}

--- a/docs/runbooks/openssl-build-dependency.md
+++ b/docs/runbooks/openssl-build-dependency.md
@@ -1,0 +1,115 @@
+# OpenSSL build-host dependency runbook
+
+The native runtime links TLS via OpenSSL (`-lssl -lcrypto`;
+`runtime/sfn/platform/tls.sfn`, SFEP-0036 gap B1 of epic #1540). Because the
+runtime is linked into **every** Sailfin binary, OpenSSL must be resolvable on
+the link host for *any* build — including the compiler's own self-host and each
+per-test binary the suite links. This is the same class of build-host
+dependency as `-lm` / `-lpthread`, not a runtime capability: linking `libssl`
+is a build-time link decision, and TLS rides the existing `![net]` effect (no
+new effect or manifest flag).
+
+Dead-strip (`--gc-sections` / `-dead_strip`) removes the unreferenced `SSL_*`
+symbols from binaries that never call TLS (the compiler), so those binaries do
+not bloat — but they **still link** `-lssl -lcrypto`, so OpenSSL's presence on
+the host is mandatory regardless of whether a binary uses TLS.
+
+This page is the reference for provisioning that dependency per platform and
+for the supported override.
+
+---
+
+## 1. Per-platform requirement
+
+| Platform | Requirement | How the link finds it |
+|---|---|---|
+| **Linux** | `libssl-dev` (Debian/Ubuntu) / `openssl-devel` (Fedora/RHEL) | On clang's default library search path — the build driver emits **no** extra `-L` (byte-identical to a no-TLS link). |
+| **macOS** | Homebrew `openssl@3` (`brew install openssl@3`) | Homebrew keeps `openssl@3` **keg-only** (not symlinked into a default `-l` dir), so without help clang reports `ld: library 'ssl' not found`. The build driver injects a single `-L<openssl>/lib` search flag (see §2). |
+| **Windows** | Deferred / stubbed | Native TLS + link form are tracked with the Windows native self-host (#1494 / #1485 M10). The `tls.sfn` extern surface is OS-independent; only the link form and CA-store discovery differ. |
+
+If `libssl` is missing on a Linux build host the link fails with
+`/usr/bin/ld: cannot find -lssl`; install the dev package. On macOS the symptom
+is `ld: library 'ssl' not found`; install `openssl@3` or set the override (§3).
+
+---
+
+## 2. How macOS `-L` discovery works
+
+`_openssl_link_search_flags` (`compiler/src/build/runtime_objs.sfn`) runs a
+single Darwin-gated shell probe (Linux returns `[]` — no probe, no cost). It
+walks candidates in priority order and stops at the **first** hit, so exactly
+one `-L<dir>` is ever emitted:
+
+1. `SAILFIN_OPENSSL_PREFIX` — the supported override (§3), tried as
+   `$SAILFIN_OPENSSL_PREFIX/lib`.
+2. Standard Homebrew kegs — `/opt/homebrew/opt/openssl@3/lib` (Apple silicon),
+   `/usr/local/opt/openssl@3/lib` (Intel).
+3. `brew --prefix openssl@3` — shelled out **only** when the `[ -d ]` keg
+   checks above all miss (a `brew` invocation is ~100–300 ms and this probe
+   fires on every link, including each `sfn test` per-binary link, so it is
+   kept off the fast keg-hit path).
+4. `pkg-config --libs-only-L openssl` — a fallback for a non-Homebrew /
+   system-registered OpenSSL, guarded by `command -v pkg-config`. Homebrew's
+   `openssl@3` is keg-only so its `openssl.pc` is generally **off** the default
+   `pkg-config` path; this branch targets system/registered installs, not the
+   Homebrew case the keg/brew candidates already cover. When `pkg-config` is
+   absent or has no `openssl.pc`, it yields empty output and the probe returns
+   `[]` — a no-op, identical to the pre-fallback behavior.
+
+The `-L` is injected into the shared runtime `link_libs` (consumed as
+`plan.libs` by both the program and the `sfn test` link-argv builders), so no
+link path can miss it, and it precedes `-lssl` / `-lcrypto` on the command line.
+
+---
+
+## 3. The `SAILFIN_OPENSSL_PREFIX` override
+
+`SAILFIN_OPENSSL_PREFIX` is a **supported, documented** way to point the macOS
+link at a specific OpenSSL install — a custom-built OpenSSL, a pinned version,
+or a non-Homebrew prefix. Set it to the install **prefix** (the parent of
+`lib/`); the driver appends `/lib`:
+
+```bash
+export SAILFIN_OPENSSL_PREFIX=/opt/my-openssl-3.5   # expects /opt/my-openssl-3.5/lib/libssl.dylib
+make compile
+```
+
+It is the **first** candidate and, because the probe stops at the first match,
+the **only** `-L` emitted when set to a valid prefix — the keg/brew/pkg-config
+candidates are not consulted. A valid prefix therefore fully determines the
+link search. (Regression coverage: `compiler/tests/e2e/openssl_prefix_honored_test.sfn`,
+Darwin-gated — a valid prefix links; an empty-lib prefix suppresses keg
+discovery and fails, proving the override is authoritative.)
+
+---
+
+## 4. CI provisioning
+
+CI provisions OpenSSL for the macOS legs in the composite build action
+`.github/actions/sailfin-build/action.yml`, step **`Provision OpenSSL link
+path (macOS)`** (`if: target == 'macos-arm64'`). It resolves `brew --prefix
+openssl@3` (installing `openssl@3` if absent) and exports both:
+
+- `LIBRARY_PATH=<prefix>/lib` — clang honors it for `-l` resolution at link,
+- `DYLD_FALLBACK_LIBRARY_PATH=<prefix>/lib` — so the linked binary loads the
+  dylib at run time,
+
+into `$GITHUB_ENV` so every later step inherits them. It runs on **all** macOS
+modes — including `skip-build` test-shard jobs, which download the prebuilt
+compiler yet still compile + link per-test binaries that need `-lssl` resolved.
+Linux and Windows legs skip the step (byte-identical link there). The build
+driver's own `-L` probe (§2) is the belt-and-suspenders complement: even
+without the CI env, a macOS build with Homebrew `openssl@3` present links.
+
+---
+
+## References
+
+- SFEP-0036 (`docs/proposals/0036-tls-runtime.md`) §3.1 (library choice /
+  link mechanism), §5 (self-hosting impact / build-host risk).
+- `#1782` — shipped `-lssl -lcrypto` + the initial keg `-L` probe.
+- `#1821` — `pkg-config` fallback + `SAILFIN_OPENSSL_PREFIX` formalized as
+  supported surface (this runbook).
+- `compiler/src/build/runtime_objs.sfn` — `_openssl_link_search_flags`.
+- `.github/actions/sailfin-build/action.yml` — CI macOS provisioning.
+- `docs/status.md` — Toolchain § "Build-host OpenSSL dependency".

--- a/docs/status.md
+++ b/docs/status.md
@@ -113,6 +113,20 @@ here.
   `process.run`. The seam is the prerequisite for the LLVM C-API backend (#347)
   and the seal-sufficient native backend (#1640) to plug in without
   re-hardcoding LLVM across the driver.
+- **Build-host OpenSSL dependency** (SFEP-0036, #1782/#1821). The native
+  runtime links `-lssl -lcrypto` (TLS; `runtime/sfn/platform/tls.sfn`), so
+  **every** Sailfin binary — including the compiler and each per-test binary
+  the suite links — needs OpenSSL present on the link host, the same class of
+  build-host dependency as `-lm` / `-lpthread`. On Linux `libssl-dev` sits on
+  clang's default search path (no-op). On macOS Homebrew's `openssl@3` is
+  keg-only, so the build driver injects a single `-L<openssl>/lib` link-search
+  flag (`_openssl_link_search_flags`, `compiler/src/build/runtime_objs.sfn`):
+  it honors `SAILFIN_OPENSSL_PREFIX` (a supported public override) first, then
+  the standard kegs, `brew --prefix openssl@3`, and a `pkg-config
+  --libs-only-L openssl` fallback for non-Homebrew installs. Dead-strip drops
+  the unreferenced `SSL_*` symbols from binaries that never call TLS, but the
+  libraries are still linked, so their presence on the host is mandatory. See
+  the OpenSSL build-dependency runbook (`docs/runbooks/openssl-build-dependency.md`).
 - **Effect enforcement is a build gate** (Phases A–F, shipped 2026-04-26):
   `validate_effects()` runs from every `compile_to_*` entry and fails the
   build on undeclared effects. `SAILFIN_EFFECT_ENFORCE=warning|off` are the


### PR DESCRIPTION
## Summary
- Fold a `pkg-config --libs-only-L openssl` fallback into the existing Darwin-gated OpenSSL `-L` probe (`_openssl_link_search_flags`, `compiler/src/build/runtime_objs.sfn`), sequenced **after** the env-override / keg / `brew --prefix` candidates and guarded by `command -v pkg-config`, so non-Homebrew / system-registered OpenSSL installs resolve `-lssl -lcrypto` at link.
- Formalize `SAILFIN_OPENSSL_PREFIX` as a **supported public override**: it stays the top-priority candidate and, because the probe stops at the first match, is the sole `-L` emitted when set to a valid prefix. Documented in a new runbook + `docs/status.md`.
- Zero cost on the fast keg-hit path (no new `brew`/`pkg-config` subshell) and byte-identical Linux argv (early `uname -s` return, #1112) — empty/absent `pkg-config` output returns `[]` exactly as before.

Closes #1821

Design: SFEP-0036 (`docs/proposals/0036-tls-runtime.md`) §3.1, §5 — gap B1 of epic #1540.

## Acceptance Criteria
- [x] The link-search probe gains a `pkg-config --libs-only-L openssl` fallback that runs **only** when the keg `[ -d ]` checks (env override + standard kegs) miss *and* `brew --prefix` yields nothing, folded into the existing single probe string (no extra shell round-trip, no new unconditional subshell on the fast path).
- [x] The `pkg-config` call is guarded (`command -v pkg-config`) so its absence yields empty output and the function returns `[]` exactly as today — Linux/default argv stays byte-identical (#1112).
- [x] `SAILFIN_OPENSSL_PREFIX` still wins as the first candidate and is documented as a supported override.
- [x] A new Darwin-gated e2e asserts a link honors `SAILFIN_OPENSSL_PREFIX` (a valid prefix surfaces the corresponding `-L.../lib`) and skips on non-Darwin.
- [x] A runbook documents the build-host OpenSSL dependency per platform, the override env var, and the CI provisioning mechanism; `docs/status.md` reflects the dependency.
- [x] `make compile` passes.
- [x] `make test` passes (see note below on the one unrelated timeout).
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## How the override is observable (test design)
The runtime links `-lssl -lcrypto` on **every** binary (SFEP-0036 §5), and `-lssl` is **not** on macOS's default link path — so a bogus `-L` fails the link even for a trivial fixture. The probe returns only the first candidate, so a valid `SAILFIN_OPENSSL_PREFIX` is the sole `-L`:
- **positive leg** — a distinct prefix whose `lib` symlinks the discovered host OpenSSL → build **succeeds** (the override path drove the link).
- **negative leg** — an empty-lib prefix suppresses keg discovery → build **fails with an ssl link error** (asserts `exit != 0` *and* stderr contains `ssl`, pinning the cause).

Both legs skip cleanly on non-Darwin and when no host OpenSSL is discoverable.

## Map reconciliation
None — `## Files Affected` matched the tree. `_openssl_link_search_flags` and its shared assembly are in `compiler/src/build/runtime_objs.sfn` as mapped; the new e2e lives under `compiler/tests/e2e/`; docs under `docs/runbooks/` + `docs/status.md`. `.github/actions/sailfin-build/action.yml` was referenced by the runbook, not changed (per `Out:`).

## Verification
```bash
make compile          # PASS — self-hosts with the runtime_objs.sfn change
sfn fmt --check ...    # clean on both touched .sfn files
sfn check ...          # ok (only expected W0210 bare-assert lints, matching the e2e convention)
sfn test compiler/tests/e2e/openssl_prefix_honored_test.sfn   # PASS (2 tests skip on Linux)
make test             # unit 194/194, integration 42/42, capsules 38/38, e2e 185/186
```
**`make test` note:** the single non-pass was `work_dir_parity_test.sfn` timing out (`Error 124`) under full-suite parallel load — it builds `-p compiler` twice into sibling work-dirs and is resource-heavy. It **passes in isolation** (re-run: all 2 tests PASS). This change is a strict Linux no-op (`_openssl_link_search_flags` returns `[]` before any probe on non-Darwin) and touches nothing on the work-dir path, so it is an environmental timeout, not a regression.

## Files Changed
- `compiler/src/build/runtime_objs.sfn` — `pkg-config` fallback + candidate-order comment in `_openssl_link_search_flags`
- `compiler/tests/e2e/openssl_prefix_honored_test.sfn` — new Darwin-gated override-honored e2e
- `docs/runbooks/openssl-build-dependency.md` — new per-platform build-host OpenSSL runbook
- `docs/status.md` — Toolchain § build-host OpenSSL dependency note

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5GSPGykjY4odcZeDyPnKv)_