### PR TITLE
feat(runtime): dispatch websocket.serve connections to the concurrency pool

### DIFF
--- a/compiler/tests/e2e/websocket_serve_loopback_test.sfn
+++ b/compiler/tests/e2e/websocket_serve_loopback_test.sfn
@@ -54,6 +54,13 @@ fn _lb_port() -> i64 { return 18791; }
 
 fn _lb_port_str() -> string { return "18791"; }
 
+// A second, distinct fixed port for the concurrent-clients test's own
+// server instance, so it never collides with the port above or with
+// `serve_loopback_test.sfn`'s 18790 under `--jobs N`.
+fn _lb_port2() -> i64 { return 18792; }
+
+fn _lb_port2_str() -> string { return "18792"; }
+
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
@@ -273,6 +280,32 @@ fn _write_server(port_str: string) -> string ![io] {
     return root + "/src/main.sfn";
 }
 
+// A second consumer tree, fully independent of `_app_root`/`_write_server`,
+// so the concurrent-clients test spawns its own server on `_lb_port2()`.
+fn _app_root2() -> string { return "build/websocket-serve-concurrent-e2e"; }
+
+fn _write_server2(port_str: string) -> string ![io] {
+    let root = _app_root2();
+    fs.createDirectory(root + "/src", true);
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"sfn/websocket-serve-loopback-e2e-app\"\n"
+        + "version = \"0.0.1\"\n"
+        + "description = \"websocket.serve loopback e2e consumer\"\n"
+        + "\n"
+        + "[capabilities]\n"
+        + "required = [\"io\", \"net\"]\n"
+        + "\n"
+        + "[build]\n"
+        + "entry = \"src/main.sfn\"\n"
+        + "kind = \"library\"\n");
+    fs.writeFile(root + "/src/main.sfn", "fn main() ![io, net] {\n"
+        + "    websocket.serve("
+        + port_str
+        + ");\n"
+        + "}\n");
+    return root + "/src/main.sfn";
+}
+
 // Compile the consumer to a standalone binary up front (synchronous), so
 // the build happens ONCE outside the readiness poll window. Threads the
 // full parent environment (the build links, needing the toolchain surface).
@@ -297,6 +330,40 @@ fn _spawn_server(bin: string) -> i64 ![io] {
     }
     argv.push(bin);
     return process.spawn_with_env(argv, _child_env());
+}
+
+// Child env with the scheduler pool pinned to two workers. The
+// concurrency test is the first test whose PASS depends on the server's
+// pool being >= 2 threads; the runtime auto-floors auto-detection at two
+// (`scheduler.sfn::sfn_scheduler_resolve_thread_count`), but an inherited
+// `SAILFIN_THREADS=1` bypasses that floor. `getenv` returns the first
+// match, so we must DROP any inherited `SAILFIN_THREADS=` before appending
+// our pin rather than just append a second entry.
+fn _pool_env() -> string[] ![io] {
+    let base = process.environ();
+    let mut e: string[] = [];
+    let mut i = 0;
+    loop {
+        if i >= base.length { break; }
+        let entry = base[i];
+        if find(entry, "SAILFIN_THREADS=", 0) != 0 { e.push(entry); }
+        i = i + 1;
+    }
+    e.push("SAILFIN_THREADS=2");
+    return e;
+}
+
+// Spawn the concurrent-test server with the pool pinned (`_pool_env`) so
+// the two-client guarantee never hinges on an inherited thread count.
+fn _spawn_server_pooled(bin: string) -> i64 ![io] {
+    let tcmd = _timeout_cmd();
+    let mut argv: string[] = [];
+    if tcmd.length > 0 {
+        argv.push(tcmd);
+        argv.push("60");
+    }
+    argv.push(bin);
+    return process.spawn_with_env(argv, _pool_env());
 }
 
 // Poll the handshake until the prebuilt server answers with a `101`.
@@ -375,4 +442,99 @@ test "websocket.serve loopback: handshake + echo + close round-trip" ![io] {
     // Best-effort cleanup of the consumer tree (the timeout reaps the
     // server process).
     let _rm = process.run(["rm", "-rf", _app_root()]);
+}
+
+test "websocket.serve loopback: two clients served concurrently" ![io] {
+    // Same rationale as the test above: without a reaper, a spawned server
+    // would orphan the fixed port 18792 and poison subsequent runs.
+    if _timeout_cmd().length == 0 {
+        print.info("[websocket-serve-concurrent] SKIP: no timeout/gtimeout to reap the blocking server");
+        return;
+    }
+
+    let port2 = _lb_port2();
+    let main_path = _write_server2(_lb_port2_str());
+
+    let server_bin = _build_bin(main_path, _app_root2() + "/server-bin");
+    assert server_bin.length > 0;
+    let _handle = _spawn_server_pooled(server_bin);
+
+    let ready_resp = _await_ready(port2);
+    print.info("[websocket-serve-concurrent] ready: " + ready_resp);
+    assert ready_resp.length > 0;
+    assert contains(ready_resp, "101");
+
+    let handshake_req: string = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    let cap: i64 = 1024;
+
+    // Open the first connection and complete its handshake, but do NOT
+    // close it or drive it further yet — a single-threaded accept loop
+    // would now be blocked in this connection's per-client frame loop.
+    let fd1: i32 = _lb_connect(port2);
+    assert fd1 >= 0;
+    assert _lb_send_all(fd1, handshake_req as * u8, strlen(handshake_req as * u8) as i64);
+    let hbuf1: * u8 = malloc((cap + 4) as usize);
+    assert hbuf1 as i64 != 0;
+    let hn1: i64 = _lb_recv_some(fd1, hbuf1, cap);
+    assert hn1 > 0;
+    memset(_lb_ptr_off(hbuf1, hn1), 0, 1 as usize);
+    let resp1: string = hbuf1 as string;
+    print.info("[websocket-serve-concurrent] fd1 handshake: " + resp1);
+    assert contains(resp1, "101");
+
+    // Load-bearing assertion: open and handshake a SECOND connection while
+    // the first is still open and mid-session. A single-threaded accept
+    // loop could not reach `accept()` again here, so a successful 101 on
+    // fd2 proves connections are dispatched to a shared thread pool (#1923),
+    // not served one at a time.
+    let fd2: i32 = _lb_connect(port2);
+    assert fd2 >= 0;
+    assert _lb_send_all(fd2, handshake_req as * u8, strlen(handshake_req as * u8) as i64);
+    let hbuf2: * u8 = malloc((cap + 4) as usize);
+    assert hbuf2 as i64 != 0;
+    let hn2: i64 = _lb_recv_some(fd2, hbuf2, cap);
+    assert hn2 > 0;
+    memset(_lb_ptr_off(hbuf2, hn2), 0, 1 as usize);
+    let resp2: string = hbuf2 as string;
+    print.info("[websocket-serve-concurrent] fd2 handshake: " + resp2);
+    assert contains(resp2, "101");
+
+    // Interleaved echo: prove both connections are independently live by
+    // sending on both, then reading fd2's echo BEFORE fd1's. Servicing fd2
+    // without waiting on fd1 shows fd1 is not holding the server hostage.
+    assert _lb_send_masked(fd1, 1, "one");
+    assert _lb_send_masked(fd2, 1, "two");
+
+    let mut op2: i64 = 0 - 1;
+    let echoed2 = _lb_read_frame(fd2, & op2);
+    print.info("[websocket-serve-concurrent] fd2 echo opcode=" + op2
+        + " payload="
+        + echoed2);
+    assert op2 == 1;
+    assert echoed2 == "two";
+
+    let mut op1: i64 = 0 - 1;
+    let echoed1 = _lb_read_frame(fd1, & op1);
+    print.info("[websocket-serve-concurrent] fd1 echo opcode=" + op1
+        + " payload="
+        + echoed1);
+    assert op1 == 1;
+    assert echoed1 == "one";
+
+    // Tear both connections down with a masked CLOSE + reply.
+    assert _lb_send_masked(fd1, 8, "");
+    let mut close_opcode1: i64 = 0 - 1;
+    let _close_payload1 = _lb_read_frame(fd1, & close_opcode1);
+    assert close_opcode1 == 8;
+    close(fd1);
+
+    assert _lb_send_masked(fd2, 8, "");
+    let mut close_opcode2: i64 = 0 - 1;
+    let _close_payload2 = _lb_read_frame(fd2, & close_opcode2);
+    assert close_opcode2 == 8;
+    close(fd2);
+
+    // Best-effort cleanup of the consumer tree (the timeout reaps the
+    // server process).
+    let _rm = process.run(["rm", "-rf", _app_root2()]);
 }

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -10,9 +10,10 @@
 // `http.sfn`'s identically-shaped helpers.
 //
 // Scope: `ws://` only (no TLS/`wss://`). Client: connect, send a single
-// masked TEXT frame, close. Server: bind/listen/accept, one connection at
-// a time, echo TEXT/BINARY frames back unmasked, reply to CLOSE. Neither
-// half implements fragmentation or ping/pong.
+// masked TEXT frame, close. Server: bind/listen/accept, dispatching each
+// connection to a shared worker pool (#1923), echo TEXT/BINARY frames back
+// unmasked, reply to CLOSE. Neither half implements fragmentation or
+// ping/pong.
 //
 // ABI. `compiler/src/llvm/runtime_helpers.sfn` points the websocket
 // registry rows at the exports below (owned by the orchestrator, not
@@ -89,6 +90,26 @@ extern fn SHA1(d: * u8, n: usize, md: * u8) -> * u8;
 extern fn EVP_EncodeBlock(dst: * u8, src: * u8, srclen: i32) -> i32;
 
 extern fn RAND_bytes(buf: * u8, num: i32) -> i32;
+
+// ── Scheduler (scheduler.sfn) — the shared MPMC task queue + fixed
+// worker pool. `sfn_websocket_serve` creates one queue + pool, then
+// enqueues a detached `Task` per accepted connection (mirrors
+// `serve.sfn`, #1923). Declared inline per the same cross-module-extern
+// workaround (#306) as the sockets above.
+extern fn sfn_taskqueue_create(capacity: i64) -> * u8;
+
+extern fn sfn_taskqueue_destroy(queue: * u8) -> void;
+
+extern fn sfn_taskqueue_enqueue(queue: * u8, task: * u8) -> void;
+
+// Per-connection tasks are fire-and-forget: `sfn_websocket_serve` never
+// joins them, so they use the detached constructor (#1203). The pool
+// worker that runs a detached task reclaims its `Task` handle after
+// `sfn_task_run` returns — so the only reclaim the worker owns is its
+// ctx cell.
+extern fn sfn_task_create_detached(fn_ptr: i64, ctx: i64) -> * u8;
+
+extern fn sfn_scheduler_create(queue: * u8) -> * u8;
 
 // `_ws_ptr_off(p, off)` — byte-stride pointer arithmetic for a
 // variable offset. Mirrors `http.sfn`'s `_ptr_off`.
@@ -290,7 +311,7 @@ fn _ws_connect_tcp(host: * u8, port: i64) -> i32 ![net] {
 // socket, retrying on short sends. Returns false if a write ever
 // fails. `ws://` is plaintext only, so unlike `http.sfn`'s `_send_all`
 // there is no `ssl` argument.
-fn _ws_send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
+fn _ws_send_all(fd: i32, buf: * u8, total: i64) -> bool {
     let mut sent: i64 = 0;
     loop {
         if sent >= total { break; }
@@ -308,7 +329,7 @@ fn _ws_send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
 // server that splits the `101` status line and headers across TCP
 // segments is not handled here; the drain-until-`\r\n\r\n` receive loop
 // lands with the server bridge and behavioral loopback test (#1877).
-fn _ws_recv_some(fd: i32, buf: * u8, cap: i64) -> i64 ![net] {
+fn _ws_recv_some(fd: i32, buf: * u8, cap: i64) -> i64 {
     return recv(fd, buf, cap, 0);
 }
 
@@ -852,7 +873,7 @@ fn _ws_srv_bind_listen(port: i64) -> i32 {
 // `_ws_recv_exact(fd, buf, n)` — loop `recv` until exactly `n` bytes have
 // landed in `buf`. Returns false on a short read, error, or EOF (any
 // `recv` returning <= 0) before `n` bytes are collected.
-fn _ws_recv_exact(fd: i32, buf: * u8, n: i64) -> bool ![net] {
+fn _ws_recv_exact(fd: i32, buf: * u8, n: i64) -> bool {
     let mut got: i64 = 0;
     loop {
         if got >= n { break; }
@@ -867,7 +888,7 @@ fn _ws_recv_exact(fd: i32, buf: * u8, n: i64) -> bool ![net] {
 // and send an UNMASKED RFC 6455 server frame (FIN=1; server→client MUST
 // NOT mask). Structurally `_ws_frame_send`'s counterpart minus the
 // masking key and XOR step. Returns false on OOM or a send failure.
-fn _ws_server_frame_send(fd: i32, opcode: i64, payload: * u8, payload_len: i64) -> bool ![net] {
+fn _ws_server_frame_send(fd: i32, opcode: i64, payload: * u8, payload_len: i64) -> bool {
     let byte0: i64 = 128 | (opcode & 15);
     let mut header_len: i64 = 2;
     if payload_len >= 126 && payload_len <= 65535 { header_len = 4; } else {
@@ -910,7 +931,7 @@ fn _ws_server_frame_send(fd: i32, opcode: i64, payload: * u8, payload_len: i64) 
 // same slot-write idiom as `_ws_parse_url`), and the payload length
 // through the three out-params. Returns false on a protocol error
 // (an unmasked "client" frame) or any `recv` failure.
-fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_slot: * i64) -> bool ![net] {
+fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_slot: * i64) -> bool {
     // malloc(12), not 8: the `len7 == 127` path fills 8 content bytes and
     // reads them with `_ws_byte_at`, whose 4-byte load at offset 7 touches
     // bytes 7..10 — so 8 content + 4 tail-load slack, matching this module's
@@ -1012,7 +1033,7 @@ fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_s
 // `_ws_recv_some` documents) and reply with the RFC 6455 `101`
 // response. Returns false on a malformed/missing
 // `Sec-WebSocket-Key` header or a recv/send failure.
-fn _ws_srv_handshake(fd: i32) -> bool ![net] {
+fn _ws_srv_handshake(fd: i32) -> bool {
     let req_cap: i64 = 2048;
     let buf: * u8 = malloc((req_cap + 4) as usize);
     if buf as i64 == 0 { return false; }
@@ -1080,16 +1101,56 @@ fn _ws_srv_handshake(fd: i32) -> bool ![net] {
     return ok;
 }
 
+// `_ws_conn_worker(ctx)` — the per-connection pool task body (#1923). It
+// matches the `Task` worker ABI (`fn (* u8) -> * u8`): `ctx` points at an
+// 8-byte cell `[client_fd: i64]` (freed here up front — no handler slot,
+// unlike `serve.sfn`'s 16-byte pair, since `websocket.serve` has no user
+// handler surface yet). Arms the socket timeouts, completes the RFC 6455
+// handshake, then loops reading single-frame (FIN=1) client frames and
+// echoing TEXT/BINARY payloads back unmasked; a CLOSE frame gets an
+// unmasked CLOSE reply before the connection closes. PING/PONG and any
+// other opcode are silently drained (#1877). Returns null (serve is
+// fire-and-forget; the `Task` result is unused). Calls only effect-free
+// externs and effect-erased helpers, so it carries no effect annotation —
+// matching `serve.sfn::_serve_conn_worker` and `future.sfn`'s trampolines.
+fn _ws_conn_worker(ctx: * u8) -> * u8 {
+    if ctx as i64 == 0 { return null; }
+    let fd_slot: * i64 = ctx as * i64;
+    let client_fd: i64 = atomic_load(fd_slot);
+    free(ctx);
+
+    let fd: i32 = client_fd as i32;
+    _ws_set_socket_timeouts(fd);
+    if !_ws_srv_handshake(fd) {
+        close(fd);
+        return null;
+    }
+    loop {
+        let mut opcode: i64 = 0;
+        let mut payload_addr: i64 = 0;
+        let mut len: i64 = 0;
+        if !_ws_frame_read(fd, & opcode, & payload_addr, & len) { break; }
+        if opcode == 8 {
+            _ws_server_frame_send(fd, 8, null, 0);
+            free(payload_addr as * u8);
+            break;
+        }
+        if opcode == 1 || opcode == 2 {
+            _ws_server_frame_send(fd, opcode, payload_addr as * u8, len);
+            free(payload_addr as * u8);
+        } else { free(payload_addr as * u8); }
+    }
+    close(fd);
+    return null;
+}
+
 // `sfn_websocket_serve(port)` — a v0 echo `ws://` server. Binds and
-// listens on `port`, then blocks forever accepting one connection at a
-// time (single-client-at-a-time — no pool dispatch; fanning connections
-// out across a worker pool is a follow-up under epic #1180). Each
-// accepted connection completes the RFC 6455 handshake, then loops
-// reading single-frame (FIN=1; fragmentation is unsupported) client
-// frames and echoing TEXT/BINARY payloads back unmasked; a CLOSE frame
-// gets an unmasked CLOSE reply before the connection closes. PING/PONG
-// and any other opcode are silently drained (no ping/pong handling yet,
-// #1877). The accept loop only exits on an `accept` error.
+// listens on `port`, builds one shared task queue + fixed worker pool,
+// then blocks forever accepting connections and dispatching each accepted
+// fd to the pool as a detached `Task` (#1923) — so multiple clients are
+// served concurrently, mirroring `serve.sfn::sfn_serve`. Each connection's
+// handshake + frame-echo loop runs on a pool thread (`_ws_conn_worker`).
+// The accept loop only exits on an `accept` error.
 fn sfn_websocket_serve(port: i32) -> void ![net] {
     // Reject an out-of-range port before packing it into the sockaddr: a
     // negative or > 65535 value would truncate into an unintended u16 (e.g.
@@ -1098,30 +1159,44 @@ fn sfn_websocket_serve(port: i32) -> void ![net] {
     if port_i64 <= 0 || port_i64 > 65535 { return; }
     let listen_fd: i32 = _ws_srv_bind_listen(port_i64);
     if listen_fd < 0 { return; }
+
+    // One shared queue + fixed worker pool for the whole server; a detached
+    // per-connection task is enqueued on each accept (mirrors `sfn_serve`).
+    // The scheduler local is never freed — its threads service the shared
+    // queue for the process lifetime (the server never returns).
+    let queue: * u8 = sfn_taskqueue_create(256);
+    if queue as i64 == 0 {
+        close(listen_fd);
+        return;
+    }
+    let scheduler: * u8 = sfn_scheduler_create(queue);
+    if scheduler as i64 == 0 {
+        sfn_taskqueue_destroy(queue);
+        close(listen_fd);
+        return;
+    }
+
     loop {
         let fd: i32 = accept(listen_fd, null, null);
         if fd < 0 { break; }
-        _ws_set_socket_timeouts(fd);
-        if !_ws_srv_handshake(fd) {
+
+        // Pack [client_fd] into an 8-byte ctx cell for the worker.
+        let conn_ctx: * u8 = malloc(8 as usize);
+        if conn_ctx as i64 == 0 {
             close(fd);
             continue;
         }
-        loop {
-            let mut opcode: i64 = 0;
-            let mut payload_addr: i64 = 0;
-            let mut len: i64 = 0;
-            if !_ws_frame_read(fd, & opcode, & payload_addr, & len) { break; }
-            if opcode == 8 {
-                _ws_server_frame_send(fd, 8, null, 0);
-                free(payload_addr as * u8);
-                break;
-            }
-            if opcode == 1 || opcode == 2 {
-                _ws_server_frame_send(fd, opcode, payload_addr as * u8, len);
-                free(payload_addr as * u8);
-            } else { free(payload_addr as * u8); }
+        let fd_slot: * i64 = conn_ctx as * i64;
+        atomic_store(fd_slot, fd as i64);
+
+        let worker: * fn (* u8) -> * u8 = _ws_conn_worker as * fn (* u8) -> * u8;
+        let task: * u8 = sfn_task_create_detached(worker as i64, conn_ctx as i64);
+        if task as i64 == 0 {
+            free(conn_ctx);
+            close(fd);
+            continue;
         }
-        close(fd);
+        sfn_taskqueue_enqueue(queue, task);
     }
     close(listen_fd);
 }


### PR DESCRIPTION
## Summary
- `websocket.serve` now dispatches each accepted connection to a shared fixed thread pool instead of the v0 single-client-at-a-time blocking loop. `sfn_websocket_serve` builds one `sfn_taskqueue_create(256)` + `sfn_scheduler_create` and enqueues a detached per-connection `Task` (`_ws_conn_worker`) on each accept — a direct mirror of `serve.sfn::sfn_serve`.
- The worker matches the `Task` ABI (`fn (* u8) -> * u8`) with an 8-byte `[client_fd]` ctx cell (no handler slot — `websocket.serve` has no user-handler surface). It frees the ctx up front; the pool worker reclaims the detached `Task` handle (#1203), so there is no per-connection leak.
- Server-side transport/framing helpers reachable from the effect-erased worker (`_ws_srv_handshake`, `_ws_frame_read`, `_ws_server_frame_send`, `_ws_recv_exact`, `_ws_recv_some`, `_ws_send_all`) are stripped of `[net]`, bringing the module into line with `serve.sfn` (whose connection-worker chain is unannotated while only the public entrypoint declares the effect). `[net]` enforcement on `websocket.serve` callers is unchanged — it is registry-derived (#1601).

Closes #1923

## Acceptance Criteria
- [x] `websocket.serve` dispatches each connection to the shared pool; two clients can be served concurrently.
- [x] No per-connection `Task`/ctx leak (detached-task reclaim, mirroring #1203).
- [x] The #1877 loopback e2e still passes; a new assertion drives two concurrent clients.
- [x] `make compile` self-hosts; `make test` passes.

## Map reconciliation
None — the advisory `## Files Affected` map (`runtime/sfn/adapters/websocket.sfn`, `compiler/tests/e2e/websocket_serve_loopback_test.sfn`) matched the tree exactly.

## Verification
```bash
make compile                 # self-hosts (exit 0)
build/native/sailfin test compiler/tests/e2e/websocket_serve_loopback_test.sfn
#   PASS (all 2 tests) — handshake+echo+close round-trip; two clients served concurrently
make test-e2e                # 192/193 passed
```
The single e2e failure was `work_dir_parity_test.sfn` with Error 124 (**timeout** under end-of-suite resource contention) — a compiler build-determinism test with no websocket involvement. It **passes in isolation** (re-run: `PASS (all 2 tests)`), confirming an environmental flake, not a regression.

The concurrency proof: the new test handshakes a second client while the first is open mid-session — something a single-threaded accept loop cannot answer (it would be blocked in the first connection's frame loop) — then interleaves echoes (reading fd2 before fd1). The child env pins `SAILFIN_THREADS=2` so the guarantee never hinges on an inherited pool size (the runtime auto-floors the pool at 2 workers, but an inherited `SAILFIN_THREADS=1` would bypass that floor).

## Files Changed
- `runtime/sfn/adapters/websocket.sfn` — pool wiring + `_ws_conn_worker`; scheduler externs; `[net]` strip on the server-side helper chain; file-header doc updated.
- `compiler/tests/e2e/websocket_serve_loopback_test.sfn` — two-concurrent-client assertion + pinned-pool spawn helper.

## Notes
Runtime-only — no compiler-source change, no seed cut (`.claude/rules/seed-dependency.md`). Epic #1180 (effect-system hardening, Phase G); parent #1630.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMzNGCQwDRyWUApYYsTZnj)_