### PR TITLE
refactor(build): add SAILFIN_TRACE_LINK to echo the resolved clang link argv

### DIFF
--- a/compiler/src/backend.sfn
+++ b/compiler/src/backend.sfn
@@ -36,6 +36,9 @@
 // importing this module (and emitting the `LlvmTextBackend` vtable). See
 // that file's header for the seed-lowering reason (#1730).
 import { _llvm_text_assemble_argv } from "./build/clang_argv";
+// `_env_flag` gives `SAILFIN_TRACE_LINK` the same toggle semantics ("",
+// "0", "false" are off) as the other `SAILFIN_TRACE_*` knobs.
+import { _env_flag } from "./build_flags";
 
 // Reserved opaque object-file handle for later backend stages (#347 /
 // #1640 produce these in-process). Stage 0's `LlvmTextBackend` returns
@@ -145,17 +148,15 @@ fn _llvm_text_link_program_argv(plan: LinkPlan) -> string[] {
 // argv (#1908): a read-only observability aid that prints exactly the argv
 // `_llvm_text_link_{program,test}_argv` already returns, so link-flag tests
 // can assert on the argv directly instead of proving honoring behaviorally
-// (the #1902 follow-up). The env is read once and all string work is
-// skipped when unset, so the unset fast path stays free of per-link cost —
-// output is byte-identical to an untraced link (the #1112 zero-behaviour
-// gate). Lives as a free function (not a struct method) to match the
-// module's self-host shape; the caller binds the argv to a local so the
-// echoed slice is the same one handed to `process.run`.
+// (the #1902 follow-up). The toggle uses the shared `_env_flag` helper so
+// its semantics match the other `SAILFIN_TRACE_*` knobs, and all string
+// work is skipped when unset, so the unset fast path stays free of per-link
+// cost — output is byte-identical to an untraced link (the #1112
+// zero-behaviour gate). Lives as a free function (not a struct method) to
+// match the module's self-host shape; the caller binds the argv to a local
+// so the echoed slice is the same one handed to `process.run`.
 fn _llvm_text_trace_link(argv: string[]) ![io] {
-    let v = env.get("SAILFIN_TRACE_LINK");
-    if v.length == 0 { return; }
-    if v == "0" { return; }
-    if v == "false" { return; }
+    if !_env_flag("SAILFIN_TRACE_LINK") { return; }
     let mut line: string = "[trace-link]";
     let mut i: int = 0;
     loop {

--- a/compiler/src/backend.sfn
+++ b/compiler/src/backend.sfn
@@ -141,6 +141,31 @@ fn _llvm_text_link_program_argv(plan: LinkPlan) -> string[] {
     return args;
 }
 
+// Env-gated (`SAILFIN_TRACE_LINK`) stderr echo of the resolved clang link
+// argv (#1908): a read-only observability aid that prints exactly the argv
+// `_llvm_text_link_{program,test}_argv` already returns, so link-flag tests
+// can assert on the argv directly instead of proving honoring behaviorally
+// (the #1902 follow-up). The env is read once and all string work is
+// skipped when unset, so the unset fast path stays free of per-link cost —
+// output is byte-identical to an untraced link (the #1112 zero-behaviour
+// gate). Lives as a free function (not a struct method) to match the
+// module's self-host shape; the caller binds the argv to a local so the
+// echoed slice is the same one handed to `process.run`.
+fn _llvm_text_trace_link(argv: string[]) ![io] {
+    let v = env.get("SAILFIN_TRACE_LINK");
+    if v.length == 0 { return; }
+    if v == "0" { return; }
+    if v == "false" { return; }
+    let mut line: string = "[trace-link]";
+    let mut i: int = 0;
+    loop {
+        if i >= argv.length { break; }
+        line = line + " " + argv[i];
+        i += 1;
+    }
+    print.err(line);
+}
+
 // The current behaviour: emit textual LLVM IR and drive `clang` for
 // assembly and linking. The methods delegate argv construction to the
 // free functions above (see the self-host note in the file header).
@@ -151,8 +176,12 @@ struct LlvmTextBackend {
 
     fn link(self, plan: LinkPlan) -> int ![io] {
         if plan.test_mode {
-            return process.run(_llvm_text_link_test_argv(plan));
+            let test_argv = _llvm_text_link_test_argv(plan);
+            _llvm_text_trace_link(test_argv);
+            return process.run(test_argv);
         }
-        return process.run(_llvm_text_link_program_argv(plan));
+        let program_argv = _llvm_text_link_program_argv(plan);
+        _llvm_text_trace_link(program_argv);
+        return process.run(program_argv);
     }
 }

--- a/compiler/tests/e2e/openssl_prefix_honored_test.sfn
+++ b/compiler/tests/e2e/openssl_prefix_honored_test.sfn
@@ -5,26 +5,24 @@
 // (`_openssl_link_search_flags` in `compiler/src/build/runtime_objs.sfn`).
 // `SAILFIN_OPENSSL_PREFIX` is the supported public override: it is the
 // FIRST candidate and, because the probe stops at the first match, the
-// SOLE `-L` emitted when it is set to a valid prefix. That single-`-L`
-// property is what makes the override observable end-to-end here without a
-// backend argv trace (out of scope for #1821):
+// SOLE `-L` emitted when it is set to a prefix whose `lib` dir exists.
 //
-//   - valid prefix  → `-L<prefix>/lib` resolves `-lssl` → build SUCCEEDS.
-//   - empty-lib prefix → `-L<prefix>/lib` is the only search dir, the keg
-//     is suppressed, `-lssl` is unresolvable → build FAILS.
-//
-// The negative leg proves the override is genuinely *honored* (it wins over
-// and suppresses keg/brew discovery), not merely that a happy build worked.
+// This asserts the override is honored by inspecting the resolved clang
+// link argv DIRECTLY via `SAILFIN_TRACE_LINK` (#1908) — the override's
+// `-L<prefix>/lib` appearing in the link argv IS the proof it was honored.
+// That replaces the prior behavioral proxy (link success/failure), which
+// forced the test to discover a real OpenSSL keg and to strip `LIBRARY_PATH`
+// so the ambient CI keg path could not mask a bogus override (the #1902
+// workaround). The trace fires before `process.run`, so the assertion holds
+// regardless of whether the (deliberately empty) `lib` dir resolves `-lssl` —
+// no host OpenSSL, no link-outcome, and no `LIBRARY_PATH` handling needed.
 //
 // Non-Darwin: `_openssl_link_search_flags` returns `[]` (the override is
-// inert), so both legs SKIP cleanly (`assert true`), mirroring the
-// tool-absent SKIP precedent. On Darwin with no discoverable host OpenSSL
-// (no keg / brew / pkg-config hit) the tests also SKIP — there is nothing
-// to symlink a valid prefix at.
+// inert), so the test SKIPs cleanly (`assert true`), mirroring the
+// tool-absent SKIP precedent.
 //
 // Matchers note (#842): `sfn/test`'s `expect_*` matchers are `![pure]` and
-// cannot be called from an `![io]` test; assert on captured text / exit
-// codes directly.
+// cannot be called from an `![io]` test; assert on captured text directly.
 import { contains } from "sfn/strings";
 
 fn _sfn_bin() -> string ![io] {
@@ -40,19 +38,6 @@ fn _is_darwin() -> boolean ![io] {
     return contains(out, "Darwin");
 }
 
-// Discover the host's real OpenSSL lib dir the same way the build driver
-// would (standard kegs, then `brew --prefix openssl@3`, then a
-// `pkg-config` fallback) but WITHOUT consulting `SAILFIN_OPENSSL_PREFIX` —
-// this is the ground-truth location we symlink a valid override prefix at.
-// Empty when the host has no discoverable OpenSSL.
-fn _discover_openssl_lib() -> string ![io] {
-    let probe = "d=\"\"; for c in /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl@3/lib; do [ -d \"$c\" ] && { d=\"$c\"; break; }; done; [ -z \"$d\" ] && { p=\"$(brew --prefix openssl@3 2>/dev/null)\"; [ -n \"$p\" ] && [ -d \"$p/lib\" ] && d=\"$p/lib\"; }; [ -z \"$d\" ] && command -v pkg-config >/dev/null 2>&1 && { L=\"$(pkg-config --libs-only-L openssl 2>/dev/null)\"; L=\"${L%% *}\"; c=\"${L#-L}\"; [ -n \"$c\" ] && [ -d \"$c\" ] && d=\"$c\"; }; printf %s \"$d\"";
-    let _exit = process.run_capture(["sh", "-c", probe], process.environ());
-    let out = process.capture_take_stdout();
-    let _err = process.capture_take_stderr();
-    return out;
-}
-
 fn _scratch_dir() -> string ![io] {
     let mut dir = env.get("SAILFIN_TEST_SCRATCH");
     if dir.length == 0 { dir = "/tmp"; }
@@ -61,42 +46,31 @@ fn _scratch_dir() -> string ![io] {
     return dir;
 }
 
-// Parent env (the nested build links clang + ld + `-lssl -lcrypto`, and
-// SAILFIN_TEST_SCRATCH keeps the build cache per-invocation under the
-// parallel pool) with an explicit `SAILFIN_OPENSSL_PREFIX` appended. Any
-// ambient copy is dropped first so the child sees exactly the value under
-// test regardless of the platform's duplicate-key getenv precedence.
-//
-// It ALSO strips `LIBRARY_PATH` (and `DYLD_FALLBACK_LIBRARY_PATH`) from the
-// child so `SAILFIN_OPENSSL_PREFIX` *solely* determines where the link finds
-// OpenSSL. CI's macOS legs export `LIBRARY_PATH=<keg>/lib` (the
-// `Provision OpenSSL link path` step), which clang also searches for `-l`
-// resolution — so without stripping it, a bogus override `-L` would be
-// masked by `LIBRARY_PATH` and the negative leg's link would wrongly
-// succeed. Removing it makes both legs sound proofs of honoring, independent
-// of CI provisioning. `-lm` / `-lpthread` live on the default SDK path (not
-// `LIBRARY_PATH`), so stripping it only removes the OpenSSL keg confound.
-fn _env_with_prefix(prefix: string) -> string[] ![io] {
-    let base = process.environ();
-    let mut e: string[] = [];
-    let mut i = 0;
-    loop {
-        if i >= base.length { break; }
-        if !_is_stripped_env_key(base[i]) { e.push(base[i]); }
-        i = i + 1;
-    }
-    e.push("SAILFIN_OPENSSL_PREFIX=" + prefix);
-    return e;
-}
-
 fn _has_key(entry: string, key: string) -> boolean {
     if entry.length < key.length { return false; }
     return substring(entry, 0, key.length) == key;
 }
 
-fn _is_stripped_env_key(entry: string) -> boolean {
-    return _has_key(entry, "SAILFIN_OPENSSL_PREFIX=") || _has_key(entry, "LIBRARY_PATH=")
-        || _has_key(entry, "DYLD_FALLBACK_LIBRARY_PATH=");
+// The nested build links clang + ld (needs the parent `PATH`) and routes its
+// build cache under `SAILFIN_TEST_SCRATCH` (per-invocation isolation under the
+// parallel pool). Inherit the parent env, but drop any ambient
+// `SAILFIN_OPENSSL_PREFIX` / `SAILFIN_TRACE_LINK` first so the child sees
+// exactly the values under test regardless of duplicate-key getenv precedence,
+// then append them.
+fn _child_env(prefix: string) -> string[] ![io] {
+    let base = process.environ();
+    let mut e: string[] = [];
+    let mut i = 0;
+    loop {
+        if i >= base.length { break; }
+        if !_has_key(base[i], "SAILFIN_OPENSSL_PREFIX=") && !_has_key(base[i], "SAILFIN_TRACE_LINK=") {
+            e.push(base[i]);
+        }
+        i = i + 1;
+    }
+    e.push("SAILFIN_OPENSSL_PREFIX=" + prefix);
+    e.push("SAILFIN_TRACE_LINK=1");
+    return e;
 }
 
 // A trivial fixture. Any Sailfin binary links `-lssl -lcrypto` (SFEP-0036
@@ -108,82 +82,28 @@ fn _write_fixture(dir: string) -> string ![io] {
     return path;
 }
 
-struct BuildOutcome {
-    exit: int;
-    err: string;
-}
-
-fn _build_with_prefix(main_path: string, bin: string, prefix: string) -> BuildOutcome ![io] {
-    let exit = process.run_capture([_sfn_bin(), "build", "-o", bin, main_path], _env_with_prefix(prefix));
-    let _o = process.capture_take_stdout();
-    let err = process.capture_take_stderr();
-    return BuildOutcome { exit: exit, err: err };
-}
-
-// ---- Positive: a valid prefix surfaces a working `-L<prefix>/lib` ----
-test "openssl prefix: a valid SAILFIN_OPENSSL_PREFIX links (macOS)" ![io] {
+// A valid `SAILFIN_OPENSSL_PREFIX` surfaces its `-L<prefix>/lib` directly in
+// the resolved clang link argv. The prefix's `lib` dir must exist for
+// `_openssl_link_search_flags` to emit the flag (`[ -d "$P/lib" ]`); it stays
+// empty because we assert on the argv, not on link success.
+test "openssl prefix: SAILFIN_OPENSSL_PREFIX surfaces -L<prefix>/lib in the link trace (macOS)" ![io] {
     if !_is_darwin() {
         print.info("[openssl-prefix] SKIP: non-Darwin (override is inert)");
         assert true;
         return;
     }
-    let real_lib = _discover_openssl_lib();
-    if real_lib.length == 0 {
-        print.info("[openssl-prefix] SKIP: no host OpenSSL to point a valid prefix at");
-        assert true;
-        return;
-    }
     let dir = _scratch_dir();
-    // A distinct prefix (NOT a keg dir) whose `lib` symlinks the real
-    // OpenSSL dir. Because the override is the first and only candidate,
-    // build success proves the `-L<prefix>/lib` it produced resolved
-    // `-lssl` — i.e. the override path, not the keg, drove the link.
     let prefix = dir + "/honored";
-    fs.createDirectory(prefix, true);
-    let _rm = process.run(["rm", "-rf", prefix + "/lib"]);
-    let ln = process.run_capture(["ln", "-s", real_lib, prefix + "/lib"], process.environ());
-    let _lo = process.capture_take_stdout();
-    let _le = process.capture_take_stderr();
-    assert ln == 0;
-
-    let main_path = _write_fixture(dir);
-    let outcome = _build_with_prefix(main_path, dir + "/honored-bin", prefix);
-    assert outcome.exit == 0;
-    assert fs.exists(dir + "/honored-bin");
-}
-
-// ---- Negative: the override is honored (suppresses keg discovery) ----
-// An existing-but-empty `lib` prefix is the first and only candidate; the
-// keg dirs are never searched, so `-lssl` is unresolvable and the link
-// fails. Sound on macOS because `-lssl` is NOT on the default link path
-// (the reason `_openssl_link_search_flags` exists at all) AND
-// `_env_with_prefix` strips `LIBRARY_PATH` (see its note), so the empty
-// override `-L` is genuinely the sole OpenSSL search dir — no ambient
-// `LIBRARY_PATH` keg can rescue the link.
-test "openssl prefix: an empty-lib SAILFIN_OPENSSL_PREFIX suppresses the keg and fails the link (macOS)" ![io] {
-    if !_is_darwin() {
-        print.info("[openssl-prefix] SKIP: non-Darwin (override is inert)");
-        assert true;
-        return;
-    }
-    // Only meaningful when the host actually HAS an OpenSSL keg that the
-    // override must be shown to suppress; otherwise the link would fail
-    // regardless and the assertion proves nothing.
-    let real_lib = _discover_openssl_lib();
-    if real_lib.length == 0 {
-        print.info("[openssl-prefix] SKIP: no host OpenSSL keg to suppress");
-        assert true;
-        return;
-    }
-    let dir = _scratch_dir();
-    let prefix = dir + "/empty";
     fs.createDirectory(prefix + "/lib", true);
 
     let main_path = _write_fixture(dir);
-    let outcome = _build_with_prefix(main_path, dir + "/empty-bin", prefix);
-    // Fail AND for the intended reason: the sole `-L<empty>/lib` leaves
-    // `-lssl` unresolvable, so clang/ld reports an ssl link error. Pinning
-    // the cause keeps the test from passing on an unrelated build failure.
-    assert outcome.exit != 0;
-    assert contains(outcome.err, "ssl");
+    let _exit = process.run_capture([_sfn_bin(), "build", "-o", dir
+        + "/honored-bin", main_path], _child_env(prefix));
+    let _out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+
+    // The override's `-L<prefix>/lib` appears in the resolved link argv —
+    // direct proof it was honored, independent of whether the link resolves.
+    assert contains(err, "[trace-link]");
+    assert contains(err, "-L" + prefix + "/lib");
 }

--- a/compiler/tests/e2e/sailfin_trace_link_test.sfn
+++ b/compiler/tests/e2e/sailfin_trace_link_test.sfn
@@ -83,10 +83,18 @@ fn _write_test_fixture(dir: string) -> string ![io] {
 // `LlvmTextBackend.link` has a separate `test_mode` argv layout; `sfn test`
 // links each test binary through it, so guard that branch too — the flag
 // must surface the test-layout argv, not only the program/build layout.
+//
+// `--no-test-cache` is load-bearing: on a test-bin cache HIT `sfn test`
+// serves the pre-linked binary and skips the clang link entirely, so no
+// `[trace-link]` line is emitted. Across the suite's repeated passes
+// (first-pass + parallel `--jobs` + seedcheck, all sharing
+// `SAILFIN_TEST_SCRATCH`) a later pass would hit the cache and the trace
+// would vanish. Disabling the cache forces the link every time so the
+// assertion is deterministic.
 test "trace-link: SAILFIN_TRACE_LINK=1 echoes the test-layout link argv" ![io] {
     let dir = _scratch_dir();
     let test_path = _write_test_fixture(dir);
-    let _exit = process.run_capture([_sfn_bin(), "test", test_path], _child_env(true));
+    let _exit = process.run_capture([_sfn_bin(), "test", "--no-test-cache", test_path], _child_env(true));
     let _out = process.capture_take_stdout();
     let err = process.capture_take_stderr();
     assert contains(err, "[trace-link]");

--- a/compiler/tests/e2e/sailfin_trace_link_test.sfn
+++ b/compiler/tests/e2e/sailfin_trace_link_test.sfn
@@ -1,0 +1,75 @@
+// Regression e2e for the `SAILFIN_TRACE_LINK` observability knob (#1908):
+// the build driver echoes the resolved clang link argv to stderr when the
+// flag is set, and is silent (no `[trace-link]` marker) when it is not —
+// the #1112 zero-behaviour gate for the unset fast path. Platform-independent:
+// a hello-world build reaches `LlvmTextBackend.link` on every target, and the
+// trace line (`_llvm_text_trace_link` in `compiler/src/backend.sfn`) fires
+// before `process.run`, so the marker's presence/absence is observable
+// regardless of whether the link ultimately succeeds.
+//
+// Matchers note (#842): `sfn/test`'s `expect_*` matchers are `![pure]` and
+// cannot be called from an `![io]` test; assert on captured text directly.
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/sfn-trace-link-e2e";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+fn _has_key(entry: string, key: string) -> boolean {
+    if entry.length < key.length { return false; }
+    return substring(entry, 0, key.length) == key;
+}
+
+// Inherit the parent env (the nested build links clang + ld via `PATH` and
+// routes its build cache under `SAILFIN_TEST_SCRATCH`), dropping any ambient
+// `SAILFIN_TRACE_LINK` so `traced` alone decides the child's value.
+fn _child_env(traced: boolean) -> string[] ![io] {
+    let base = process.environ();
+    let mut e: string[] = [];
+    let mut i = 0;
+    loop {
+        if i >= base.length { break; }
+        if !_has_key(base[i], "SAILFIN_TRACE_LINK=") { e.push(base[i]); }
+        i = i + 1;
+    }
+    if traced { e.push("SAILFIN_TRACE_LINK=1"); }
+    return e;
+}
+
+fn _write_fixture(dir: string) -> string ![io] {
+    let path = dir + "/main.sfn";
+    fs.writeFile(path, "fn main() ![io] {\n    print(\"ok\");\n}\n");
+    return path;
+}
+
+fn _build_stderr(main_path: string, bin: string, traced: boolean) -> string ![io] {
+    let _exit = process.run_capture([_sfn_bin(), "build", "-o", bin, main_path], _child_env(traced));
+    let _out = process.capture_take_stdout();
+    return process.capture_take_stderr();
+}
+
+test "trace-link: SAILFIN_TRACE_LINK=1 echoes the resolved link argv" ![io] {
+    let dir = _scratch_dir();
+    let main_path = _write_fixture(dir);
+    let err = _build_stderr(main_path, dir + "/traced-bin", true);
+    // The greppable marker plus the `clang` invoker it prefixes.
+    assert contains(err, "[trace-link]");
+    assert contains(err, "clang");
+}
+
+test "trace-link: unset leaves the link path silent" ![io] {
+    let dir = _scratch_dir();
+    let main_path = _write_fixture(dir);
+    let err = _build_stderr(main_path, dir + "/silent-bin", false);
+    assert ! contains(err, "[trace-link]");
+}

--- a/compiler/tests/e2e/sailfin_trace_link_test.sfn
+++ b/compiler/tests/e2e/sailfin_trace_link_test.sfn
@@ -73,3 +73,22 @@ test "trace-link: unset leaves the link path silent" ![io] {
     let err = _build_stderr(main_path, dir + "/silent-bin", false);
     assert ! contains(err, "[trace-link]");
 }
+
+fn _write_test_fixture(dir: string) -> string ![io] {
+    let path = dir + "/probe_test.sfn";
+    fs.writeFile(path, "test \"trace-link probe: trivial\" { assert true; }\n");
+    return path;
+}
+
+// `LlvmTextBackend.link` has a separate `test_mode` argv layout; `sfn test`
+// links each test binary through it, so guard that branch too — the flag
+// must surface the test-layout argv, not only the program/build layout.
+test "trace-link: SAILFIN_TRACE_LINK=1 echoes the test-layout link argv" ![io] {
+    let dir = _scratch_dir();
+    let test_path = _write_test_fixture(dir);
+    let _exit = process.run_capture([_sfn_bin(), "test", test_path], _child_env(true));
+    let _out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    assert contains(err, "[trace-link]");
+    assert contains(err, "clang");
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -112,7 +112,10 @@ here.
   selection, dead-strip, and link-libs; the backend owns only the final argv +
   `process.run`. The seam is the prerequisite for the LLVM C-API backend (#347)
   and the seal-sufficient native backend (#1640) to plug in without
-  re-hardcoding LLVM across the driver.
+  re-hardcoding LLVM across the driver. `SAILFIN_TRACE_LINK=1` echoes the
+  resolved clang link argv to stderr (`[trace-link] <argv>`, #1908) for both
+  the program and test link layouts — a read-only debugging aid with no
+  behavior change when unset.
 - **Build-host OpenSSL dependency** (SFEP-0036, #1782/#1821). The native
   runtime links `-lssl -lcrypto` (TLS; `runtime/sfn/platform/tls.sfn`), so
   **every** Sailfin binary — including the compiler and each per-test binary


### PR DESCRIPTION
## Summary
- Add an env-gated (`SAILFIN_TRACE_LINK`) stderr echo of the resolved clang link argv in `LlvmTextBackend.link` (`compiler/src/backend.sfn`), covering **both** the program-layout and test-layout link paths. It's a read-only echo of what `_llvm_text_link_{program,test}_argv` already return — argv construction is byte-identical, and the unset fast path does no string work (#1112 zero-behaviour gate).
- Refactor `openssl_prefix_honored_test.sfn` to assert the override surfaces `-L<prefix>/lib` **directly in the trace**, retiring the behavioral link success/failure proxy and its `LIBRARY_PATH`-stripping workaround (the #1902 follow-up).
- Add a platform-independent regression test (`sailfin_trace_link_test.sfn`) asserting the trace fires under the flag and is silent without it.

Closes #1908

## Acceptance Criteria
- [x] `SAILFIN_TRACE_LINK=1` prints the resolved clang link argv to stderr in a stable, greppable form (`[trace-link] <argv>`); with the flag unset, output is byte-identical to today.
- [x] Both the program-layout and test-layout link paths emit the trace.
- [x] `openssl_prefix_honored_test.sfn` asserts on the trace directly (`-L<prefix>/lib` present), no longer depends on link success/failure or on stripping `LIBRARY_PATH`; stays Darwin-gated and skips cleanly on non-Darwin.
- [x] A regression test asserts the trace is present under the flag and absent without it.
- [x] `make compile` passes (self-host via `make rebuild` from the pinned seed).
- [x] `make test` passes (unit 196/196, integration 42/42, e2e 188/188, capsules 38/38).
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Map reconciliation
None — the advisory `## Files Affected` map matched the tree. The optional `docs/status.md` note was added under the existing Backend seam bullet (the natural home alongside the seam it documents), not a new Toolchain line.

## Verification
```bash
make rebuild   # self-host from seed — pass
make test      # unit 196/196, integration 42/42, e2e 188/188, capsules 38/38 — pass

# manual
SAILFIN_TRACE_LINK=1 build/native/sailfin build -o /tmp/x examples/basics/hello-world.sfn 2>&1 | grep trace-link
#   [trace-link] clang -O2 -Wno-override-module -fuse-ld=lld ... program.ll -o /tmp/x -lm -lpthread -lssl -lcrypto
build/native/sailfin build -o /tmp/x2 examples/basics/hello-world.sfn 2>&1 | grep -c trace-link
#   0  (silent when unset)
```

## Files Changed
- `compiler/src/backend.sfn` — new `_llvm_text_trace_link` free function; `LlvmTextBackend.link` binds each argv to a local, traces it, then passes the same slice to `process.run`.
- `compiler/tests/e2e/openssl_prefix_honored_test.sfn` — assert on the trace instead of the behavioral proxy; drop the `LIBRARY_PATH` handling.
- `compiler/tests/e2e/sailfin_trace_link_test.sfn` — new on/off regression test.
- `docs/status.md` — one-line note on the knob under the Backend seam bullet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMKjuWRdGXmDLa2FwJ8ymC)_