### PR TITLE
feat(build): add `sfn cache` (info/prune/clean) with size/age GC

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -80,7 +80,7 @@ import {
     _write_text_cmd
 } from "./build/fs";
 import { _get_env_cmd } from "./build_flags";
-import { char_code_at_text, substring } from "./string_utils";
+import { char_code_at_text, find_last_index_of_char, substring } from "./string_utils";
 
 // ----------------------------------------------------------------
 // Schema version
@@ -248,6 +248,309 @@ fn cache_clean(root: string) -> boolean ![io] {
     if !fs.exists(root) { return true; }
     let rc = process.run(["rm", "-rf", root]);
     return rc == 0;
+}
+
+// ----------------------------------------------------------------
+// Cache GC: mtime-on-hit, info, prune, stale-schema sweep
+// ----------------------------------------------------------------
+// SFEP-0040 §3.2–3.4. All operate on a resolved schema root
+// (`<base>/v<N>`) and never touch the cache *key*, entry *layout*, or
+// the atomic-publish protocol — only when entries are removed and the
+// recency signal `cache_prune` reads. Every removal path is `![io]`
+// (the same effect class the cache already carries) and shell-quotes
+// the root, which can derive from `$SAILFIN_BUILD_CACHE_DIR`.
+// A cache HIT copies artifacts OUT of the entry directory into the
+// build tree; it never writes into the entry itself, so the entry's
+// mtime would otherwise stay pinned at creation time and `cache_prune`
+// would evict a hot entry as though it were cold. Touch the entry
+// directory on every hit so mtime is a true LRU recency signal
+// (SFEP-0040 §3.4). Metadata-only; a failure is non-fatal (best-effort
+// recency — the build has already succeeded).
+fn cache_touch_entry(root: string, key: CacheKey) -> boolean ![io] {
+    if !_is_valid_digest(key.digest) { return false; }
+    let dir = _cache_entry_dir(root, key);
+    if !fs.exists(dir) { return false; }
+    return process.run(["touch", dir]) == 0;
+}
+
+// Split `text` on newlines, dropping empty lines and stray `\r`.
+fn _split_lines(text: string) -> string[] {
+    let mut out: string[] = [];
+    let mut cur: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= text.length { break; }
+        let ch = substring(text, i, i + 1);
+        if ch == "\n" {
+            if cur.length > 0 { out.push(cur); }
+            cur = "";
+        } else if ch != "\r" { cur = cur + ch; }
+        i += 1;
+    }
+    if cur.length > 0 { out.push(cur); }
+    return out;
+}
+
+// Parse a leading run of decimal digits as a non-negative int. Returns
+// 0 when `text` has no leading digit (shell helpers below already trim
+// their output, so a well-formed number is the whole string).
+fn _parse_nonneg_int(text: string) -> int {
+    let mut val: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= text.length { break; }
+        let code = char_code_at_text(text, i);
+        if code < 48 || code > 57 { break; }
+        val = val * 10 + (code - 48);
+        i += 1;
+    }
+    return val;
+}
+
+fn _basename_cmd(path: string) -> string {
+    let idx = find_last_index_of_char(path, "/");
+    if idx < 0 { return path; }
+    return substring(path, idx + 1, path.length);
+}
+
+// The `<prefix>/<key>` entry directories under `root` (layout depth 2).
+fn _cache_entry_dirs(root: string) -> string[] ![io] {
+    if !fs.exists(root) { return []; }
+    let q = _shell_single_quote_arg(root);
+    let out = _shell_read_cmd("find " + q
+        + " -mindepth 2 -maxdepth 2 -type d 2>/dev/null");
+    return _split_lines(out);
+}
+
+// Directory mtime in epoch seconds. Tries GNU `stat -c %Y` then BSD
+// `stat -f %m` so the LRU signal is portable across Linux and macOS.
+fn _entry_mtime_epoch(dir: string) -> int ![io] {
+    let q = _shell_single_quote_arg(dir);
+    let out = _shell_read_cmd("stat -c %Y " + q + " 2>/dev/null || stat -f %m "
+        + q
+        + " 2>/dev/null");
+    return _parse_nonneg_int(out);
+}
+
+// On-disk size of `dir` in bytes. `du -sk` (1024-byte blocks) is
+// portable across GNU and BSD; block-rounding is the correct notion of
+// "on-disk size" and is precise enough for both `info` and LRU compares.
+fn _dir_size_bytes(dir: string) -> int ![io] {
+    let q = _shell_single_quote_arg(dir);
+    let out = _shell_read_cmd("du -sk " + q + " 2>/dev/null | awk '{print $1}'");
+    return _parse_nonneg_int(out) * 1024;
+}
+
+fn _now_epoch() -> int ![io] {
+    return _parse_nonneg_int(_shell_read_cmd("date +%s"));
+}
+
+// `rm -rf` guarded against the empty path and `/` (mirrors cache_clean).
+fn _rm_rf_dir(dir: string) -> boolean ![io] {
+    if dir.length == 0 { return false; }
+    if strings_equal(dir, "/") { return false; }
+    return process.run(["rm", "-rf", dir]) == 0;
+}
+
+// Best-effort removal of now-empty prefix shards (and any empty entry
+// dirs) so `cache info` entry counts stay honest after a prune.
+fn _prune_empty_shards(root: string) ![io] {
+    if !fs.exists(root) { return; }
+    let q = _shell_single_quote_arg(root);
+    let _ = _shell_read_cmd("find " + q
+        + " -mindepth 1 -type d -empty -delete 2>/dev/null");
+}
+
+// Index permutation that orders `mtimes` ascending (oldest first).
+// Insertion sort — entry counts are small and this runs only on the
+// eviction path. Stable, so equal-mtime entries keep enumeration order.
+fn _order_by_mtime_asc(mtimes: int[]) -> int[] {
+    let mut order: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= mtimes.length { break; }
+        order.push(i);
+        i += 1;
+    }
+    let mut k: int = 1;
+    loop {
+        if k >= order.length { break; }
+        let cur = order[k];
+        let cur_m = mtimes[cur];
+        let mut j: int = k - 1;
+        loop {
+            if j < 0 { break; }
+            if mtimes[order[j]] <= cur_m { break; }
+            order[j + 1] = order[j];
+            j -= 1;
+        }
+        order[j + 1] = cur;
+        k += 1;
+    }
+    return order;
+}
+
+// ----------------------------------------------------------------
+// `sfn cache info`
+// ----------------------------------------------------------------
+struct CacheInfo {
+    root: string;
+    entry_count: int;
+    total_bytes: int;
+}
+
+// Resolved root, live entry count, and total on-disk size (bytes). A
+// non-existent root reports zero/zero rather than erroring — `info` on
+// a machine that has never built is a valid, empty answer.
+fn cache_info(root: string) -> CacheInfo ![io] {
+    let dirs = _cache_entry_dirs(root);
+    let mut total: int = 0;
+    if fs.exists(root) {
+        let q = _shell_single_quote_arg(root);
+        let out = _shell_read_cmd("du -sk " + q
+            + " 2>/dev/null | awk '{print $1}'");
+        total = _parse_nonneg_int(out) * 1024;
+    }
+    return CacheInfo {
+        root: root,
+        entry_count: dirs.length,
+        total_bytes: total
+    };
+}
+
+// ----------------------------------------------------------------
+// `sfn cache prune`
+// ----------------------------------------------------------------
+struct PruneResult {
+    removed_entries: int;
+    removed_bytes: int;
+}
+
+// LRU eviction. `max_age_days >= 0` removes any entry whose mtime is
+// older than that many days; `max_size_bytes >= 0` then deletes
+// oldest-first until the total falls to or below the cap (so
+// `--max-size 0` empties the cache). A negative bound disables that
+// axis. Age is applied before size so an aged-out entry never counts
+// toward the size total. mtime is a true recency signal because a hit
+// touches the entry (`cache_touch_entry`).
+fn cache_prune(root: string, max_size_bytes: int, max_age_days: int) -> PruneResult ![io] {
+    let mut removed_entries: int = 0;
+    let mut removed_bytes: int = 0;
+    if !fs.exists(root) {
+        return PruneResult { removed_entries: 0, removed_bytes: 0 };
+    }
+    let dirs = _cache_entry_dirs(root);
+    let now = _now_epoch();
+
+    // Clamp the age axis: a `--max-age` past ~10,000 years is treated as
+    // "unbounded" (no age eviction). This guards `max_age_days * 86400`
+    // against i64 overflow, which would otherwise wrap negative and
+    // invert the comparison into evicting *every* entry — the opposite
+    // of the "keep everything" intent behind a very large value.
+    let age_active = max_age_days >= 0 && max_age_days <= 3650000;
+
+    let mut kept_dirs: string[] = [];
+    let mut kept_mtimes: int[] = [];
+    let mut kept_sizes: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= dirs.length { break; }
+        let d = dirs[i];
+        let mt = _entry_mtime_epoch(d);
+        let sz = _dir_size_bytes(d);
+        let aged_out = age_active && now > 0 && (now - mt) > max_age_days * 86400;
+        if aged_out {
+            if _rm_rf_dir(d) {
+                removed_entries += 1;
+                removed_bytes += sz;
+            }
+        } else {
+            kept_dirs.push(d);
+            kept_mtimes.push(mt);
+            kept_sizes.push(sz);
+        }
+        i += 1;
+    }
+
+    if max_size_bytes >= 0 {
+        let mut total: int = 0;
+        let mut s: int = 0;
+        loop {
+            if s >= kept_sizes.length { break; }
+            total += kept_sizes[s];
+            s += 1;
+        }
+        if total > max_size_bytes {
+            let order = _order_by_mtime_asc(kept_mtimes);
+            let mut o: int = 0;
+            loop {
+                if o >= order.length { break; }
+                if total <= max_size_bytes { break; }
+                let idx = order[o];
+                if _rm_rf_dir(kept_dirs[idx]) {
+                    removed_entries += 1;
+                    removed_bytes += kept_sizes[idx];
+                    total -= kept_sizes[idx];
+                }
+                o += 1;
+            }
+        }
+    }
+
+    _prune_empty_shards(root);
+    return PruneResult {
+        removed_entries: removed_entries,
+        removed_bytes: removed_bytes
+    };
+}
+
+// ----------------------------------------------------------------
+// Stale-schema sweep (`sfn cache clean --all-schemas`)
+// ----------------------------------------------------------------
+// Remove sibling `<base>/v<M>` trees for `M < N`, where `root` is
+// `<base>/v<N>`. Explicit-only — invoked from `sfn cache clean
+// --all-schemas`, never eagerly on a build (SFEP-0040 §3.3/§6 default:
+// no eager sweep). Skips the current schema, any `v<M>` with `M >= N`,
+// and every non-`v<digits>` sibling (e.g. the `test-bin/` cache), so a
+// stale-schema sweep can never evict a live or unrelated tree.
+fn cache_sweep_stale_schemas(root: string) -> int ![io] {
+    let base = _dirname_cmd(root);
+    let cur_num = _parse_schema_num(_basename_cmd(root));
+    if cur_num < 0 { return 0; }
+    if !fs.exists(base) { return 0; }
+    let q = _shell_single_quote_arg(base);
+    let out = _shell_read_cmd("find " + q
+        + " -mindepth 1 -maxdepth 1 -type d 2>/dev/null");
+    let entries = _split_lines(out);
+    let mut removed: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= entries.length { break; }
+        let n = _parse_schema_num(_basename_cmd(entries[i]));
+        if n >= 0 && n < cur_num {
+            if _rm_rf_dir(entries[i]) { removed += 1; }
+        }
+        i += 1;
+    }
+    return removed;
+}
+
+// Parse `v<digits>` -> the integer schema number; -1 when `name` is not
+// exactly `v` followed by one or more decimal digits (rejects
+// `test-bin`, `v2x`, bare `v`, and any tmp sibling).
+fn _parse_schema_num(name: string) -> int {
+    if name.length < 2 { return -1; }
+    if substring(name, 0, 1) != "v" { return -1; }
+    let mut val: int = 0;
+    let mut i: int = 1;
+    loop {
+        if i >= name.length { break; }
+        let code = char_code_at_text(name, i);
+        if code < 48 || code > 57 { return -1; }
+        val = val * 10 + (code - 48);
+        i += 1;
+    }
+    return val;
 }
 
 // ----------------------------------------------------------------
@@ -515,7 +818,11 @@ fn cache_copy_artifact_to(root: string, key: CacheKey, kind: string, dst_path: s
     if !fs.exists(src) { return false; }
     let dst_dir = _dirname_cmd(dst_path);
     if dst_dir.length > 0 { _ensure_dir_recursive_cmd(dst_dir); }
-    return _cache_atomic_copy(src, dst_path);
+    let ok = _cache_atomic_copy(src, dst_path);
+    // Cache hit: bump the entry's mtime so `cache_prune` sees true
+    // recency (SFEP-0040 §3.4). Best-effort — never fails the restore.
+    if ok { let _ = cache_touch_entry(root, key); }
+    return ok;
 }
 
 // Copy `src_path` into the cache as the artifact of `kind` for
@@ -1087,6 +1394,12 @@ export {
     empty_build_cache_config,
     resolve_build_cache_config,
     cache_clean,
+    cache_touch_entry,
+    CacheInfo,
+    cache_info,
+    PruneResult,
+    cache_prune,
+    cache_sweep_stale_schemas,
     is_valid_digest,
     test_bin_cache_schema_version,
     test_bin_cache_root_with_override,

--- a/compiler/src/cli/commands/cache.sfn
+++ b/compiler/src/cli/commands/cache.sfn
@@ -1,0 +1,121 @@
+// compiler/src/cli/commands/cache.sfn
+//
+// `sfn cache` subcommand (SFEP-0040 §3.2). Gives the content-addressed
+// build artifact cache a bounded-size story: `info` reports usage,
+// `prune` evicts by size/age (LRU), and `clean` reclaims the current
+// schema tree (with `--all-schemas` sweeping stale sibling versions).
+// All GC mechanics live in `build_cache.sfn`; this module is the thin
+// CLI surface (flag parsing + human-readable output) over them.
+//
+// The resolved cache root follows the same ladder every build uses
+// (`cache_root`, SFEP-0040 §3.1): `$SAILFIN_BUILD_CACHE_DIR` wins, else
+// the global `$XDG_CACHE_HOME`/`$HOME/.cache/sailfin` default. `cache`
+// is not tied to a build capsule, so it resolves with an empty capsule
+// name — the self-host in-tree pin only applies to the compiler's own
+// build, never to an interactive `sfn cache` invocation.
+import {
+    Command,
+    Matches,
+    command,
+    flag,
+    flag_int,
+    get_int,
+    has,
+    has_flag,
+    subcommand,
+    with_flag,
+    with_subcommand
+} from "sfn/cli";
+
+import {
+    CacheInfo,
+    PruneResult,
+    cache_clean,
+    cache_info,
+    cache_prune,
+    cache_root,
+    cache_sweep_stale_schemas
+} from "../../build_cache";
+import { number_to_string } from "../../num_format";
+import { CliContext } from "../context";
+
+// Render a byte count as `<n> bytes (<m> MiB)` for `cache info`. Integer
+// MiB (rounded down) is enough context for an at-a-glance size; the raw
+// byte count stays authoritative.
+fn _format_bytes(bytes: int) -> string {
+    let mib = bytes / 1048576;
+    return number_to_string(bytes) + " bytes (" + number_to_string(mib)
+        + " MiB)";
+}
+
+fn _run_info(root: string) -> int ![io] {
+    let info: CacheInfo = cache_info(root);
+    print("root: " + info.root);
+    print("entries: " + number_to_string(info.entry_count));
+    print("size: " + _format_bytes(info.total_bytes));
+    return 0;
+}
+
+fn _run_prune(root: string, matches: Matches) -> int ![io] {
+    // Defaults apply only when NEITHER bound is given, so passing one
+    // axis never silently activates the other (least-surprise). SFEP
+    // §3.2 conservative defaults: ~5 GiB, 30 days.
+    let has_size = has(matches, "max-size");
+    let has_age = has(matches, "max-age");
+    let mut max_size: int = -1;
+    let mut max_age: int = -1;
+    if has_size { max_size = get_int(matches, "max-size"); }
+    if has_age { max_age = get_int(matches, "max-age"); }
+    if !has_size && !has_age {
+        max_size = 5368709120;  // 5 GiB
+        max_age = 30;
+    }
+    let result: PruneResult = cache_prune(root, max_size, max_age);
+    print("pruned " + number_to_string(result.removed_entries) + " entries ("
+        + _format_bytes(result.removed_bytes)
+        + ")");
+    return 0;
+}
+
+fn _run_clean(root: string, matches: Matches) -> int ![io] {
+    let all_schemas = has_flag(matches, "all-schemas");
+    if !cache_clean(root) {
+        print("error: failed to remove cache root " + root);
+        return 1;
+    }
+    if all_schemas {
+        let removed = cache_sweep_stale_schemas(root);
+        print("cleaned cache and swept " + number_to_string(removed)
+            + " stale schema version(s)");
+        return 0;
+    }
+    print("cleaned cache root " + root);
+    return 0;
+}
+
+// The `sfn/cli` definition for `cache`, registered on the v2 root via
+// `with_subcommand`. Three leaf subcommands: `info` (no flags), `prune`
+// (`--max-size <bytes>` / `--max-age <days>`), `clean` (`--all-schemas`).
+fn command_def() -> Command {
+    let info_cmd: Command = command("info", "Show the resolved cache root, entry count, and total on-disk size");
+    let prune_cmd: Command = with_flag(with_flag(command("prune", "Evict cache entries by size and/or age (LRU)"), flag_int("max-size", "Evict oldest-first until total on-disk size is <= N bytes")), flag_int("max-age", "Remove entries whose last use is older than N days"));
+    let clean_cmd: Command = with_flag(command("clean", "Remove the current cache schema tree"), flag("all-schemas", "Also sweep stale sibling cache schema versions"));
+    return with_subcommand(with_subcommand(with_subcommand(command("cache", "Inspect and garbage-collect the build artifact cache"), info_cmd), prune_cmd), clean_cmd);
+}
+
+// `cache` is not tied to a build capsule, so the root resolves with an
+// empty capsule name (never the self-host in-tree pin). `subcommand`
+// returns the leaf name, or `"cache"` for a bare `sfn cache`, which we
+// answer with a usage message and exit 2. `ctx` is part of the
+// per-command contract but unused here (cache sources no driver state).
+fn run(matches: Matches, ctx: CliContext) -> int ![io] {
+    let root: string = cache_root("");
+    let sub: string = subcommand(matches);
+    if strings_equal(sub, "info") { return _run_info(root); }
+    if strings_equal(sub, "prune") { return _run_prune(root, matches); }
+    if strings_equal(sub, "clean") { return _run_clean(root, matches); }
+    print("usage: sfn cache <info|prune|clean>");
+    return 2;
+}
+
+export { command_def, run };

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -44,6 +44,7 @@ import { ice_set_binary_dir } from "../ice";
 import { number_to_string } from "../num_format";
 import { command_def as add_command_def, run as add_run } from "./commands/add";
 import { command_def as build_command_def, run as build_run } from "./commands/build";
+import { command_def as cache_command_def, run as cache_run } from "./commands/cache";
 import { command_def as check_command_def, run as check_run } from "./commands/check";
 import { command_def as config_command_def, run as config_run } from "./commands/config";
 import { command_def as emit_command_def, run as emit_run } from "./commands/emit";
@@ -121,6 +122,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     root = with_subcommand(root, fmt_command_def());
     root = with_subcommand(root, test_command_def());
     root = with_subcommand(root, config_command_def());
+    root = with_subcommand(root, cache_command_def());
     root = with_subcommand(root, lock_command_def());
     root = with_subcommand(root, package_command_def());
     root = with_subcommand(root, emit_command_def());
@@ -348,6 +350,29 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
             } else {
                 print("usage: sfn config <get|set|unset|list> [key] [value]");
             }
+            return 2;
+        }
+    }
+
+    // `sfn cache <info|prune|clean>` — the registered subcommand matched.
+    // Like `config`, `cache` has nested subcommands, so
+    // `subcommand(result.matches)` returns the *leaf* (e.g. "prune") and
+    // the dispatch gates on the descent path's root (`subcommand_path[0]`).
+    // A clean parse dispatches to `cache.run`; a non-ok parse that
+    // descended into `cache` (an unrecognized flag, a `--max-size`
+    // non-integer, or `--help`) is a usage error (exit 2) — the parser
+    // owns flag validation. A carried diagnostic (unknown subcommand/flag)
+    // is printed when present; otherwise a fixed usage line. The literal
+    // `2` mirrors the dispatches above (the `sfn/cli` `EXIT_*` constants
+    // lower to 0 here).
+    let cache_path: string[] = subcommand_path(result.matches);
+    if cache_path.length > 0 {
+        if strings_equal(cache_path[0], "cache") {
+            if ctx.trace_argv { _v2_trace_argv(argv); }
+            if result.ok { return cache_run(result.matches, ctx); }
+            if result.error.message.length > 0 {
+                print(result.error.message);
+            } else { print("usage: sfn cache <info|prune|clean>"); }
             return 2;
         }
     }

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -79,6 +79,8 @@ fn _usage() -> string {
         + "  sfn run   [--no-cache] [--clean] [--cache-trace] (<file.sfn> | <exe>)\n";
     out = out
         + "  sfn emit  [--timing] [-o OUTPUT] [--module-name SLUG] [--import-context DIR] llvm|sailfin|native <file.sfn>\n";
+    out = out
+        + "  sfn cache <info|prune|clean> [--max-size N] [--max-age N] [--all-schemas]\n";
     out = out + "\n";
     out = out + "project:\n";
     out = out + "  sfn init\n";

--- a/compiler/tests/e2e/cache_command_test.sfn
+++ b/compiler/tests/e2e/cache_command_test.sfn
@@ -139,7 +139,7 @@ test "cache: prune --max-age removes old entries and keeps fresh ones" ![io] {
     _seed_entry(base, "aa", "old_entry");
     _seed_entry(base, "bb", "fresh_entry");
     // Age one entry well past the threshold; the other stays at ~now.
-    process.run(["touch", "-d", "2000-01-01", base + "/v2/aa/old_entry"]);
+    process.run(["touch", "-t", "200001010000", base + "/v2/aa/old_entry"]);
     let r = _run_cache(base, ["prune", "--max-age", "30"]);
     assert r.exit == 0;
     assert ! fs.exists(base + "/v2/aa/old_entry");
@@ -178,9 +178,9 @@ test "cache: prune --max-size evicts oldest-first (partial)" ![io] {
     _seed_big_entry(base, "bb", "middle");
     _seed_big_entry(base, "cc", "newest");
     // Distinct ages so LRU ordering is unambiguous (oldest → newest).
-    process.run(["touch", "-d", "2000-01-01", base + "/v2/aa/oldest"]);
-    process.run(["touch", "-d", "2001-01-01", base + "/v2/bb/middle"]);
-    process.run(["touch", "-d", "2002-01-01", base + "/v2/cc/newest"]);
+    process.run(["touch", "-t", "200001010000", base + "/v2/aa/oldest"]);
+    process.run(["touch", "-t", "200101010000", base + "/v2/bb/middle"]);
+    process.run(["touch", "-t", "200201010000", base + "/v2/cc/newest"]);
     // Three ~200 KiB entries (~600 KiB total) under a 450 KiB cap: exactly
     // one eviction is needed, and it must be the oldest.
     let r = _run_cache(base, ["prune", "--max-size", "450000"]);
@@ -224,9 +224,11 @@ test "cache: a cache hit refreshes entry mtime (verified by prune ordering)" ![i
     let info1 = _run_cache(base, ["info"]);
     assert find(info1.out, "entries: 0", 0) < 0;
 
-    // Age every cache entry into the distant past.
+    // Age every cache entry into the distant past. `touch -t` (not `-d`)
+    // for GNU/BSD portability — the macOS-arm64 CI leg's BSD touch does
+    // not accept the GNU `-d YYYY-MM-DD` form.
     process.run(["bash", "-c", "find '" + base
-        + "/v2' -mindepth 2 -maxdepth 2 -type d -exec touch -d 2000-01-01 {} +"]);
+        + "/v2' -mindepth 2 -maxdepth 2 -type d -exec touch -t 200001010000 {} +"]);
 
     // Warm build in a *fresh* work-dir (B): every module restores from
     // the content-addressed cache, and each hit must touch the served

--- a/compiler/tests/e2e/cache_command_test.sfn
+++ b/compiler/tests/e2e/cache_command_test.sfn
@@ -1,0 +1,244 @@
+// End-to-end tests for `sfn cache` (SFEP-0040 §3.2–3.4, #1893).
+//
+// Covers `cache info` / `prune` / `clean` and the two GC behaviors:
+// mtime-on-hit (a cache hit refreshes the entry's mtime so `prune`
+// evicts by true LRU recency) and the explicit stale-schema sweep
+// (`clean --all-schemas`). Every test threads a private scratch cache
+// root via `$SAILFIN_BUILD_CACHE_DIR` and scopes env per child (an
+// empty `run_capture` env array is the *empty* environment, not
+// "inherit"), per `no-bash-e2e.md`.
+//
+// Most tests pre-seed synthetic entry directories so the GC mechanics
+// are exercised deterministically without depending on build internals;
+// the mtime-on-hit test drives a real `sfn build` twice because the
+// touch only fires on a genuine cache hit.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _scratch() -> string ![io] {
+    let base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { return "/tmp"; }
+    return base;
+}
+
+struct Run {
+    exit: int,
+    out: string
+}
+
+// A private cache base for `tag`, wiped first so each run starts clean.
+// The resolved cache root the compiler and `sfn cache` share is
+// `<base>/v2` (`cache_root` appends the schema suffix).
+fn _cache_base(tag: string) -> string ![io] {
+    let base = _scratch() + "/sfn-cache-" + tag;
+    if fs.exists(base) { process.run(["rm", "-rf", base]); }
+    fs.createDirectory(base, true);
+    return base;
+}
+
+// Run `sfn cache <args...>` with the scratch cache root (+ PATH/HOME)
+// threaded to the child, returning the exit code and combined output.
+fn _run_cache(cache_base: string, args: string[]) -> Run ![io] {
+    let mut e: string[] = ["SAILFIN_BUILD_CACHE_DIR=" + cache_base];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let mut argv: string[] = [_sfn_bin(), "cache"];
+    let mut i = 0;
+    loop {
+        if i >= args.length { break; }
+        argv.push(args[i]);
+        i += 1;
+    }
+    let exit = process.run_capture(argv, e);
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return Run { exit: exit, out: out + err };
+}
+
+// Materialize a synthetic cache entry `<base>/v2/<prefix>/<key>` with a
+// couple of artifact files so `du` reports a plausible size and `find`
+// counts it at layout depth 2.
+fn _seed_entry(cache_base: string, prefix: string, key: string) ![io] {
+    let dir = cache_base + "/v2/" + prefix + "/" + key;
+    fs.createDirectory(dir, true);
+    fs.writeFile(dir + "/mod.ll", "; ll\n");
+    fs.writeFile(dir + "/mod.o", "obj\n");
+}
+
+// Like `_seed_entry` but with a ~200 KiB artifact so size-based eviction
+// crosses a byte threshold predictably regardless of block rounding.
+fn _seed_big_entry(cache_base: string, prefix: string, key: string) ![io] {
+    let dir = cache_base + "/v2/" + prefix + "/" + key;
+    fs.createDirectory(dir, true);
+    process.run(["bash", "-c", "head -c 200000 /dev/zero > '" + dir + "/mod.o'"]);
+}
+
+// Build `src` to `out` with the scratch cache root and the full child
+// env a nested compile needs (PATH for clang/linker, HOME/TMPDIR).
+// `work` is a *distinct* per-build scratch dir threaded as
+// SAILFIN_TEST_SCRATCH: it isolates the driver's non-content-addressed
+// build scratch per invocation, and — critically for the mtime-on-hit
+// test — forces a warm build to restore module artifacts from the
+// content-addressed cache (rather than reusing already-staged `.ll`s in
+// a shared work-dir), which is the path that refreshes entry mtime.
+fn _build(cache_base: string, work: string, src: string, out: string) -> Run ![io] {
+    let mut e: string[] = ["SAILFIN_BUILD_CACHE_DIR=" + cache_base];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    e.push("SAILFIN_TEST_SCRATCH=" + work);
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", out, src], e);
+    let so = process.capture_take_stdout();
+    let se = process.capture_take_stderr();
+    return Run { exit: exit, out: so + se };
+}
+
+// ---- info ----
+test "cache: info on an empty cache reports zero entries" ![io] {
+    let base = _cache_base("info_empty");
+    let r = _run_cache(base, ["info"]);
+    assert r.exit == 0;
+    assert find(r.out, "entries: 0", 0) >= 0;
+    // The reported root is the schema-suffixed resolution of the base.
+    assert find(r.out, "/v2", 0) >= 0;
+}
+
+test "cache: info counts seeded entries and reports a size" ![io] {
+    let base = _cache_base("info_count");
+    _seed_entry(base, "aa", "aa_entry_one");
+    _seed_entry(base, "bb", "bb_entry_two");
+    let r = _run_cache(base, ["info"]);
+    assert r.exit == 0;
+    assert find(r.out, "entries: 2", 0) >= 0;
+    assert find(r.out, "size:", 0) >= 0;
+}
+
+// ---- prune ----
+test "cache: prune --max-size 0 empties the cache" ![io] {
+    let base = _cache_base("prune_size0");
+    _seed_entry(base, "aa", "aa_entry_one");
+    _seed_entry(base, "bb", "bb_entry_two");
+    let r = _run_cache(base, ["prune", "--max-size", "0"]);
+    assert r.exit == 0;
+    let info = _run_cache(base, ["info"]);
+    assert find(info.out, "entries: 0", 0) >= 0;
+}
+
+test "cache: prune --max-age removes old entries and keeps fresh ones" ![io] {
+    let base = _cache_base("prune_age");
+    _seed_entry(base, "aa", "old_entry");
+    _seed_entry(base, "bb", "fresh_entry");
+    // Age one entry well past the threshold; the other stays at ~now.
+    process.run(["touch", "-d", "2000-01-01", base + "/v2/aa/old_entry"]);
+    let r = _run_cache(base, ["prune", "--max-age", "30"]);
+    assert r.exit == 0;
+    assert ! fs.exists(base + "/v2/aa/old_entry");
+    assert fs.exists(base + "/v2/bb/fresh_entry");
+}
+
+// ---- clean + stale-schema sweep ----
+test "cache: clean --all-schemas sweeps stale sibling schema trees" ![io] {
+    let base = _cache_base("sweep");
+    _seed_entry(base, "aa", "current_entry");
+    // A stale sibling schema tree (`v1`) beside the current `v2`.
+    fs.createDirectory(base + "/v1/aa/old_schema", true);
+    fs.writeFile(base + "/v1/aa/old_schema/mod.o", "x\n");
+    let r = _run_cache(base, ["clean", "--all-schemas"]);
+    assert r.exit == 0;
+    assert ! fs.exists(base + "/v1");
+    assert ! fs.exists(base + "/v2");
+}
+
+test "cache: clean --all-schemas leaves non-schema siblings (test-bin)" ![io] {
+    let base = _cache_base("sweep_keeps_testbin");
+    _seed_entry(base, "aa", "current_entry");
+    // A stale schema sibling to sweep, plus the per-test-binary cache
+    // (`test-bin/`) which is NOT a `v<N>` schema and must survive.
+    fs.createDirectory(base + "/v1/aa/old_schema", true);
+    fs.createDirectory(base + "/test-bin/v2/aa/some_bin", true);
+    let r = _run_cache(base, ["clean", "--all-schemas"]);
+    assert r.exit == 0;
+    assert ! fs.exists(base + "/v1");
+    assert fs.exists(base + "/test-bin");
+}
+
+test "cache: prune --max-size evicts oldest-first (partial)" ![io] {
+    let base = _cache_base("prune_lru");
+    _seed_big_entry(base, "aa", "oldest");
+    _seed_big_entry(base, "bb", "middle");
+    _seed_big_entry(base, "cc", "newest");
+    // Distinct ages so LRU ordering is unambiguous (oldest → newest).
+    process.run(["touch", "-d", "2000-01-01", base + "/v2/aa/oldest"]);
+    process.run(["touch", "-d", "2001-01-01", base + "/v2/bb/middle"]);
+    process.run(["touch", "-d", "2002-01-01", base + "/v2/cc/newest"]);
+    // Three ~200 KiB entries (~600 KiB total) under a 450 KiB cap: exactly
+    // one eviction is needed, and it must be the oldest.
+    let r = _run_cache(base, ["prune", "--max-size", "450000"]);
+    assert r.exit == 0;
+    assert ! fs.exists(base + "/v2/aa/oldest");
+    assert fs.exists(base + "/v2/bb/middle");
+    assert fs.exists(base + "/v2/cc/newest");
+}
+
+test "cache: clean without --all-schemas leaves sibling schema trees" ![io] {
+    let base = _cache_base("clean_keep");
+    _seed_entry(base, "aa", "current_entry");
+    fs.createDirectory(base + "/v1/aa/old_schema", true);
+    let r = _run_cache(base, ["clean"]);
+    assert r.exit == 0;
+    assert fs.exists(base + "/v1");
+    assert ! fs.exists(base + "/v2");
+}
+
+// ---- dispatch ----
+test "cache: no subcommand prints usage and exits non-zero" ![io] {
+    let base = _cache_base("usage");
+    let r = _run_cache(base, []);
+    assert r.exit != 0;
+    assert find(r.out, "usage", 0) >= 0;
+}
+
+// ---- mtime-on-hit (real build) ----
+test "cache: a cache hit refreshes entry mtime (verified by prune ordering)" ![io] {
+    let base = _cache_base("mtime_hit");
+    let src_dir = _scratch() + "/sfn-cache-mtime-src";
+    if fs.exists(src_dir) { process.run(["rm", "-rf", src_dir]); }
+    fs.createDirectory(src_dir, true);
+    let src = src_dir + "/hello.sfn";
+    fs.writeFile(src, "fn main() ![io] { print(\"hi\"); }\n");
+    let out = src_dir + "/hello";
+
+    // Cold build (work-dir A) populates the content-addressed module cache.
+    let b1 = _build(base, src_dir + "/work_a", src, out);
+    assert b1.exit == 0;
+    let info1 = _run_cache(base, ["info"]);
+    assert find(info1.out, "entries: 0", 0) < 0;
+
+    // Age every cache entry into the distant past.
+    process.run(["bash", "-c", "find '" + base
+        + "/v2' -mindepth 2 -maxdepth 2 -type d -exec touch -d 2000-01-01 {} +"]);
+
+    // Warm build in a *fresh* work-dir (B): every module restores from
+    // the content-addressed cache, and each hit must touch the served
+    // entry's mtime back to now (SFEP-0040 §3.4).
+    let b2 = _build(base, src_dir + "/work_b", src, out + "2");
+    assert b2.exit == 0;
+
+    // Evict anything older than one day. Without mtime-on-hit the aged
+    // entries would remain at 2000 and be swept to empty; the refresh
+    // keeps the hit entries, so the cache is non-empty after the prune.
+    let r = _run_cache(base, ["prune", "--max-age", "1"]);
+    assert r.exit == 0;
+    let info2 = _run_cache(base, ["info"]);
+    assert find(info2.out, "entries: 0", 0) < 0;
+}

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -1072,6 +1072,13 @@ able to act on link failures.
 - The build report (`--json`) lists cache hits/misses per module. CI can
   fail the build if the hit rate drops below a threshold (regression
   signal).
+- `sfn cache info/prune/clean` (SFEP-0040 §3.2–3.4) provides bounded-size GC
+  over this same store: `info` reports the resolved root, entry count, and
+  total on-disk size; `prune [--max-size <bytes>] [--max-age <days>]` evicts
+  entries oldest-first by mtime (touched on cache hit, so eviction order is
+  true LRU) down to a size/age bound, opt-in only (no implicit prune on
+  ordinary builds); `clean [--all-schemas]` extends `--clean` to optionally
+  sweep stale sibling `v<M>` schema trees as well as the current one.
 
 Determinism: the fixed-point check currently in `make check` (stage2 vs
 stage3 IR hashes) becomes a first-class assertion of the driver. If two
@@ -1583,9 +1590,10 @@ actual split is an ecosystem-maturity cleanup.
 1. **Workspace file location.** Does the shipped stdlib workspace file
    live at `$PREFIX/lib/sailfin/workspace.toml` (Unix convention) or
    next to the binary? Affects how installers lay things out.
-2. **Cache eviction.** Bounded by size, age, or never? A compiler build
-   is ~120 modules × ~1 MB each ≈ 120 MB per successful build; CI
-   caches could bloat quickly.
+2. **Cache eviction.** Resolved by SFEP-0040 §3.2–3.4 (#1893): bounded by
+   size and age via the explicit, opt-in `sfn cache prune`
+   (`--max-size`/`--max-age`, LRU by mtime-on-hit) and `sfn cache clean
+   [--all-schemas]` — never implicit on an ordinary build.
 3. **Per-target sub-graphs.** Cross-compilation to wasm32 needs a
    different runtime capsule. Does the driver build both graphs in one
    invocation (`sfn build --target=native --target=wasm32`) or require

--- a/docs/status.md
+++ b/docs/status.md
@@ -59,7 +59,13 @@ here.
   `$HOME` is unresolvable and pinned in-tree for the compiler self-host build —
   SFEP-0040 §3.1) with per-source dep manifests,
   `--no-cache` / `--clean` / `--cache-trace` flags, and a `[cache]` summary on
-  stderr (Stage C PR1–1f, #254–#259). Runtime C/LL/sfn objects share the same
+  stderr (Stage C PR1–1f, #254–#259). `sfn cache info/prune/clean` (SFEP-0040
+  §3.2–3.4, #1893) adds bounded-size GC over the same store: `info` reports
+  root/entry-count/size, `prune [--max-size <bytes>] [--max-age <days>]`
+  evicts LRU (mtime touched on cache hit) with conservative defaults (~5 GiB /
+  30 days) and is opt-in only (no implicit prune on builds), and `clean
+  [--all-schemas]` removes the current schema tree, optionally sweeping stale
+  sibling `v<M>` schema trees too. Runtime C/LL/sfn objects share the same
   cache across work-dirs (#915, #1096). `sfn test` content-addresses each
   linked test binary, cross-commit-stable (#1230, #1233); `make check` passes
   `--no-test-cache` so the full gate always cold-builds. **Runtime object
@@ -243,6 +249,7 @@ here.
 | `sfn vet` / `sfn lsp` / `sfn doc` / `sfn fix` | Planned | See `docs/proposals/0003-tooling.md` |
 | Package registry (`sfn init/add/publish`) | Shipped | Default registry `pkg.sfn.dev`; `SFN_REGISTRY` / `sfn config set registry` override |
 | `workspace.lock` (`sfn lock` write + resolver consume) | **Shipped** | Explicit `sfn lock` writes the root lockfile (#1070); `sfn lock --work-dir DIR` sets the workspace-discovery start dir so the command can run against a workspace without `cd`. Resolver prefers `workspace → workspace.lock → capsule.lock → cache → registry` for external deps, sibling-first untouched (#1071). Roots own lockfiles; library capsules don't commit them. Committing the root `workspace.lock` is #1050, gated on a seed embedding #1071 (satisfied at `v0.7.0-alpha.31`) |
+| `sfn cache` (`info`/`prune`/`clean`) | **Shipped** | Bounded-size GC over the content-addressed build cache (SFEP-0040 §3.2–3.4, #1893): `info` prints root/entry-count/size; `prune [--max-size <bytes>] [--max-age <days>]` evicts oldest-first by true LRU (mtime touched on cache hit), defaults ~5 GiB/30 days, opt-in only; `clean [--all-schemas]` removes the current schema tree and optionally stale sibling `v<M>` trees. `![io]` command, no eager auto-sweep on builds |
 | Notebook support | Not started | Post-1.0 |
 
 ## Print API (Current)

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -252,6 +252,42 @@ This is primarily used by the self-hosting build scripts.
 
 ---
 
+### `sfn cache <info|prune|clean>`
+
+Inspect and garbage-collect the content-addressed build artifact cache (the
+same store `sfn build`/`sfn run`/`sfn check`/`sfn test` read and write
+through, keyed on source + dependency hashes + compiler version + flags).
+`sfn cache` is an `![io]` command; it never runs implicitly during a normal
+build.
+
+**Subcommands:**
+
+| Form | Description |
+|---|---|
+| `sfn cache info` | Print the resolved cache root, entry count, and total on-disk size. |
+| `sfn cache prune [--max-size <bytes>] [--max-age <days>]` | LRU eviction: remove entries older than `--max-age` days, then delete oldest-first (by last-hit time) until total size is under `--max-size`. |
+| `sfn cache clean [--all-schemas]` | Remove the current cache schema tree. With `--all-schemas`, also sweep stale sibling schema-version trees left behind by a compiler upgrade. |
+
+**Usage:**
+
+```bash
+sfn cache info
+sfn cache prune                          # conservative defaults (~5 GiB / 30 days)
+sfn cache prune --max-size 1000000000    # cap the cache at 1 GB
+sfn cache prune --max-age 7              # evict anything not hit in 7 days
+sfn cache prune --max-size 0             # empty the cache
+sfn cache clean                          # remove the current schema tree
+sfn cache clean --all-schemas            # also remove stale prior-schema trees
+```
+
+**Behavior:**
+
+- `prune` is explicit and opt-in — it never runs automatically on `sfn build`/`sfn run`/`sfn check`/`sfn test`. With neither `--max-size` nor `--max-age` given, conservative defaults apply (~5 GiB total size, 30-day max age).
+- Eviction order is a true LRU: a cache *hit* touches the entry directory's mtime, so `prune` evicts by last-use recency rather than creation time.
+- The cache root follows the same resolution as the build cache generally: `$SAILFIN_BUILD_CACHE_DIR`, then `$XDG_CACHE_HOME/sailfin`, then `$HOME/.cache/sailfin`, falling back to the in-tree `build/cache` when `$HOME` is unresolvable. The compiler's own self-host build always pins the in-tree root and is unaffected by `sfn cache`.
+
+---
+
 ### `sfn --version`
 
 Display the compiler version string and exit with code 0.


### PR DESCRIPTION
## Summary
- Adds a `sfn cache` command giving the content-addressed build artifact cache a bounded-size story (SFEP-0040 §3.2–3.4): `info` reports usage, `prune` evicts by size/age (LRU), `clean [--all-schemas]` reclaims the current schema tree and sweeps stale sibling versions.
- Mtime-on-hit: a cache hit now touches the entry dir so `prune` evicts by true LRU recency, wired centrally into the `cache_copy_artifact_to` restore path shared by the module `.ll`, `runtime-obj`, and `test-bin` consumers.
- GC mechanics live in `build_cache.sfn`; `cli/commands/cache.sfn` is a thin CLI surface registered on the v2 root (its own `with_subcommand` line, per the #1773 nested-chain seed caveat).

Closes #1893

**Design decision (confirmed):** the stale-schema sweep is **explicit-only** (`sfn cache clean --all-schemas`) — there is no eager auto-sweep on builds. This resolves the SFEP §3.3/§6 open question conservatively: no surprise deletes on the first build after an upgrade, no hermeticity risk to `make compile`/`make check`, and it is cleanly testable via the scratch cache root.

This is one slice of the two-issue SFEP-0040 (§3.1 global-root default is #1892, already landed), so the SFEP stays `Accepted` rather than graduating to `Implemented`.

## Acceptance Criteria
- [x] `sfn cache info` prints the resolved root, entry count, and total on-disk size.
- [x] `sfn cache prune --max-size 0` empties the cache; `--max-age` removes entries older than N days.
- [x] A cache hit updates the entry mtime (verified by prune ordering — real-build e2e test).
- [x] The stale-schema sweep removes a pre-seeded `v/` tree (via `clean --all-schemas`, the chosen §6 policy).
- [x] A compiler self-host build is unaffected (hermetic in-tree root; the command resolves the user root with an empty capsule name).
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Behavior notes
- `prune` is opt-in and never runs implicitly on a normal build. When neither `--max-size` nor `--max-age` is given, conservative defaults apply (~5 GiB / 30 days); passing one axis does not silently activate the other.
- `--max-age` is clamped before `* 86400` (treated as unbounded past ~10,000 years) to avoid an i64-overflow edge that would otherwise invert "keep everything" into "evict everything".
- mtime-on-hit refreshes entries when a build restores from the content-addressed cache into a cold/cross-project work-dir (the LRU-relevant path); a warm same-work-dir incremental build reuses staged artifacts without re-touching, which is acceptable for LRU.

## Map reconciliation
Advisory `## Files Affected` matched the tree, with one clarification: `compiler/src/build_cache.sfn` already carried the SFEP-0040 §3.1 root-resolution ladder (companion #1892, landed), so this PR adds the §3.2–3.4 GC surface (`cache_info`/`cache_prune`/`cache_sweep_stale_schemas`/`cache_touch_entry`) and the mtime-on-hit touch on top of it. CLI dispatch registration went in `compiler/src/cli/main.sfn` (the `In:` "cli dispatch" unit) plus the usage banner in `compiler/src/cli_main.sfn`.

## Verification
```bash
make compile   # self-hosts (clean structural rebuild) → pass
make test      # unit 194/194, integration 42/42, e2e 186/186, capsules 38/38 → pass
build/native/sailfin test compiler/tests/e2e/cache_command_test.sfn   # 10/10 pass
```
Manual CLI smoke: `info` (empty + seeded), `prune --max-size 0` (empties), `prune --max-age` (drops old / keeps fresh), `clean --all-schemas` (sweeps `v1` + current `v2`), bare `cache` → usage + exit 2. Empirically confirmed a warm cross-work-dir build refreshes all 27 restored entry mtimes.

## Files Changed
- `compiler/src/build_cache.sfn` — GC surface (info/prune/sweep/touch + helpers); mtime-on-hit in the restore path; age-overflow clamp.
- `compiler/src/cli/commands/cache.sfn` — new command (`info`/`prune`/`clean [--all-schemas]`, `--max-size`/`--max-age`).
- `compiler/src/cli/main.sfn` — import + registration + nested-subcommand dispatch.
- `compiler/src/cli_main.sfn` — usage-banner line.
- `compiler/tests/e2e/cache_command_test.sfn` — new Sailfin-native e2e coverage (10 tests).
- `docs/status.md`, `docs/proposals/0006-build-architecture.md`, `site/src/content/docs/docs/reference/cli.md` — documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQmcaAApjSHZUVs4vUBnCj)_