### PR TITLE
fix(build): self-supply the macOS SDK to clang so nested links resolve platform libs (#1914)

### DIFF
--- a/compiler/src/backend.sfn
+++ b/compiler/src/backend.sfn
@@ -7,7 +7,10 @@
 // clang path is the sole implementation (`LlvmTextBackend`); it
 // reproduces every existing clang invocation byte-for-byte (zero
 // behaviour change — `--check-determinism` must still pass with no
-// rebaseline).
+// rebaseline), with the one deliberate exception that on Darwin the link
+// now self-supplies an explicit `-isysroot`/`-L<sdk>/usr/lib` (see the
+// `_macos_sdk_link_flags` note below, #1914); the Linux invocation is
+// unchanged and the addition is memoized/deterministic per machine.
 //
 // Later codegen/link work plugs in here instead of re-hardcoding LLVM
 // assumptions across the driver: the LLVM C-API binding (#347) lands as
@@ -36,9 +39,13 @@
 // importing this module (and emitting the `LlvmTextBackend` vtable). See
 // that file's header for the seed-lowering reason (#1730).
 import { _llvm_text_assemble_argv } from "./build/clang_argv";
+// `_shell_read_cmd` runs a command and trims its stdout — used by the
+// macOS SDK probe (`uname -s`, `xcrun --show-sdk-path`).
+import { _shell_read_cmd } from "./build/fs";
 // `_env_flag` gives `SAILFIN_TRACE_LINK` the same toggle semantics ("",
-// "0", "false" are off) as the other `SAILFIN_TRACE_*` knobs.
-import { _env_flag } from "./build_flags";
+// "0", "false" are off) as the other `SAILFIN_TRACE_*` knobs;
+// `_get_env_cmd` reads a single env var (the macOS SDK probe below).
+import { _env_flag, _get_env_cmd } from "./build_flags";
 
 // Reserved opaque object-file handle for later backend stages (#347 /
 // #1640 produce these in-process). Stage 0's `LlvmTextBackend` returns
@@ -84,10 +91,71 @@ interface Backend {
     fn link(self, plan: LinkPlan) -> int ![io];
 }
 
+// macOS SDK link flags (#1914). The driver invokes `clang` by bare name
+// and, on Darwin, has historically leaned on the *ambient* environment
+// (`SDKROOT` / `LIBRARY_PATH`) for the linker to locate the platform
+// libraries (`libSystem`, `libm`, `libpthread`). That is fragile: a
+// non-Apple `clang` first on `PATH` (a common Homebrew-LLVM setup) with
+// those vars unset fails the link outright (`ld: library 'System'/'m' not
+// found`), and a subprocess build that inherits a stripped env — e.g. the
+// parallel test pool's per-child env, which forwards only PATH/HOME/TMPDIR
+// — reintroduces the same gap. That gap surfaced as non-deterministic
+// macOS-arm64 e2e failures because whether a nested build's link resolved
+// depended on load-timed SDK re-detection rather than on the source.
+// Passing an explicitly-probed `-isysroot`/`-L<sdk>/usr/lib` makes the
+// link self-sufficient regardless of which clang is on PATH or whether the
+// SDK env is present. Non-Darwin returns [] (no-op); additive only when a
+// real SDK is found, so a working Apple-clang link is byte-unchanged.
+//
+// Probed once and cached (a link may recur per test binary in one process;
+// caching also avoids re-running `xcrun` under load, the very race this
+// closes). Only scalars are memoized — matching the `errno_locator_symbol`
+// lazy-init contract in `llvm/lowering_debug_state.sfn`.
+let mut _macos_sdk_probe_done: boolean = false;
+let mut _macos_sdk_root: string = "";
+
+fn _macos_sdk_link_flags() -> string[] ![io] {
+    if !_macos_sdk_probe_done {
+        _macos_sdk_root = _probe_macos_sdk_root();
+        _macos_sdk_probe_done = true;
+    }
+    if _macos_sdk_root.length == 0 { return []; }
+    return ["-isysroot", _macos_sdk_root, "-L" + _macos_sdk_root + "/usr/lib"];
+}
+
+// Resolve the macOS SDK root, or "" when not on Darwin / none found.
+// Order: `SAILFIN_TARGET_OS` (cross-compile override) then `uname -s` to
+// gate on Darwin; then `SDKROOT` (no subprocess, most stable when set),
+// `xcrun --show-sdk-path`, and the Command Line Tools default. Each SDK
+// candidate must exist on disk before it is trusted, so a stale env var
+// cannot force a bad `-isysroot`.
+fn _probe_macos_sdk_root() -> string ![io] {
+    let mut os: string = _get_env_cmd("SAILFIN_TARGET_OS");
+    if os.length == 0 { os = _shell_read_cmd("uname -s"); }
+    if os != "Darwin" { return ""; }
+    let env_sdk = _get_env_cmd("SDKROOT");
+    if env_sdk.length > 0 {
+        if fs.exists(env_sdk) { return env_sdk; }
+    }
+    let xcrun_sdk = _shell_read_cmd("xcrun --show-sdk-path 2>/dev/null");
+    if xcrun_sdk.length > 0 {
+        if fs.exists(xcrun_sdk) { return xcrun_sdk; }
+    }
+    let clt = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk";
+    if fs.exists(clt) { return clt; }
+    return "";
+}
+
 // Build the clang link argv for the `sfn test` layout:
-// `clang -O0 -Wno-override-module -o OUT <test.ll> <dep.ll…> <runtime.o…> <libs…>`.
-fn _llvm_text_link_test_argv(plan: LinkPlan) -> string[] {
+// `clang -O0 -Wno-override-module <sdk_flags…> -o OUT <test.ll> <dep.ll…> <runtime.o…> <libs…>`.
+fn _llvm_text_link_test_argv(plan: LinkPlan, sdk_flags: string[]) -> string[] {
     let mut args: string[] = ["clang", plan.opt_flag, "-Wno-override-module"];
+    let mut si: int = 0;
+    loop {
+        if si >= sdk_flags.length { break; }
+        args.push(sdk_flags[si]);
+        si += 1;
+    }
     args.push("-o");
     args.push(plan.out_path);
     let mut ii: int = 0;
@@ -112,9 +180,15 @@ fn _llvm_text_link_test_argv(plan: LinkPlan) -> string[] {
 }
 
 // Build the clang link argv for the program/build layout:
-// `clang <opt> -Wno-override-module <link_flags…> <runtime.o…> <ir.ll…> -o OUT <libs…>`.
-fn _llvm_text_link_program_argv(plan: LinkPlan) -> string[] {
+// `clang <opt> -Wno-override-module <sdk_flags…> <link_flags…> <runtime.o…> <ir.ll…> -o OUT <libs…>`.
+fn _llvm_text_link_program_argv(plan: LinkPlan, sdk_flags: string[]) -> string[] {
     let mut args: string[] = ["clang", plan.opt_flag, "-Wno-override-module"];
+    let mut si: int = 0;
+    loop {
+        if si >= sdk_flags.length { break; }
+        args.push(sdk_flags[si]);
+        si += 1;
+    }
     let mut fi: int = 0;
     loop {
         if fi >= plan.link_flags.length { break; }
@@ -183,12 +257,13 @@ struct LlvmTextBackend {
     }
 
     fn link(self, plan: LinkPlan) -> int ![io] {
+        let sdk_flags = _macos_sdk_link_flags();
         if plan.test_mode {
-            let test_argv = _llvm_text_link_test_argv(plan);
+            let test_argv = _llvm_text_link_test_argv(plan, sdk_flags);
             _llvm_text_trace_link(test_argv);
             return process.run(test_argv);
         }
-        let program_argv = _llvm_text_link_program_argv(plan);
+        let program_argv = _llvm_text_link_program_argv(plan, sdk_flags);
         _llvm_text_trace_link(program_argv);
         return process.run(program_argv);
     }

--- a/compiler/tests/e2e/macos_sdk_link_flags_test.sfn
+++ b/compiler/tests/e2e/macos_sdk_link_flags_test.sfn
@@ -33,8 +33,14 @@ fn _scratch_dir() -> string ![io] {
     return dir;
 }
 
+// Forward `PATH` so `uname` resolves: `run_capture`'s empty env is the
+// *empty* environment (no PATH), under which the `uname` spawn could fail
+// and mis-report the host as non-Darwin (Copilot review, PR #1929).
 fn _is_darwin() -> boolean ![io] {
-    let _exit = process.run_capture(["uname", "-s"], []);
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let _exit = process.run_capture(["uname", "-s"], e);
     let out = process.capture_take_stdout();
     let _err = process.capture_take_stderr();
     return find(out, "Darwin", 0) >= 0;

--- a/compiler/tests/e2e/macos_sdk_link_flags_test.sfn
+++ b/compiler/tests/e2e/macos_sdk_link_flags_test.sfn
@@ -1,0 +1,95 @@
+// Regression e2e for #1914: on macOS the build driver must pass an
+// explicitly-probed `-isysroot <sdk>` / `-L<sdk>/usr/lib` to `clang` so the
+// link resolves the platform libraries (`libSystem`, `libm`, `libpthread`)
+// on its own — independent of the ambient SDK environment (`SDKROOT` /
+// `LIBRARY_PATH`) or which `clang` is first on `PATH`. Before the fix the
+// nested link leaned on that ambient env; a subprocess build that inherited
+// a stripped env (the parallel test pool forwards only PATH/HOME/TMPDIR) or
+// a non-Apple `clang` on `PATH` then failed the link (`ld: library
+// 'System'/'m' not found`), which surfaced as non-deterministic macOS-arm64
+// e2e failures because success depended on load-timed SDK re-detection.
+//
+// The discriminator is deterministic on Darwin: the link argv carries
+// `-isysroot` after the fix and not before, and a `![io]` runtime-linking
+// program built under a deliberately stripped env must succeed. On
+// non-Darwin the flags are a no-op, so assert they are absent — guarding
+// against accidentally emitting a macOS `-isysroot` on Linux.
+//
+// Matchers note (#842): `sfn/test`'s `expect_*` matchers are `![pure]` and
+// cannot be called from an `![io]` test; assert on captured text directly.
+import { contains, find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    dir = dir + "/sfn-macos-sdk-link";
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+fn _is_darwin() -> boolean ![io] {
+    let _exit = process.run_capture(["uname", "-s"], []);
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return find(out, "Darwin", 0) >= 0;
+}
+
+// Deliberately minimal: forward only PATH (clang/ld discovery), HOME,
+// TMPDIR, and SAILFIN_TEST_SCRATCH (per-invocation build-cache isolation).
+// `SDKROOT` / `LIBRARY_PATH` are intentionally NOT forwarded — the whole
+// point is that the compiler supplies the SDK itself. `SAILFIN_TRACE_LINK`
+// echoes the resolved clang link argv to stderr.
+fn _stripped_traced_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    e.push("SAILFIN_TRACE_LINK=1");
+    return e;
+}
+
+// A program that pulls the runtime link libs (`-lm`/`-lpthread`): `parallel`
+// links the concurrency runtime, exercising the exact link that failed.
+fn _write_fixture(dir: string) -> string ![io] {
+    let path = dir + "/prog.sfn";
+    fs.writeFile(path, "fn _w() -> int { return 7; }\n" + "fn main() ![io] {\n"
+        + "    let _h = parallel [\n"
+        + "        fn() -> int { return _w(); },\n"
+        + "    ];\n"
+        + "    print(\"sdk-link-ok\");\n"
+        + "}\n");
+    return path;
+}
+
+test "macos-sdk-link: build carries explicit -isysroot and links under a stripped env (#1914)" ![io] {
+    let dir = _scratch_dir();
+    let main_path = _write_fixture(dir);
+    let bin = dir + "/prog.bin";
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", bin, main_path], _stripped_traced_env());
+    let _out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+
+    if _is_darwin() {
+        // The fix: the link argv self-supplies the SDK.
+        assert contains(err, "-isysroot");
+        assert contains(err, "/usr/lib");
+        // Behavioural proof: the runtime-linking build succeeds without any
+        // ambient SDK env — the regression was this link failing.
+        assert exit == 0;
+    } else {
+        // No-op on non-Darwin: a Linux link must not carry a macOS SDK root.
+        assert ! contains(err, "-isysroot");
+        assert exit == 0;
+    }
+}

--- a/compiler/tests/unit/backend_link_libs_parity_test.sfn
+++ b/compiler/tests/unit/backend_link_libs_parity_test.sfn
@@ -51,7 +51,8 @@ fn _representative_plan() -> LinkPlan ![pure] {
 
 test "backend: test-layout builder reproduces every plan.libs entry" ![pure] {
     let plan = _representative_plan();
-    let argv = _llvm_text_link_test_argv(plan);
+    let no_sdk: string[] = [];
+    let argv = _llvm_text_link_test_argv(plan, no_sdk);
     let mut i: int = 0;
     loop {
         if i >= plan.libs.length { break; }
@@ -62,7 +63,8 @@ test "backend: test-layout builder reproduces every plan.libs entry" ![pure] {
 
 test "backend: program-layout builder reproduces every plan.libs entry" ![pure] {
     let plan = _representative_plan();
-    let argv = _llvm_text_link_program_argv(plan);
+    let no_sdk: string[] = [];
+    let argv = _llvm_text_link_program_argv(plan, no_sdk);
     let mut i: int = 0;
     loop {
         if i >= plan.libs.length { break; }
@@ -76,8 +78,9 @@ test "backend: program-layout builder reproduces every plan.libs entry" ![pure] 
 // above genuinely fail if a builder ever drops an entry.
 test "backend: parity check is meaningful (absent lib is not found)" ![pure] {
     let plan = _representative_plan();
-    let test_argv = _llvm_text_link_test_argv(plan);
-    let program_argv = _llvm_text_link_program_argv(plan);
+    let no_sdk: string[] = [];
+    let test_argv = _llvm_text_link_test_argv(plan, no_sdk);
+    let program_argv = _llvm_text_link_program_argv(plan, no_sdk);
     assert expect_eq_bool(_argv_contains(test_argv, "-lnot-a-real-lib"), false).ok;
     assert expect_eq_bool(_argv_contains(program_argv, "-lnot-a-real-lib"), false).ok;
 }


### PR DESCRIPTION
## Summary
- The intermittent macOS-arm64 `Error 134` (SIGABRT) e2e flake tracked in #1914 is **not** the arena/emit UAF the issue hypothesized. That premise was disproven: running the suite with the arena disabled (`SAILFIN_USE_ARENA=0`) reproduces the crash **identically** (same files, same assertion lines), and emit is byte-identical across parallel runs.
- **Real cause:** nested `sfn build`/`sfn run` **link** failures. The driver invoked `clang` by bare name and depended on the ambient environment (`SDKROOT`/`LIBRARY_PATH`) to locate the macOS SDK. A subprocess build inheriting a stripped env (the parallel `int-e2e-caps` pool forwards only `PATH`/`HOME`/`TMPDIR`) — or a non-Apple `clang` first on `PATH` — then failed the link (`ld: library 'System'/'m' not found`), tripping the test's `assert exit == 0` → runtime `abort()` → 134. It read as non-deterministic because success hinged on load-timed SDK re-detection, not on the source.
- **Fix:** on Darwin only, probe the SDK once (`SDKROOT` → `xcrun --show-sdk-path` → CommandLineTools default, each `fs.exists`-validated) and pass an explicit `-isysroot <sdk>` / `-L<sdk>/usr/lib` in the clang link argv, so the link is self-sufficient regardless of ambient env or which clang is on PATH. Non-Darwin returns no flags — the Linux link argv is byte-identical.

Closes #1914

## Root-cause reconciliation
The issue's `In:`/`Files Affected` scoped an emit-path UAF (`effects.sfn`, `lowering_helpers.sfn`). Diagnosis disproved that and localized the flake to the macOS link path; `substring` was also confirmed to be an owned copy (not a view), so the named surfaces don't alias. The **Goal** (eliminate the `Error 134` flake) is unchanged; the fix lands in `compiler/src/backend.sfn` (link-argv assembly) instead. Scope reframe was raised with and approved by the maintainer before implementation.

## Acceptance Criteria
- [x] A regression test reliably reproduces the failure before the fix and passes after — `macos_sdk_link_flags_test.sfn` (deterministic on Darwin: link argv lacked `-isysroot` before, carries it after; runtime-linking build under a stripped env fails before / succeeds after).
- [x] After the fix the previously-flaky tests pass — local full e2e went **37 → 4 failures**; the CI-cited failures (`array_reduce_closure`, `runtime_array`, `linker_selection`) are green.
- [x] `make compile` self-hosts clean; Linux link path byte-identical (probe returns `[]` off-Darwin).
- [ ] macOS-arm64 CI shards run without `Error 134` — **deferred to CI** (see Caveats).

## Caveats / residuals
- The **4 local residuals** after the fix are orthogonal local-toolchain artifacts, not this flake and not regressions (all were in the pre-fix failure set): `runtime_memory_mem` / `runtime_memory_rc` invoke `clang` **directly** with `-lm` and a stripped env (bypassing the compiler, so this fix can't reach them — they only fail on a non-Apple-clang machine); `serve_keepalive` (networking/ASAN leg) and `work_dir_parity` (rebuilds the compiler twice) are locally flaky/slow.
- This machine has Homebrew LLVM clang first on `PATH` + Xcode-beta selected, which made the failure **deterministic** locally; CI (Apple clang) hits it non-deterministically under load. CI is the authoritative check that the macOS-arm64 shards are now clean.

## Verification
```bash
make compile                                                   # self-hosts clean
build/native/sailfin test compiler/tests/e2e/macos_sdk_link_flags_test.sfn   # PASS
build/native/sailfin test compiler/tests/unit/backend_link_libs_parity_test.sfn  # PASS (3)
build/native/sailfin test compiler/tests/e2e --jobs 12         # 187/191 (was 154/191); residuals above
# CI-cited, previously flaky, now green:
build/native/sailfin test compiler/tests/e2e/{array_reduce_closure,runtime_array,linker_selection}_test.sfn
```

## Files Changed
- `compiler/src/backend.sfn` — Darwin SDK probe (`_macos_sdk_link_flags`/`_probe_macos_sdk_root`, memoized) + `sdk_flags` param on both link-argv builders, computed once in `link()`.
- `compiler/tests/e2e/macos_sdk_link_flags_test.sfn` — new regression.
- `compiler/tests/unit/backend_link_libs_parity_test.sfn` — thread the new arg through the 3 builder call sites.