### PR TITLE
fix(build): parse the registry index natively in `sfn add` (drop python3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,10 +114,12 @@ not subject to `sfn fmt` or the self-host gate.
 
 - Use clear, atomic commits. Conventional prefixes (`feat(compiler):`, `fix(bootstrap):`)
   are encouraged.
-- Note: automated GitHub releases are driven by `python-semantic-release`, which relies on
-  Conventional Commit-style prefixes to decide whether to cut a new version. If you expect
-  a new prerelease (e.g., on the `alpha` branch), use a release-worthy prefix like `fix:`
-  or `feat:` in the commit subject.
+- Note: releases are **not** cut automatically from commit prefixes. They are triggered
+  manually via `gh workflow run release.yml -f channel=<alpha|beta|stable> -f bump=<prerelease|minor|…>`
+  (`workflow_dispatch`), and the release workflow is pure bash — there is no
+  `python-semantic-release` or any Python in the toolchain. The version source of truth is
+  `[capsule] version` in `compiler/capsule.toml`. Conventional Commit prefixes still aid
+  changelog readability, but they do not gate whether a version is cut.
 - Document how you validated the change (commands, tests, screenshots).
 - When behaviour shifts, include reproduction steps and link to the relevant
   roadmap/status entries.

--- a/compiler/src/cli/commands/add.sfn
+++ b/compiler/src/cli/commands/add.sfn
@@ -45,12 +45,7 @@ import {
     with_flag
 } from "sfn/cli";
 
-import {
-    _dirname_cmd,
-    _ensure_dir_recursive_cmd,
-    _sha256_of_file_cmd,
-    _shell_read_cmd
-} from "../../build/fs";
+import { _dirname_cmd, _ensure_dir_recursive_cmd, _sha256_of_file_cmd } from "../../build/fs";
 import { _get_home_cmd } from "../../build_flags";
 import { _display_capsule_name_cmd, _resolve_capsule_name_cmd } from "../../capsule_names";
 import { lock_add_entry, lock_get_version } from "../../lock";
@@ -103,6 +98,137 @@ fn _curl_post_json_cmd(url: string, body_path: string, auth_header: string) -> s
 
 fn _curl_download_cmd(url: string, output_path: string) -> int ![io] {
     return process.run(["curl", "-sfSL", "-o", output_path, url]);
+}
+
+// GET `url` and return the response body as a string ("" on any curl
+// error). Mirrors `_curl_post_json_cmd`'s file-based capture minus the
+// POST flags: the URL is passed as an argv element, never interpolated
+// into a shell string, so there is no shell-injection surface to defend.
+fn _curl_get_cmd(url: string) -> string ![io] {
+    let tmp = "/tmp/.sfn_curl_index_cmd_tmp";
+    let rc = process.run(["curl", "-sfS", "-o", tmp, url]);
+    if rc != 0 { return ""; }
+    if !fs.exists(tmp) { return ""; }
+    let response = fs.readFile(tmp);
+    process.run(["rm", "-f", tmp]);
+    return response;
+}
+
+// First index of `needle` in `haystack` at or after `start`, or -1.
+fn _find_substr_cmd(haystack: string, needle: string, start: int) -> int {
+    if needle.length == 0 { return start; }
+    if haystack.length < needle.length { return -1; }
+    let limit = haystack.length - needle.length;
+    let mut i: int = start;
+    loop {
+        if i > limit { break; }
+        if substring(haystack, i, i + needle.length) == needle { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
+// Return the index just past the `}` matching the `{` at `open`, or -1 if
+// unbalanced. String contents (and escaped quotes) are skipped so braces
+// inside string values never affect nesting depth.
+fn _json_match_brace_cmd(body: string, open: int) -> int {
+    let mut depth: int = 0;
+    let mut i: int = open;
+    let mut in_string: boolean = false;
+    loop {
+        if i >= body.length { return -1; }
+        let ch = substring(body, i, i + 1);
+        if in_string {
+            if ch == "\\" {
+                i += 2;
+                continue;
+            }
+            if ch == "\"" { in_string = false; }
+            i += 1;
+            continue;
+        }
+        if ch == "\"" {
+            in_string = true;
+            i += 1;
+            continue;
+        }
+        if ch == "{" {
+            depth += 1;
+            i += 1;
+            continue;
+        }
+        if ch == "}" {
+            depth -= 1;
+            if depth == 0 { return i + 1; }
+            i += 1;
+            continue;
+        }
+        i += 1;
+    }
+}
+
+// Extract `capsules.<registry_name>.latest` from a registry index response
+// (`GET /api/index.json`, shape `{"capsules":{"<scope/name>":{"latest":
+// "..."}}}`). Hand-rolled rather than importing `sfn/json`: the target is
+// a single fixed field, and pulling the general parser into compiler
+// source carries a self-host workspace-resolver hang risk (#842) with no
+// `compiler/src/` precedent — this follows the `_package_extract_top_level`
+// house pattern (package.sfn). Returns "" when the capsule is absent or
+// carries no `latest`, matching the prior `python3` one-liner's
+// `.get(...,'')` semantics. Whitespace-tolerant (compact or pretty JSON).
+//
+// This is a *textual* anchor, not a full JSON key walk: equivalence with
+// `.get('capsules',{}).get(name,{}).get('latest','')` holds because the
+// index schema is flat and the only slash-bearing strings are capsule-name
+// keys (`registry_name` is slash-validated upstream; version values,
+// `"latest"`, and `"capsules"` contain no slash — so `"<name>"` can only
+// anchor on the real key). It would diverge only if the schema grew a
+// per-capsule string value containing a `/` before the key, or a nested
+// object carrying its own `"latest"` before the top-level one — neither
+// exists on today's index.
+fn _extract_index_latest_cmd(body: string, registry_name: string) -> string {
+    if body.length == 0 { return ""; }
+    if registry_name.length == 0 { return ""; }
+    // Descend into the `capsules` object first (mirrors the prior
+    // `.get('capsules',{})`), so a value elsewhere in the document that
+    // happens to equal the capsule name cannot be mistaken for its entry.
+    let caps_idx = _find_substr_cmd(body, "\"capsules\"", 0);
+    if caps_idx < 0 { return ""; }
+    // Anchor on the capsule's own entry key so a `latest` belonging to a
+    // sibling capsule can never be returned. The trailing quote in the key
+    // prevents a prefix collision (`acme/router` vs `acme/router-extras`).
+    let entry_key = "\"" + registry_name + "\"";
+    let entry_idx = _find_substr_cmd(body, entry_key, caps_idx);
+    if entry_idx < 0 { return ""; }
+    // Bound the search to this capsule's object value: opening brace to the
+    // matching close brace.
+    let brace_start = find_char_local(body, "{", entry_idx + entry_key.length);
+    if brace_start < 0 { return ""; }
+    let obj_end = _json_match_brace_cmd(body, brace_start);
+    if obj_end < 0 { return ""; }
+    let key_idx = _find_substr_cmd(body, "\"latest\"", brace_start);
+    if key_idx < 0 { return ""; }
+    if key_idx >= obj_end { return ""; }
+    // Skip past the colon (and any whitespace) to the value's opening quote.
+    let colon = find_char_local(body, ":", key_idx + 8);
+    if colon < 0 { return ""; }
+    if colon >= obj_end { return ""; }
+    let vq_start = find_char_local(body, "\"", colon + 1);
+    if vq_start < 0 { return ""; }
+    if vq_start >= obj_end { return ""; }
+    let value_start = vq_start + 1;
+    let mut end: int = value_start;
+    loop {
+        if end >= obj_end { return ""; }
+        let ch = substring(body, end, end + 1);
+        if ch == "\\" {
+            end += 2;
+            continue;
+        }
+        if ch == "\"" { break; }
+        end += 1;
+    }
+    return substring(body, value_start, end);
 }
 
 fn _extract_sfnpkg_cmd(content: string, dest_dir: string) -> void ![io] {
@@ -169,10 +295,11 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     // `scope/name` format.
     let display_name = _display_capsule_name_cmd(registry_name);
 
-    // Validate scope/name up front — registry_name is interpolated into a
-    // shell pipeline below when fetching the index, and into the cache path
-    // and download URL after. Rejecting path-traversal and directory-separator
-    // characters early covers both the shell-injection and traversal risks.
+    // Validate scope/name up front — registry_name is interpolated into the
+    // cache path and download URL below. Rejecting path-traversal and
+    // directory-separator characters early covers the traversal risk. (The
+    // index fetch passes it as JSON data to `_extract_index_latest_cmd`, not
+    // through a shell, so there is no injection surface on that path.)
     let slash_pos = find_char_local(registry_name, "/", 0);
     if slash_pos < 0 {
         print("invalid capsule id — expected scope/name format: "
@@ -213,11 +340,8 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     } else {
         print("fetching registry index...");
         let registry_base = _resolve_registry_url_cmd();
-        resolved_version = _shell_read_cmd("curl -sfS '" + registry_base
-            + "/api/index.json'"
-            + " | python3 -c \"import json,sys; d=json.load(sys.stdin); c=d.get('capsules',{}).get('"
-            + registry_name
-            + "',{}); print(c.get('latest',''))\" 2>/dev/null");
+        let index_body = _curl_get_cmd(registry_base + "/api/index.json");
+        resolved_version = _extract_index_latest_cmd(index_body, registry_name);
         if resolved_version.length == 0 {
             print("capsule not found in registry: " + registry_name);
             return 1;

--- a/compiler/src/cli/commands/add.sfn
+++ b/compiler/src/cli/commands/add.sfn
@@ -100,17 +100,24 @@ fn _curl_download_cmd(url: string, output_path: string) -> int ![io] {
     return process.run(["curl", "-sfSL", "-o", output_path, url]);
 }
 
-// GET `url` and return the response body as a string ("" on any curl
-// error). Mirrors `_curl_post_json_cmd`'s file-based capture minus the
-// POST flags: the URL is passed as an argv element, never interpolated
-// into a shell string, so there is no shell-injection surface to defend.
+// GET `url` and return the response body as a string ("" on any curl or
+// filesystem error). Like `_curl_post_json_cmd` this stages the response in
+// a file rather than capturing stdout, but passes the URL as an argv element
+// (never interpolated into a shell string, so no shell-injection surface).
+// The staging file lives in a per-invocation `mkdtemp` directory: an
+// unpredictable path defeats symlink clobbering, and two concurrent
+// `sfn add` runs cannot collide on a shared temp file.
 fn _curl_get_cmd(url: string) -> string ![io] {
-    let tmp = "/tmp/.sfn_curl_index_cmd_tmp";
+    let dir = fs.mkdtemp(".sfn_index_");
+    if dir.length == 0 { return ""; }
+    let tmp = dir + "/index";
     let rc = process.run(["curl", "-sfS", "-o", tmp, url]);
-    if rc != 0 { return ""; }
-    if !fs.exists(tmp) { return ""; }
-    let response = fs.readFile(tmp);
-    process.run(["rm", "-f", tmp]);
+    let mut response: string = "";
+    if rc == 0 {
+        if fs.exists(tmp) { response = fs.readFile(tmp); }
+    }
+    if fs.exists(tmp) { fs.deleteFile(tmp); }
+    fs.removeDirectory(dir);
     return response;
 }
 
@@ -171,7 +178,9 @@ fn _json_match_brace_cmd(body: string, open: int) -> int {
 // (`GET /api/index.json`, shape `{"capsules":{"<scope/name>":{"latest":
 // "..."}}}`). Hand-rolled rather than importing `sfn/json`: the target is
 // a single fixed field, and pulling the general parser into compiler
-// source carries a self-host workspace-resolver hang risk (#842) with no
+// source carries a workspace-resolver hang risk when imported transitively
+// into the compiler (documented in `capsule_ir_layout_test.sfn` /
+// `capsule_artifact_sidecar_test.sfn`, test-infra epic #842) with no
 // `compiler/src/` precedent — this follows the `_package_extract_top_level`
 // house pattern (package.sfn). Returns "" when the capsule is absent or
 // carries no `latest`, matching the prior `python3` one-liner's

--- a/compiler/tests/e2e/add_registry_index_test.sfn
+++ b/compiler/tests/e2e/add_registry_index_test.sfn
@@ -1,0 +1,237 @@
+// E2E tests for `sfn add` registry-index version resolution (#1894).
+//
+// `sfn add <capsule>` (without `--update` and with no lockfile entry)
+// resolves the dependency's latest version from the registry index
+// (`GET <registry>/api/index.json`). That resolution used to shell out to
+// `python3 -c "...json..."`; it is now parsed natively in
+// `compiler/src/cli/commands/add.sfn` (`_extract_index_latest_cmd`), so no
+// `python3` is spawned. These tests drive the native path via a
+// PATH-injected fake `curl` shim (NOT a real server): the shim writes a
+// canned `index.json` body for the index GET and exits non-zero for the
+// subsequent `.sfnpkg` download, so the test observes the resolved version
+// (`downloading <name>@<version>...`, printed before the download) without
+// needing a real package payload.
+//
+// `sfn add` reads/writes `capsule.toml` in the CWD and has no path arg, so
+// each case runs inside its own temp dir via a `cd <dir> && exec <sfn>`
+// bash vehicle (run_capture cannot chdir) with an ABSOLUTE compiler path.
+//
+// NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]` and so
+// cannot be called from an `![io]` test; assert on captured stdout/stderr
+// with `sfn/strings::contains` instead. (#842.)
+import { contains, split } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Absolute path of the runner's working directory (repo root).
+fn _pwd() -> string ![io] {
+    let exit = process.run_capture(["pwd"], _child_env());
+    let out = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    return _first_line(out);
+}
+
+// Absolute compiler path: the tests `cd` into a temp dir before running,
+// so a repo-relative `build/native/sailfin` would not resolve.
+fn _sfn_bin_abs() -> string ![io] {
+    let bin = _sfn_bin();
+    if bin.length > 0 && bin[0] == "/" { return bin; }
+    let root = _pwd();
+    if root.length == 0 { return bin; }
+    return root + "/" + bin;
+}
+
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// Absolute scratch root. `SAILFIN_TEST_SCRATCH` is often the relative
+// `build/sailfin`; the tests `cd` into a temp dir via a bash vehicle, so a
+// relative shim-dir PATH entry would break after the `cd` (the shim would
+// silently fall through to the real `curl`). Anchor it to the repo root.
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    if dir[0] != "/" {
+        let root = _pwd();
+        if root.length > 0 { dir = root + "/" + dir; }
+    }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+fn _test_root(tag: string) -> string ![io] {
+    let root = _scratch_dir() + "/add-idx-" + tag;
+    fs.createDirectory(root, true);
+    return root;
+}
+
+fn _first_line(text: string) -> string {
+    let lines = split(text, "\n");
+    if lines.length == 0 { return text; }
+    return lines[0];
+}
+
+// Minimal consumer capsule so `add` gets past its `capsule.toml` guard.
+fn _make_consumer(dir: string) -> void ![io] {
+    fs.createDirectory(dir, true);
+    fs.writeFile(dir + "/capsule.toml", "[capsule]\nname = \"test/consumer\"\nversion = \"0.1.0\"\n\n[dependencies]\n");
+}
+
+fn _chmod_x(path: string) -> void ![io] {
+    let _ = process.run_capture(["chmod", "+x", path], _child_env());
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+}
+
+// Fake `curl`: for a URL containing `index.json`, write `body` to the `-o`
+// target and exit 0; for anything else (the `.sfnpkg` download) exit 1.
+// `body` is embedded single-quoted, so it must contain no single quotes
+// (JSON here never does).
+fn _make_index_shim(dir: string, body: string) -> void ![io] {
+    fs.createDirectory(dir, true);
+    let shim = "#!/usr/bin/env bash\n" + "out_file=\"\"\n" + "url=\"\"\n"
+        + "prev=\"\"\n"
+        + "for arg in \"$@\"; do\n"
+        + "    if [ \"$prev\" = \"-o\" ]; then out_file=\"$arg\"; fi\n"
+        + "    url=\"$arg\"\n"
+        + "    prev=\"$arg\"\n"
+        + "done\n"
+        + "case \"$url\" in\n"
+        + "    *index.json*)\n"
+        + "        if [ -n \"$out_file\" ]; then\n"
+        + "            printf '%s' '"
+        + body
+        + "' > \"$out_file\"\n"
+        + "        fi\n"
+        + "        exit 0\n"
+        + "        ;;\n"
+        + "    *)\n"
+        + "        exit 1\n"
+        + "        ;;\n"
+        + "esac\n";
+    fs.writeFile(dir + "/curl", shim);
+    _chmod_x(dir + "/curl");
+}
+
+// Child env with a shim-prefixed PATH, forced HOME, and a deterministic
+// registry so the index URL host is fixed. `extra` appends KEY=value pairs.
+fn _env_for(home: string, shim_dir: string, extra: string[]) -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    e.push("PATH=" + shim_dir + ":" + path);
+    e.push("HOME=" + home);
+    e.push("SFN_REGISTRY=https://registry.test");
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    let mut i = 0;
+    loop {
+        if i >= extra.length { break; }
+        e.push(extra[i]);
+        i += 1;
+    }
+    return e;
+}
+
+// Run `sfn add <capsule>` in `workdir` (cd vehicle) with `home`/`shim_dir`.
+fn _run_add(workdir: string, home: string, shim_dir: string, capsule: string) -> string ![io] {
+    let sfn_abs = _sfn_bin_abs();
+    let e = _env_for(home, shim_dir, []);
+    let cmd = "cd \"" + workdir + "\" && exec \"" + sfn_abs + "\" add "
+        + capsule;
+    let _exit = process.run_capture(["bash", "-c", cmd], e);
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return out + err;
+}
+
+// ---- Test 1: latest resolved natively from a compact index ----
+test "add: resolves latest from compact registry index" ![io] {
+    let root = _test_root("t1");
+    let home = root + "/home";
+    let workdir = root + "/work";
+    let shim_dir = root + "/shim";
+    _make_consumer(workdir);
+    _make_index_shim(shim_dir, "{\"capsules\":{\"acme/router\":{\"latest\":\"1.2.3\"}}}");
+    let all = _run_add(workdir, home, shim_dir, "acme/router");
+    // The version printed in the download line proves native resolution
+    // to 1.2.3 (no python3 involved).
+    assert contains(all, "downloading acme/router@1.2.3");
+    assert ! contains(all, "capsule not found in registry");
+}
+
+// ---- Test 2: whitespace-tolerant parse (pretty-printed index) ----
+test "add: resolves latest from pretty-printed index" ![io] {
+    let root = _test_root("t2");
+    let home = root + "/home";
+    let workdir = root + "/work";
+    let shim_dir = root + "/shim";
+    _make_consumer(workdir);
+    // Spaces after colons and around braces exercise the whitespace
+    // tolerance of the hand-rolled extractor.
+    _make_index_shim(shim_dir, "{ \"capsules\": { \"acme/router\": { \"latest\": \"4.5.6\" } } }");
+    let all = _run_add(workdir, home, shim_dir, "acme/router");
+    assert contains(all, "downloading acme/router@4.5.6");
+}
+
+// ---- Test 3: capsule absent from the index -> not found ----
+test "add: reports not found when capsule absent from index" ![io] {
+    let root = _test_root("t3");
+    let home = root + "/home";
+    let workdir = root + "/work";
+    let shim_dir = root + "/shim";
+    _make_consumer(workdir);
+    // The requested capsule has no entry at all (only an unrelated one),
+    // so resolution fails at the entry-key lookup.
+    _make_index_shim(shim_dir, "{\"capsules\":{\"other/pkg\":{\"latest\":\"9.9.9\"}}}");
+    let all = _run_add(workdir, home, shim_dir, "acme/router");
+    assert contains(all, "capsule not found in registry: acme/router");
+    assert ! contains(all, "downloading");
+}
+
+// ---- Test 4: capsule present but carries no `latest`; sibling has one ----
+// Exercises the object-bound guard: the requested capsule's object has no
+// `latest`, and a *sibling* that does must NOT bleed through.
+test "add: does not borrow a sibling's latest" ![io] {
+    let root = _test_root("t4");
+    let home = root + "/home";
+    let workdir = root + "/work";
+    let shim_dir = root + "/shim";
+    _make_consumer(workdir);
+    _make_index_shim(shim_dir, "{\"capsules\":{\"acme/router\":{\"version\":\"1.0.0\"},\"other/pkg\":{\"latest\":\"9.9.9\"}}}");
+    let all = _run_add(workdir, home, shim_dir, "acme/router");
+    assert contains(all, "capsule not found in registry: acme/router");
+    assert ! contains(all, "9.9.9");
+    assert ! contains(all, "downloading");
+}
+
+// ---- Test 5: prefix-collision — `acme/router` vs `acme/router-extras` ----
+// The longer-named sibling is listed FIRST; the trailing-quote anchor must
+// resolve the exact requested key, not the prefix match.
+test "add: resolves the exact key, not a prefix sibling" ![io] {
+    let root = _test_root("t5");
+    let home = root + "/home";
+    let workdir = root + "/work";
+    let shim_dir = root + "/shim";
+    _make_consumer(workdir);
+    _make_index_shim(shim_dir, "{\"capsules\":{\"acme/router-extras\":{\"latest\":\"7.7.7\"},\"acme/router\":{\"latest\":\"1.2.3\"}}}");
+    let all = _run_add(workdir, home, shim_dir, "acme/router");
+    assert contains(all, "downloading acme/router@1.2.3");
+    assert ! contains(all, "7.7.7");
+}


### PR DESCRIPTION
## Summary
- `sfn add` resolved a dependency's latest version by piping the `api/index.json` response through `curl ... | python3 -c "...json..."` — the last live `python3` shell-out in the shipped compiler. Replaced with a native GET (`_curl_get_cmd`) plus a hand-rolled, string-aware field extractor (`_extract_index_latest_cmd` + `_json_match_brace_cmd` + `_find_substr_cmd`) reading `capsules.<name>.latest`. Restores the no-Python-in-the-toolchain invariant and removes the shell-injection surface (the capsule name now flows as JSON data, never a shell string).
- Corrected a stale `CONTRIBUTING.md` note claiming releases are cut by `python-semantic-release` from commit prefixes — they are manual `workflow_dispatch` + pure bash (version source: `compiler/capsule.toml`).

Closes #1894

## Approach & tradeoff
Hand-rolled rather than importing the `sfn/json` capsule. Rationale: the parse target is a single fixed field; `sfn/json::parse` carries a flagged hang risk when pulled transitively into the compiler workspace-resolver path (#842) and has **zero precedent** in `compiler/src/`; and the issue's `Out:` scope explicitly sanctions a minimal native extraction. This mirrors the existing `package.sfn::_package_extract_top_level` house pattern. The extractor descends into `"capsules"` first, anchors on the exact `"<name>"` key (trailing quote defeats `acme/router` vs `acme/router-extras` prefix collisions), bounds the search to that capsule's object via a string/escape-aware brace matcher (so a sibling's `latest` can't bleed through), and is whitespace-tolerant (compact or pretty JSON).

## Acceptance Criteria
- [x] `sfn add` resolves a registry index response without invoking `python3` (no `python3` in the spawned argv)
- [x] `sfn add` e2e coverage of the fake-`curl`-shim path passes — new `add_registry_index_test.sfn` (no prior `add` e2e existed)
- [x] `CONTRIBUTING.md` no longer claims `python-semantic-release` / commit-prefix-driven releases; reflects manual `workflow_dispatch` + pure-bash reality
- [x] `grep -rn "python" compiler/src CONTRIBUTING.md` returns no live invocation or stale release claim (only history-citing comments remain)
- [x] `make compile` passes (compiler self-hosts)
- [x] `make test` — see Verification note

## Verification
```bash
make compile                                              # PASS (self-hosts)
build/native/sailfin test compiler/tests/e2e/add_registry_index_test.sfn   # PASS 5/5
build/native/sailfin test compiler/tests/e2e/publish_test.sfn              # PASS 13/13 (shared curl-temp pattern intact)
sfn fmt --check compiler/src/cli/commands/add.sfn compiler/tests/e2e/add_registry_index_test.sfn  # clean
```
The full `make test` (serial `--jobs 1`) reached **379 test files passed, 0 failures** — covering all unit + integration and most of the e2e tier — before a **transient environmental stall** on `runtime_obj_shared_cache_test.sfn`, a cold-build runtime-object-cache test. That test **passes cleanly in isolation** and is a cold-`sfn build` scenario that cannot exercise the `add` subcommand this PR touches, so the stall is unrelated to this change (container resource/lock contention over the multi-hour serial run).

The new e2e test drives the native path through a PATH-injected fake `curl` shim; two of its cases (sibling-`latest` non-bleed, prefix-collision) would fail if the extractor's anchoring/bounding were wrong.

## Files Changed
- `compiler/src/cli/commands/add.sfn` — native GET + JSON field extractor; removed the now-unused `_shell_read_cmd` import
- `compiler/tests/e2e/add_registry_index_test.sfn` — new (5 tests)
- `CONTRIBUTING.md` — corrected the stale release note

---
_Generated by [Claude Code](https://claude.ai/code/session_01JA8Ykceu6FkRgcwPB4CnqJ)_