### PR TITLE
test(build): guard runtime link_libs parity across both link-argv builders

### DIFF
--- a/compiler/src/backend.sfn
+++ b/compiler/src/backend.sfn
@@ -144,6 +144,13 @@ fn _llvm_text_link_program_argv(plan: LinkPlan) -> string[] {
     return args;
 }
 
+// Both builders are module-private by naming convention; export them so
+// the runtime `link_libs` parity regression guard
+// (`compiler/tests/unit/backend_link_libs_parity_test.sfn`, SFEP-0036 /
+// #1782) can call them directly. Mirrors the `build/clang_argv.sfn`
+// export-of-underscore-helper precedent; no rename, no behavior change.
+export { _llvm_text_link_test_argv, _llvm_text_link_program_argv };
+
 // Env-gated (`SAILFIN_TRACE_LINK`) stderr echo of the resolved clang link
 // argv (#1908): a read-only observability aid that prints exactly the argv
 // `_llvm_text_link_{program,test}_argv` already returns, so link-flag tests

--- a/compiler/tests/unit/backend_link_libs_parity_test.sfn
+++ b/compiler/tests/unit/backend_link_libs_parity_test.sfn
@@ -1,0 +1,83 @@
+// compiler/tests/unit/backend_link_libs_parity_test.sfn
+//
+// Regression guard for the #1782 macOS TLS link-path bug class
+// (SFEP-0036, `docs/proposals/0036-tls-runtime.md`, gap B1 of epic
+// #1540): the OpenSSL `-L`/`-lssl`/`-lcrypto` linker inputs ride into
+// the final clang link via `LinkPlan.libs`, and BOTH backend link-argv
+// builders — the `sfn test` per-binary layout
+// (`_llvm_text_link_test_argv`) and the `sfn build`/`run` program layout
+// (`_llvm_text_link_program_argv`) — must reproduce every `plan.libs`
+// entry. #1782 was the class of bug where one link path silently dropped
+// the runtime libs while the other kept them; this test fails if either
+// builder omits any `plan.libs` entry.
+//
+// `plan.libs` is the parity-critical channel, NOT `plan.link_flags`:
+// `link_flags` is deliberately asymmetric (populated only for the
+// program layout, empty in test mode by design — see `LinkPlan` in
+// `compiler/src/backend.sfn`), so `link_flags` symmetry is intentionally
+// NOT guarded here. The guarded property is only that both builders
+// carry the full `plan.libs` set.
+import { expect_eq_bool } from "sfn/test";
+
+import { LinkPlan, _llvm_text_link_program_argv, _llvm_text_link_test_argv } from "../../src/backend";
+
+// Membership check over an emitted argv (`string[]`).
+fn _argv_contains(argv: string[], needle: string) -> boolean ![pure] {
+    let mut i: int = 0;
+    loop {
+        if i >= argv.length { break; }
+        if argv[i] == needle { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// A representative link plan whose `libs` carry OpenSSL-shaped entries:
+// the Darwin `-L<dir>` search flag plus the `-l…` library flags the
+// runtime manifest (`runtime/capsule.toml` `link-libs`) contributes.
+// `link_flags` is populated to mirror the program layout; the test
+// layout builder ignores it by design (the intentional asymmetry).
+fn _representative_plan() -> LinkPlan ![pure] {
+    return LinkPlan {
+        objects: ["runtime.o"],
+        ir_inputs: ["main.ll"],
+        out_path: "a.out",
+        opt_flag: "-O0",
+        link_flags: ["-fuse-ld=mold", "-ffunction-sections"],
+        libs: ["-L/opt/homebrew/opt/openssl@3/lib", "-lssl", "-lcrypto", "-lm", "-lpthread"],
+        test_mode: false
+    };
+}
+
+test "backend: test-layout builder reproduces every plan.libs entry" ![pure] {
+    let plan = _representative_plan();
+    let argv = _llvm_text_link_test_argv(plan);
+    let mut i: int = 0;
+    loop {
+        if i >= plan.libs.length { break; }
+        assert expect_eq_bool(_argv_contains(argv, plan.libs[i]), true).ok;
+        i += 1;
+    }
+}
+
+test "backend: program-layout builder reproduces every plan.libs entry" ![pure] {
+    let plan = _representative_plan();
+    let argv = _llvm_text_link_program_argv(plan);
+    let mut i: int = 0;
+    loop {
+        if i >= plan.libs.length { break; }
+        assert expect_eq_bool(_argv_contains(argv, plan.libs[i]), true).ok;
+        i += 1;
+    }
+}
+
+// Sanity: the membership helper is not trivially true — a lib that is
+// NOT in the plan must be reported absent, so the parity assertions
+// above genuinely fail if a builder ever drops an entry.
+test "backend: parity check is meaningful (absent lib is not found)" ![pure] {
+    let plan = _representative_plan();
+    let test_argv = _llvm_text_link_test_argv(plan);
+    let program_argv = _llvm_text_link_program_argv(plan);
+    assert expect_eq_bool(_argv_contains(test_argv, "-lnot-a-real-lib"), false).ok;
+    assert expect_eq_bool(_argv_contains(program_argv, "-lnot-a-real-lib"), false).ok;
+}


### PR DESCRIPTION
## Summary
- Adds a unit regression guard proving **both** backend link-argv builders — the `sfn test` per-binary layout (`_llvm_text_link_test_argv`) and the `sfn build`/`run` program layout (`_llvm_text_link_program_argv`) — reproduce every `LinkPlan.libs` entry (the channel the OpenSSL `-L`/`-lssl`/`-lcrypto` runtime linker inputs ride through). Guards the #1782 macOS link-path bug class where one path silently dropped the runtime libs.
- Exports the two module-private builders from `compiler/src/backend.sfn` (visibility-only, no rename — mirrors the `build/clang_argv.sfn` export-of-underscore-helper precedent) so the test can call them directly.

Closes #1822

## Acceptance Criteria
- [x] New test proves both builders reproduce all `plan.libs` entries; fails if either drops one (membership-based, with a sanity test defeating a trivially-true helper).
- [x] The test's rationale comment cites SFEP-0036 and the #1782 failure mode, and states `plan.libs` is the parity target (not the deliberate `link_flags` split).
- [x] Visibility change is the minimum needed (one `export { ... }` line); no behavior change to either builder.
- [x] `make compile` passes (self-hosts with the export change).
- [x] `make test` passes.
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Design
SFEP-0036 (`docs/proposals/0036-tls-runtime.md`, Accepted) — regression guard for the #1782 macOS link-path bug class; gap B1 of epic #1540. This PR implements one guard slice of a multi-issue SFEP; the SFEP stays `Accepted`.

## Map reconciliation
None — advisory `## Files Affected` matched the tree: `compiler/src/backend.sfn` (export) and a new `compiler/tests/unit/*_test.sfn` (`backend_link_libs_parity_test.sfn`).

## Verification
```bash
make compile   # exit 0 — self-hosts with the export change
make test      # exit 0 — full suite green (unit/integration/e2e + 38/38 capsules)
build/native/sailfin test compiler/tests/unit/backend_link_libs_parity_test.sfn   # PASS (3/3)
build/native/sailfin fmt --check compiler/src/backend.sfn compiler/tests/unit/backend_link_libs_parity_test.sfn   # clean
```

## Files Changed
- `compiler/src/backend.sfn` — export the two link-argv builders (+ rationale comment); visibility-only.
- `compiler/tests/unit/backend_link_libs_parity_test.sfn` — new parity guard (test-layout parity, program-layout parity, meaningfulness sanity check).

## Notes
Scoped strictly to observing current behavior: no builder unification, no changes to the OpenSSL keg logic in `runtime_objs.sfn`, and `link_flags` asymmetry is intentionally **not** asserted (the header comment records why). W0210 "prefer expect() over bare assert" lint warnings are expected and tolerated project-wide (#1173).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFXYdJwVpv5VqCPneQeGhP)_