### PR TITLE
docs(sfep-0039): track E0828 coverage split (#1900, #1904, #1905)

### DIFF
--- a/docs/proposals/0039-nominal-object-model.md
+++ b/docs/proposals/0039-nominal-object-model.md
@@ -6,7 +6,7 @@ type: language
 created: 2026-07-04
 updated: 2026-07-04
 author: "agent:compiler-architect; human review"
-tracking: "#1860, #1887, #1888, #1838, #1855"
+tracking: "#1860, #1887, #1888, #1838, #1855, #1900, #1904, #1905"
 supersedes:
 superseded-by:
 graduates-to: reference/spec/06-types.md


### PR DESCRIPTION
## Summary

Grooming pass on #1900 (residual `E0828` coverage from SFEP-0039 §3.2). The single issue was too large for one session — the four uncovered object-literal positions have very different threading cost — so it was decomposed into three session-sized, `claude-ready` issues. This PR links them into the SFEP's `tracking:` front-matter so the design record and the execution stay cross-referenced.

No code change; the diff is one line of SFEP front-matter.

## The split

| Issue | Slice | Size | Threading |
|---|---|---|---|
| #1900 (retargeted) | array/generic-head normalization + parameter defaults | S | none — classifier already has `top_level` in scope |
| #1904 | return-position object literals | M | return-type context through `check_function_body → check_block → check_statement` |
| #1905 | lambda-body / lambda-return object literals | M | `top_level` through `walk_expression` (44+ sites) + helpers |

## Design decision recorded

Array targets (`let x: Named[] = { ... }`) are rejected with **`E0828`** + a dedicated array message branch, **not** a new diagnostic code — consistent with the SFEP's "nominal, Rust/Go-shaped object model" framing (Rust `E0308` / Go assignability both reject via general machinery, not a bespoke per-shape code). The array case fires regardless of element type (an object literal never yields an array); the generic-head case strips `<...>` and classifies the base. Full rationale in #1900.

## Notes

- Recommended pickup order: #1900 first (its normalization lands in the shared `check_object_literal_target` that #1904/#1905 reuse), then #1904 and #1905 in parallel. None hard-blocks another.
- Required-in-pinned-seed: **None** for all three (SFEP-0039 §5); pre-flight audit confirmed the compiler's own source contains no newly-rejected idiom.
- Does not close #1900/#1904/#1905 — those track the implementation work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WThV8wRB4ozX4NVqaCwG9M)_