### PR TITLE
fix(parser): reject data-field-shaped interface members (E0827)

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -273,6 +273,16 @@ struct FunctionSignature {
     name_span: SourceSpan?;
 }
 
+// A data-field-shaped interface member (`name: Type`) captured by the
+// interface member loop so typecheck can reject it with `E0827`
+// (SFEP-0039 §3.1). Interfaces are method-only contracts; a field
+// belongs on a concrete `struct` that implements the interface, not on
+// the interface itself.
+struct InterfaceFieldMember {
+    name: string;
+    name_span: SourceSpan?;
+}
+
 struct TestDeclaration {
     name: string;
     body: Block;
@@ -385,6 +395,7 @@ enum Statement {
         type_parameters: TypeParameter[];
         members: FunctionSignature[];
         decorators: Decorator[];
+        field_members: InterfaceFieldMember[];
     },
     EnumDeclaration {
         name: string;

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -12,6 +12,7 @@ import {
     FieldDeclaration,
     FunctionSignature,
     ImportSpecifier,
+    InterfaceFieldMember,
     MethodDeclaration,
     Parameter,
     Statement,
@@ -1537,6 +1538,7 @@ fn parse_interface(initial_parser: Parser, decorators: Decorator[]) -> Statement
     parser = consume_symbol(parser, "{");
 
     let mut members: FunctionSignature[] = [];
+    let mut field_members: InterfaceFieldMember[] = [];
     loop {
         parser = skip_trivia(parser);
         let token = parser_peek_raw(parser);
@@ -1561,6 +1563,24 @@ fn parse_interface(initial_parser: Parser, decorators: Decorator[]) -> Statement
             continue;
         }
 
+        // The member did not parse as a method signature. If it has a
+        // data-field shape (an identifier followed by a type separator
+        // `:` or the legacy `->`), record it so typecheck rejects it
+        // with `E0827` (SFEP-0039 §3.1): interfaces are method-only.
+        // Genuine garbage (neither `fn` nor a field shape) keeps the
+        // existing silent recovery so recovery does not cascade.
+        let head = parser_peek_raw(parser);
+        if head.kind.variant == "Identifier" && !identifier_matches(head, "fn") {
+            let after_name = skip_trivia(parser_advance_raw(parser));
+            let colon = consume_annotation_separator(after_name);
+            let arrow = consume_return_type_separator(after_name);
+            if colon.found || arrow.found {
+                field_members.push(InterfaceFieldMember {
+                    name: identifier_text(head), name_span: source_span_from_tokens([head])
+                });
+            }
+        }
+
         parser = skip_struct_member(member_start);
     }
 
@@ -1569,7 +1589,8 @@ fn parse_interface(initial_parser: Parser, decorators: Decorator[]) -> Statement
         name_span: name_span,
         type_parameters: type_parameters,
         members: members,
-        decorators: decorators
+        decorators: decorators,
+        field_members: field_members
     };
     return StatementParseResult { parser: parser, statement: statement };
 }

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -36,6 +36,7 @@ import {
     check_fn_reference_raw,
     check_function_signature,
     check_generic_instantiation,
+    check_interface_field_members,
     check_interface_members,
     check_intersection_value_type_annotation,
     check_object_literal_target,
@@ -598,6 +599,13 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             if _ci2 >= _im_diags.length { break; }
             diagnostics.push(_im_diags[_ci2]);
             _ci2 += 1;
+        }
+        let _fm_diags = check_interface_field_members(statement.field_members);
+        let mut _ci3: int = 0;
+        loop {
+            if _ci3 >= _fm_diags.length { break; }
+            diagnostics.push(_fm_diags[_ci3]);
+            _ci3 += 1;
         }
         return ScopeResult {
             bindings: registration.bindings,

--- a/compiler/src/typecheck_imports.sfn
+++ b/compiler/src/typecheck_imports.sfn
@@ -28,6 +28,7 @@
 import {
     Decorator,
     FunctionSignature,
+    InterfaceFieldMember,
     Parameter,
     Statement,
     TypeAnnotation,
@@ -133,12 +134,16 @@ fn function_signatures_from_native(signatures: NativeInterfaceSignature[]) -> Fu
 // -------------------------------------------------------------------
 fn interface_statement_from_native(native: NativeInterface) -> Statement {
     let empty_decorators: Decorator[] = [];
+    // Native/FFI interfaces are synthesized from descriptors, never
+    // parsed from user source, so they carry no field-shaped members.
+    let empty_field_members: InterfaceFieldMember[] = [];
     return Statement.InterfaceDeclaration {
         name: native.name,
         name_span: null,
         type_parameters: type_parameters_from_names(native.type_parameters),
         members: function_signatures_from_native(native.signatures),
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        field_members: empty_field_members
     };
 }
 

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -7,6 +7,7 @@ import {
     Expression,
     FieldDeclaration,
     FunctionSignature,
+    InterfaceFieldMember,
     MethodDeclaration,
     SourceSpan,
     Statement,
@@ -319,6 +320,44 @@ fn check_intersection_value_type_annotation(annotation: TypeAnnotation?, anchor_
     if annotation == null { return []; }
     if !type_annotation_is_intersection(annotation.text) { return []; }
     return [make_intersection_value_type_diagnostic(annotation.text, token_from_name(anchor_name, anchor_span))];
+}
+
+// E0827: a data-field-shaped interface member (`name: Type`). Interfaces
+// are method-only contracts (SFEP-0039 §3.1); a data field belongs on a
+// concrete `struct` that implements the interface, not on the interface.
+// The parser (interface member loop) records the field-shaped members it
+// could not parse as method signatures; this factory turns each into the
+// diagnostic that was silently dropped before.
+fn make_interface_field_member_diagnostic(name: string, span: SourceSpan?) -> Diagnostic {
+    let fix = FixSuggestion {
+        message: "declare a `struct` with this field and have the struct implement the "
+            + "interface (interfaces carry only method signatures)",
+        edits: []
+    };
+    return Diagnostic {
+        code: "E0827",
+        severity: "error",
+        message: "interface members must be method signatures; `" + name
+            + "` is a data field",
+        file_path: "",
+        primary: token_from_name(name, span),
+        suggestion: fix
+    };
+}
+
+// Turn every field-shaped interface member the parser captured into an
+// `E0827` diagnostic. A method-only interface captures none, so this
+// returns empty and leaves such interfaces unaffected.
+fn check_interface_field_members(field_members: InterfaceFieldMember[]) -> Diagnostic[] {
+    let mut diagnostics: Diagnostic[] = [];
+    let mut _fmi: int = 0;
+    loop {
+        if _fmi >= field_members.length { break; }
+        let fm = field_members[_fmi];
+        diagnostics.push(make_interface_field_member_diagnostic(fm.name, fm.name_span));
+        _fmi += 1;
+    }
+    return diagnostics;
 }
 
 // E0828: a bare object literal whose target is not a concrete `struct`.

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -26,9 +26,61 @@ fn _has_code(diagnostics: Diagnostic[], code: string) -> boolean {
     return false;
 }
 
+fn _count_code(diagnostics: Diagnostic[], code: string) -> int {
+    let mut n: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= diagnostics.length { break; }
+        if strings_equal(diagnostics[i].code, code) { n += 1; }
+        i += 1;
+    }
+    return n;
+}
+
 fn _diags(source: string) -> Diagnostic[] ![io] {
     let program = parse_program(source);
     return typecheck_diagnostics(program);
+}
+
+// -------------------------------------------------------------------
+// E0827 — a data-field-shaped interface member (`name: Type`).
+// Interfaces are method-only contracts (SFEP-0039 §3.1); a data field
+// belongs on a concrete `struct` that implements the interface. Before
+// this fix the member was silently dropped, leaving a zero-member
+// interface (the "parsed but not enforced" anti-pattern).
+// -------------------------------------------------------------------
+test "object-model: field-shaped interface member is E0827" ![io] {
+    let source = "interface Admin { isAdmin: boolean }\n";
+    assert _has_code(_diags(source), "E0827");
+}
+
+test "object-model: legacy-arrow field-shaped interface member is E0827" ![io] {
+    let source = "interface Admin { isAdmin -> boolean }\n";
+    assert _has_code(_diags(source), "E0827");
+}
+
+test "object-model: method-only interface is not E0827" ![io] {
+    let source = "interface Named { fn name() -> string; }\n";
+    assert ! _has_code(_diags(source), "E0827");
+}
+
+test "object-model: mixed interface reports only the field member" ![io] {
+    let source = "interface Account {\n" + "    fn name() -> string;\n"
+        + "    isAdmin: boolean;\n"
+        + "}\n";
+    let diagnostics = _diags(source);
+    assert _has_code(diagnostics, "E0827");
+    assert _count_code(diagnostics, "E0827") == 1;
+}
+
+// A field member between two method signatures: recovery skips only the
+// offending member (exactly one E0827), so it does not cascade past it.
+test "object-model: recovery does not cascade past a field member" ![io] {
+    let source = "interface Account {\n" + "    fn id() -> int;\n"
+        + "    isAdmin: boolean;\n"
+        + "    fn name() -> string;\n"
+        + "}\n";
+    assert _count_code(_diags(source), "E0827") == 1;
 }
 
 // -------------------------------------------------------------------

--- a/docs/status.md
+++ b/docs/status.md
@@ -191,8 +191,14 @@ here.
   the RHS of a `type X = A & B` alias) fails typecheck with `E0829` — `A & B`
   stays in the grammar but is reserved for generic trait-bound composition
   (`<T: A + B>`, SFEP-0038) and is not diagnosed in bound position. The sibling
-  rule that interface members must be method signatures (`E0827`) is designed
-  in SFEP-0039 but **not yet enforced** — tracked separately in #1888.
+  rule that interface members must be method signatures (`E0827`, SFEP-0039,
+  #1888) is now enforced: the parser detects a data-field-shaped interface
+  member (an identifier followed by `:` or `->` where a method signature was
+  expected) and typecheck emits `E0827` with a fix-it steering the field to a
+  concrete `struct` that implements the interface, instead of silently
+  dropping the member. Interface *signature conformance* (checking that an
+  implementing struct's method signatures match the interface) remains a
+  separate, still-draft effort (`draft-interface-signature-conformance`).
 
 ## Feature Matrix
 
@@ -203,7 +209,7 @@ here.
 | Functions (`fn`) | Shipped | Generics, default params, decorators |
 | `async fn` | Parsed | Structural only; `spawn`/`await` on spawned tasks works end-to-end (v0, #1084 closed, #1474/#1477/#1546); `await` on `async fn` return values is not wired into the live typecheck walk (pending #829). Use `spawn fn() -> T { ... }` + `await` instead |
 | Structs | Shipped | Generic params, `implements` clause. Sole sanctioned bare-object-literal target (`E0828`, SFEP-0039, #1860) — a literal targeting an interface or an un-inferable unannotated `let` is rejected |
-| Interfaces | Shipped | Trait-style method signatures. Nominal model intent is method-only contracts (SFEP-0039); data-field-shaped members are still parsed without a diagnostic pending `E0827` enforcement (#1888) |
+| Interfaces | Shipped | Trait-style method signatures, enforced method-only: a data-field-shaped member is rejected at typecheck with `E0827` (SFEP-0039, #1888), fix-it points at a concrete `struct`. Interface *signature conformance* checking is separate and still draft |
 | Enums / ADTs | Shipped | Payload variants; generic payloads monomorphise per instantiation (#830). >8-byte by-value payload layouts not yet emitted |
 | Type aliases | Shipped | Including generic params. `A & B` is reserved for generic trait bounds, not a data type — `type X = A & B` is rejected at the definition (`E0829`, SFEP-0039, #1860) |
 | Module exports | **Shipped** | Block form `export { name };` / `export { x } from "./m";` and inline `export <declaration>` (`export fn`/`export struct`/`export enum`/`export interface`/`export type`/`export let`/`export extern …`/`export thread_local let mut`). Inline form added in SFEP-0031 (#1681); equivalent to `<decl> export { name };` |

--- a/site/src/content/docs/docs/reference/spec/06-types.md
+++ b/site/src/content/docs/docs/reference/spec/06-types.md
@@ -55,6 +55,18 @@ boundaries — bindings, call arguments, struct fields, and arithmetic operands:
 
 **Composite types**: structs, enums, arrays (`T[]`)
 
+**Interfaces are method-only contracts**: an interface member must be a method
+signature (`fn name(...) -> T`). A data-field-shaped member (`name: Type`) is
+a typecheck error (`E0827`); data fields belong on a concrete `struct` that
+implements the interface:
+
+```sfn
+interface Named {
+    fn name() -> string;   // OK — method-only contract
+    // isAdmin: boolean;   // E0827 — declare a struct for data fields
+}
+```
+
 **Object literals require a concrete `struct` target**: data is constructed
 only through a `struct`. A bare object literal `{ ... }` resolves its shape
 against the annotation or contextual type it targets; if that target is an


### PR DESCRIPTION
## Summary
- Interfaces are now enforced as **method-only contracts** (SFEP-0039 §3.1): a data-field-shaped interface member (`interface Admin { isAdmin: boolean }`) becomes a compile-time **E0827** instead of being silently dropped into a zero-member interface (the "parsed but not enforced" anti-pattern).
- The interface member loop detects a field shape (an identifier that is not `fn`, followed by a `:` or `->` separator) on the member-parse failure path and records it on a new `InterfaceDeclaration.field_members` AST slot; typecheck turns each into `E0827` with a fix-it steering the field onto a concrete `struct`. Mirrors the sibling E0828/E0829 nominal-object-model diagnostics.
- Genuine garbage members keep the existing silent recovery, so recovery does not cascade past the offending member.

Closes #1888

## Acceptance Criteria
- [x] `interface Admin { isAdmin: boolean }` emits `E0827` at the member span with a fix-it pointing to `struct` (verified: diagnostic anchors the `isAdmin` name token).
- [x] Method-only interfaces are unaffected.
- [x] Recovery does not cascade past the offending member (a field member between two methods yields exactly one `E0827`; both methods still parse).
- [x] Regression tests in `compiler/tests/` (5 new E0827 cases in `typecheck_object_model_test.sfn`).
- [x] `make compile` passes (self-hosts).
- [x] `make test` passes.

## Map reconciliation
The advisory `## Files Affected` map named `compiler/src/parser/` for the fix. The parser has no diagnostic channel of its own (even the existing `Expression.ParseError` path emits its diagnostic from typecheck), so — following the only established parser-diagnostic pattern and the E08xx range's home in `typecheck_types.sfn` — the parser *detects* the field shape and records it on the AST, and typecheck *emits* `E0827`. This touched `compiler/src/ast.sfn` (new `InterfaceFieldMember` struct + `field_members` slot), `compiler/src/typecheck_types.sfn` (`make_interface_field_member_diagnostic` + `check_interface_field_members`, mirroring E0828/E0829), `compiler/src/typecheck.sfn` (wire-in), and `compiler/src/typecheck_imports.sfn` (empty `field_members` for FFI-synthesized interfaces) in addition to the parser. The Goal and `In:`/`Out:` semantic scope are unchanged — no new acceptance criterion or public surface beyond the `E0827` the issue names.

## Verification
```bash
make compile                                              # self-hosts: status:pass
build/native/sailfin check <interface Admin { isAdmin: boolean }>  # error[E0827] at isAdmin span
sailfin test compiler/tests/unit/typecheck_object_model_test.sfn   # all 18 pass (5 new E0827)
make test                                                 # unit + integration + e2e + capsules(38/38) green
```

## Files Changed
- `compiler/src/ast.sfn` — `InterfaceFieldMember` struct; `field_members` appended to `Statement.InterfaceDeclaration`.
- `compiler/src/parser/declarations.sfn` — field-shape detection on the interface member-parse failure path.
- `compiler/src/typecheck_types.sfn` — `E0827` diagnostic factory + `check_interface_field_members`.
- `compiler/src/typecheck.sfn` — call the E0827 check in the `InterfaceDeclaration` scope arm.
- `compiler/src/typecheck_imports.sfn` — empty `field_members` for native/FFI interfaces.
- `compiler/tests/unit/typecheck_object_model_test.sfn` — 5 E0827 regression tests.
- `docs/status.md`, `site/src/content/docs/docs/reference/spec/06-types.md` — interfaces-are-method-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018JCPCNMMcKDqchH1orYavB)_