### PR TITLE
fix(typecheck): complete E0828 object-literal coverage via a unified TypeckCtx walk context

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -419,12 +419,17 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
 // reaches a nested `return` (the #1904 fix). `expected_type` is the
 // general local channel reserved for future positions (call args, field
 // defaults) so they plug in without another signature change.
+// `in_function_body` marks that the walk is inside a fn/lambda body, so a
+// `return { ... }` is classified there but a top-level `return` — or one
+// in a top-level nested block (`if`/`with`/`{}`), which is `!is_top_level`
+// yet has no enclosing function — is exempt.
 struct TypeckCtx {
     bindings: SymbolEntry[];
     imports: ImportSymbolTable;
     interfaces: Statement[];
     top_level: SymbolEntry[];
     is_top_level: boolean;
+    in_function_body: boolean;
     scope_start: int;
     enclosing_return_type: TypeAnnotation?;
     expected_type: TypeAnnotation?;
@@ -438,6 +443,7 @@ fn make_typeck_ctx(bindings: SymbolEntry[], imports: ImportSymbolTable, interfac
         interfaces: interfaces,
         top_level: top_level,
         is_top_level: is_top_level,
+        in_function_body: false,
         scope_start: 0,
         enclosing_return_type: null,
         expected_type: null
@@ -445,7 +451,10 @@ fn make_typeck_ctx(bindings: SymbolEntry[], imports: ImportSymbolTable, interfac
 }
 
 // Enter a nested block scope: swap in the block's bindings + shadowing
-// boundary, drop to non-top-level, preserve the ambient return type.
+// boundary, drop to non-top-level, preserve the ambient return type and
+// the in-function-body flag. `expected_type` is a parent-imposed *local*
+// expectation, so it is cleared at a statement/block boundary — it must
+// not leak into unrelated statements once the channel becomes active.
 fn ctx_with_bindings(ctx: TypeckCtx, bindings: SymbolEntry[], scope_start: int) -> TypeckCtx {
     return TypeckCtx {
         bindings: bindings,
@@ -453,15 +462,16 @@ fn ctx_with_bindings(ctx: TypeckCtx, bindings: SymbolEntry[], scope_start: int) 
         interfaces: ctx.interfaces,
         top_level: ctx.top_level,
         is_top_level: false,
+        in_function_body: ctx.in_function_body,
         scope_start: scope_start,
         enclosing_return_type: ctx.enclosing_return_type,
-        expected_type: ctx.expected_type
+        expected_type: null
     };
 }
 
 // Enter a fn/lambda body: install its parameter-scope bindings and the
-// declared return type as the ambient `enclosing_return_type`, clearing
-// any local expected type.
+// declared return type as the ambient `enclosing_return_type`, mark the
+// in-function-body context, and clear any local expected type.
 fn ctx_enter_body(ctx: TypeckCtx, bindings: SymbolEntry[], return_type: TypeAnnotation?) -> TypeckCtx {
     return TypeckCtx {
         bindings: bindings,
@@ -469,6 +479,7 @@ fn ctx_enter_body(ctx: TypeckCtx, bindings: SymbolEntry[], return_type: TypeAnno
         interfaces: ctx.interfaces,
         top_level: ctx.top_level,
         is_top_level: false,
+        in_function_body: true,
         scope_start: 0,
         enclosing_return_type: return_type,
         expected_type: null
@@ -513,6 +524,7 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
     let imports = ctx.imports;
     let top_level = ctx.top_level;
     let is_top_level = ctx.is_top_level;
+    let in_function_body = ctx.in_function_body;
     let enclosing_return_type = ctx.enclosing_return_type;
     if statement.variant == "VariableDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
@@ -792,10 +804,12 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
     if statement.variant == "ReturnStatement" {
         let return_diags = walk_expression(statement.expression, ctx);
         // A `return { ... }` is classified against the enclosing function's
-        // declared return type (#1904). Gate on `!is_top_level`: a top-level
-        // `return` has no enclosing function, so `enclosing_return_type` is
-        // absent and the un-inferable branch must not fire spuriously.
-        if is_top_level {
+        // declared return type (#1904). Gate on `in_function_body`, not
+        // `!is_top_level`: a `return` in a top-level nested block (`if`/`with`/
+        // `{}`) is `!is_top_level` yet has no enclosing function, so its
+        // `enclosing_return_type` is absent and the un-inferable branch must
+        // not fire there.
+        if !in_function_body {
             return ScopeResult {
                 bindings: bindings,
                 diagnostics: return_diags

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -516,7 +516,7 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
     let enclosing_return_type = ctx.enclosing_return_type;
     if statement.variant == "VariableDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
-        let walk_diags = walk_expression(statement.initializer, bindings, imports);
+        let walk_diags = walk_expression(statement.initializer, ctx);
         let annotation_diags = check_bare_fn_type_annotation(statement.type_annotation, statement.name, statement.span);
         let intersection_diags = check_intersection_value_type_annotation(statement.type_annotation, statement.name, statement.span);
         let object_literal_diags = check_object_literal_target(statement.initializer, statement.type_annotation, statement.name, statement.span, top_level);
@@ -706,8 +706,8 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
         };
     }
     if statement.variant == "ForStatement" {
-        let target_diags = walk_expression(statement.clause.target, bindings, imports);
-        let iter_diags = walk_expression(statement.clause.iterable, bindings, imports);
+        let target_diags = walk_expression(statement.clause.target, ctx);
+        let iter_diags = walk_expression(statement.clause.iterable, ctx);
         let body_diags = check_block(statement.body, ctx_with_bindings(ctx, bindings, scope_start));
         return ScopeResult {
             bindings: bindings,
@@ -715,13 +715,13 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
         };
     }
     if statement.variant == "MatchStatement" {
-        let mut diagnostics = walk_expression(statement.expression, bindings, imports);
+        let mut diagnostics = walk_expression(statement.expression, ctx);
         let mut index: int = 0;
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
-            diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, bindings, imports));
-            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
+            diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, ctx));
+            diagnostics = diagnostics.concat(walk_expression(case.guard, ctx));
             let arm_bindings = register_match_pattern_bindings(case.pattern, bindings);
             let _blk_diags = check_block(case.body, ctx_with_bindings(ctx, arm_bindings, scope_start));
             let mut _ci: int = 0;
@@ -735,7 +735,7 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
         return ScopeResult { bindings: bindings, diagnostics: diagnostics };
     }
     if statement.variant == "IfStatement" {
-        let mut diagnostics = walk_expression(statement.condition, bindings, imports);
+        let mut diagnostics = walk_expression(statement.condition, ctx);
         diagnostics = diagnostics.concat(check_block(statement.then_block, ctx_with_bindings(ctx, bindings, scope_start)));
         if statement.else_branch != null {
             let branch = statement.else_branch;
@@ -786,11 +786,11 @@ fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
     if statement.variant == "ExpressionStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: walk_expression(statement.expression, bindings, imports)
+            diagnostics: walk_expression(statement.expression, ctx)
         };
     }
     if statement.variant == "ReturnStatement" {
-        let return_diags = walk_expression(statement.expression, bindings, imports);
+        let return_diags = walk_expression(statement.expression, ctx);
         // A `return { ... }` is classified against the enclosing function's
         // declared return type (#1904). Gate on `!is_top_level`: a top-level
         // `return` has no enclosing function, so `enclosing_return_type` is
@@ -1097,7 +1097,9 @@ fn register_raw_pattern_bindings(text: string, bindings: SymbolEntry[]) -> Symbo
     return result;
 }
 
-fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
+fn walk_expression(expression: Expression?, ctx: TypeckCtx) -> Diagnostic[] {
+    let bindings = ctx.bindings;
+    let imports = ctx.imports;
     if expression == null { return []; }
     if expression.variant == "Call" {
         // A bare-identifier callee is a *call target*, not a value
@@ -1109,7 +1111,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         let mut diagnostics: Diagnostic[] = [];
         if expression.callee != null {
             if expression.callee.variant != "Identifier" {
-                diagnostics = walk_expression(expression.callee, bindings, imports);
+                diagnostics = walk_expression(expression.callee, ctx);
             }
         }
         // #812: a bare-identifier callee that resolves to neither an
@@ -1135,14 +1137,14 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         let mut index: int = 0;
         loop {
             if index >= expression.arguments.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.arguments[index], bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(expression.arguments[index], ctx));
             index += 1;
         }
         return diagnostics;
     }
     if expression.variant == "Binary" {
-        let mut diagnostics = walk_expression(expression.left, bindings, imports);
-        diagnostics = diagnostics.concat(walk_expression(expression.right, bindings, imports));
+        let mut diagnostics = walk_expression(expression.left, ctx);
+        diagnostics = diagnostics.concat(walk_expression(expression.right, ctx));
         return diagnostics;
     }
     if expression.variant == "Unary" {
@@ -1152,7 +1154,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         // `Raw`), the operand `Identifier` reaches the `Identifier` arm below,
         // which emits E0808 for a function used in value position — preserving
         // the prior `check_fn_reference_raw` `& fn` behavior.
-        return walk_expression(expression.operand, bindings, imports);
+        return walk_expression(expression.operand, ctx);
     }
     if expression.variant == "Member" {
         // A bare-identifier member *object* is a receiver / namespace
@@ -1165,11 +1167,11 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         if expression.object != null {
             if expression.object.variant == "Identifier" { return []; }
         }
-        return walk_expression(expression.object, bindings, imports);
+        return walk_expression(expression.object, ctx);
     }
     if expression.variant == "Index" {
-        let mut diagnostics = walk_expression(expression.sequence, bindings, imports);
-        diagnostics = diagnostics.concat(walk_expression(expression.index, bindings, imports));
+        let mut diagnostics = walk_expression(expression.sequence, ctx);
+        diagnostics = diagnostics.concat(walk_expression(expression.index, ctx));
         return diagnostics;
     }
     if expression.variant == "Array" {
@@ -1177,7 +1179,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         let mut index: int = 0;
         loop {
             if index >= expression.elements.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.elements[index], bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(expression.elements[index], ctx));
             index += 1;
         }
         return diagnostics;
@@ -1187,7 +1189,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, ctx));
             index += 1;
         }
         return diagnostics;
@@ -1197,13 +1199,13 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, ctx));
             index += 1;
         }
         return diagnostics;
     }
     if expression.variant == "Lambda" {
-        let mut diagnostics = walk_block_expressions(expression.body, bindings, imports);
+        let mut diagnostics = walk_block_expressions(expression.body, ctx_enter_body(ctx, bindings, expression.return_type));
         let mut lambda_span: SourceSpan? = null;
         let mut _lp: int = 0;
         loop {
@@ -1233,17 +1235,17 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         return diagnostics;
     }
     if expression.variant == "Range" {
-        let mut diagnostics = walk_expression(expression.start, bindings, imports);
-        diagnostics = diagnostics.concat(walk_expression(expression.end, bindings, imports));
+        let mut diagnostics = walk_expression(expression.start, ctx);
+        diagnostics = diagnostics.concat(walk_expression(expression.end, ctx));
         return diagnostics;
     }
     if expression.variant == "Conditional" {
         // Ternary `cond ? then : else` (#1690) — recurse into all three
         // children so nested diagnostics (undefined symbols, parse-error
         // nodes, removed-keyword statements) inside any branch still fire.
-        let mut diagnostics = walk_expression(expression.condition, bindings, imports);
-        diagnostics = diagnostics.concat(walk_expression(expression.then_value, bindings, imports));
-        diagnostics = diagnostics.concat(walk_expression(expression.else_value, bindings, imports));
+        let mut diagnostics = walk_expression(expression.condition, ctx);
+        diagnostics = diagnostics.concat(walk_expression(expression.then_value, ctx));
+        diagnostics = diagnostics.concat(walk_expression(expression.else_value, ctx));
         // #1715: constrain the condition to boolean and unify the two branch
         // types. Types are literal-inferred (#829 has no live inferencer), so
         // an un-inferable branch/condition is left unconstrained.
@@ -1257,8 +1259,8 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         // Assignment `target <op> rhs` (#1627 Part D) — recurse into both
         // sides so diagnostics (undefined symbols, fn-value misuse, nested
         // parse-error nodes) in the lvalue and the rvalue still fire.
-        let mut diagnostics = walk_expression(expression.target, bindings, imports);
-        diagnostics = diagnostics.concat(walk_expression(expression.rhs, bindings, imports));
+        let mut diagnostics = walk_expression(expression.target, ctx);
+        diagnostics = diagnostics.concat(walk_expression(expression.rhs, ctx));
         return diagnostics;
     }
     if expression.variant == "Cast" {
@@ -1280,7 +1282,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
                 }
             }
         }
-        return walk_expression(expression.operand, bindings, imports);
+        return walk_expression(expression.operand, ctx);
     }
     if expression.variant == "Is" {
         // Type-guard `x is T` (#1753) — recurse into the operand so inner
@@ -1289,10 +1291,10 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         // expression, so there is nothing to walk there. Flow-sensitive
         // narrowing is applied at lowering via the `narrowed_variant`
         // machinery (the typecheck pass tracks names only — no type field).
-        return walk_expression(expression.operand, bindings, imports);
+        return walk_expression(expression.operand, ctx);
     }
     if expression.variant == "TryOperator" {
-        return walk_expression(expression.operand, bindings, imports);
+        return walk_expression(expression.operand, ctx);
     }
     // Concurrency nodes (issue #1082). Recurse into operands so inner
     // diagnostics still fire. The only statically-sound live rule is E0813:
@@ -1302,7 +1304,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
     // (E0815) all need expression-type inference (#829, out of scope) and
     // ship as helpers exercised by `concurrency_typecheck_test.sfn`.
     if expression.variant == "Spawn" {
-        let mut diagnostics = walk_expression(expression.operand, bindings, imports);
+        let mut diagnostics = walk_expression(expression.operand, ctx);
         if expression.operand.variant == "Lambda" {
             let return_type = expression.operand.return_type;
             if return_type == null {
@@ -1312,11 +1314,11 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         return diagnostics;
     }
     if expression.variant == "Await" {
-        return walk_expression(expression.operand, bindings, imports);
+        return walk_expression(expression.operand, ctx);
     }
     if expression.variant == "Channel" {
         if expression.capacity == null { return []; }
-        return walk_expression(expression.capacity, bindings, imports);
+        return walk_expression(expression.capacity, ctx);
     }
     // A parser-originated diagnostic node (issue #1531): the parser emitted
     // this for syntax that must fail closed (e.g. the internal-only
@@ -1365,10 +1367,10 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
 // *expressions*, and carry no effects, so they must not trip E0818. Their
 // bindings are registered separately via `register_match_pattern_bindings`.
 // Structured patterns (Struct/Identifier) are still walked normally.
-fn walk_match_pattern(pattern: Expression?, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
+fn walk_match_pattern(pattern: Expression?, ctx: TypeckCtx) -> Diagnostic[] {
     if pattern == null { return []; }
     if pattern.variant == "Raw" { return []; }
-    return walk_expression(pattern, bindings, imports);
+    return walk_expression(pattern, ctx);
 }
 
 // `?` operator (TryOperator) type rules — issue #833, epic #371 (R.3).
@@ -1581,62 +1583,71 @@ fn typecheck_walker_resolves_import(name: string, imports: ImportSymbolTable) ->
 // Top-level statement traversal still flows through `check_block` →
 // `check_statement`; this helper is only the expression-positions
 // recursion for lambda bodies (which `check_block` never descends into).
-fn walk_block_expressions(block: Block, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
+fn walk_block_expressions(block: Block, ctx: TypeckCtx) -> Diagnostic[] {
     let mut diagnostics: Diagnostic[] = [];
     let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
-        diagnostics = diagnostics.concat(walk_statement_expressions(block.statements[index], bindings, imports));
+        diagnostics = diagnostics.concat(walk_statement_expressions(block.statements[index], ctx));
         index += 1;
     }
     return diagnostics;
 }
 
-fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
+fn walk_statement_expressions(statement: Statement, ctx: TypeckCtx) -> Diagnostic[] {
     if statement.variant == "ExpressionStatement" {
-        return walk_expression(statement.expression, bindings, imports);
+        return walk_expression(statement.expression, ctx);
     }
     if statement.variant == "ReturnStatement" {
-        return walk_expression(statement.expression, bindings, imports);
+        let return_diags = walk_expression(statement.expression, ctx);
+        // A lambda-body `return { ... }` is classified against the lambda's
+        // declared return type (installed as `ctx.enclosing_return_type` by
+        // the `Lambda` branch's `ctx_enter_body`) — the #1905 lambda-return
+        // twin of the #1904 function-return check.
+        let object_literal_diags = check_object_literal_target(statement.expression, ctx.enclosing_return_type, "return", statement.span, ctx.top_level);
+        return return_diags.concat(object_literal_diags);
     }
     if statement.variant == "ThrowStatement" {
-        return walk_expression(statement.expression, bindings, imports);
+        return walk_expression(statement.expression, ctx);
     }
     if statement.variant == "VariableDeclaration" {
-        let init_diags = walk_expression(statement.initializer, bindings, imports);
+        let init_diags = walk_expression(statement.initializer, ctx);
         let annotation_diags = check_bare_fn_type_annotation(statement.type_annotation, statement.name, statement.span);
         let intersection_diags = check_intersection_value_type_annotation(statement.type_annotation, statement.name, statement.span);
-        return init_diags.concat(annotation_diags).concat(intersection_diags);
+        // The lambda-body `let` twin of the primary let-site E0828 (#1905):
+        // classify a bare object-literal initializer against its annotation.
+        let object_literal_diags = check_object_literal_target(statement.initializer, statement.type_annotation, statement.name, statement.span, ctx.top_level);
+        return init_diags.concat(annotation_diags).concat(intersection_diags).concat(object_literal_diags);
     }
     if statement.variant == "IfStatement" {
-        let mut diagnostics = walk_expression(statement.condition, bindings, imports);
-        diagnostics = diagnostics.concat(walk_block_expressions(statement.then_block, bindings, imports));
+        let mut diagnostics = walk_expression(statement.condition, ctx);
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.then_block, ctx));
         if statement.else_branch != null {
             let branch = statement.else_branch;
             if branch.body != null {
-                diagnostics = diagnostics.concat(walk_block_expressions(branch.body, bindings, imports));
+                diagnostics = diagnostics.concat(walk_block_expressions(branch.body, ctx));
             }
             if branch.statement != null {
-                diagnostics = diagnostics.concat(walk_statement_expressions(branch.statement, bindings, imports));
+                diagnostics = diagnostics.concat(walk_statement_expressions(branch.statement, ctx));
             }
         }
         return diagnostics;
     }
     if statement.variant == "ForStatement" {
-        let mut diagnostics = walk_expression(statement.clause.target, bindings, imports);
-        diagnostics = diagnostics.concat(walk_expression(statement.clause.iterable, bindings, imports));
-        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings, imports));
+        let mut diagnostics = walk_expression(statement.clause.target, ctx);
+        diagnostics = diagnostics.concat(walk_expression(statement.clause.iterable, ctx));
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, ctx));
         return diagnostics;
     }
     if statement.variant == "MatchStatement" {
-        let mut diagnostics = walk_expression(statement.expression, bindings, imports);
+        let mut diagnostics = walk_expression(statement.expression, ctx);
         let mut index: int = 0;
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
-            diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, bindings, imports));
-            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
-            diagnostics = diagnostics.concat(walk_block_expressions(case.body, bindings, imports));
+            diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, ctx));
+            diagnostics = diagnostics.concat(walk_expression(case.guard, ctx));
+            diagnostics = diagnostics.concat(walk_block_expressions(case.body, ctx));
             index += 1;
         }
         return diagnostics;
@@ -1646,25 +1657,25 @@ fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[], imp
         let mut clause_index: int = 0;
         loop {
             if clause_index >= statement.clauses.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(statement.clauses[clause_index].expression, bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(statement.clauses[clause_index].expression, ctx));
             clause_index += 1;
         }
-        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings, imports));
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, ctx));
         return diagnostics;
     }
     if statement.variant == "LoopStatement" {
-        return walk_block_expressions(statement.body, bindings, imports);
+        return walk_block_expressions(statement.body, ctx);
     }
     if statement.variant == "BlockStatement" {
-        return walk_block_expressions(statement.body, bindings, imports);
+        return walk_block_expressions(statement.body, ctx);
     }
     if statement.variant == "TryStatement" {
-        let mut diagnostics = walk_block_expressions(statement.try_block, bindings, imports);
+        let mut diagnostics = walk_block_expressions(statement.try_block, ctx);
         if statement.catch_block != null {
-            diagnostics = diagnostics.concat(walk_block_expressions(statement.catch_block, bindings, imports));
+            diagnostics = diagnostics.concat(walk_block_expressions(statement.catch_block, ctx));
         }
         if statement.finally_block != null {
-            diagnostics = diagnostics.concat(walk_block_expressions(statement.finally_block, bindings, imports));
+            diagnostics = diagnostics.concat(walk_block_expressions(statement.finally_block, ctx));
         }
         return diagnostics;
     }

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -410,12 +410,77 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
     return SymbolCollectionResult { symbols: existing, diagnostics: [] };
 }
 
+// The typing environment + expected-type channel threaded through the
+// typecheck walk (SFEP-0039 addendum). One record serves both the
+// statement/block family and the expression family; a family reads only
+// the subset it needs (inert fields are free). Unifying the record is
+// what gives lambda-body walking `top_level` + `enclosing_return_type`
+// (the #1905 fix); `enclosing_return_type` is the ambient channel that
+// reaches a nested `return` (the #1904 fix). `expected_type` is the
+// general local channel reserved for future positions (call args, field
+// defaults) so they plug in without another signature change.
+struct TypeckCtx {
+    bindings: SymbolEntry[];
+    imports: ImportSymbolTable;
+    interfaces: Statement[];
+    top_level: SymbolEntry[];
+    is_top_level: boolean;
+    scope_start: int;
+    enclosing_return_type: TypeAnnotation?;
+    expected_type: TypeAnnotation?;
+}
+
+// Root context for a walk: top-level scope, no enclosing return type.
+fn make_typeck_ctx(bindings: SymbolEntry[], imports: ImportSymbolTable, interfaces: Statement[], top_level: SymbolEntry[], is_top_level: boolean) -> TypeckCtx {
+    return TypeckCtx {
+        bindings: bindings,
+        imports: imports,
+        interfaces: interfaces,
+        top_level: top_level,
+        is_top_level: is_top_level,
+        scope_start: 0,
+        enclosing_return_type: null,
+        expected_type: null
+    };
+}
+
+// Enter a nested block scope: swap in the block's bindings + shadowing
+// boundary, drop to non-top-level, preserve the ambient return type.
+fn ctx_with_bindings(ctx: TypeckCtx, bindings: SymbolEntry[], scope_start: int) -> TypeckCtx {
+    return TypeckCtx {
+        bindings: bindings,
+        imports: ctx.imports,
+        interfaces: ctx.interfaces,
+        top_level: ctx.top_level,
+        is_top_level: false,
+        scope_start: scope_start,
+        enclosing_return_type: ctx.enclosing_return_type,
+        expected_type: ctx.expected_type
+    };
+}
+
+// Enter a fn/lambda body: install its parameter-scope bindings and the
+// declared return type as the ambient `enclosing_return_type`, clearing
+// any local expected type.
+fn ctx_enter_body(ctx: TypeckCtx, bindings: SymbolEntry[], return_type: TypeAnnotation?) -> TypeckCtx {
+    return TypeckCtx {
+        bindings: bindings,
+        imports: ctx.imports,
+        interfaces: ctx.interfaces,
+        top_level: ctx.top_level,
+        is_top_level: false,
+        scope_start: 0,
+        enclosing_return_type: return_type,
+        expected_type: null
+    };
+}
+
 fn check_program_scopes(program: Program, interfaces: Statement[], imports: ImportSymbolTable, top_level: SymbolEntry[]) -> Diagnostic[] {
     let mut bindings: SymbolEntry[] = [];
     let mut diagnostics: Diagnostic[] = [];
 
     for statement in program.statements {
-        let result = check_statement(statement, bindings, interfaces, 0, imports, top_level, true);
+        let result = check_statement(statement, make_typeck_ctx(bindings, imports, interfaces, top_level, true));
         bindings = result.bindings;
         let mut _ci: int = 0;
         loop {
@@ -441,7 +506,14 @@ fn check_program_scopes(program: Program, interfaces: Statement[], imports: Impo
 // callee lookup resolves sibling top-level functions and imports
 // regardless of source order. It is never re-registered, so it does not
 // affect duplicate detection.
-fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: Statement[], scope_start: int, imports: ImportSymbolTable, top_level: SymbolEntry[], is_top_level: boolean) -> ScopeResult {
+fn check_statement(statement: Statement, ctx: TypeckCtx) -> ScopeResult {
+    let bindings = ctx.bindings;
+    let interfaces = ctx.interfaces;
+    let scope_start = ctx.scope_start;
+    let imports = ctx.imports;
+    let top_level = ctx.top_level;
+    let is_top_level = ctx.is_top_level;
+    let enclosing_return_type = ctx.enclosing_return_type;
     if statement.variant == "VariableDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
         let walk_diags = walk_expression(statement.initializer, bindings, imports);
@@ -470,7 +542,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             diagnostics.push(_main_diags[_cim]);
             _cim += 1;
         }
-        let function_diagnostics = check_function_body(statement.signature, statement.body, interfaces, imports, top_level);
+        let function_diagnostics = check_function_body(statement.signature, statement.body, ctx);
         let mut _ci2: int = 0;
         loop {
             if _ci2 >= function_diagnostics.length { break; }
@@ -547,7 +619,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         loop {
             if index >= statement.methods.length { break; }
             let method = statement.methods[index];
-            let _mb_diags = check_function_body(method.signature, method.body, interfaces, imports, top_level);
+            let _mb_diags = check_function_body(method.signature, method.body, ctx);
             let mut _ci5: int = 0;
             loop {
                 if _ci5 >= _mb_diags.length { break; }
@@ -615,7 +687,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "TestDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "test", statement.name_span, scope_start);
         let mut diagnostics = registration.diagnostics;
-        let _blk_diags = check_block(statement.body, top_level, interfaces, imports, top_level);
+        let _blk_diags = check_block(statement.body, ctx_with_bindings(ctx, top_level, scope_start));
         let mut _ci: int = 0;
         loop {
             if _ci >= _blk_diags.length { break; }
@@ -630,13 +702,13 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "WithStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces, imports, top_level)
+            diagnostics: check_block(statement.body, ctx_with_bindings(ctx, bindings, scope_start))
         };
     }
     if statement.variant == "ForStatement" {
         let target_diags = walk_expression(statement.clause.target, bindings, imports);
         let iter_diags = walk_expression(statement.clause.iterable, bindings, imports);
-        let body_diags = check_block(statement.body, bindings, interfaces, imports, top_level);
+        let body_diags = check_block(statement.body, ctx_with_bindings(ctx, bindings, scope_start));
         return ScopeResult {
             bindings: bindings,
             diagnostics: target_diags.concat(iter_diags).concat(body_diags)
@@ -651,7 +723,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             diagnostics = diagnostics.concat(walk_match_pattern(case.pattern, bindings, imports));
             diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
             let arm_bindings = register_match_pattern_bindings(case.pattern, bindings);
-            let _blk_diags = check_block(case.body, arm_bindings, interfaces, imports, top_level);
+            let _blk_diags = check_block(case.body, ctx_with_bindings(ctx, arm_bindings, scope_start));
             let mut _ci: int = 0;
             loop {
                 if _ci >= _blk_diags.length { break; }
@@ -664,11 +736,11 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     }
     if statement.variant == "IfStatement" {
         let mut diagnostics = walk_expression(statement.condition, bindings, imports);
-        diagnostics = diagnostics.concat(check_block(statement.then_block, bindings, interfaces, imports, top_level));
+        diagnostics = diagnostics.concat(check_block(statement.then_block, ctx_with_bindings(ctx, bindings, scope_start)));
         if statement.else_branch != null {
             let branch = statement.else_branch;
             if branch.body != null {
-                let _blk_diags = check_block(branch.body, bindings, interfaces, imports, top_level);
+                let _blk_diags = check_block(branch.body, ctx_with_bindings(ctx, bindings, scope_start));
                 let mut _ci: int = 0;
                 loop {
                     if _ci >= _blk_diags.length { break; }
@@ -677,7 +749,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 }
             }
             if branch.statement != null {
-                let result = check_statement(branch.statement, bindings, interfaces, scope_start, imports, top_level, false);
+                let result = check_statement(branch.statement, ctx_with_bindings(ctx, bindings, scope_start));
                 let mut _ci2: int = 0;
                 loop {
                     if _ci2 >= result.diagnostics.length { break; }
@@ -691,7 +763,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "BlockStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces, imports, top_level)
+            diagnostics: check_block(statement.body, ctx_with_bindings(ctx, bindings, scope_start))
         };
     }
     if statement.variant == "TypeAliasDeclaration" {
@@ -718,9 +790,21 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         };
     }
     if statement.variant == "ReturnStatement" {
+        let return_diags = walk_expression(statement.expression, bindings, imports);
+        // A `return { ... }` is classified against the enclosing function's
+        // declared return type (#1904). Gate on `!is_top_level`: a top-level
+        // `return` has no enclosing function, so `enclosing_return_type` is
+        // absent and the un-inferable branch must not fire spuriously.
+        if is_top_level {
+            return ScopeResult {
+                bindings: bindings,
+                diagnostics: return_diags
+            };
+        }
+        let object_literal_diags = check_object_literal_target(statement.expression, enclosing_return_type, "return", statement.span, top_level);
         return ScopeResult {
             bindings: bindings,
-            diagnostics: walk_expression(statement.expression, bindings, imports)
+            diagnostics: return_diags.concat(object_literal_diags)
         };
     }
     if statement.variant == "Unknown" {
@@ -762,9 +846,10 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     return ScopeResult { bindings: bindings, diagnostics: [] };
 }
 
-fn check_function_body(signature: FunctionSignature, body: Block, interfaces: Statement[], imports: ImportSymbolTable, top_level: SymbolEntry[]) -> Diagnostic[] {
-    let parameter_scope = seed_parameter_scope(signature, top_level);
-    let body_diagnostics = check_block(body, parameter_scope.bindings, interfaces, imports, top_level);
+fn check_function_body(signature: FunctionSignature, body: Block, ctx: TypeckCtx) -> Diagnostic[] {
+    let parameter_scope = seed_parameter_scope(signature, ctx.top_level);
+    let body_ctx = ctx_enter_body(ctx, parameter_scope.bindings, signature.return_type);
+    let body_diagnostics = check_block(body, body_ctx);
     let mut _result = parameter_scope.diagnostics;
     let mut _ci: int = 0;
     loop {
@@ -806,13 +891,13 @@ fn seed_parameter_scope(signature: FunctionSignature, top_level: SymbolEntry[]) 
     return ScopeResult { bindings: bindings, diagnostics: diagnostics };
 }
 
-fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Statement[], imports: ImportSymbolTable, top_level: SymbolEntry[]) -> Diagnostic[] {
-    let mut bindings = clone_bindings(parent_bindings);
+fn check_block(block: Block, ctx: TypeckCtx) -> Diagnostic[] {
+    let mut bindings = clone_bindings(ctx.bindings);
     let scope_start = bindings.length;
     let mut diagnostics: Diagnostic[] = [];
 
     for statement in block.statements {
-        let result = check_statement(statement, bindings, interfaces, scope_start, imports, top_level, false);
+        let result = check_statement(statement, ctx_with_bindings(ctx, bindings, scope_start));
         bindings = result.bindings;
         let mut _ci: int = 0;
         loop {

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -794,6 +794,13 @@ fn seed_parameter_scope(signature: FunctionSignature, top_level: SymbolEntry[]) 
             diagnostics.push(registration.diagnostics[_ci]);
             _ci += 1;
         }
+        let default_diags = check_object_literal_target(parameter.default_value, parameter.type_annotation, parameter.name, parameter.span, top_level);
+        let mut _di: int = 0;
+        loop {
+            if _di >= default_diags.length { break; }
+            diagnostics.push(default_diags[_di]);
+            _di += 1;
+        }
     }
 
     return ScopeResult { bindings: bindings, diagnostics: diagnostics };

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -422,10 +422,12 @@ fn _object_literal_head_type(text: string) -> string {
 // True when the object-literal target's head is an array type (`T[]`).
 // An object literal never produces an array, so an array target is
 // rejected regardless of the element type — the caller short-circuits
-// on this before the head-symbol lookup (SFEP-0039 §3.2).
+// on this before the head-symbol lookup (SFEP-0039 §3.2). Match the `[]`
+// suffix specifically (not any trailing `]`) so a future `]`-terminated
+// type form or a malformed annotation is not mistaken for an array.
 fn _object_literal_target_is_array(head: string) -> boolean {
-    if head.length == 0 { return false; }
-    return head[head.length - 1] == "]";
+    if head.length < 2 { return false; }
+    return head[head.length - 2] == "[" && head[head.length - 1] == "]";
 }
 
 // Base name of a possibly-generic head (`Box<int>` -> `Box`,
@@ -469,7 +471,10 @@ fn check_object_literal_target(initializer: Expression?, annotation: TypeAnnotat
     let target = find_symbol(top_level, base);
     if target == null { return []; }
     if strings_equal(target.kind, "interface") {
-        return [make_object_literal_requires_struct_diagnostic(base, "interface", anchor_name, anchor_span)];
+        // Name the full head (`Container<int>`) in the message so it
+        // matches the source annotation verbatim, while still resolving the
+        // symbol by `base` (`Container`).
+        return [make_object_literal_requires_struct_diagnostic(head, "interface", anchor_name, anchor_span)];
     }
     return [];
 }

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -369,24 +369,30 @@ fn check_interface_field_members(field_members: InterfaceFieldMember[]) -> Diagn
 }
 
 // E0828: a bare object literal whose target is not a concrete `struct`.
-// `is_interface` selects between the interface-target and the
-// un-inferable-unannotated wording.
-fn make_object_literal_requires_struct_diagnostic(target: string, is_interface: boolean, anchor_name: string, anchor_span: SourceSpan?) -> Diagnostic {
+// `kind` selects the wording: "interface" (target names an interface),
+// "array" (target is an array type `T[]` — an object literal never
+// yields an array, so this fires regardless of the element type), or
+// "uninferable" (unannotated binding with no contextual struct target).
+fn make_object_literal_requires_struct_diagnostic(target: string, kind: string, anchor_name: string, anchor_span: SourceSpan?) -> Diagnostic {
     let anchor = token_from_name(anchor_name, anchor_span);
     let mut message: string = "";
-    if is_interface {
+    let mut fix_message: string = "declare a `struct` with these fields and annotate the binding with it "
+        + "(data is constructed only through concrete structs)";
+    if strings_equal(kind, "interface") {
         message = "object literal requires a concrete `struct` type; `"
             + trim_text(target)
             + "` is an interface, not a struct";
+    } else if strings_equal(kind, "array") {
+        message = "object literal requires a concrete `struct` type; `"
+            + trim_text(target)
+            + "` is an array type, and an object literal never yields an array";
+        fix_message = "build each element and collect them into an array literal `[...]`, "
+            + "or annotate with the concrete `struct` element type for a single value";
     } else {
         message = "object literal requires a concrete `struct` type annotation; "
             + "its target type cannot be inferred";
     }
-    let fix = FixSuggestion {
-        message: "declare a `struct` with these fields and annotate the binding with it "
-            + "(data is constructed only through concrete structs)",
-        edits: []
-    };
+    let fix = FixSuggestion { message: fix_message, edits: [] };
     return Diagnostic {
         code: "E0828",
         severity: "error",
@@ -399,9 +405,9 @@ fn make_object_literal_requires_struct_diagnostic(target: string, is_interface: 
 
 // Head type name of a value annotation, stripping a trailing optional
 // marker (`Named?` -> `Named`) so an object literal targeting an
-// optional interface is still classified by its head type. Broader
-// wrapper normalization (array `T[]`, generic-instantiation heads) and
-// the return/parameter positions are the coverage follow-up (#1900).
+// optional interface is still classified by its head type. Array and
+// generic-instantiation-head normalization is layered on top by the
+// caller via `_object_literal_target_is_array` / `_object_literal_head_base`.
 fn _object_literal_head_type(text: string) -> string {
     let mut head = trim_text(text);
     loop {
@@ -409,6 +415,31 @@ fn _object_literal_head_type(text: string) -> string {
         if head[head.length - 1] == "?" {
             head = trim_text(substring(head, 0, head.length - 1));
         } else { break; }
+    }
+    return head;
+}
+
+// True when the object-literal target's head is an array type (`T[]`).
+// An object literal never produces an array, so an array target is
+// rejected regardless of the element type — the caller short-circuits
+// on this before the head-symbol lookup (SFEP-0039 §3.2).
+fn _object_literal_target_is_array(head: string) -> boolean {
+    if head.length == 0 { return false; }
+    return head[head.length - 1] == "]";
+}
+
+// Base name of a possibly-generic head (`Box<int>` -> `Box`,
+// `Named` -> `Named`), so a generic-instantiation target is classified
+// by its base symbol rather than the raw instantiation text — which
+// `find_symbol` would otherwise miss.
+fn _object_literal_head_base(head: string) -> string {
+    let mut index: int = 0;
+    loop {
+        if index >= head.length { break; }
+        if head[index] == "<" {
+            return trim_text(substring(head, 0, index));
+        }
+        index += 1;
     }
     return head;
 }
@@ -426,15 +457,19 @@ fn check_object_literal_target(initializer: Expression?, annotation: TypeAnnotat
     if initializer == null { return []; }
     if initializer.variant != "Object" { return []; }
     if annotation == null {
-        return [make_object_literal_requires_struct_diagnostic("", false, anchor_name, anchor_span)];
+        return [make_object_literal_requires_struct_diagnostic("", "uninferable", anchor_name, anchor_span)];
     }
     let text = trim_text(annotation.text);
     if type_annotation_is_intersection(text) { return []; }
     let head = _object_literal_head_type(text);
-    let target = find_symbol(top_level, head);
+    if _object_literal_target_is_array(head) {
+        return [make_object_literal_requires_struct_diagnostic(head, "array", anchor_name, anchor_span)];
+    }
+    let base = _object_literal_head_base(head);
+    let target = find_symbol(top_level, base);
     if target == null { return []; }
     if strings_equal(target.kind, "interface") {
-        return [make_object_literal_requires_struct_diagnostic(head, true, anchor_name, anchor_span)];
+        return [make_object_literal_requires_struct_diagnostic(base, "interface", anchor_name, anchor_span)];
     }
     return [];
 }

--- a/compiler/tests/unit/effect_raw_failclosed_test.sfn
+++ b/compiler/tests/unit/effect_raw_failclosed_test.sfn
@@ -15,15 +15,30 @@
 // contains no effect keyword still fires (no text scan, no effect-keyword
 // anchor); (d) match-arm shorthand patterns (which legitimately degrade to
 // `Raw`) are exempt.
-import { Expression } from "../../src/ast";
+import { Expression, Statement } from "../../src/ast";
 import { empty_import_symbols } from "../../src/effect_imports";
 import { parse_program } from "../../src/parser/mod";
-import { typecheck_diagnostics, walk_expression, walk_match_pattern } from "../../src/typecheck";
+import {
+    TypeckCtx,
+    make_typeck_ctx,
+    typecheck_diagnostics,
+    walk_expression,
+    walk_match_pattern
+} from "../../src/typecheck";
 import { Diagnostic, SymbolEntry } from "../../src/typecheck_types";
 
 fn _no_bindings() -> SymbolEntry[] {
     let empty: SymbolEntry[] = [];
     return empty;
+}
+
+// A minimal root walk context: empty scope, no enclosing return type.
+// The expression walk takes a `TypeckCtx` (SFEP-0039 addendum); these
+// fail-closed tests only exercise the Raw/Identifier arms, which read
+// `ctx.bindings`/`ctx.imports` — both empty here.
+fn _walk_ctx() -> TypeckCtx {
+    let no_interfaces: Statement[] = [];
+    return make_typeck_ctx(_no_bindings(), empty_import_symbols(), no_interfaces, _no_bindings(), false);
 }
 
 fn _has_code(diags: Diagnostic[], code: string) -> boolean {
@@ -38,7 +53,7 @@ fn _has_code(diags: Diagnostic[], code: string) -> boolean {
 
 fn _raw_diags(text: string) -> Diagnostic[] ![io] {
     let raw = Expression.Raw { text: text, span: null };
-    return walk_expression(raw, _no_bindings(), empty_import_symbols());
+    return walk_expression(raw, _walk_ctx());
 }
 
 // ── (a) a non-empty, non-fn-reference Raw fails closed ──
@@ -66,7 +81,7 @@ test "raw: a whitespace-only Raw is clean (trimmed to empty)" ![io] {
 // E0818 — the backstop keys on `variant == "Raw"`, never on text content.
 test "raw: a structured Identifier mentioning `print` does not fire E0818" ![io] {
     let ident = Expression.Identifier { name: "printable", span: null };
-    let diags = walk_expression(ident, _no_bindings(), empty_import_symbols());
+    let diags = walk_expression(ident, _walk_ctx());
     assert ! _has_code(diags, "E0818");
 }
 
@@ -88,13 +103,13 @@ test "raw: a Raw mentioning `print` as a substring fails closed by shape" ![io] 
 // unstructured expressions, so `walk_match_pattern` exempts them from E0818.
 test "match pattern: a Raw shorthand destructure is exempt from E0818" ![io] {
     let pattern = Expression.Raw { text: "Result.Ok { value }", span: null };
-    let diags = walk_match_pattern(pattern, _no_bindings(), empty_import_symbols());
+    let diags = walk_match_pattern(pattern, _walk_ctx());
     assert diags.length == 0;
 }
 
 test "match pattern: an empty-text Raw pattern is exempt from E0818" ![io] {
     let pattern = Expression.Raw { text: "", span: null };
-    let diags = walk_match_pattern(pattern, _no_bindings(), empty_import_symbols());
+    let diags = walk_match_pattern(pattern, _walk_ctx());
     assert diags.length == 0;
 }
 
@@ -102,7 +117,7 @@ test "match pattern: an empty-text Raw pattern is exempt from E0818" ![io] {
 // helper — the exemption is scoped to the `Raw` shorthand form only.
 test "match pattern: a structured Identifier pattern walks clean" ![io] {
     let pattern = Expression.Identifier { name: "x", span: null };
-    let diags = walk_match_pattern(pattern, _no_bindings(), empty_import_symbols());
+    let diags = walk_match_pattern(pattern, _walk_ctx());
     assert ! _has_code(diags, "E0818");
 }
 

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -190,6 +190,15 @@ test "object-model: return literal targeting an array type is E0828" ![io] {
     assert _has_code(_diags(source), "E0828");
 }
 
+// A function with no declared return type returning a bare object literal
+// has no concrete struct target, so it fires the un-inferable E0828 — the
+// return check runs because it is `in_function_body`, independent of
+// whether a return type is declared.
+test "object-model: function with no declared return type returning a literal is E0828" ![io] {
+    let source = "fn make() { return { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
 // -------------------------------------------------------------------
 // E0828 — lambda-body positions (#1905). A bare object literal in a
 // lambda-body `let` or a lambda `return` is classified via the same

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -168,6 +168,29 @@ test "object-model: struct-typed parameter-default literal is not E0828" ![io] {
 }
 
 // -------------------------------------------------------------------
+// E0828 — return-position object literals (#1904). A `return { ... }`
+// is classified against the enclosing function's declared return type,
+// threaded through the walk as `TypeckCtx.enclosing_return_type`.
+// -------------------------------------------------------------------
+test "object-model: return literal targeting an interface is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn make() -> Named { return { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: return literal targeting a concrete struct is not E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn make() -> Person { return { name: \"Alice\" }; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
+test "object-model: return literal targeting an array type is E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn make() -> Person[] { return { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+// -------------------------------------------------------------------
 // E0829 — `A & B` in value / type-annotation position.
 // -------------------------------------------------------------------
 test "object-model: intersection type alias is E0829 at the definition" ![io] {

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -191,6 +191,60 @@ test "object-model: return literal targeting an array type is E0828" ![io] {
 }
 
 // -------------------------------------------------------------------
+// E0828 — lambda-body positions (#1905). A bare object literal in a
+// lambda-body `let` or a lambda `return` is classified via the same
+// TypeckCtx channel: `top_level` reaches the lambda-body walk, and the
+// lambda's declared return type flows in as `enclosing_return_type`.
+// -------------------------------------------------------------------
+test "object-model: lambda-body let targeting an interface is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn main() ![io] { let f = fn() -> int { let bad: Named = { name: \"Alice\" }; return 0; }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: lambda-body let targeting a struct is not E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn main() ![io] { let f = fn() -> int { let p: Person = { name: \"Alice\" }; return 0; }; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
+test "object-model: lambda returning an interface literal is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn main() ![io] { let f = fn() -> Named { return { name: \"Alice\" }; }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: lambda returning a struct literal is not E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn main() ![io] { let f = fn() -> Person { return { name: \"Alice\" }; }; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
+// Uninferable lambda positions: an unannotated lambda-body `let` and a
+// lambda `return` with no declared return type both have no concrete
+// struct target, so they fire the un-inferable E0828 (consistent with
+// the non-lambda let/return sites).
+test "object-model: lambda-body unannotated let literal is E0828" ![io] {
+    let source = "fn main() ![io] { let f = fn() -> int { let huh = { name: \"Alice\" }; return 0; }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: lambda return with no declared return type is E0828" ![io] {
+    let source = "fn main() ![io] { let f = fn() { return { name: \"Alice\" }; }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+// Nested lambdas each carry their own `enclosing_return_type`: the inner
+// lambda returns an interface literal (E0828) while the outer returns a
+// struct literal (clean) — exactly one E0828 proves per-lambda scoping.
+test "object-model: nested lambda return types are classified independently" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "struct Person { name: string; }\n"
+        + "fn main() ![io] { let f = fn() -> Person { let g = fn() -> Named { return { name: \"x\" }; }; return { name: \"y\" }; }; }\n";
+    assert _count_code(_diags(source), "E0828") == 1;
+}
+
+// -------------------------------------------------------------------
 // E0829 — `A & B` in value / type-annotation position.
 // -------------------------------------------------------------------
 test "object-model: intersection type alias is E0829 at the definition" ![io] {

--- a/compiler/tests/unit/typecheck_object_model_test.sfn
+++ b/compiler/tests/unit/typecheck_object_model_test.sfn
@@ -116,6 +116,58 @@ test "object-model: bare literal targeting an optional struct is not E0828" ![io
 }
 
 // -------------------------------------------------------------------
+// E0828 — array targets (#1900). An object literal never yields an
+// array, so an array target `T[]` is rejected regardless of whether the
+// element type `T` is a struct (the array short-circuit fires before the
+// head-symbol lookup, SFEP-0039 §3.2).
+// -------------------------------------------------------------------
+test "object-model: array-of-interface literal target is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn main() ![io] { let bad: Named[] = { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: array-of-struct literal target is still E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn main() ![io] { let bad: Person[] = { name: \"Alice\" }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+// -------------------------------------------------------------------
+// E0828 — generic-instantiation-head targets (#1900). The head is
+// classified by its base name (`Box<int>` -> `Box`), so a generic
+// interface head is rejected and a generic struct head still compiles.
+// -------------------------------------------------------------------
+test "object-model: generic-interface-head literal target is E0828" ![io] {
+    let source = "interface Container<T> { fn get() -> T; }\n"
+        + "fn main() ![io] { let bad: Container<int> = { value: 1 }; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: generic-struct-head literal target is not E0828" ![io] {
+    let source = "struct Box<T> { value: T; }\n"
+        + "fn main() ![io] { let b: Box<int> = { value: 1 }; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
+// -------------------------------------------------------------------
+// E0828 — parameter-default initializers (#1900). A bare object literal
+// as a parameter default is classified against the parameter's declared
+// type via the same rule.
+// -------------------------------------------------------------------
+test "object-model: interface-typed parameter-default literal is E0828" ![io] {
+    let source = "interface Named { fn display_name() -> string; }\n"
+        + "fn describe(p: Named = { name: \"Alice\" }) -> int { return 0; }\n";
+    assert _has_code(_diags(source), "E0828");
+}
+
+test "object-model: struct-typed parameter-default literal is not E0828" ![io] {
+    let source = "struct Person { name: string; }\n"
+        + "fn describe(p: Person = { name: \"Alice\" }) -> int { return 0; }\n";
+    assert ! _has_code(_diags(source), "E0828");
+}
+
+// -------------------------------------------------------------------
 // E0829 — `A & B` in value / type-annotation position.
 // -------------------------------------------------------------------
 test "object-model: intersection type alias is E0829 at the definition" ![io] {

--- a/docs/proposals/0039-nominal-object-model.md
+++ b/docs/proposals/0039-nominal-object-model.md
@@ -181,6 +181,41 @@ never reached for the illegal case and the placeholder store is dead.
 not a struct` with a fix-it: *"declare a `struct` and annotate the binding with
 it."*
 
+**Coverage status: complete across value positions (closed by SFEP-0041).**
+`E0828` shipped (#1899) at exactly one position — the `let` site
+(`typecheck.sfn:450`). Three follow-up issues have since closed every other
+residual position, via SFEP-0041's unified `TypeckCtx` expected-type /
+typing-environment context threaded through both typecheck walk families
+(statements and the lighter expression family lambda bodies use):
+
+- [x] `let` site (#1899) — the original enforcement.
+- [x] Array targets and generic-instantiation-head targets (#1900) — `let x:
+      Named[] = { ... }` fires `E0828` regardless of the element type, and a
+      generic instantiation target (`Iface<...>`) is classified by its base
+      name rather than falling through unrejected.
+- [x] Parameter-default initializers (#1900) — `fn f(p: Iface = { ... })` is
+      classified against `parameter.type_annotation` the same way the `let`
+      site is.
+- [x] Return-position object literals (#1904) — `fn f() -> Iface { return {
+      ... }; }` now has the enclosing function's declared return type threaded
+      down through `check_block` → `check_statement` to the `ReturnStatement`
+      branch, so it can call the classifier.
+- [x] Lambda-body `let` and lambda-return object literals (#1905) — the
+      lighter expression-family walk (`walk_expression` →
+      `walk_block_expressions` → `walk_statement_expressions`) now carries
+      `top_level` and an enclosing return type, so a lambda body's `let` and
+      `return` positions run the same classifier as the top-level walk.
+
+`E0828` is therefore enforced at **every** value position that can hold a bare
+object literal — `let`, parameter defaults, return, and lambda-body/return —
+with array and generic-instantiation-head target normalization applied
+uniformly. The named-`struct` construction path (the `Struct` AST variant, the
+#1855 path) remains exempt throughout. See SFEP-0041
+(`docs/proposals/0041-typeck-expected-type-context.md`) for the `TypeckCtx`
+mechanism; struct-field defaults, generic-instantiation arguments, and call
+arguments remain open future consumers of that same channel, tracked
+separately.
+
 ### 3.3 Rule 3 — `A & B` is not a data type (`E0829`); it is reserved for generic bounds
 
 `A & B` **stays in the grammar**. In **value / type-annotation position** — a

--- a/docs/proposals/0039-nominal-object-model.md
+++ b/docs/proposals/0039-nominal-object-model.md
@@ -183,7 +183,7 @@ it."*
 
 **Coverage status: complete across value positions (closed by SFEP-0041).**
 `E0828` shipped (#1899) at exactly one position — the `let` site
-(`typecheck.sfn:450`). Three follow-up issues have since closed every other
+(`check_statement`'s `VariableDeclaration` branch). Three follow-up issues have since closed every other
 residual position, via SFEP-0041's unified `TypeckCtx` expected-type /
 typing-environment context threaded through both typecheck walk families
 (statements and the lighter expression family lambda bodies use):

--- a/docs/proposals/0041-typeck-expected-type-context.md
+++ b/docs/proposals/0041-typeck-expected-type-context.md
@@ -1,7 +1,7 @@
 ---
-sfep: TBD
+sfep: 0041
 title: Unified expected-type + typing-environment context for the typecheck walk
-status: Draft
+status: Implemented
 type: tooling             # a compiler-internal refactor; no user-facing surface
 created: 2026-07-04
 updated: 2026-07-04
@@ -9,10 +9,10 @@ author: "agent:compiler-architect; human review"
 tracking: "#1900, #1904, #1905"
 supersedes:
 superseded-by:
-graduates-to:
+graduates-to: "docs/status.md (E0828 object-literal coverage); SFEP-0039 §3.2"
 ---
 
-# SFEP-XXXX — Unified expected-type + typing-environment context for the typecheck walk
+# SFEP-0041 — Unified expected-type + typing-environment context for the typecheck walk
 
 > Addendum to SFEP-0039 (`0039-nominal-object-model.md`). This is a
 > compiler-internal refactor, not a language change, so it is deliberately

--- a/docs/proposals/0041-typeck-expected-type-context.md
+++ b/docs/proposals/0041-typeck-expected-type-context.md
@@ -24,7 +24,7 @@ graduates-to: "docs/status.md (E0828 object-literal coverage); SFEP-0039 §3.2"
 
 SFEP-0039 §3.2 introduced `E0828` — a bare object literal `{ ... }` requires a
 concrete-`struct` target. It shipped (#1899) at exactly **one** position: the
-`let` site (`typecheck.sfn:450`). The residual positions were split into three
+`let` site (`check_statement`'s `VariableDeclaration` branch). The residual positions were split into three
 issues — array/generic-head normalization + parameter defaults (#1900), return
 position (#1904), lambda body/return (#1905) — and each is being handled
 individually, with more positions still to come (struct-field defaults,
@@ -115,8 +115,10 @@ shape as `FunctionSignature`, `ast.sfn:266`, and `SymbolEntry`,
 `typecheck_types.sfn:73` — plain records, no struct generics):
 
 ```sfn
-// typecheck_types.sfn — the typing environment + expected-type channel
-// threaded through the typecheck walk. One record serves both the
+// typecheck.sfn — the typing environment + expected-type channel
+// threaded through the typecheck walk. (As built, TypeckCtx and its
+// helpers live in typecheck.sfn, not typecheck_types.sfn, because
+// ImportSymbolTable is imported there.) One record serves both the
 // statement/block family and the expression family; a given family reads
 // only the subset it needs (unused fields are inert).
 struct TypeckCtx {
@@ -170,7 +172,7 @@ Crucially, unifying the record is what finally gives lambda-body walking
 ### 3.2 Constructors / derivation helpers
 
 Because Sailfin records are constructed by literal, ctx derivation is a set of
-small pure helpers (all in `typecheck_types.sfn`), so no call site hand-copies
+small pure helpers (all in `typecheck.sfn`), so no call site hand-copies
 eight fields:
 
 ```sfn

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -63,6 +63,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0038](./0038-generic-constraints.md) | Generic Type Parameter Constraints and Monomorphization | Accepted | language |
 | [0039](./0039-nominal-object-model.md) | Nominal Object Model — Honest Rejection of TypeScript-Shaped Data Syntax | Accepted | language |
 | [0040](./0040-artifact-cache.md) | Global Artifact Cache Store and Garbage Collection | Accepted | tooling |
+| [0041](./0041-typeck-expected-type-context.md) | Unified expected-type + typing-environment context for the typecheck walk | Implemented | tooling |
 
 ## Drafts under review (numbers assigned at merge)
 

--- a/docs/proposals/draft-typeck-expected-type-context.md
+++ b/docs/proposals/draft-typeck-expected-type-context.md
@@ -1,0 +1,424 @@
+---
+sfep: TBD
+title: Unified expected-type + typing-environment context for the typecheck walk
+status: Draft
+type: tooling             # a compiler-internal refactor; no user-facing surface
+created: 2026-07-04
+updated: 2026-07-04
+author: "agent:compiler-architect; human review"
+tracking: "#1900, #1904, #1905"
+supersedes:
+superseded-by:
+graduates-to:
+---
+
+# SFEP-XXXX — Unified expected-type + typing-environment context for the typecheck walk
+
+> Addendum to SFEP-0039 (`0039-nominal-object-model.md`). This is a
+> compiler-internal refactor, not a language change, so it is deliberately
+> lighter than a full feature SFEP. It defines the abstraction that lets the
+> `E0828` bare-object-literal rule (and its future siblings) be applied
+> uniformly at every position instead of being bolted on one issue at a time.
+
+## 1. Summary
+
+SFEP-0039 §3.2 introduced `E0828` — a bare object literal `{ ... }` requires a
+concrete-`struct` target. It shipped (#1899) at exactly **one** position: the
+`let` site (`typecheck.sfn:450`). The residual positions were split into three
+issues — array/generic-head normalization + parameter defaults (#1900), return
+position (#1904), lambda body/return (#1905) — and each is being handled
+individually, with more positions still to come (struct-field defaults,
+generic-instantiation arguments, call arguments).
+
+The root cause is a **missing abstraction, not four bugs**: the typecheck walk
+has no unified channel for the type an expression is *expected* to have, nor a
+bundled typing environment. Each position that wants to consult the expected
+type has to re-thread whatever it needs by hand, and two of the walk families
+(statements vs. expressions) carry *different, coincidentally-overlapping*
+positional parameter lists, so a position reachable only through the lighter
+expression family (lambda bodies) literally cannot see `top_level` or the
+enclosing return type.
+
+This addendum defines a single `TypeckCtx` record — the typing environment plus
+an `expected_type` / `enclosing_return_type` channel — threaded through both
+walk families, mirroring Rust's `FnCtxt` + `Expectation` and Go's assignment
+target propagation. It then folds the three open residual issues (#1900, #1904,
+#1905) into staged consumers of that channel.
+
+## 2. Motivation
+
+### 2.1 The status quo is per-position hand-threading
+
+The single consumption point today is `check_object_literal_target(initializer,
+annotation, anchor_name, anchor_span, top_level)` (`typecheck_types.sfn:425`).
+It is a clean, testable classifier. The problem is entirely *upstream* of it —
+getting the right `annotation` (the expected type) and `top_level` to each call
+site:
+
+- **`let` (works, #1899).** `check_statement`'s `VariableDeclaration` branch
+  (`typecheck.sfn:445-454`) has both the annotation (`statement.type_annotation`)
+  and `top_level` locally, so it just calls the classifier.
+- **Return (#1904, not done).** The `ReturnStatement` branch
+  (`typecheck.sfn:720-724`) only calls `walk_expression`. The enclosing function's
+  declared return type lives in `check_function_body`'s `signature.return_type`
+  (`ast.sfn:270`) but is **never threaded down** through `check_block` →
+  `check_statement`. So the return position has no expected type to hand the
+  classifier.
+- **Lambda body / return (#1905, not done).** Lambda bodies are walked *only*
+  through the lighter expression family — `walk_expression` (`typecheck.sfn:1008`)
+  → `walk_block_expressions` (`:1492`) → `walk_statement_expressions` (`:1503`)
+  — which takes `(… , bindings, imports)` and has **no `top_level` and no
+  return-type** parameter at all (see the comment at `:1489-1491`). The
+  lambda-body `let` twin (`:1513-1517`) therefore runs the bare-fn and
+  intersection checks but *cannot* call `check_object_literal_target` (no
+  `top_level`). The `Lambda` branch already reads `expression.return_type`
+  (`ast.sfn:78-93`) for the bare-fn/intersection checks, but has nowhere to
+  route it as an enclosing return type.
+- **Parameter defaults (#1900, not done).** `Parameter.default_value`
+  (`ast.sfn:216`) is a bare-object-literal position classified against
+  `parameter.type_annotation`; `seed_parameter_scope` (`typecheck.sfn:783`) has
+  both in hand but never runs the classifier.
+- **Coming next.** Struct-field defaults (blocked — `FieldDeclaration`
+  (`ast.sfn:247`) has no `default_value` field yet), generic-instantiation
+  arguments, and call arguments each add another position that will want the
+  same channel.
+
+Each of these is the *same* question — "what type is this expression expected to
+be, and is a bare object literal legal there?" — asked at a different node.
+Solving them one issue at a time re-derives the plumbing five times and leaves
+the two walk families permanently divergent.
+
+### 2.2 Why the two families diverged
+
+`check_statement` / `check_block` / `check_function_body` carry the full
+resolution environment: `interfaces`, `top_level`, `scope_start`,
+`is_top_level`. `walk_expression` / `walk_block_expressions` /
+`walk_statement_expressions` carry only `bindings` and `imports`. They share
+`bindings`/`imports` **by coincidence**, not by design — the expression family
+was introduced (`:1487-1491`) purely to recurse into lambda-body expression
+positions and only ever needed the two symbols it happened to grab. That
+coincidence is exactly the #1905 blocker: the family that walks lambda bodies is
+the one missing `top_level`.
+
+Unifying the environment into one record is therefore not just tidier — it is
+the concrete fix for #1905, because it gives lambda-body walking `top_level` and
+`enclosing_return_type` for the first time.
+
+## 3. Design
+
+### 3.1 The context record — `TypeckCtx`
+
+A single plain record carries the typing environment and the expected-type
+channel for **both** walk families. Every field type already exists in the
+compiler, so the record is expressible under the current seed (it is the same
+shape as `FunctionSignature`, `ast.sfn:266`, and `SymbolEntry`,
+`typecheck_types.sfn:73` — plain records, no struct generics):
+
+```sfn
+// typecheck_types.sfn — the typing environment + expected-type channel
+// threaded through the typecheck walk. One record serves both the
+// statement/block family and the expression family; a given family reads
+// only the subset it needs (unused fields are inert).
+struct TypeckCtx {
+    // --- typing environment (was loose positional params) ---
+    bindings: SymbolEntry[];          // in-scope symbols for the current frame
+    imports: ImportSymbolTable;       // localized import/effect table
+    interfaces: Statement[];          // interface decls (statement family only)
+    top_level: SymbolEntry[];         // #812 resolution-only top-level scope
+    is_top_level: boolean;            // statement family: top-level vs nested
+    scope_start: int;                 // shadowing boundary for register_local_symbol
+
+    // --- expected-type channel ---
+    enclosing_return_type: TypeAnnotation?;  // declared return type of the
+                                             // innermost enclosing fn/lambda;
+                                             // ambient, stable across a body
+    expected_type: TypeAnnotation?;          // the type the *current* expression
+                                             // is expected to have, set by its
+                                             // immediate syntactic parent
+}
+```
+
+**`expected_type` vs. `enclosing_return_type`.** They are different scopes of the
+same idea:
+
+- `enclosing_return_type` is **ambient** — set once when a function or lambda
+  body is entered, unchanged for the whole body. It is *one producer* of
+  `expected_type` (at a `return` statement, the expected type of the returned
+  expression *is* the enclosing return type). It also gives the currently-dead
+  `check_try_operator` (`typecheck.sfn:1299`) a natural live home later
+  (§3.6).
+- `expected_type` is **local** — the contextual type of the specific expression
+  being checked right now, set by its immediate parent position (a `let`
+  annotation, a return, later a call argument or field default) and cleared when
+  recursing into a child position that imposes no contextual type (e.g. the
+  operands of a `Binary`). Usually `null`.
+
+For the positions wired in this addendum, every producer is *co-located* with
+its consumer except the function-return → nested-return case, which is precisely
+why `enclosing_return_type` is threaded as its own ambient field. `expected_type`
+is the general channel reserved so the future positions (call args, field
+defaults) plug in without another signature change.
+
+**One record, both families.** The expression family reads the subset
+`{bindings, imports, top_level, enclosing_return_type, expected_type}`; the
+statement family additionally reads `{interfaces, scope_start, is_top_level}`.
+Carrying inert fields in one family is free and is the standard shape (Rust's
+`FnCtxt` carries the whole environment; `check_expr` takes an `Expectation`).
+Crucially, unifying the record is what finally gives lambda-body walking
+`top_level` + `enclosing_return_type` — the fix for #1905.
+
+### 3.2 Constructors / derivation helpers
+
+Because Sailfin records are constructed by literal, ctx derivation is a set of
+small pure helpers (all in `typecheck_types.sfn`), so no call site hand-copies
+eight fields:
+
+```sfn
+fn make_typeck_ctx(bindings, imports, interfaces, top_level, is_top_level) -> TypeckCtx
+    // root: scope_start = 0, enclosing_return_type = null, expected_type = null
+
+fn ctx_with_bindings(ctx: TypeckCtx, bindings: SymbolEntry[], scope_start: int) -> TypeckCtx
+    // entering a nested block scope (clone_bindings already done by caller)
+
+fn ctx_enter_body(ctx: TypeckCtx, bindings: SymbolEntry[], return_type: TypeAnnotation?) -> TypeckCtx
+    // entering a fn/lambda body: sets enclosing_return_type, clears expected_type
+
+fn ctx_with_expected(ctx: TypeckCtx, expected: TypeAnnotation?) -> TypeckCtx
+    // set the local expected type for a subexpression
+
+fn ctx_no_expected(ctx: TypeckCtx) -> TypeckCtx
+    // clear expected_type when recursing into a non-propagating child
+```
+
+### 3.3 The single consumption point stays put
+
+`check_object_literal_target` (`typecheck_types.sfn:425`) remains the **only**
+place that decides whether a bare object literal is legal, and its signature is
+**unchanged**:
+
+```sfn
+fn check_object_literal_target(
+    initializer: Expression?, annotation: TypeAnnotation?,
+    anchor_name: string, anchor_span: SourceSpan?,
+    top_level: SymbolEntry[]) -> Diagnostic[]
+```
+
+Keeping the classifier ctx-*agnostic* (it takes the resolved expected annotation
++ `top_level`, not the whole ctx) is deliberate: it stays a pure function
+testable in isolation (the 7 existing unit tests keep compiling), and it forces
+the *caller* — the position that knows its own expected type — to resolve the
+annotation. The ctx's job is only to *deliver* the annotation and `top_level` to
+call sites that previously couldn't reach them. Each caller supplies the
+`annotation` argument from the right source:
+
+| Position | `annotation` argument | `top_level` source | Closes |
+|---|---|---|---|
+| `let` (statement) | `statement.type_annotation` | `ctx.top_level` | shipped (#1899) |
+| parameter default | `parameter.type_annotation` | `ctx.top_level` (in `seed_parameter_scope`) | #1900 |
+| return (statement) | `ctx.enclosing_return_type` | `ctx.top_level` | #1904 |
+| lambda-body `let` | `statement.type_annotation` | `ctx.top_level` | #1905 |
+| lambda return | `ctx.enclosing_return_type` (= lambda return type) | `ctx.top_level` | #1905 |
+| *future:* call arg | `ctx.expected_type` (param type) | `ctx.top_level` | — |
+| *future:* field default | `field.type_annotation` | `ctx.top_level` | blocked on AST |
+
+### 3.4 `_object_literal_head_type` normalization (rides along from #1900)
+
+The classifier's head normalizer `_object_literal_head_type`
+(`typecheck_types.sfn:405`) currently only strips a trailing `?`. #1900's design
+requires two more cases, added here so the classifier is complete once and for
+all before it is called from four more positions:
+
+1. **Array short-circuit.** After trimming and `?`-stripping, if the target head
+   ends in `[]` (an array type `T[]`), a bare object literal can **never**
+   satisfy it — emit `E0828` (the un-inferable / mismatch form,
+   `has_concrete_target = false`) **regardless of whether `T` is a struct**. Add
+   a predicate `_object_literal_target_is_array(text)` and short-circuit in
+   `check_object_literal_target` *after* the intersection check (so `E0829`
+   precedence, SFEP-0039 §3.3, is preserved) and *before* head lookup.
+2. **Generic-head base normalization.** If the (non-array) head contains `<`,
+   strip the generic argument block (`Base<...>` → `Base`) and classify the
+   base. Reuse the existing `extract_generic_argument_block` /
+   `split_generic_argument_list` machinery (`typecheck_types.sfn:508`) or a
+   simple substring-to-first-`<`. Effect: `Box<int>` where `Box` is a concrete
+   `struct` compiles (sanctioned construction path); `Container<T>` where
+   `Container` is an interface fires `E0828`.
+
+Precedence inside the classifier is therefore: intersection (`E0829`, untouched)
+→ array short-circuit (`E0828`) → generic-head strip → head lookup (interface →
+`E0828`; struct / unknown / alias → conservative pass, unchanged).
+
+### 3.5 How context flows through each family
+
+**Statement/block family (has `top_level` today).** Replace the loose
+`(bindings, interfaces, scope_start, imports, top_level, is_top_level)` tail on
+`check_statement` / `check_block` / `check_function_body` with a single `ctx:
+TypeckCtx`. `check_function_body` enters the body via `ctx_enter_body(ctx,
+parameter_scope.bindings, signature.return_type)`; nested-block branches
+(TestDeclaration `:618`, WithStatement `:633`, ForStatement `:639`, MatchStatement
+`:654`, IfStatement `:667`/`:671`/`:680`, BlockStatement `:694`) derive child
+ctxs via `ctx_with_bindings`. The `ReturnStatement` branch (`:720`) gains the
+classifier call using `ctx.enclosing_return_type` + `ctx.top_level`.
+
+**Expression family (lacks `top_level` today).** Replace `(bindings, imports)` on
+`walk_expression` / `walk_block_expressions` / `walk_statement_expressions` /
+`walk_match_pattern` with `ctx: TypeckCtx`. Most self-recursive calls pass `ctx`
+unchanged (or `ctx_no_expected(ctx)` where a child imposes no contextual type).
+The `Lambda` branch (`:1113`) enters the body with `ctx_enter_body(ctx,
+<bindings + lambda params>, expression.return_type)`, so nested returns inside
+the lambda see the lambda's return type as `enclosing_return_type`. The
+`walk_statement_expressions` `ReturnStatement` branch (`:1507`) and the
+lambda-body `let` twin (`:1513`) gain classifier calls, now that `top_level` is
+reachable via `ctx`.
+
+### 3.6 `check_try_operator` (out of scope, noted)
+
+`check_try_operator` (`typecheck.sfn:1299`) is dead — only 7 unit tests call it;
+the `TryOperator` branch (`:1202`) never does. With `ctx.enclosing_return_type`
+now threaded, wiring it live is a natural follow-up (its `enclosing_return_type`
+argument is exactly the new ctx field). It is **explicitly out of scope** here to
+keep the refactor tight; it stays dead, and this SFEP just records that the ctx
+gives it a live home whenever `?`-operand-type inference lands (#829).
+
+### 3.7 Staged implementation plan
+
+Each stage self-hosts (`make compile` green) on its own; stages are independently
+mergeable and ordered by increasing blast radius.
+
+- **Stage A — classifier completion (closes #1900).** Add
+  `_object_literal_target_is_array`, the array short-circuit, and generic-head
+  base normalization to `check_object_literal_target` / `_object_literal_head_type`
+  (`typecheck_types.sfn`). Add the parameter-default classifier call in
+  `seed_parameter_scope` (`typecheck.sfn:783`) — it already has
+  `parameter.type_annotation`, `parameter.default_value`, and `top_level`; **no
+  ctx needed**. Purely additive to behavior; no signature churn.
+- **Stage B — introduce `TypeckCtx`, migrate the statement/block family (closes
+  #1904).** Add the record + helpers (§3.1–3.2). Flip `check_statement` /
+  `check_block` / `check_function_body` to take `ctx`. This trio is a closed
+  mutually-recursive cluster in one file, so all ~15 internal call sites (`:418`,
+  `:550`, `:618`, `:633`, `:639`, `:654`, `:667`, `:671`, `:680`, `:694`, `:767`,
+  `:808`) change in one atomic edit. Construct the root ctx at the two entries:
+  the program walk (`:418`) and the method body (`:550`). Wire the return-position
+  classifier call. **Bridge:** statement-family calls into the still-unmigrated
+  expression family pass `ctx.bindings, ctx.imports` (additive, self-hosting).
+- **Stage C — migrate the expression family (closes #1905).** Flip
+  `walk_expression` / `walk_block_expressions` / `walk_statement_expressions` /
+  `walk_match_pattern` to take `ctx` (~57 sites, mostly the mechanical
+  `bindings, imports` → `ctx` transform). Remove the Stage-B bridges. Wire the
+  `Lambda`-branch `ctx_enter_body`, the `walk_statement_expressions`
+  `ReturnStatement` classifier call, and the lambda-body `let` classifier call.
+- **Stage D — reserved extension channel (design-only here).** Document the
+  call-argument (`ctx.expected_type` = parameter type) and struct-field-default
+  (blocked on adding `FieldDeclaration.default_value`) consumers as the next
+  positions to plug into the channel. No code in this SFEP.
+
+## 4. Effect & capability impact
+
+**None.** This is a compiler-internal refactor of the typecheck walk. It adds no
+effects, no capabilities, no user-facing syntax, and does not touch the effect
+checker. The only observable behavior change is *more* `E0828` diagnostics firing
+at the return / lambda / parameter-default / array / generic-head positions that
+SFEP-0039 §3.2 already specified but that shipped only at the `let` site.
+
+## 5. Self-hosting impact
+
+Only **typecheck** (`typecheck.sfn`, `typecheck_types.sfn`) changes; lexer,
+parser, AST, effect checker, emitter, and LLVM lowering are untouched. Every
+change is a plain record definition plus positional-parameter threading —
+constructs the pinned seed has supported since long before this work.
+
+Per `.claude/rules/seed-dependency.md`: **no seed dependency, no seed cut.**
+`TypeckCtx` is *compiled by* the old seed, not *used by* it — `make compile`
+builds the new compiler from the pinned seed, and that fresh compiler exercises
+the new walk on its own source. Each stage is one self-contained PR whose `make
+compile` builds green from the current seed; nothing here needs to be present in
+the seed before its consumer lands. The self-host invariant (`make compile`
+before commit; `make check` for the full gate) holds at every stage boundary
+because each stage leaves the walk complete and every call site updated.
+
+## 6. Alternatives considered
+
+- **Keep two ad-hoc parameter-threadings (the status quo, rejected).** Thread
+  `enclosing_return_type` through the statement family and `top_level` through
+  the expression family as bare positional parameters, per-issue. Rejected: it
+  re-derives the plumbing at every new position (five positions and counting),
+  cements the two families' divergent shapes, and each future position (call
+  args, field defaults) is another cross-family signature change. The user
+  explicitly chose the unified context over this.
+- **Two separate context records, one per family.** A `StmtCtx` and an `ExprCtx`.
+  Rejected: doubles the surface, and the expression family's *missing* fields
+  (`top_level`, `enclosing_return_type`) are exactly what #1905 needs — a separate
+  `ExprCtx` that omits them just reproduces the bug. One record is what unblocks
+  lambda bodies.
+- **Put the expected type on the classifier signature (ctx-aware classifier).**
+  Have `check_object_literal_target` take the whole `ctx`. Rejected: couples a
+  pure, unit-tested classifier to the walk state and would churn the 7 existing
+  unit tests for no gain. The caller resolves the annotation; the classifier
+  stays pure.
+- **A full bidirectional type inferencer now.** Overkill and off-roadmap: #829
+  has no live inferencer, types are strings, and this SFEP needs only a
+  contextual *expected type* channel, not inference. The channel is designed so a
+  real inferencer can later populate `expected_type` without another refactor.
+
+## 7. Stage1 readiness mapping
+
+Internal refactor — no new user-facing feature, so parser/emitter/LLVM rows are
+"unchanged" rather than "new work."
+
+- [x] Parses — no syntax change.
+- [ ] Type-checks / effect-checks — the deliverable: `E0828` fires uniformly at
+  the return / lambda / parameter-default / array / generic-head positions via
+  the unified channel.
+- [x] Emits valid `.sfn-asm` — unchanged (rejected programs never reach the
+  emitter; accepted programs emit identically).
+- [x] Lowers to LLVM IR — unchanged.
+- [ ] Regression coverage — per-position `assert_does_not_compile` (E0828) +
+  positive `assert_compiles` cases; classifier unit tests for array / generic
+  heads (§8).
+- [ ] Self-hosts — `make compile` green after each of Stages A/B/C.
+- [ ] `sfn fmt --check` clean on `typecheck.sfn`, `typecheck_types.sfn`.
+- [ ] Documented — `docs/status.md` E0828 row updated to "all positions"; SFEP-0039
+  §3.2 cross-links this addendum.
+
+## 8. Test plan
+
+Regression per position, extending the SFEP-0039 typecheck suite
+(`compiler/tests/`):
+
+- **Classifier units (Stage A)** in `typecheck_types`-level unit tests: array
+  target `let x: Order[] = { ... }` → E0828 even when `Order` is a struct;
+  generic head `Box<int>` (struct `Box`) compiles; `Container<T>` (interface
+  `Container`) → E0828; `Named?` optional-interface unchanged; intersection
+  `A & B` still yields E0829 (precedence).
+- **Parameter default (Stage A):** `fn f(o: SomeInterface = { ... })` → E0828;
+  `fn f(o: SomeStruct = { ... })` compiles.
+- **Return (Stage B):** a function `-> SomeInterface { return { ... }; }` →
+  E0828; `-> SomeStruct { return { ... }; }` compiles; a bare `{ ... }` returned
+  where the enclosing return type is an array → E0828.
+- **Lambda (Stage C):** a lambda `fn() -> SomeInterface { return { ... }; }` →
+  E0828; a lambda-body `let bad: SomeInterface = { ... };` → E0828; the
+  struct-target twins compile.
+- **No-regression:** the existing `let`-site E0828 cases (#1899) and the 7
+  `check_try_operator` unit tests stay green; a full `make check` triple-pass
+  self-host confirms the compiler still type-checks its own source after each
+  stage.
+
+Use `assert_does_not_compile(source, "E0828")` / `assert_compiles(source, ...)`
+from `sfn/test` per `.claude/rules/no-bash-e2e.md`.
+
+## 9. References
+
+- Parent: SFEP-0039 (`docs/proposals/0039-nominal-object-model.md`), §3.2 (`E0828`),
+  §3.3 (`E0829` precedence).
+- Issues: #1899 (shipped `let` site), #1900 (array/generic-head normalization +
+  parameter defaults), #1904 (return position), #1905 (lambda body/return),
+  #829 (`?`-operand inference — future `check_try_operator` consumer).
+- Code: `typecheck.sfn` (`check_statement:444`, `check_block:802`,
+  `check_function_body:765`, `seed_parameter_scope:783`, `walk_expression:1008`,
+  `walk_block_expressions:1492`, `walk_statement_expressions:1503`,
+  `check_try_operator:1299`); `typecheck_types.sfn`
+  (`check_object_literal_target:425`, `_object_literal_head_type:405`,
+  `ScopeResult:92`, `SymbolEntry:73`); `ast.sfn`
+  (`FunctionSignature:266`, `Parameter:216`, `FieldDeclaration:247`).
+- Prior art: Rust `FnCtxt` + `Expectation` (`check_expr_with_expectation`); Go
+  assignment-target propagation.
+- Process: `.claude/rules/seed-dependency.md` (no seed cut), SFEP-0001.

--- a/docs/status.md
+++ b/docs/status.md
@@ -206,14 +206,24 @@ here.
   aliases.
 - **Nominal object model — object literals and intersections** (`E0828`/`E0829`,
   SFEP-0039, #1860): data is constructed only through a concrete `struct`. A
-  bare object literal `{ ... }` whose resolved target is an **interface**, or
-  an unannotated `let` the compiler cannot infer a struct for, fails typecheck
-  with `E0828`; `let p: Person = { name: "Alice" }` against a `struct Person`
-  is the sanctioned path (#1855) and is unaffected. Separately, `A & B` used as
-  a **data/value type** (variable, parameter, field, or return annotation, or
-  the RHS of a `type X = A & B` alias) fails typecheck with `E0829` — `A & B`
-  stays in the grammar but is reserved for generic trait-bound composition
-  (`<T: A + B>`, SFEP-0038) and is not diagnosed in bound position. The sibling
+  bare object literal `{ ... }` whose resolved target is an **interface**, an
+  **array** type (a bare literal never yields an array, so this fires
+  regardless of the element type — even `Named[]` where `Named` is a struct), a
+  **generic instantiation** whose head names a non-struct (classified by base
+  name, e.g. `Iface<...>`), or an **unannotated `let`** the compiler cannot
+  infer a struct for, fails typecheck with `E0828`; `let p: Person = { name: "Alice" }`
+  against a `struct Person` is the sanctioned path (#1855) and is unaffected.
+  Coverage is now complete across value positions — `let` (#1899), parameter
+  defaults and array/generic-head target normalization (#1900), return
+  position (#1904), and lambda-body `let` / lambda return (#1905) — via a
+  unified `TypeckCtx` expected-type/typing-environment context threaded
+  through both typecheck walk families (SFEP-0041). The named-`struct`
+  construction path (the `Struct` AST variant) stays exempt. Separately, `A &
+  B` used as a **data/value type** (variable, parameter, field, or return
+  annotation, or the RHS of a `type X = A & B` alias) fails typecheck with
+  `E0829` — `A & B` stays in the grammar but is reserved for generic
+  trait-bound composition (`<T: A + B>`, SFEP-0038) and is not diagnosed in
+  bound position. The sibling
   rule that interface members must be method signatures (`E0827`, SFEP-0039,
   #1888) is now enforced: the parser detects a data-field-shaped interface
   member (an identifier followed by `:` or `->` where a method signature was
@@ -231,7 +241,7 @@ here.
 | `thread_local let mut` | Shipped | Top-level only; ELF TLS; immutable form rejected (`E0807`) |
 | Functions (`fn`) | Shipped | Generics, default params, decorators |
 | `async fn` | Parsed | Structural only; `spawn`/`await` on spawned tasks works end-to-end (v0, #1084 closed, #1474/#1477/#1546); `await` on `async fn` return values is not wired into the live typecheck walk (pending #829). Use `spawn fn() -> T { ... }` + `await` instead |
-| Structs | Shipped | Generic params, `implements` clause. Sole sanctioned bare-object-literal target (`E0828`, SFEP-0039, #1860) — a literal targeting an interface or an un-inferable unannotated `let` is rejected |
+| Structs | Shipped | Generic params, `implements` clause. Sole sanctioned bare-object-literal target (`E0828`, SFEP-0039/SFEP-0041, #1860/#1899/#1900/#1904/#1905) — a literal targeting an interface, an un-inferable unannotated `let`, any array type (regardless of element type), or a non-struct generic-instantiation head is rejected at every value position: `let`, parameter defaults, return, and lambda-body/return |
 | Interfaces | Shipped | Trait-style method signatures, enforced method-only: a data-field-shaped member is rejected at typecheck with `E0827` (SFEP-0039, #1888), fix-it points at a concrete `struct`. Interface *signature conformance* checking is separate and still draft |
 | Enums / ADTs | Shipped | Payload variants; generic payloads monomorphise per instantiation (#830). >8-byte by-value payload layouts not yet emitted |
 | Type aliases | Shipped | Including generic params. `A & B` is reserved for generic trait bounds, not a data type — `type X = A & B` is rejected at the definition (`E0829`, SFEP-0039, #1860) |


### PR DESCRIPTION
## Summary

Closes the residual `E0828` ("bare object literal `{ ... }` requires a concrete-`struct` target", SFEP-0039 §3.2) surface. `E0828` previously fired only at the primary `let` site (#1899); a bare object literal targeting an interface/array/generic-head — or returned from a function or lambda — slipped through silently.

Rather than land the three follow-up issues as three separate ad-hoc parameter-threadings, this PR introduces **one unified `TypeckCtx` expected-type + typing-environment context** threaded through both typecheck walk families — the same abstraction Rust (`FnCtxt` + `Expectation`) and Go (assignment-target propagation) use. Every value position now reads the expected type from the *same* channel, so the residual-position backlog is retired structurally instead of extended one issue at a time. Design record: **SFEP-0041** (`docs/proposals/0041-typeck-expected-type-context.md`, Implemented).

> Note: #1900 was found closed-as-completed but never actually implemented (only a docs PR had merged); it was reopened and its work is delivered here.

## What changed

Staged so each step self-hosts on its own:

- **Stage A — classifier (`typecheck_types.sfn`), closes #1900.** Array targets (`Named[]`) fire `E0828` **regardless of element type** (an object literal never yields an array), via a short-circuit before the head-symbol lookup; generic-instantiation heads (`Iface<...>`) are classified by base name; parameter-default initializers (`fn f(p: Iface = { ... })`) are walked in `seed_parameter_scope`. The diagnostic maker gained a dedicated array message branch.
- **Stage B — statement walk (`typecheck.sfn`), closes #1904.** New `TypeckCtx` record + `make_typeck_ctx`/`ctx_with_bindings`/`ctx_enter_body` helpers. `check_statement`/`check_block`/`check_function_body` migrated onto it via destructure-at-entry (bodies stay behavior-identical). A `return { ... }` is classified against the enclosing function's declared return type (`ctx.enclosing_return_type`), gated on `!is_top_level`.
- **Stage C — expression walk (`typecheck.sfn`), closes #1905.** The expression family (`walk_expression`/`walk_match_pattern`/`walk_block_expressions`/`walk_statement_expressions`) migrated onto `TypeckCtx`. The `Lambda` branch enters the body via `ctx_enter_body`, installing the lambda's return type; lambda-body `let` and lambda-`return` object literals are now classified (per-lambda scoping preserved for nested lambdas). Unifying the record is what finally gives the lambda-body walk `top_level` + the enclosing return type — the structural fix #1905 needed.

The single classifier `check_object_literal_target` is unchanged and remains the only decision point; the named-`struct` construction path (`Struct` AST variant, the #1855 path) stays exempt throughout.

## Validation

- `make compile` (self-host) green after **each** stage.
- `sfn fmt --check` clean on every touched `.sfn`; `sfn check` clean.
- `compiler/tests/unit/typecheck_object_model_test.sfn`: **34/34** (let / array / generic-head / parameter-default / return / lambda-body / lambda-return, with struct-target negative controls and a nested-lambda per-scope test); `effect_raw_failclosed_test.sfn` adapted for the new signature (**11/11**). Walk-sensitive suites (scope/shadowing, expression walk, conditionals, `check_try_operator`, lambda capture, effect checker, concurrency) all green.
- SFEP-0039 §5 self-host audit: `make compile` confirms no `compiler/src` idiom (return-position or lambda-body) is newly rejected — the compiler contains no bare `return { ... }` object literals.

## Docs

- `docs/proposals/0041-typeck-expected-type-context.md` — new SFEP (Implemented) + registry row.
- `docs/status.md` and SFEP-0039 §3.2 — record complete `E0828` coverage across value positions.

Closes #1900
Closes #1904
Closes #1905

---
_Generated by [Claude Code](https://claude.ai/code/session_017qdF3dXtNJExYNSUkmkR2E)_