### PR TITLE
fix(typecheck): register lambda body-local `let`s in the lambda-body walk scope (E0420 false-positive)

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -1617,10 +1617,25 @@ fn typecheck_walker_resolves_import(name: string, imports: ImportSymbolTable) ->
 // recursion for lambda bodies (which `check_block` never descends into).
 fn walk_block_expressions(block: Block, ctx: TypeckCtx) -> Diagnostic[] {
     let mut diagnostics: Diagnostic[] = [];
+    // Thread a growing binding scope through the block so a body-local `let`
+    // declared earlier is visible to later statements as a call target (else
+    // it falsely trips E0420, #1921 — the #1917 parameter-scope sibling gap).
+    // A fresh clone + `scope_start` per block confines each nested block's own
+    // `let`s to that block, mirroring `check_block`'s discipline. Variable
+    // registration never dedups (`register_local_symbol` skips the duplicate
+    // check for the `variable` kind), so it yields no diagnostics to surface;
+    // lambda-body E0001 handling is out of this scope.
+    let mut bindings: SymbolEntry[] = clone_bindings(ctx.bindings);
+    let scope_start: int = bindings.length;
     let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
-        diagnostics = diagnostics.concat(walk_statement_expressions(block.statements[index], ctx));
+        let statement = block.statements[index];
+        diagnostics = diagnostics.concat(walk_statement_expressions(statement, ctx_with_bindings(ctx, bindings, scope_start)));
+        if statement.variant == "VariableDeclaration" {
+            let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
+            bindings = registration.bindings;
+        }
         index += 1;
     }
     return diagnostics;

--- a/compiler/tests/unit/typecheck_undefined_function_test.sfn
+++ b/compiler/tests/unit/typecheck_undefined_function_test.sfn
@@ -147,6 +147,29 @@ test "E0001: duplicate lambda parameter names are still caught (#1917)" ![io] {
 }
 
 // -------------------------------------------------------------------
+// Lambda-body local-binding scope (#1921): a `let` declared earlier in a
+// lambda body is registered into the scope its later statements are walked
+// in, the #1917 parameter-scope sibling gap.
+// -------------------------------------------------------------------
+test "E0420: lambda body local declared earlier resolves as a later callee (#1921)" ![io] {
+    // `g` is a body-local `let` declared before the `return g()` that calls
+    // it; threading the binding scope through the body walk must resolve it.
+    assert _e0420_for("fn main() { let f = fn() -> int { let g = fn() -> int { return 0; }; return g(); }; }") == 0;
+}
+
+test "E0420: genuinely undefined callee inside a lambda body still fires (#1921)" ![io] {
+    // No body-local `let` or parameter named `nope`, so the undefined-callee
+    // check must still fire after the scope-threading change.
+    assert _e0420_for("fn main() { let f = fn() -> int { let g = fn() -> int { return 0; }; return nope(); }; }") == 1;
+}
+
+test "E0420: lambda inner-block local does not leak to the enclosing body (#1921)" ![io] {
+    // `g` is declared only inside an `if` block; it must not resolve as a
+    // call target after the block, so the outer `g()` still trips E0420.
+    assert _e0420_for("fn main() { let f = fn() -> int { if true { let g = fn() -> int { return 0; }; } return g(); }; }") == 1;
+}
+
+// -------------------------------------------------------------------
 // Imports: resolution via the program's own import specifier
 // -------------------------------------------------------------------
 fn _imports_with_helper() -> ImportSymbolTable {


### PR DESCRIPTION
## Summary

`walk_block_expressions` (`compiler/src/typecheck.sfn`) walked a lambda body with a fixed `ctx` and never registered a `VariableDeclaration`'s name, so a `let` declared earlier in the body was invisible to later statements — a body-local binding used as a call target falsely tripped `error[E0420]: undefined function`. This is the direct sibling of #1917 / PR #1918, which fixed lambda **parameters** the same way; surfaced by Copilot review on PR #1918.

Repro (before this change):

```sfn
fn main() { let f = fn() -> int { let g = fn() -> int { return 0; }; return g(); }; }
// error[E0420]: undefined function `g`
```

## The fix

`walk_block_expressions` now threads a growing binding scope through the block, mirroring the non-lambda `check_block` discipline in the same file:

- clone `ctx.bindings` and set `scope_start = bindings.length`;
- walk each statement with `ctx_with_bindings(ctx, bindings, scope_start)` **before** appending its declaration (so an initializer never sees its own name);
- register each `VariableDeclaration` into the growing `bindings` via `register_local_symbol`.

Nested-block arms (`if`/`for`/`loop`/`match`/`with`/`block`/`try`) re-dispatch to `walk_block_expressions`, which re-clones and re-establishes `scope_start` — so an inner-block `let` cannot leak to the enclosing block. Registration diagnostics are a strict no-op here (`register_local_symbol` skips the duplicate check for the `variable` kind), so no new E0001 handling is introduced.

## Scope

- **In:** thread the binding scope through the lambda-body walker; register body-local `let`s; respect nested-block scoping + shadowing.
- **Out:** lambda parameters (#1917/#1918, shipped); capture analysis (`typecheck_captures.sfn`); E0828 object-literal / E0001 duplicate handling; **nested statement-position `fn` declarations** inside lambda bodies — the untreated sibling in this family, filed as follow-up #1922.

## Testing

- New regression tests in `compiler/tests/unit/typecheck_undefined_function_test.sfn`:
  - body-local `let` declared earlier resolves as a later callee (no E0420);
  - a genuinely undefined callee inside a lambda body still fires E0420;
  - an inner-block-local `let` does not leak to the enclosing body (still fires E0420).
- Additional manual verification: chained body-locals (`a` visible to `b`), for-loop-body-local non-leak, top-level fn still resolves from a lambda body.
- `make rebuild` (self-host) — pass.
- `make test` (full suite) — pass; capsules 38/38.
- `sfn fmt --check` on both touched files — clean.

Closes #1921


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYQMirX1wKkuP4BxCq3udU)_