### PR TITLE
fix(fmt): keep bounded generic declaration headers tight

### DIFF
--- a/compiler/src/tools/fmt.sfn
+++ b/compiler/src/tools/fmt.sfn
@@ -546,7 +546,11 @@ fn _valid_post_generic(fmt_tokens: FmtToken[], close_idx: int) -> boolean {
 // Scan a balanced generic starting at `start` (a `<`). Returns the index
 // of the matching outermost close (`>` or `>>`) on success, or -1 if the
 // span is not a generic (a comparison/shift expression instead).
-fn _scan_generic(fmt_tokens: FmtToken[], start: int) -> int {
+// `allow_bounds` is true for a declaration-site clause (`fn f<T: Bound>`,
+// `struct Box<T: Bound>`), where a `:` is a type-parameter bound and `+`
+// joins multiple bounds — neither disproves the generic. It is false for a
+// use-site type argument list, where those tokens signal a comparison (#1903).
+fn _scan_generic(fmt_tokens: FmtToken[], start: int, allow_bounds: boolean) -> int {
     let mut depth = 0;
     let mut j = start;
     let len = fmt_tokens.length;
@@ -591,12 +595,20 @@ fn _scan_generic(fmt_tokens: FmtToken[], start: int) -> int {
         if strings_equal(role, "block_close") { return -1; }
         if strings_equal(role, "assign") { return -1; }
         if strings_equal(role, "arrow") { return -1; }
-        if strings_equal(role, "colon") { return -1; }
+        // A `:` is a type-parameter bound in a declaration-site clause
+        // (`T: Bound`); anywhere else it proves the `<` was a comparison.
+        if strings_equal(role, "colon") {
+            if !allow_bounds { return -1; }
+        }
         if strings_equal(role, "decorator") { return -1; }
         if strings_equal(role, "bang_bracket") { return -1; }
         // Any operator other than the angle delimiters handled above
-        // (e.g. `>=`, `+`, `&&`, `==`) → comparison/arithmetic, not a type.
-        if strings_equal(role, "operator") { return -1; }
+        // (e.g. `>=`, `&&`, `==`) → comparison/arithmetic, not a type. The
+        // one exception is `+` joining multiple bounds (`T: A + B`) in a
+        // declaration-site clause.
+        if strings_equal(role, "operator") {
+            if !(allow_bounds && strings_equal(lex, "+")) { return -1; }
+        }
         if strings_equal(lex, "<<") { return -1; }
 
         j += 1;
@@ -651,13 +663,31 @@ fn _is_generic_open_candidate(fmt_tokens: FmtToken[], i: int) -> boolean {
     return false;
 }
 
+// Is the candidate generic open at index `i` a *declaration-site* clause
+// (`fn f<…>`, `struct Box<…>`, `enum`/`interface`/`impl`/`type`)? Such a
+// clause may carry type-parameter bounds (`T: Bound`, `T: A + B`) that a
+// use-site type argument list never contains. Distinguished by the token two
+// before the `<`: a declaration keyword, not the `:`/`->` of a type position.
+fn _is_decl_site_generic_open(fmt_tokens: FmtToken[], i: int) -> boolean {
+    if i < 2 { return false; }
+    let kw = fmt_tokens[i - 2].token.lexeme;
+    if strings_equal(kw, "struct") { return true; }
+    if strings_equal(kw, "enum") { return true; }
+    if strings_equal(kw, "interface") { return true; }
+    if strings_equal(kw, "impl") { return true; }
+    if strings_equal(kw, "fn") { return true; }
+    if strings_equal(kw, "type") { return true; }
+    return false;
+}
+
 fn _reclassify_generics(fmt_tokens: FmtToken[]) -> FmtToken[] {
     let mut toks = fmt_tokens;
     let mut i = 0;
     loop {
         if i >= toks.length { break; }
         if _is_generic_open_candidate(toks, i) {
-            let match_end = _scan_generic(toks, i);
+            let allow_bounds = _is_decl_site_generic_open(toks, i);
+            let match_end = _scan_generic(toks, i, allow_bounds);
             if match_end > i {
                 toks = _apply_generic_roles(toks, i, match_end);
                 i = match_end + 1;

--- a/compiler/tests/e2e/fixtures/mono_generic_sort.sfn
+++ b/compiler/tests/e2e/fixtures/mono_generic_sort.sfn
@@ -22,7 +22,7 @@ struct Widget implements Comparable {
     fn compare(self, other: Widget) -> int { return self.rank - other.rank; }
 }
 
-fn sort < T: Comparable > (items: T[]) -> T[] {
+fn sort<T: Comparable>(items: T[]) -> T[] {
     let mut out: T[] = items;
     let n = out.length;
     let mut i = 0;

--- a/compiler/tests/unit/fmt_generic_annotations_test.sfn
+++ b/compiler/tests/unit/fmt_generic_annotations_test.sfn
@@ -98,3 +98,52 @@ test "fmt generic: right-shift expression is unaffected" ![io] {
     let out = format_source(src);
     assert _contains(out, "a >> 1");
 }
+
+// ── Bounded declaration-site clauses stay tight (#1903) ──────────────
+// A type-parameter bound (`T: Bound`) made `_scan_generic` bail on the
+// interior `:` and re-emit the `<`/`>` with binary-operator spacing
+// (`fn sort < T: Comparable > (...)`). A declaration-site clause now
+// permits a bound and formats as tightly as its unbounded sibling.
+test "fmt generic: single-bound fn header stays tight" ![io] {
+    let src = "fn sort<T: Comparable>(items: T[]) -> T[] {\n    return items;\n}\n";
+    let out = format_source(src);
+    assert _contains(out, "fn sort<T: Comparable>(items: T[]) -> T[]");
+    assert _contains(out, "sort < T") == false;
+    assert _contains(out, "Comparable >") == false;
+}
+
+test "fmt generic: multi-bound fn header keeps `+` spacing, brackets tight" ![io] {
+    let src = "fn multi<T: A + B>(x: T) -> T {\n    return x;\n}\n";
+    let out = format_source(src);
+    assert _contains(out, "fn multi<T: A + B>(x: T) -> T");
+    assert _contains(out, "multi < T") == false;
+    assert _contains(out, "B >") == false;
+}
+
+test "fmt generic: generic-bound multi-param fn header stays tight" ![io] {
+    let src = "fn gbound<E, T: From<E>>(x: T) -> T {\n    return x;\n}\n";
+    let out = format_source(src);
+    assert _contains(out, "fn gbound<E, T: From<E>>(x: T) -> T");
+    assert _contains(out, "gbound < E") == false;
+}
+
+test "fmt generic: bounded struct type-parameter clause stays tight" ![io] {
+    let src = "struct Box<T: Comparable> {\n    value: T\n}\n";
+    let out = format_source(src);
+    assert _contains(out, "struct Box<T: Comparable>");
+    assert _contains(out, "Box < T") == false;
+}
+
+test "fmt generic: unbounded fn header is unchanged by bound handling" ![io] {
+    let src = "fn id<T>(x: T) -> T {\n    return x;\n}\n";
+    let out = format_source(src);
+    assert _contains(out, "fn id<T>(x: T) -> T");
+    assert _contains(out, "id < T") == false;
+}
+
+test "fmt generic: bounded fn header is idempotent" ![io] {
+    let src = "fn sort<T: Comparable>(items: T[]) -> T[] {\n    return items;\n}\n";
+    let once = format_source(src);
+    let twice = format_source(once);
+    assert once == twice;
+}


### PR DESCRIPTION
## Summary
- `sfn fmt` no longer mis-spaces a **bounded** generic declaration header: `fn sort<T: Comparable>(...)` now formats tight instead of `fn sort < T: Comparable > (...)`.
- Root cause: `_scan_generic` (`compiler/src/tools/fmt.sfn`) treated any `:` inside a `<...>` span as proof the brackets were a comparison and bailed, leaving the `<`/`>` classified as binary operators. Unbounded headers (`fn id<T>`) were unaffected because they never hit the interior colon.
- Fix: a new `_is_decl_site_generic_open` predicate sets an `allow_bounds` flag that lets `_scan_generic` accept a top-level bound `:` and the `+` multi-bound separator **only** in declaration-site clauses (`fn`/`struct`/`enum`/`interface`/`impl`/`type` name `<...>`), where `name <` can never be a comparison. Use-site type argument lists (`Box<int>`, after `:`/`->`) are byte-for-byte unchanged, and the generic-close/`=` fusion guard is untouched.

Closes #1903

## Acceptance Criteria
- [x] `fn f<T>(x: T)` formats to `fn f<T>(x: T)` (no spaces around `<`/`>`), idempotent under `fmt --check`.
- [x] Multi-bound (`T: A + B`), multi-param (`T, U`), and generic-bound (`T: From<E>`) headers format tightly.
- [x] Unbounded headers (`fn id<T>`, `fn map_one<T, U>`) unchanged.
- [x] `make compile` self-hosts; `make check` passes.

## Map reconciliation
The advisory `## Files Affected` pointed at "`compiler/src/` formatter"; the fix landed precisely there (`compiler/src/tools/fmt.sfn`). Additionally reformatted the in-tree fixture `compiler/tests/e2e/fixtures/mono_generic_sort.sfn:25`, which had the buggy `fn sort < T: Comparable > (...)` spacing checked in as the old formatter's canonical output (the exact case Copilot flagged on PR #1901). No semantic scope change.

## Verification
```bash
# Before (seed binary): fn sort<T: Comparable>(...) -> fn sort < T: Comparable > (...)
# After (rebuilt binary):
build/native/sailfin fmt /tmp/repro.sfn
#   fn sort<T: Comparable>(items: T[]) -> T[] { return items; }
#   fn id<T>(x: T) -> T { return x; }                     # unbounded, unchanged
#   fn map_one<T, U>(f: fn (T) -> U, x: T) -> U { ... }   # unbounded, unchanged
#   fn multi<T: A + B>(x: T) -> T { return x; }           # multi-bound
#   fn gbound<E, T: From<E>>(x: T) -> T { return x; }     # generic-bound
#   struct Box<T: Comparable> { value: T; }               # struct

build/native/sailfin fmt --check <touched files>          # clean (idempotent)
build/native/sailfin test compiler/tests/unit/fmt_generic_annotations_test.sfn
#   PASS (all 16 tests passed)  — 10 existing + 6 new

make compile   # self-hosts (pass)
make check     # full triple-pass self-host + suite (pass)
```

## Files Changed
- `compiler/src/tools/fmt.sfn` — `allow_bounds` parameter on `_scan_generic`; new `_is_decl_site_generic_open` predicate; caller wiring in `_reclassify_generics`.
- `compiler/tests/unit/fmt_generic_annotations_test.sfn` — 6 regression tests (single-bound, multi-bound `+`, generic-bound `From<E>`, bounded struct, unbounded-unchanged control, idempotency).
- `compiler/tests/e2e/fixtures/mono_generic_sort.sfn` — reformat the bounded header to the corrected tight form.

---
_Generated by [Claude Code](https://claude.ai/code/session_014X7Q3vTFSmHTero6vMjUxj)_