### PR TITLE
feat(runtime): bridge websocket.serve to a native RFC 6455 echo server

### DIFF
--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -252,29 +252,23 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.target == "sailfin_intrinsic_fs_get_perms" {
                 _preamble_inlined = true;
             }
-            // #1601 / #1876: `websocket.serve` and the Call-form `serve` stay
-            // effect-metadata-only, so they stay sentinel-skipped — their
-            // descriptor `symbol`s are deliberately fake
-            // (`sfn_websocket_unbridged` / `sfn_serve_unbridged`) and no
-            // lowering emits a `call` against them. The source-text walker
-            // (`filter_runtime_helper_targets`) can still surface these
-            // targets from a literal `serve` / `websocket.serve` token in a
-            // compiled module, which would otherwise drive the loop below to
-            // emit a `declare` to an undefined symbol and break the link. Skip
-            // them so a metadata-only row never declares. The real serve
-            // runtime declares come from the `serve_start` /
-            // `serve_handler_dispatch` rows (distinct targets, real
-            // `sfn_serve` symbol) and are unaffected.
+            // #1601 / #1876 / #1877: the Call-form `serve` stays
+            // effect-metadata-only, so it stays sentinel-skipped — its
+            // descriptor `symbol` is deliberately fake (`sfn_serve_unbridged`)
+            // and no lowering emits a `call` against it. The source-text
+            // walker (`filter_runtime_helper_targets`) can still surface this
+            // target from a literal `serve` token in a compiled module, which
+            // would otherwise drive the loop below to emit a `declare` to an
+            // undefined symbol and break the link. Skip it so a metadata-only
+            // row never declares. The real serve runtime declares come from
+            // the `serve_start` / `serve_handler_dispatch` rows (distinct
+            // targets, real `sfn_serve` symbol) and are unaffected.
             //
-            // `websocket.connect`/`.send`/`.close` are NO LONGER skipped: they
-            // are bridged to real `sfn_websocket_*` symbols in
-            // `runtime/sfn/adapters/websocket.sfn` (#1876), so the normal
-            // declare path below emits a real `declare` the linker resolves
-            // against that runtime module. `websocket.serve`'s runtime bridge
-            // is tracked in #1877.
-            if descriptor.target == "websocket.serve" {
-                _preamble_inlined = true;
-            }
+            // `websocket.connect`/`.send`/`.close`/`.serve` are NO LONGER
+            // skipped: they are all bridged to real `sfn_websocket_*` symbols
+            // in `runtime/sfn/adapters/websocket.sfn` (#1876, #1877), so the
+            // normal declare path below emits a real `declare` the linker
+            // resolves against that runtime module.
             if descriptor.target == "serve" { _preamble_inlined = true; }
             if _preamble_inlined {
                 index += 1;

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -1024,20 +1024,27 @@ fn _rh_descriptors_07(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
     // `rendering.sfn::render_runtime_helper_declarations` were removed with
     // the bridge.
     //
-    // `websocket.serve` and the Call-form `serve` remain effect-metadata-only:
-    // their `symbol`s are deliberately fake (`sfn_*_unbridged`) and they stay
-    // sentinel-skipped so a metadata row never produces a call/declare to an
-    // undefined symbol (the spurious-declare/link hazard that kept #1183 from
-    // adding them). The `websocket.serve` runtime bridge is tracked in #1877;
-    // the Call-form `serve` lowers via its own bespoke path
-    // (`serve_start`/`serve_handler_dispatch` rows + `core.sfn`).
+    // `websocket.serve` is now BRIDGED to the Sailfin-native server runtime
+    // (#1877): `sfn_websocket_serve`, `parameter_types: ["i32"]` (the scalar
+    // port; an object literal `{ port }` is NOT used because member-call
+    // registry bridges marshal scalars, not struct literals), mirroring the
+    // connect/send/close bridge above. Its sentinel-skip in
+    // `rendering.sfn::render_runtime_helper_declarations` was removed with
+    // the bridge.
+    //
+    // The Call-form `serve` remains effect-metadata-only: its `symbol` is
+    // deliberately fake (`sfn_serve_unbridged`) and it stays sentinel-skipped
+    // so a metadata row never produces a call/declare to an undefined symbol
+    // (the spurious-declare/link hazard that kept #1183 from adding it). It
+    // lowers via its own bespoke path (`serve_start`/`serve_handler_dispatch`
+    // rows + `core.sfn`).
     //
     // `serve` carries `["io", "net"]` to match the prelude/capsule
     // `fn serve(...) ![io, net]` signatures and the
     // `serve_start`/`serve_handler_dispatch` rows above — the honest set,
     // tighter than #1183's retained `net`-only check.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "websocket.serve", symbol: "sfn_websocket_unbridged", return_type: "void", parameter_types: [], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "websocket.serve", symbol: "sfn_websocket_serve", return_type: "void", parameter_types: ["i32"], effects: ["net"], native_signature: "sfn_websocket_serve", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "websocket.send", symbol: "sfn_websocket_send", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_websocket_send", c_abi_return_type: null

--- a/compiler/tests/e2e/runtime_adapter_websocket_test.sfn
+++ b/compiler/tests/e2e/runtime_adapter_websocket_test.sfn
@@ -16,11 +16,11 @@
 //                    real `@sfn_websocket_*` calls and NOT the unbridged
 //                    `@sfn_websocket_unbridged` sentinel.
 //
-// OMITTED here: the behavioral loopback send/receive/close round-trip. It
-// needs a real server end (`websocket.serve`), which lands in #1877; the
-// loopback test lands with it. This test covers the client registry-flip
-// behavior (emit shape + routing) without a network, mirroring
-// `runtime_adapter_http_test.sfn`.
+// OMITTED here: the behavioral loopback send/receive/close round-trip — it
+// lives in the sibling `websocket_serve_loopback_test.sfn` (#1877), which
+// drives a real `sfn_websocket_serve` server with a raw-socket client. This
+// test covers the client registry-flip behavior (emit shape + routing)
+// without a network, mirroring `runtime_adapter_http_test.sfn`.
 //
 // NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]`, so
 // they cannot be called from an `![io]` test. For subprocess/IR-output
@@ -154,6 +154,7 @@ test "websocket emit: define for every sfn_websocket_* client export" ![io] {
     assert _has_define(ir, "sfn_websocket_connect");
     assert _has_define(ir, "sfn_websocket_send");
     assert _has_define(ir, "sfn_websocket_close");
+    assert _has_define(ir, "sfn_websocket_serve");
 }
 
 test "websocket emit: declares the BSD-sockets libc surface" ![io] {
@@ -196,5 +197,19 @@ test "websocket.connect/.send/.close lower to @sfn_websocket_*, not the unbridge
     assert _calls(ir, "sfn_websocket_send");
     assert _calls(ir, "sfn_websocket_close");
     // The deliberately-fake metadata sentinel must never be called.
+    assert ! _calls(ir, "sfn_websocket_unbridged");
+}
+
+test "websocket.serve lowers to @sfn_websocket_serve, not the unbridged sentinel" ![io] {
+    // `websocket.serve(9)` alone needs only the registry's `net` effect —
+    // keep the probe minimal, unlike the connect/send/close probe above
+    // (whose `.send(` additionally trips the receiver-agnostic
+    // `channel_send` `io` rule).
+    let source = "fn main() -> int ![net] {\n" + "    websocket.serve(9);\n"
+        + "    return 0;\n"
+        + "}\n";
+    let ir = _emit_source("websocket_serve_probe", source);
+    assert ir != "EMIT_FAILED";
+    assert _calls(ir, "sfn_websocket_serve");
     assert ! _calls(ir, "sfn_websocket_unbridged");
 }

--- a/compiler/tests/e2e/websocket_serve_loopback_test.sfn
+++ b/compiler/tests/e2e/websocket_serve_loopback_test.sfn
@@ -1,0 +1,378 @@
+// Native server-loopback e2e for the Sailfin-native `ws://` SERVER bridge
+// (#1877) — `sfn_websocket_serve`, bridged behind `websocket.serve(port)`
+// in `runtime/sfn/adapters/websocket.sfn`.
+//
+// Mirrors the structure of `serve_loopback_test.sfn`: build a tiny consumer
+// app that calls `websocket.serve(<port>)`, spawn it as a background
+// subprocess wrapped in a wall-clock `timeout` (the server never returns —
+// the timeout is the only teardown mechanism), and drive it with a
+// self-contained raw-socket websocket CLIENT inlined in this test. The
+// #1876 client adapter has no receive primitive, so this test cannot reuse
+// `sfn_websocket_connect`/`.send` — adding a receive to the client module is
+// out of scope here (see `websocket.sfn`'s own client/server split).
+//
+// Coverage: the handshake (fixed `Sec-WebSocket-Key` -> the RFC 6455
+// canonical `Sec-WebSocket-Accept`, proving `_ws_sec_accept`); a masked
+// TEXT frame round-trips as an unmasked echo (proving `_ws_frame_read`'s
+// unmask step and `_ws_server_frame_send`'s unmasked framing); a masked
+// CLOSE frame is accepted without hanging the connection.
+//
+// Matchers note (#842): `sfn/test`'s `expect_*` matchers are `![pure]` and
+// cannot be called from an `![io]` test; assert on captured bytes with
+// `sfn/strings::contains`/`find` instead.
+import { contains, find } from "sfn/strings";
+
+// ── libc memory + string + socket surface (test-local raw client) ──
+// Prefixed `_lb_` so the file-local helpers never collide with the
+// external-linkage runtime helpers of the same shape in `websocket.sfn`
+// (not linked into this test binary, but the prefix keeps that guarantee
+// independent of link order).
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+
+extern fn connect(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn send(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn close(fd: i32) -> i32;
+
+// The listening port for the loopback server. Fixed and distinct from
+// `serve_loopback_test.sfn`'s 18790 so the two never collide under
+// `--jobs N`.
+fn _lb_port() -> i64 { return 18791; }
+
+fn _lb_port_str() -> string { return "18791"; }
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `run_capture`/`spawn_with_env`'s empty env is the EMPTY environment, not
+// "inherit" — snapshot the parent's full environment (the nested build
+// links, needing the toolchain surface; SAILFIN_TEST_SCRATCH is already in
+// there, keeping the nested build cache per-invocation under the parallel
+// pool, `.claude/rules/no-bash-e2e.md`).
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// Resolve a wall-clock timeout command, mirroring
+// `serve_loopback_test.sfn::_timeout_cmd`. Empty string => none found.
+fn _timeout_cmd() -> string ![io] {
+    let probe = process.run(["sh", "-c", "command -v timeout >/dev/null 2>&1"]);
+    if probe == 0 { return "timeout"; }
+    let gprobe = process.run(["sh", "-c", "command -v gtimeout >/dev/null 2>&1"]);
+    if gprobe == 0 { return "gtimeout"; }
+    return "";
+}
+
+// ── raw loopback websocket client (test-local, not the #1876 adapter) ──
+fn _lb_ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+fn _lb_byte_at(base: * u8, off: i64) -> i64 {
+    return (sailfin_intrinsic_pointer_read_i32(_lb_ptr_off(base, off)) as i64) & 255;
+}
+
+// Connect a stream socket to `127.0.0.1:port`. Tries both `sockaddr_in`
+// byte layouts (Linux u16 sin_family at 0; macOS/BSD u8 sin_len at 0 +
+// u8 sin_family at 1), first success wins. Returns the connected fd or -1.
+fn _lb_connect(port: i64) -> i32 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 { return 0 - 1; }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            memset(_lb_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            memset(_lb_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_lb_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        memset(_lb_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_lb_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        // sin_addr = 127.0.0.1
+        memset(_lb_ptr_off(addr, 4), 127, 1 as usize);
+        memset(_lb_ptr_off(addr, 7), 1, 1 as usize);
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 {
+            free(addr);
+            return 0 - 1;
+        }
+        let rc: i32 = connect(fd, addr, 16);
+        free(addr);
+        if rc == 0 { return fd; }
+        close(fd);
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+fn _lb_send_all(fd: i32, buf: * u8, total: i64) -> bool {
+    let mut sent: i64 = 0;
+    loop {
+        if sent >= total { break; }
+        let n: i64 = send(fd, _lb_ptr_off(buf, sent), total - sent, 0);
+        if n <= 0 { return false; }
+        sent = sent + n;
+    }
+    return true;
+}
+
+// A single bounded `recv` (enough for the ~150-byte handshake response on
+// loopback — the same v0 single-recv scope `websocket.sfn::_ws_recv_some`
+// documents). Returns the byte count, or -1 on error.
+fn _lb_recv_some(fd: i32, buf: * u8, cap: i64) -> i64 {
+    return recv(fd, buf, cap, 0);
+}
+
+// `_lb_recv_exact(fd, buf, n)` — loop `recv` until exactly `n` bytes land.
+fn _lb_recv_exact(fd: i32, buf: * u8, n: i64) -> bool {
+    let mut got: i64 = 0;
+    loop {
+        if got >= n { break; }
+        let r: i64 = recv(fd, _lb_ptr_off(buf, got), n - got, 0);
+        if r <= 0 { return false; }
+        got = got + r;
+    }
+    return true;
+}
+
+// Send the fixed RFC 6455 handshake request (the well-known test key from
+// the spec's own example, so the expected accept value is a fixed
+// constant) and return the raw response bytes (or "" on failure).
+fn _lb_handshake(port: i64) -> string {
+    let fd: i32 = _lb_connect(port);
+    if fd < 0 { return ""; }
+    let req: string = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    if !_lb_send_all(fd, req as * u8, strlen(req as * u8) as i64) {
+        close(fd);
+        return "";
+    }
+    let cap: i64 = 1024;
+    let buf: * u8 = malloc((cap + 4) as usize);
+    if buf as i64 == 0 {
+        close(fd);
+        return "";
+    }
+    let n: i64 = _lb_recv_some(fd, buf, cap);
+    close(fd);
+    if n <= 0 { return ""; }
+    memset(_lb_ptr_off(buf, n), 0, 1 as usize);
+    return buf as string;
+}
+
+// Send a MASKED frame (client -> server MUST mask). `payload` is a raw
+// string; only TEXT (opcode 1) and CLOSE (opcode 8, empty payload) are
+// exercised by this test.
+fn _lb_send_masked(fd: i32, opcode: i64, payload: string) -> bool {
+    let payload_bytes: * u8 = payload as * u8;
+    let payload_len: i64 = strlen(payload_bytes) as i64;
+    let byte0: i64 = 128 | (opcode & 15);
+    let header_len: i64 = 2;
+    let total: i64 = header_len + 4 + payload_len;
+    let out: * u8 = malloc(total as usize);
+    if out as i64 == 0 { return false; }
+    memset(_lb_ptr_off(out, 0), byte0 as i32, 1 as usize);
+    memset(_lb_ptr_off(out, 1), (128 | payload_len) as i32, 1 as usize);
+    // A fixed (non-random) mask key is fine here — this is a directed test
+    // vehicle, not the production client (which uses RAND_bytes).
+    let mut k: i64 = 0;
+    loop {
+        if k >= 4 { break; }
+        memset(_lb_ptr_off(out, header_len + k), (11 + k) as i32, 1 as usize);
+        k = k + 1;
+    }
+    let mut i: i64 = 0;
+    loop {
+        if i >= payload_len { break; }
+        let mb: i64 = _lb_byte_at(out, header_len + (i & 3));
+        let pb: i64 = _lb_byte_at(payload_bytes, i);
+        memset(_lb_ptr_off(out, header_len + 4 + i), (pb ^ mb) as i32, 1 as usize);
+        i = i + 1;
+    }
+    let ok: bool = _lb_send_all(fd, out, total);
+    free(out);
+    return ok;
+}
+
+// Read one server (UNMASKED) frame's opcode + payload. Returns the payload
+// as a string (possibly empty), and writes the opcode through `out_opcode`.
+// Only handles the short-length (< 126) form the server ever emits for this
+// test's small payloads. Returns "" (with opcode left at -1) on any recv
+// failure.
+fn _lb_read_frame(fd: i32, out_opcode: * i64) -> string {
+    // malloc(8), not 4: `_lb_byte_at`'s 4-byte load at offset 1 touches bytes
+    // 1..4, so a 2-byte header buffer needs the same content+slack headroom
+    // the runtime's own frame buffers keep.
+    let hdr: * u8 = malloc(8 as usize);
+    if hdr as i64 == 0 {
+        atomic_store(out_opcode, 0 - 1);
+        return "";
+    }
+    if !_lb_recv_exact(fd, hdr, 2) {
+        free(hdr);
+        atomic_store(out_opcode, 0 - 1);
+        return "";
+    }
+    let byte0: i64 = _lb_byte_at(hdr, 0);
+    let byte1: i64 = _lb_byte_at(hdr, 1);
+    let opcode: i64 = byte0 & 15;
+    let masked: bool = (byte1 & 128) != 0;
+    let len: i64 = byte1 & 127;
+    free(hdr);
+    atomic_store(out_opcode, opcode);
+    if masked { return ""; }
+    if len == 0 { return ""; }
+    let payload: * u8 = malloc((len + 4) as usize);
+    if payload as i64 == 0 { return ""; }
+    if !_lb_recv_exact(fd, payload, len) {
+        free(payload);
+        return "";
+    }
+    memset(_lb_ptr_off(payload, len), 0, 1 as usize);
+    return payload as string;
+}
+
+// Lay out a consumer capsule whose `main` calls `websocket.serve(<port>)`.
+fn _app_root() -> string { return "build/websocket-serve-loopback-e2e"; }
+
+fn _write_server(port_str: string) -> string ![io] {
+    let root = _app_root();
+    fs.createDirectory(root + "/src", true);
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"sfn/websocket-serve-loopback-e2e-app\"\n"
+        + "version = \"0.0.1\"\n"
+        + "description = \"websocket.serve loopback e2e consumer\"\n"
+        + "\n"
+        + "[capabilities]\n"
+        + "required = [\"io\", \"net\"]\n"
+        + "\n"
+        + "[build]\n"
+        + "entry = \"src/main.sfn\"\n"
+        + "kind = \"library\"\n");
+    fs.writeFile(root + "/src/main.sfn", "fn main() ![io, net] {\n"
+        + "    websocket.serve("
+        + port_str
+        + ");\n"
+        + "}\n");
+    return root + "/src/main.sfn";
+}
+
+// Compile the consumer to a standalone binary up front (synchronous), so
+// the build happens ONCE outside the readiness poll window. Threads the
+// full parent environment (the build links, needing the toolchain surface).
+fn _build_bin(main_path: string, bin: string) -> string ![io] {
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", bin, main_path], _child_env());
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    if exit != 0 { return ""; }
+    return bin;
+}
+
+// Spawn the prebuilt blocking server, wrapped in a wall-clock timeout so it
+// self-reaps — there is no process-kill primitive and `websocket.serve`
+// never returns. The test guards on a timeout command being present before
+// calling this, so `tcmd` is always non-empty here.
+fn _spawn_server(bin: string) -> i64 ![io] {
+    let tcmd = _timeout_cmd();
+    let mut argv: string[] = [];
+    if tcmd.length > 0 {
+        argv.push(tcmd);
+        argv.push("60");
+    }
+    argv.push(bin);
+    return process.spawn_with_env(argv, _child_env());
+}
+
+// Poll the handshake until the prebuilt server answers with a `101`.
+// ~45s budget (90 attempts x ~0.5s) stays under the 60s server timeout.
+fn _await_ready(port: i64) -> string ![io] {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 90 { break; }
+        let resp = _lb_handshake(port);
+        if resp.length > 0 {
+            if contains(resp, "101") { return resp; }
+        }
+        let _ = process.run(["sleep", "0.5"]);
+        attempt = attempt + 1;
+    }
+    return "";
+}
+
+test "websocket.serve loopback: handshake + echo + close round-trip" ![io] {
+    // Teardown of the blocking server relies on a wall-clock timeout (no
+    // process-kill primitive; `websocket.serve` never returns). Without
+    // `timeout`/`gtimeout`, spawning the server would orphan the fixed port
+    // 18791 and poison subsequent runs — skip cleanly instead.
+    if _timeout_cmd().length == 0 {
+        print.info("[websocket-serve-loopback] SKIP: no timeout/gtimeout to reap the blocking server");
+        return;
+    }
+
+    let port = _lb_port();
+    let main_path = _write_server(_lb_port_str());
+
+    let server_bin = _build_bin(main_path, _app_root() + "/server-bin");
+    assert server_bin.length > 0;
+    let _handle = _spawn_server(server_bin);
+
+    // Readiness + handshake correctness: the fixed RFC 6455 example key
+    // `dGhlIHNhbXBsZSBub25jZQ==` must produce the canonical accept value
+    // `s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`, isolating handshake bugs (`_ws_sec_accept`)
+    // from framing bugs below.
+    let handshake_resp = _await_ready(port);
+    print.info("[websocket-serve-loopback] handshake: " + handshake_resp);
+    assert handshake_resp.length > 0;
+    assert contains(handshake_resp, "101");
+    assert contains(handshake_resp, "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+
+    // A fresh connection for the framed round-trip (the handshake connection
+    // above was used only to prove the accept value and is left to the
+    // server's own per-connection teardown).
+    let fd: i32 = _lb_connect(port);
+    assert fd >= 0;
+    let handshake_req: string = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    assert _lb_send_all(fd, handshake_req as * u8, strlen(handshake_req as * u8) as i64);
+    let cap: i64 = 1024;
+    let hbuf: * u8 = malloc((cap + 4) as usize);
+    assert hbuf as i64 != 0;
+    let hn: i64 = _lb_recv_some(fd, hbuf, cap);
+    assert hn > 0;
+
+    // Masked TEXT frame "hi" round-trips as an unmasked echo.
+    assert _lb_send_masked(fd, 1, "hi");
+    let mut opcode: i64 = 0 - 1;
+    let echoed = _lb_read_frame(fd, & opcode);
+    print.info("[websocket-serve-loopback] echo opcode=" + opcode + " payload="
+        + echoed);
+    assert opcode == 1;
+    assert echoed == "hi";
+
+    // Masked CLOSE frame -> the server replies with an unmasked CLOSE
+    // (opcode 8, empty payload) before it tears the connection down.
+    assert _lb_send_masked(fd, 8, "");
+    let mut close_opcode: i64 = 0 - 1;
+    let _close_payload = _lb_read_frame(fd, & close_opcode);
+    assert close_opcode == 8;
+    close(fd);
+
+    // Best-effort cleanup of the consumer tree (the timeout reaps the
+    // server process).
+    let _rm = process.run(["rm", "-rf", _app_root()]);
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-07-04. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
+Updated: 2026-07-05. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -188,6 +188,27 @@ here.
   to a structured `Is` AST node (not `Expression.Raw`), and the effect checker
   walks the operand — so `readFile() is T` correctly requires `![io]`. Effect
   polymorphism (`!E` variables, polymorphic HOFs) remains post-1.0.
+- **`websocket.*` runtime bridge** (epic #1180 Phase G): the `websocket.connect`/
+  `.send`/`.close`/`.serve` registry rows in `runtime_helpers.sfn` now point at
+  real `sfn_websocket_*` symbols in `runtime/sfn/adapters/websocket.sfn` — the
+  `sfn_websocket_unbridged` metadata-only sentinel is gone for this family, so
+  the calls lower, link, and self-host like any other member-call bridge (e.g.
+  `http.*`). Client (#1876): `ws://` connect + a single masked TEXT/BINARY send
+  + close. Server (#1877, v0): `websocket.serve(port)` binds/listens/accepts and
+  runs an RFC 6455 echo loop — single connection at a time, blocking, unmasked
+  server frames, no fragmentation/ping-pong, no `wss://`. `![net]` is enforced
+  via the registry rows (single source of truth since #1601); `websocket.send`
+  additionally requires `![io]` — any `.send(...)` member call trips the
+  checker's pre-existing conservative, receiver-agnostic channel-op rule
+  (shared with `channel.send`) on top of the registry's `net` row. Durable
+  convention: a registry-driven member-call bridge marshals scalar arguments
+  only — `websocket.serve(8080)` is the canonical call shape; an object literal
+  (`websocket.serve({ port })`) is unreachable without bespoke lowering.
+  Follow-ups tracked under epic #1180: concurrency-pool dispatch (#1923),
+  ping/pong + fragmentation + close-code completeness (#1924), `wss://`/TLS
+  (#1925), a per-client handler API — `server.clients()`/`onMessage`/per-client
+  send (#1926), typed message channels/backpressure (#1927), and client-side
+  receive.
 - **Undefined free-function rejection** (`E0420`, #616/#812): unresolvable
   bare-identifier callees fail typecheck.
 - **Function references**: a bare fn name in value position lowers to the
@@ -259,6 +280,7 @@ here.
 | Effect enforcement — `gpu`, `rand` | Parsed only | Reserved in the taxonomy; no detectors yet |
 | Cross-module effect propagation | **Shipped** | `E0402` (Phase E); E2 deferred |
 | Capsule capability cross-check | **Shipped** | `E0403` (Phase F) |
+| `websocket.*` (`connect`/`send`/`close`; `serve(port)`) | **Shipped (v0)** | RFC 6455 `ws://` bridged end-to-end to real `sfn_websocket_*` runtime symbols (`runtime/sfn/adapters/websocket.sfn`), replacing the `sfn_websocket_unbridged` metadata-only sentinel — client (#1876), single-connection blocking echo server (#1877), epic #1180 Phase G. `![net]` enforced via the registry rows (#1601). v0 scope: `ws://` only (no `wss://`), no fragmentation/ping-pong, unmasked server frames, one connection at a time. Follow-ups: #1923 (pool dispatch), #1924 (ping/pong + fragmentation + close codes), #1925 (`wss://`/TLS), #1926 (per-client handler API), #1927 (typed channels/backpressure) |
 | `int` / `float` numeric types | **Shipped** | Slices A–E complete (#296 closed): i64/f64 annotations, bitwise/shift ops, the `as` cast lowering matrix, integer-literal default, full source migration, strict int↔float refusal with `as` fix-it, bool-kind tightening (#537). `number` is an alias for `float` |
 | Bitwise operators (`&`, `\|`, `^`, `<<`, `>>`) | **Shipped** | Slice B; rejected on `double` operands |
 | `Result<T, E>` + `?` operator | **Shipped** | Prelude `Result`/`Error` (#832), typed `?` (`E0810`–`E0812`, #833), pure control-flow desugar (#834); spec §12. `From<E>` coercion and the `E: Error` bound gate on generic constraints |

--- a/docs/status.md
+++ b/docs/status.md
@@ -193,7 +193,7 @@ here.
   real `sfn_websocket_*` symbols in `runtime/sfn/adapters/websocket.sfn` — the
   `sfn_websocket_unbridged` metadata-only sentinel is gone for this family, so
   the calls lower, link, and self-host like any other member-call bridge (e.g.
-  `http.*`). Client (#1876): `ws://` connect + a single masked TEXT/BINARY send
+  `http.*`). Client (#1876): `ws://` connect + a single masked TEXT send
   + close. Server (#1877, v0): `websocket.serve(port)` binds/listens/accepts and
   runs an RFC 6455 echo loop — single connection at a time, blocking, unmasked
   server frames, no fragmentation/ping-pong, no `wss://`. `![net]` is enforced

--- a/examples/web/websocket-chat.sfn
+++ b/examples/web/websocket-chat.sfn
@@ -1,17 +1,18 @@
 // examples/web/websocket-chat.sfn
-
+//
+// v0 WebSocket echo server (#1877, epic #1180 Phase G). `websocket.serve(port)`
+// binds ws://localhost:8080, completes the RFC 6455 handshake per connection,
+// and echoes each client message back until the client closes. It is a
+// blocking accept loop (does not return), so anything after the call is
+// unreachable — the greeting therefore prints BEFORE it.
+//
+// The richer per-client API the original illustrative example sketched
+// (server.clients() iterator, client.onMessage callbacks, per-client send)
+// is a handler-bearing surface tracked as follow-up under epic #1180, not
+// part of the v0 bridge.
 import { websocket } from "http";
 
 fn main() ![io, net] {
-    let server = websocket.serve({ port: 8080 });
-    print("WebSocket server is running on ws://localhost:8080");
-
-    routine {
-        for client in server.clients() {
-            client.onMessage(fn(message) {
-                print("Received: {{message}}");
-                client.send("Echo: {{message}}");
-            });
-        }
-    }
+    print("WebSocket echo server starting on ws://localhost:8080");
+    websocket.serve(8080);
 }

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -1,18 +1,18 @@
 // runtime/sfn/adapters/websocket.sfn
 //
-// First-wave Sailfin-native RFC 6455 `ws://` CLIENT adapter (#1876).
-// Mirrors the socket/pointer idioms of `runtime/sfn/adapters/http.sfn`
-// (TCP connect, DNS resolution, socket-timeout arming) and the
-// `_serve_`-prefix collision-avoidance convention of
-// `runtime/sfn/concurrency/serve.sfn`: the native backend gives
-// file-local runtime helpers external linkage, so every helper here
-// carries a `_ws_` prefix to avoid a duplicate-symbol link error
-// against `http.sfn`'s identically-shaped helpers.
+// Sailfin-native RFC 6455 `ws://` adapter: a first-wave CLIENT half
+// (#1876) plus a v0 echo SERVER half (#1877). Mirrors the socket/pointer
+// idioms of `runtime/sfn/adapters/http.sfn` (TCP connect, DNS resolution,
+// socket-timeout arming) and the `_serve_`-prefix collision-avoidance
+// convention of `runtime/sfn/concurrency/serve.sfn`: the native backend
+// gives file-local runtime helpers external linkage, so every helper here
+// carries a `_ws_` prefix to avoid a duplicate-symbol link error against
+// `http.sfn`'s identically-shaped helpers.
 //
-// Scope: `ws://` only (no TLS/`wss://`), client-side only (connect,
-// send a single masked TEXT frame, close). No fragmentation, no
-// ping/pong, no receive-loop — the minimal handshake + framed send
-// needed to talk to a websocket server from Sailfin code.
+// Scope: `ws://` only (no TLS/`wss://`). Client: connect, send a single
+// masked TEXT frame, close. Server: bind/listen/accept, one connection at
+// a time, echo TEXT/BINARY frames back unmasked, reply to CLOSE. Neither
+// half implements fragmentation or ping/pong.
 //
 // ABI. `compiler/src/llvm/runtime_helpers.sfn` points the websocket
 // registry rows at the exports below (owned by the orchestrator, not
@@ -20,6 +20,7 @@
 //   - `websocket.connect(url)`        -> `sfn_websocket_connect` (i8*) -> i8*
 //   - `websocket.send(handle, msg)`   -> `sfn_websocket_send`    (i8*, i8*) -> i8*
 //   - `websocket.close(handle)`       -> `sfn_websocket_close`   (i8*) -> i8*
+//   - `websocket.serve(port)`         -> `sfn_websocket_serve`   (i32) -> void
 //
 // The handle is a `malloc(16)` cell: the connected socket fd is stored
 // as an `i32` at offset 0 (one byte at a time, matching http.sfn's
@@ -67,6 +68,14 @@ extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
 extern fn close(fd: i32) -> i32;
 
 extern fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: * u8, optlen: i32) -> i32;
+
+// The server bridge (#1877) needs the three passive-socket calls the client
+// half never uses.
+extern fn bind(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn listen(sockfd: i32, backlog: i32) -> i32;
+
+extern fn accept(sockfd: i32, addr: * u8, addrlen: * i32) -> i32;
 
 // ── DNS resolution (libc) ─────────────────────────────────────
 extern fn getaddrinfo(node: * u8, service: * u8, hints: * u8, res: * * u8) -> i32;
@@ -778,4 +787,325 @@ fn sfn_websocket_close(handle: * u8) -> * u8 ![net] {
     close(fd);
     free(handle);
     return null;
+}
+
+// ── server bridge (#1877) ──────────────────────────────────────
+// `_ws_srv_set_reuseaddr(fd)` — arm SO_REUSEADDR on the listening socket
+// before `bind` so the server can rebind its port immediately after a
+// restart instead of failing with `EADDRINUSE` while the prior socket
+// lingers in `TIME_WAIT`. Direct copy of
+// `serve.sfn::_serve_set_reuseaddr`'s dual-platform constants:
+//   - Linux:     SOL_SOCKET = 1,     SO_REUSEADDR = 2.
+//   - macOS/BSD: SOL_SOCKET = 65535, SO_REUSEADDR = 4.
+fn _ws_srv_set_reuseaddr(fd: i32) -> void {
+    let optval: * u8 = malloc(4 as usize);
+    if optval as i64 == 0 { return; }
+    memset(optval, 0, 4 as usize);
+    memset(_ws_ptr_off(optval, 0), 1, 1 as usize);
+    setsockopt(fd, 1, 2, optval, 4);
+    setsockopt(fd, 65535, 4, optval, 4);
+    free(optval);
+}
+
+// `_ws_srv_bind_listen(port)` — build an IPv4 `sockaddr_in` (dual
+// Linux/macOS layout, matching `_ws_connect_tcp`'s client-side attempt
+// loop), bind, and listen. Returns the listening fd, or -1 on any
+// failure. Direct copy of `serve.sfn::_serve_bind_listen`.
+fn _ws_srv_bind_listen(port: i64) -> i32 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 { return 0 - 1; }
+        _ws_srv_set_reuseaddr(fd);
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 {
+            close(fd);
+            return 0 - 1;
+        }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            // Linux: u16 sin_family at offset 0.
+            memset(_ws_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            // macOS/BSD: u8 sin_len at 0, u8 sin_family at 1.
+            memset(_ws_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_ws_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        // sin_port (network byte order = big-endian).
+        memset(_ws_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_ws_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        // sin_addr stays zero (INADDR_ANY) at offset 4..8.
+        let rc: i32 = bind(fd, addr, 16);
+        free(addr);
+        if rc == 0 {
+            if listen(fd, 128) == 0 { return fd; }
+            close(fd);
+            return 0 - 1;
+        }
+        close(fd);
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+// `_ws_recv_exact(fd, buf, n)` — loop `recv` until exactly `n` bytes have
+// landed in `buf`. Returns false on a short read, error, or EOF (any
+// `recv` returning <= 0) before `n` bytes are collected.
+fn _ws_recv_exact(fd: i32, buf: * u8, n: i64) -> bool ![net] {
+    let mut got: i64 = 0;
+    loop {
+        if got >= n { break; }
+        let r: i64 = recv(fd, _ws_ptr_off(buf, got), n - got, 0);
+        if r <= 0 { return false; }
+        got = got + r;
+    }
+    return true;
+}
+
+// `_ws_server_frame_send(fd, opcode, payload, payload_len)` — assemble
+// and send an UNMASKED RFC 6455 server frame (FIN=1; server→client MUST
+// NOT mask). Structurally `_ws_frame_send`'s counterpart minus the
+// masking key and XOR step. Returns false on OOM or a send failure.
+fn _ws_server_frame_send(fd: i32, opcode: i64, payload: * u8, payload_len: i64) -> bool ![net] {
+    let byte0: i64 = 128 | (opcode & 15);
+    let mut header_len: i64 = 2;
+    if payload_len >= 126 && payload_len <= 65535 { header_len = 4; } else {
+        if payload_len > 65535 { header_len = 10; }
+    }
+    let total: i64 = header_len + payload_len;
+    let out: * u8 = malloc(total as usize);
+    if out as i64 == 0 { return false; }
+    memset(_ws_ptr_off(out, 0), byte0 as i32, 1 as usize);
+    if payload_len < 126 {
+        memset(_ws_ptr_off(out, 1), payload_len as i32, 1 as usize);
+    } else {
+        if payload_len <= 65535 {
+            memset(_ws_ptr_off(out, 1), 126, 1 as usize);
+            memset(_ws_ptr_off(out, 2), ((payload_len >> 8) & 255) as i32, 1 as usize);
+            memset(_ws_ptr_off(out, 3), (payload_len & 255) as i32, 1 as usize);
+        } else {
+            memset(_ws_ptr_off(out, 1), 127, 1 as usize);
+            let mut k: i64 = 0;
+            loop {
+                if k >= 8 { break; }
+                let shift: i64 = 8 * (7 - k);
+                memset(_ws_ptr_off(out, 2 + k), ((payload_len >> shift) & 255) as i32, 1 as usize);
+                k = k + 1;
+            }
+        }
+    }
+    if payload as i64 != 0 && payload_len > 0 {
+        memcpy(_ws_ptr_off(out, header_len), payload, payload_len as usize);
+    }
+    let ok: bool = _ws_send_all(fd, out, total);
+    free(out);
+    return ok;
+}
+
+// `_ws_frame_read(fd, out_opcode, out_payload_slot, out_len_slot)` —
+// read exactly one CLIENT frame and unmask it. Writes the opcode, the
+// `i64` bit-pattern of a freshly `malloc`'d NUL-terminated payload
+// buffer (the caller casts back with `as * u8` and owns/frees it — the
+// same slot-write idiom as `_ws_parse_url`), and the payload length
+// through the three out-params. Returns false on a protocol error
+// (an unmasked "client" frame) or any `recv` failure.
+fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_slot: * i64) -> bool ![net] {
+    // malloc(12), not 8: the `len7 == 127` path fills 8 content bytes and
+    // reads them with `_ws_byte_at`, whose 4-byte load at offset 7 touches
+    // bytes 7..10 — so 8 content + 4 tail-load slack, matching this module's
+    // content+4 over-allocation invariant (the 2-byte header read needs less,
+    // but the buffer is reused for the widest read).
+    let hdr: * u8 = malloc(12 as usize);
+    if hdr as i64 == 0 { return false; }
+    if !_ws_recv_exact(fd, hdr, 2) {
+        free(hdr);
+        return false;
+    }
+    let byte0: i64 = _ws_byte_at(hdr, 0);
+    let byte1: i64 = _ws_byte_at(hdr, 1);
+    let opcode: i64 = byte0 & 15;
+    if (byte1 & 128) == 0 {
+        // RFC 6455: client-to-server frames MUST be masked.
+        free(hdr);
+        return false;
+    }
+    let len7: i64 = byte1 & 127;
+    let mut len: i64 = len7;
+    if len7 == 126 {
+        if !_ws_recv_exact(fd, hdr, 2) {
+            free(hdr);
+            return false;
+        }
+        len = (_ws_byte_at(hdr, 0) << 8) | _ws_byte_at(hdr, 1);
+    } else {
+        if len7 == 127 {
+            if !_ws_recv_exact(fd, hdr, 8) {
+                free(hdr);
+                return false;
+            }
+            let mut v: i64 = 0;
+            let mut k: i64 = 0;
+            loop {
+                if k >= 8 { break; }
+                v = (v << 8) | _ws_byte_at(hdr, k);
+                k = k + 1;
+            }
+            len = v;
+        }
+    }
+    free(hdr);
+
+    // malloc(8), not 4: `_ws_byte_at`'s 4-byte tail load at key[3] needs the
+    // slack, matching `_ws_frame_send`'s identical over-allocation.
+    let key: * u8 = malloc(8 as usize);
+    if key as i64 == 0 { return false; }
+    if !_ws_recv_exact(fd, key, 4) {
+        free(key);
+        return false;
+    }
+
+    // +4, not +1: the NUL terminator needs the same `_ws_byte_at` tail-load
+    // slack every strdup'd buffer in this module carries.
+    let payload: * u8 = malloc((len + 4) as usize);
+    if payload as i64 == 0 {
+        free(key);
+        return false;
+    }
+    if len > 0 {
+        if !_ws_recv_exact(fd, payload, len) {
+            free(key);
+            free(payload);
+            return false;
+        }
+    }
+    let mut i: i64 = 0;
+    loop {
+        if i >= len { break; }
+        let mb: i64 = _ws_byte_at(key, i & 3);
+        let pb: i64 = _ws_byte_at(payload, i);
+        memset(_ws_ptr_off(payload, i), (pb ^ mb) as i32, 1 as usize);
+        i = i + 1;
+    }
+    memset(_ws_ptr_off(payload, len), 0, 1 as usize);
+    free(key);
+
+    atomic_store(out_opcode, opcode);
+    atomic_store(out_payload_slot, payload as i64);
+    atomic_store(out_len_slot, len);
+    return true;
+}
+
+// `_ws_srv_handshake(fd)` — read the client's HTTP GET upgrade request
+// (a single bounded `recv`, the same v0 loopback scope
+// `_ws_recv_some` documents) and reply with the RFC 6455 `101`
+// response. Returns false on a malformed/missing
+// `Sec-WebSocket-Key` header or a recv/send failure.
+fn _ws_srv_handshake(fd: i32) -> bool ![net] {
+    let req_cap: i64 = 2048;
+    let buf: * u8 = malloc((req_cap + 4) as usize);
+    if buf as i64 == 0 { return false; }
+    let n: i64 = _ws_recv_some(fd, buf, req_cap);
+    if n <= 0 {
+        free(buf);
+        return false;
+    }
+    memset(_ws_ptr_off(buf, n), 0, 1 as usize);
+
+    let needle: string = "sec-websocket-key:";
+    let nlen: i64 = strlen(needle as * u8) as i64;
+    let hit: i64 = _ws_ci_find(buf, n, needle as * u8, nlen);
+    if hit < 0 {
+        free(buf);
+        return false;
+    }
+    let mut cursor: i64 = hit + nlen;
+    loop {
+        if _ws_byte_at(buf, cursor) != 32 { break; }
+        cursor = cursor + 1;
+    }
+    let key: * u8 = malloc(64 as usize);
+    if key as i64 == 0 {
+        free(buf);
+        return false;
+    }
+    let mut klen: i64 = 0;
+    loop {
+        if klen >= 63 { break; }
+        let b: i64 = _ws_byte_at(buf, cursor + klen);
+        if b == 0 || b == 13 || b == 10 { break; }
+        memset(_ws_ptr_off(key, klen), b as i32, 1 as usize);
+        klen = klen + 1;
+    }
+    memset(_ws_ptr_off(key, klen), 0, 1 as usize);
+    free(buf);
+
+    let accept_val: * u8 = malloc(29 as usize);
+    if accept_val as i64 == 0 {
+        free(key);
+        return false;
+    }
+    _ws_sec_accept(key, accept_val);
+    free(key);
+
+    let status: string = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ";
+    let tail: string = "\r\n\r\n";
+    let total: i64 = (strlen(status as * u8) as i64) + (strlen(accept_val) as i64)
+        + (strlen(tail as * u8) as i64);
+    let resp: * u8 = malloc((total + 1) as usize);
+    if resp as i64 == 0 {
+        free(accept_val);
+        return false;
+    }
+    let mut off: i64 = 0;
+    off = _ws_append(resp, off, status as * u8);
+    off = _ws_append(resp, off, accept_val);
+    off = _ws_append(resp, off, tail as * u8);
+    memset(_ws_ptr_off(resp, off), 0, 1 as usize);
+    free(accept_val);
+
+    let ok: bool = _ws_send_all(fd, resp, off);
+    free(resp);
+    return ok;
+}
+
+// `sfn_websocket_serve(port)` — a v0 echo `ws://` server. Binds and
+// listens on `port`, then blocks forever accepting one connection at a
+// time (single-client-at-a-time — no pool dispatch; fanning connections
+// out across a worker pool is a follow-up under epic #1180). Each
+// accepted connection completes the RFC 6455 handshake, then loops
+// reading single-frame (FIN=1; fragmentation is unsupported) client
+// frames and echoing TEXT/BINARY payloads back unmasked; a CLOSE frame
+// gets an unmasked CLOSE reply before the connection closes. PING/PONG
+// and any other opcode are silently drained (no ping/pong handling yet,
+// #1877). The accept loop only exits on an `accept` error.
+fn sfn_websocket_serve(port: i32) -> void ![net] {
+    let listen_fd: i32 = _ws_srv_bind_listen(port as i64);
+    if listen_fd < 0 { return; }
+    loop {
+        let fd: i32 = accept(listen_fd, null, null);
+        if fd < 0 { break; }
+        _ws_set_socket_timeouts(fd);
+        if !_ws_srv_handshake(fd) {
+            close(fd);
+            continue;
+        }
+        loop {
+            let mut opcode: i64 = 0;
+            let mut payload_addr: i64 = 0;
+            let mut len: i64 = 0;
+            if !_ws_frame_read(fd, & opcode, & payload_addr, & len) { break; }
+            if opcode == 8 {
+                _ws_server_frame_send(fd, 8, null, 0);
+                free(payload_addr as * u8);
+                break;
+            }
+            if opcode == 1 || opcode == 2 {
+                _ws_server_frame_send(fd, opcode, payload_addr as * u8, len);
+                free(payload_addr as * u8);
+            } else { free(payload_addr as * u8); }
+        }
+        close(fd);
+    }
+    close(listen_fd);
 }

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -956,6 +956,17 @@ fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_s
     }
     free(hdr);
 
+    // v0 frame-length guard: reject a negative length (a 64-bit extended
+    // length with the MSB set, which would wrap the `len + 4` allocation
+    // request) and cap the payload at a generous v0 maximum so a malicious
+    // `127`-length frame cannot force an unbounded `malloc` (remote DoS) —
+    // the compiled server is not memory-capped, only the toolchain self-caps.
+    // The full configurable cap + RFC 6455 close `1009` (message too big) is
+    // tracked in #1924; this is the minimal safety floor. The client half
+    // never sends frames anywhere near this size.
+    let max_frame: i64 = 16777216;
+    if len < 0 || len > max_frame { return false; }
+
     // malloc(8), not 4: `_ws_byte_at`'s 4-byte tail load at key[3] needs the
     // slack, matching `_ws_frame_send`'s identical over-allocation.
     let key: * u8 = malloc(8 as usize);
@@ -1080,7 +1091,12 @@ fn _ws_srv_handshake(fd: i32) -> bool ![net] {
 // and any other opcode are silently drained (no ping/pong handling yet,
 // #1877). The accept loop only exits on an `accept` error.
 fn sfn_websocket_serve(port: i32) -> void ![net] {
-    let listen_fd: i32 = _ws_srv_bind_listen(port as i64);
+    // Reject an out-of-range port before packing it into the sockaddr: a
+    // negative or > 65535 value would truncate into an unintended u16 (e.g.
+    // -1 -> 65535) and bind a port the caller never asked for.
+    let port_i64: i64 = port as i64;
+    if port_i64 <= 0 || port_i64 > 65535 { return; }
+    let listen_fd: i32 = _ws_srv_bind_listen(port_i64);
     if listen_fd < 0 { return; }
     loop {
         let fd: i32 = accept(listen_fd, null, null);

--- a/site/src/content/docs/docs/reference/effects.md
+++ b/site/src/content/docs/docs/reference/effects.md
@@ -98,10 +98,20 @@ Required for all outbound network calls, WebSocket connections, and binding to a
 |-----|-------|
 | `http.get(url)` | HTTP GET request |
 | `http.post(url, body)` | HTTP POST request |
-| `websocket.connect(url)` | Open a WebSocket connection |
-| `websocket.send(conn, msg)` | Send a message on a connection |
-| `websocket.recv(conn)` | Receive a message from a connection |
+| `websocket.connect(url)` | Open a `ws://` client connection (#1876) |
+| `websocket.send(handle, msg)` | Send a masked TEXT/BINARY frame on a connection (#1876); also requires `io` — see note below |
+| `websocket.close(handle)` | Send a CLOSE frame and close the connection (#1876) |
+| `websocket.serve(port)` | Bind/listen/accept a v0 single-connection `ws://` echo server (#1877) |
 | `serve(handler)` | Bind and serve an HTTP handler |
+
+Client-side message *receive* (`websocket.recv`) is not yet implemented — a
+follow-up under epic #1180 (see `docs/status.md`).
+
+`websocket.send(handle, msg)` needs `![io, net]`, not `![net]` alone: any
+`.send(...)` member call, regardless of receiver, trips the effect checker's
+conservative receiver-agnostic channel-op rule (shared with `channel.send`),
+which adds `io` on top of the registry's `net` requirement for
+`websocket.send` itself.
 
 ### `model` effect
 

--- a/site/src/content/docs/docs/reference/effects.md
+++ b/site/src/content/docs/docs/reference/effects.md
@@ -99,7 +99,7 @@ Required for all outbound network calls, WebSocket connections, and binding to a
 | `http.get(url)` | HTTP GET request |
 | `http.post(url, body)` | HTTP POST request |
 | `websocket.connect(url)` | Open a `ws://` client connection (#1876) |
-| `websocket.send(handle, msg)` | Send a masked TEXT/BINARY frame on a connection (#1876); also requires `io` — see note below |
+| `websocket.send(handle, msg)` | Send a masked TEXT frame on a connection (#1876); also requires `io` — see note below |
 | `websocket.close(handle)` | Send a CLOSE frame and close the connection (#1876) |
 | `websocket.serve(port)` | Bind/listen/accept a v0 single-connection `ws://` echo server (#1877) |
 | `serve(handler)` | Bind and serve an HTTP handler |

--- a/site/src/content/docs/docs/reference/spec/10-runtime.md
+++ b/site/src/content/docs/docs/reference/spec/10-runtime.md
@@ -24,6 +24,18 @@ sidebar:
 `header(req, name)`, `query_param(req, name)`, `reason_phrase(status)`.
 See [Standard Library — `sfn/http` capsule](/docs/reference/standard-library#sfnhttp-capsule) for full signatures.
 
+**WebSocket (v0, `ws://` only, require `![net]`)**:
+`websocket.connect(url)`, `websocket.send(handle, msg)`, `websocket.close(handle)` —
+a client that opens a connection, sends one masked TEXT/BINARY frame at a
+time, and closes it. `websocket.send` additionally requires `![io]` (the
+effect checker's conservative, receiver-agnostic `.send(...)` rule, shared
+with `channel.send`, applies here too). `websocket.serve(port)` binds/
+listens/accepts and runs a single-connection, blocking RFC 6455 echo server
+(bind → handshake → echo TEXT/BINARY frames back unmasked → reply to CLOSE).
+Neither half handles fragmentation or ping/pong, and there is no `wss://`/TLS
+or client-side receive yet — see [Standard Library — `websocket` module](/docs/reference/standard-library#websocket-module)
+for the full v0 scope and follow-ups.
+
 **Logging** (via `sfn/log` capsule, require `![io]`):
 `log.info(msg)`, `log.warn(msg)`, `log.error(msg)`, `log.debug(msg)`
 `log.warn` and `log.error` write to stderr.

--- a/site/src/content/docs/docs/reference/spec/10-runtime.md
+++ b/site/src/content/docs/docs/reference/spec/10-runtime.md
@@ -26,7 +26,7 @@ See [Standard Library — `sfn/http` capsule](/docs/reference/standard-library#s
 
 **WebSocket (v0, `ws://` only, require `![net]`)**:
 `websocket.connect(url)`, `websocket.send(handle, msg)`, `websocket.close(handle)` —
-a client that opens a connection, sends one masked TEXT/BINARY frame at a
+a client that opens a connection, sends one masked TEXT frame at a
 time, and closes it. `websocket.send` additionally requires `![io]` (the
 effect checker's conservative, receiver-agnostic `.send(...)` rule, shared
 with `channel.send`, applies here too). `websocket.serve(port)` binds/

--- a/site/src/content/docs/docs/reference/standard-library.md
+++ b/site/src/content/docs/docs/reference/standard-library.md
@@ -740,8 +740,68 @@ The following HTTP features are planned for a future release:
 - Timeout and retry configuration
 - `http.put`, `http.delete`, `http.patch`
 - Streaming response bodies
-- `websocket.connect` for WebSocket support
 - TLS, per-request allocation cleanup, and a typed routing layer (sfn/http Waves 3+)
+
+---
+
+## `websocket` module
+
+The `websocket` module provides a Sailfin-native RFC 6455 `ws://` client and a v0 echo server, imported as `import { websocket } from "http";`. The module is bound from `runtime/sfn/adapters/websocket.sfn` and, as of #1876 (client) and #1877 (server), lowers to real `sfn_websocket_*` runtime symbols — not the `sfn_websocket_unbridged` metadata-only sentinel these calls previously carried. There is no `WebSocket` struct type — a connection is an opaque handle (a raw pointer under the hood); treat it as an unannotated value threaded between calls.
+
+---
+
+#### `websocket.connect(url: string) -> <handle> ![net]`
+
+Parse `url` (`ws://host[:port][/path]`), open a TCP connection, and perform the RFC 6455 client handshake. Returns an opaque connection handle, or a null-equivalent handle on failure (DNS/connect/handshake error).
+
+```sfn
+fn open_conn(url: string) ![net] {
+    let conn = websocket.connect(url);
+}
+```
+
+---
+
+#### `websocket.send(handle, msg: string) -> <handle> ![io, net]`
+
+Send `msg` as a single masked TEXT frame over `handle`'s connection (client → server frames must be masked per RFC 6455). Returns the handle unchanged on success. **Requires `![io, net]`, not just `![net]`:** any `.send(...)` member call — regardless of receiver — trips the effect checker's conservative, receiver-agnostic channel-op rule (shared with `channel.send`), which adds `io` on top of the registry's `net` requirement for `websocket.send` itself.
+
+```sfn
+fn round_trip(url: string) ![io, net] {
+    let conn = websocket.connect(url);
+    websocket.send(conn, "hello");
+    websocket.close(conn);
+}
+```
+
+---
+
+#### `websocket.close(handle) -> <handle> ![net]`
+
+Send a masked CLOSE frame, close the underlying socket, and free the handle. Safe to call on an already-failed handle.
+
+---
+
+#### `websocket.serve(port: int) ![net]`
+
+Bind and listen on `port`, then block forever, accepting **one connection at a time**. Each accepted connection completes the RFC 6455 server handshake and then echoes TEXT/BINARY frames back **unmasked** (server → client frames must not be masked) until the client sends CLOSE (answered with an unmasked CLOSE reply) or the connection drops.
+
+```sfn
+fn run_echo_server() ![net] {
+    websocket.serve(8080);
+}
+```
+
+> **Convention:** like other registry-driven member-call runtime bridges, the argument is a bare scalar — `websocket.serve(8080)` — not an object literal. `websocket.serve({ port: 8080 })` is unreachable; the bridge marshals scalar arguments only, not struct literals.
+
+**v0 scope.** Shipped: the client half (connect / one masked TEXT-or-BINARY send / close) and a single-connection blocking echo server (bind/listen/accept, RFC 6455 handshake, unmasked TEXT/BINARY echo, CLOSE reply). Not yet shipped (epic #1180 follow-ups):
+
+- Concurrency-pool dispatch, so the server can hold more than one connection at a time (#1923)
+- Ping/pong, frame fragmentation, and close-code completeness (#1924)
+- `wss://` / TLS (#1925)
+- A richer per-client handler API — `server.clients()`, `onMessage`, per-client send (#1926)
+- Typed message channels and backpressure (#1927)
+- Client-side receive
 
 ---
 

--- a/site/src/content/docs/docs/reference/standard-library.md
+++ b/site/src/content/docs/docs/reference/standard-library.md
@@ -746,7 +746,7 @@ The following HTTP features are planned for a future release:
 
 ## `websocket` module
 
-The `websocket` module provides a Sailfin-native RFC 6455 `ws://` client and a v0 echo server, imported as `import { websocket } from "http";`. The module is bound from `runtime/sfn/adapters/websocket.sfn` and, as of #1876 (client) and #1877 (server), lowers to real `sfn_websocket_*` runtime symbols — not the `sfn_websocket_unbridged` metadata-only sentinel these calls previously carried. There is no `WebSocket` struct type — a connection is an opaque handle (a raw pointer under the hood); treat it as an unannotated value threaded between calls.
+The `websocket` module provides a Sailfin-native RFC 6455 `ws://` client and a v0 echo server. Like `http.*`, the `websocket.*` calls are a built-in runtime namespace available without an explicit import (the examples below call `websocket.*` directly); an `import { websocket } from "http";` also resolves for readers who prefer a named import. The module is bound from `runtime/sfn/adapters/websocket.sfn` and, as of #1876 (client) and #1877 (server), lowers to real `sfn_websocket_*` runtime symbols — not the `sfn_websocket_unbridged` metadata-only sentinel these calls previously carried. There is no `WebSocket` struct type — a connection is an opaque handle (a raw pointer under the hood); treat it as an unannotated value threaded between calls.
 
 ---
 
@@ -794,7 +794,7 @@ fn run_echo_server() ![net] {
 
 > **Convention:** like other registry-driven member-call runtime bridges, the argument is a bare scalar — `websocket.serve(8080)` — not an object literal. `websocket.serve({ port: 8080 })` is unreachable; the bridge marshals scalar arguments only, not struct literals.
 
-**v0 scope.** Shipped: the client half (connect / one masked TEXT-or-BINARY send / close) and a single-connection blocking echo server (bind/listen/accept, RFC 6455 handshake, unmasked TEXT/BINARY echo, CLOSE reply). Not yet shipped (epic #1180 follow-ups):
+**v0 scope.** Shipped: the client half (connect / one masked TEXT send / close) and a single-connection blocking echo server (bind/listen/accept, RFC 6455 handshake, unmasked TEXT/BINARY echo, CLOSE reply). Not yet shipped (epic #1180 follow-ups):
 
 - Concurrency-pool dispatch, so the server can hold more than one connection at a time (#1923)
 - Ping/pong, frame fragmentation, and close-code completeness (#1924)


### PR DESCRIPTION
## Summary

Bridges `websocket.serve` to a real Sailfin-native runtime, completing the `websocket.*` family end-to-end (epic #1180, effect-system hardening, Phase G). #1876 landed the `ws://` client; this lands the server half and flips `websocket.*` to **shipped (v0)**.

The `websocket.serve` registry row moves from the deliberately-fake `sfn_websocket_unbridged` metadata-only sentinel to a real `sfn_websocket_serve` symbol, so the member call lowers, links, and self-hosts like any other registry-driven bridge (e.g. `http.*`) — **no bespoke lowering**. The member-call path marshals a scalar port, so the canonical call shape is `websocket.serve(8080)`.

## What changed

**Runtime — `runtime/sfn/adapters/websocket.sfn`** (server half, reusing the client's SHA1/base64/frame helpers):
- `_ws_srv_bind_listen` / `_ws_srv_set_reuseaddr` — dual Linux/macOS `sockaddr_in`, `SO_REUSEADDR`, `INADDR_ANY` (mirrors `serve.sfn`).
- `_ws_srv_handshake` — reads the client `Sec-WebSocket-Key`, replies `101 Switching Protocols` with the computed `Sec-WebSocket-Accept`.
- `_ws_frame_read` — reads one **masked** client frame (rejects unmasked per RFC 6455), decodes 16/64-bit extended lengths, XOR-unmasks the payload.
- `_ws_server_frame_send` — writes an **unmasked** server frame (RFC 6455 §5.1).
- `sfn_websocket_serve(port)` — bind/listen/accept, per-connection handshake, then an echo loop (TEXT/BINARY echoed, CLOSE replied), blocking, one connection at a time.
- Adds `bind`/`listen`/`accept` externs.

**Compiler:**
- `compiler/src/llvm/runtime_helpers.sfn` — `websocket.serve` row → real `sfn_websocket_serve`, `parameter_types: ["i32"]`, `native_signature`, `effects: ["net"]`.
- `compiler/src/llvm/rendering.sfn` — remove the `websocket.serve` sentinel-skip (the Call-form `serve` skip stays).

**Tests:**
- `compiler/tests/e2e/runtime_adapter_websocket_test.sfn` — adds serve emit-`define` + routing (`@sfn_websocket_serve`, not the sentinel).
- `compiler/tests/e2e/websocket_serve_loopback_test.sfn` (new) — behavioral loopback: a raw-socket client drives the real server through handshake → masked `"hi"` send → **unmasked echo** → CLOSE reply. The handshake asserts the canonical RFC vector (`dGhlIHNhbXBsZSBub25jZQ==` → `s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`), isolating handshake correctness from framing.

**Docs / example:**
- `docs/status.md`, spec `10-runtime.md`, `standard-library.md`, `effects.md` — `websocket.*` shipped (v0), precisely scoped.
- `examples/web/websocket-chat.sfn` — rewritten to the supported `websocket.serve(8080)` echo surface.

## Verification

- `make compile` — **self-hosts** (status `pass`, exit 0).
- `sfn fmt --check` — clean on all 6 touched `.sfn` files.
- `runtime_adapter_websocket_test.sfn` — 7/7 (incl. serve emit + routing).
- `websocket_serve_loopback_test.sfn` — behavioral echo + close round-trip passes.
- Reviewed by the Opus code-reviewer: one memory-safety finding (a 3-byte heap over-read in `_ws_frame_read`'s 64-bit-length header buffer — `malloc(8)`→`malloc(12)`, the loopback test structurally couldn't catch it) fixed in this branch; the unbounded inbound-frame-length allocation is deferred to #1924 (comment added).

## Scope (v0) and follow-ups

v0 is `ws://` only, single connection at a time, blocking, no fragmentation or ping/pong, unmasked server frames. Gaps are tracked as sub-issues under #1630 / epic #1180:
- #1923 — concurrency-pool dispatch (concurrent clients)
- #1924 — ping/pong + fragmentation + close-code completeness + inbound frame-length cap
- #1925 — `wss://` / TLS termination
- #1926 — per-client handler API (`server.clients()` / `onMessage` / per-client send; needs its own SFEP)
- #1927 — typed message channels + backpressure (post-1.0)

Per CLAUDE.md "don't ship unfinished safety claims," the docs mark exactly the v0 surface as shipped and enumerate the above as not-yet-shipped.

Closes #1877.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUWqB8CudYDGWqhsq63FdB)_