### PR TITLE
fix(llvm): resolve Self-typed method params/return to enclosing struct

### DIFF
--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -573,6 +573,54 @@ fn extend_native_functions_inplace(dst: NativeFunction[], src: NativeFunction[])
     return out;
 }
 
+// Identifier-character test for `Self`-token substitution: ASCII letters,
+// digits, and `_`. Used to keep the rewrite identifier-boundary aware so a
+// distinct type such as `SelfContained` is never partially rewritten.
+fn _lhm_is_ident_char(ch: string) -> boolean {
+    if ch.length == 0 { return false; }
+    if ch >= "a" && ch <= "z" { return true; }
+    if ch >= "A" && ch <= "Z" { return true; }
+    if ch >= "0" && ch <= "9" { return true; }
+    if ch == "_" { return true; }
+    return false;
+}
+
+// Rewrite every whole-identifier `Self` token in a method type annotation to
+// the enclosing struct's concrete name. This is the compiler's `Self`
+// desugaring inside a concrete struct method: `Self` denotes the enclosing
+// type in every position, exactly as the `self` receiver is already typed to
+// `%Struct*`. The walk is identifier-boundary aware so wrappers and suffixes
+// resolve (`Self[]`, `&Self`, `Self?`, `mut Self`) while a distinct type such
+// as `SelfContained` is left intact. Without this a `Self`-typed non-receiver
+// parameter lowers to an opaque `i8*`, corrupting field access on it (#1898).
+fn _lhm_resolve_self_annotation(annotation: string, struct_name: string) -> string {
+    if annotation == null { return annotation; }
+    if annotation.length == 0 { return annotation; }
+    let mut result: string = "";
+    let mut token: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= annotation.length { break; }
+        let ch = substring(annotation, i, i + 1);
+        if _lhm_is_ident_char(ch) { token = token + ch; } else {
+            if token.length > 0 {
+                if token == "Self" { result = result + struct_name; } else {
+                    result = result + token;
+                }
+                token = "";
+            }
+            result = result + ch;
+        }
+        i += 1;
+    }
+    if token.length > 0 {
+        if token == "Self" { result = result + struct_name; } else {
+            result = result + token;
+        }
+    }
+    return result;
+}
+
 fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
     if structs.length > 100000 { return []; }
     let mut result: NativeFunction[] = [];
@@ -630,6 +678,11 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
                 if p_name == "self" {
                     if p_type.length == 0 { p_type = definition.name; }
                 }
+                // A `Self`-spelled non-receiver parameter (and nested forms
+                // like `Self[]`) denotes the enclosing struct just like the
+                // receiver; resolve it to the concrete type so it lowers to
+                // `%Struct*` instead of an opaque `i8*` (#1898).
+                p_type = _lhm_resolve_self_annotation(p_type, definition.name);
                 let fixed_p = NativeParameter {
                     name: p_name,
                     type_annotation: p_type,
@@ -640,11 +693,15 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
                 fixed_params.push(fixed_p);
                 pi += 1;
             }
+            // Return-position `Self` resolves to the enclosing struct too, so
+            // a method declared `-> Self` carries the concrete return type
+            // through lowering (#1898).
+            let fixed_return = _lhm_resolve_self_annotation(method.return_type, definition.name);
             let qualified = NativeFunction {
                 name: qualified_name,
                 is_async: method.is_async,
                 parameters: fixed_params,
-                return_type: method.return_type,
+                return_type: fixed_return,
                 effects: method.effects,
                 decorators: method.decorators,
                 instructions: method.instructions,

--- a/compiler/tests/e2e/fixtures/mono_generic_sort.sfn
+++ b/compiler/tests/e2e/fixtures/mono_generic_sort.sfn
@@ -10,16 +10,13 @@
 // the final order (ranks 1,2,3 -> 1*100 + 2*10 + 3 = 123), so a mis-ordered or
 // unresolved dispatch produces a different code.
 //
-// `compare` takes `other: Widget` rather than the interface's `other: Self`
-// spelling: a `Self`-typed non-receiver parameter is not yet resolved to the
-// enclosing struct type at lowering (it lowers to an opaque pointer, corrupting
-// field access) — a separate, pre-existing gap outside this issue's dispatch
-// scope. `other: Widget` satisfies `Comparable` conformance identically and
-// keeps this fixture focused on the bound-method resolution under test.
+// `compare` takes `other: Self` — the canonical `Comparable.compare(self,
+// other: Self)` spelling — now that a `Self`-typed non-receiver parameter
+// resolves to the enclosing struct type at lowering (#1898).
 struct Widget implements Comparable {
     rank: int;
 
-    fn compare(self, other: Widget) -> int { return self.rank - other.rank; }
+    fn compare(self, other: Self) -> int { return self.rank - other.rank; }
 }
 
 fn sort < T: Comparable > (items: T[]) -> T[] {

--- a/compiler/tests/e2e/fixtures/self_param_method.sfn
+++ b/compiler/tests/e2e/fixtures/self_param_method.sfn
@@ -1,0 +1,17 @@
+// Fixture for #1898: a `Self`-typed non-receiver parameter on a struct method
+// resolves to the enclosing struct at lowering, exactly like the `self`
+// receiver. `diff` reads `other.rank` — a field access on a `Self`-typed
+// parameter. Before the fix `other` lowered to an opaque `i8*`, so the field
+// load and the subtraction miscompiled (`sub i8* ...`). The exit code encodes
+// the result (5 - 2 = 3), so a miscompile produces a different code.
+struct Widget {
+    rank: int;
+
+    fn diff(self, other: Self) -> int { return self.rank - other.rank; }
+}
+
+fn main() -> int {
+    let a = Widget { rank: 5 };
+    let b = Widget { rank: 2 };
+    return a.diff(b);
+}

--- a/compiler/tests/e2e/fixtures/self_return_method.sfn
+++ b/compiler/tests/e2e/fixtures/self_return_method.sfn
@@ -1,0 +1,20 @@
+// Fixture for #1898 (return position): a method declared `-> Self` resolves to
+// the enclosing struct's concrete type at lowering, the same uniform `Self`
+// desugaring applied to `Self`-typed parameters. `with_x` returns a fresh
+// `Point`; the caller reads `.x` off the result, which only type-checks and
+// GEPs correctly if the return type lowered to `%Point*` rather than `i8*`.
+// The exit code encodes the field (7), so a miscompile produces a different
+// code.
+struct Point {
+    x: int;
+
+    fn with_x(self, nx: int) -> Self {
+        return Point { x: nx };
+    }
+}
+
+fn main() -> int {
+    let p = Point { x: 1 };
+    let q = p.with_x(7);
+    return q.x;
+}

--- a/compiler/tests/e2e/self_param_lowering_test.sfn
+++ b/compiler/tests/e2e/self_param_lowering_test.sfn
@@ -1,0 +1,57 @@
+// End-to-end coverage for #1898: a `Self`-typed non-receiver parameter on a
+// struct method must lower to the enclosing struct's concrete type, mirroring
+// how the `self` receiver is already typed to `%Struct*`. Before the fix a
+// `Self`-typed parameter lowered to an opaque `i8*`, so field access on it went
+// through `sfn_mem_get_field` (yielding `i8*`) instead of a typed GEP, and any
+// arithmetic on that field miscompiled (`sub i8* ...`, rejected by LLVM).
+//
+// Drives the production `sfn build` path as a subprocess over
+// `fixtures/self_param_method.sfn` and asserts the run exit code encodes the
+// correct field arithmetic (5 - 2 = 3). Build/emit isolation follows
+// `.claude/rules/no-bash-e2e.md`: the full parent environment is threaded
+// (PATH for clang/ld, SAILFIN_TEST_SCRATCH for per-invocation build-cache
+// isolation under the parallel pool).
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Build the fixture to a unique path and run it; return the run's exit code,
+// or -100 if the build itself failed.
+fn _build_and_run(fixture: string, tag: string) -> int ![io] {
+    let dir = _scratch_dir();
+    let bin = dir + "/sfn-self-param-" + tag;
+    if fs.exists(bin) { fs.deleteFile(bin); }
+    let build_exit = process.run_capture([_sfn_bin(), "build", "-o", bin, fixture], _child_env());
+    let _bo = process.capture_take_stdout();
+    let _be = process.capture_take_stderr();
+    if build_exit != 0 { return -100; }
+    let run_exit = process.run_capture([bin], _child_env());
+    let _ro = process.capture_take_stdout();
+    let _re = process.capture_take_stderr();
+    fs.deleteFile(bin);
+    return run_exit;
+}
+
+test "self-param lowering: `other: Self` field access builds and computes correctly" ![io] {
+    let exit = _build_and_run("compiler/tests/e2e/fixtures/self_param_method.sfn", "diff");
+    // 5 - 2 = 3: proves `other.rank` loaded a typed `i64` field, not an `i8*`.
+    assert exit == 3;
+}
+
+test "self-param lowering: return-position `-> Self` resolves to the concrete type" ![io] {
+    let exit = _build_and_run("compiler/tests/e2e/fixtures/self_return_method.sfn", "ret");
+    // `with_x` returns a `Point`; reading `.x` off the result yields 7 only if
+    // the `-> Self` return lowered to `%Point*`, not an opaque `i8*`.
+    assert exit == 7;
+}


### PR DESCRIPTION
## Summary
- A `Self`-typed **non-receiver parameter** (e.g. `fn diff(self, other: Self)`) lowered to an opaque `i8*` because only the `self` receiver was resolved to `%Struct*`. Field access on the `Self` param went through `sfn_mem_get_field` (returning `i8*`) instead of a typed GEP, so arithmetic/comparison on that field miscompiled (`sub i8* ...`, rejected by LLVM).
- Fix: in `flatten_struct_methods` — the single point where the `self` receiver is already concretized — resolve every whole-identifier `Self` token in each method's **parameter** and **return** type annotations to the enclosing struct's concrete name. The rewrite is identifier-boundary aware, so nested forms (`Self[]`, `&Self`, `Self?`, `mut Self`) resolve while a distinct type like `SelfContained` stays intact. This is the compiler's uniform `Self` desugaring inside a concrete struct method, matching Rust semantics.
- Lets `Comparable`/`Eq`/`Hashable` impls use the canonical `other: Self` spelling; the `mono_generic_sort` fixture drops its `other: Widget` workaround.

Closes #1898

## Acceptance Criteria
- [x] The repro (`Widget.diff(self, other: Self)`) builds and runs, returning **3**.
- [x] `fn compare(self, other: Self) -> int` on a `Comparable` impl builds; the bounded `sort` fixture now uses the idiomatic `other: Self` and runs correctly (exit 123, ascending order) — `mono_generic_sort.sfn` workaround removed.
- [x] `make compile` self-hosts; full e2e suite passes **188/188** under check's flags (`--jobs 4 --no-test-cache`), including `work_dir_parity` and the new tests. (`make check` re-running for the aggregate gate; the fix provably doesn't alter compiler-source lowering.)

## Design notes
`Self` is not lexed/parsed/typechecked specially anywhere — the parameter already parses and typechecks; the bug was solely that LLVM type mapping resolves an unknown type name (`Self`) to `i8*`. The `self` receiver worked only because its empty type is force-filled with the struct name before type mapping. Extending that same substitution to sibling `Self` tokens (param + return, nested-aware) is the minimal, uniform fix. Interface *declarations* (dynamic-dispatch `Self`) are a separate path (out of scope, #1872) and unaffected — interfaces are not `NativeStruct` and never reach this rewrite.

Reviewer note (non-blocking): the dormant `lowering_recovery.sfn` light-recovery textual path (old-seed only) does not apply this desugaring; if it is ever revived as primary, the same rewrite must be ported there.

## Map reconciliation
Advisory `## Files Affected` pointed at `compiler/src/llvm/` method-lowering + `compiler/tests/e2e/fixtures/`. Reconciled to the concrete site: the receiver-typing already lives in `compiler/src/llvm/lowering/lowering_helpers_mangling.sfn::flatten_struct_methods`, so the sibling-`Self` fix landed there (same semantic In: unit). Added a dedicated run test + two fixtures rather than only editing the existing fixture.

## Verification
```bash
build/native/sailfin build -o /tmp/d repro.sfn && /tmp/d     # exit 3
build/native/sailfin build -o /tmp/r return_self.sfn && /tmp/r # exit 7 (-> Self)
build/native/sailfin test compiler/tests/e2e/self_param_lowering_test.sfn   # 2/2 PASS
build/native/sailfin test compiler/tests/e2e/generic_sort_run_test.sfn      # 2/2 PASS (other: Self)
build/native/sailfin test compiler/tests/e2e --jobs 4 --no-test-cache       # e2e 188/188
make compile                                                                # self-hosts (exit 0)
```
unit 196/196, integration 42/42, capsules 38/38 all green.

## Files Changed
- `compiler/src/llvm/lowering/lowering_helpers_mangling.sfn` — `_lhm_is_ident_char`, `_lhm_resolve_self_annotation`; applied to params + return in `flatten_struct_methods`.
- `compiler/tests/e2e/self_param_lowering_test.sfn` — new e2e run test (param `other: Self` → 3; return `-> Self` → 7).
- `compiler/tests/e2e/fixtures/self_param_method.sfn`, `self_return_method.sfn` — new fixtures.
- `compiler/tests/e2e/fixtures/mono_generic_sort.sfn` — `other: Widget` → canonical `other: Self`, comment updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_018cb1u4faiSdR46wGnwSq3c)_