### PR TITLE
feat(runtime): RFC 6455 protocol completeness for websocket.serve

### DIFF
--- a/compiler/tests/e2e/websocket_serve_loopback_test.sfn
+++ b/compiler/tests/e2e/websocket_serve_loopback_test.sfn
@@ -255,6 +255,127 @@ fn _lb_read_frame(fd: i32, out_opcode: * i64) -> string {
     return payload as string;
 }
 
+// Send a raw client frame with explicit FIN, opcode, and masking, from a
+// raw byte buffer. Handles all three RFC 6455 length encodings (7-bit,
+// 126 + 16-bit, 127 + 64-bit) so the fragmentation / control-code / oversize
+// tests can drive frames the string-based `_lb_send_masked` cannot. A fixed
+// mask key is fine for a directed test vehicle (the production client uses
+// `RAND_bytes`).
+fn _lb_send_frame_raw(fd: i32, fin: i64, opcode: i64, masked: bool, payload: * u8, payload_len: i64) -> bool {
+    let byte0: i64 = (fin << 7) | (opcode & 15);
+    let mut header_len: i64 = 2;
+    if payload_len >= 126 && payload_len <= 65535 { header_len = 4; } else {
+        if payload_len > 65535 { header_len = 10; }
+    }
+    let mut mask_len: i64 = 0;
+    if masked { mask_len = 4; }
+    let total: i64 = header_len + mask_len + payload_len;
+    // +4 tail-load slack for `_lb_byte_at`'s 4-byte load during masking.
+    let out: * u8 = malloc((total + 4) as usize);
+    if out as i64 == 0 { return false; }
+    memset(_lb_ptr_off(out, 0), byte0 as i32, 1 as usize);
+    let mut len_bits: i64 = payload_len;
+    if payload_len >= 126 && payload_len <= 65535 {
+        len_bits = 126;
+        memset(_lb_ptr_off(out, 2), ((payload_len >> 8) & 255) as i32, 1 as usize);
+        memset(_lb_ptr_off(out, 3), (payload_len & 255) as i32, 1 as usize);
+    } else {
+        if payload_len > 65535 {
+            len_bits = 127;
+            let mut k: i64 = 0;
+            loop {
+                if k >= 8 { break; }
+                let shift: i64 = 8 * (7 - k);
+                memset(_lb_ptr_off(out, 2 + k), ((payload_len >> shift) & 255) as i32, 1 as usize);
+                k = k + 1;
+            }
+        }
+    }
+    let mut mask_flag: i64 = 0;
+    if masked { mask_flag = 128; }
+    memset(_lb_ptr_off(out, 1), (mask_flag | len_bits) as i32, 1 as usize);
+    if masked {
+        let mut m: i64 = 0;
+        loop {
+            if m >= 4 { break; }
+            memset(_lb_ptr_off(out, header_len + m), (11 + m) as i32, 1 as usize);
+            m = m + 1;
+        }
+        let mut i: i64 = 0;
+        loop {
+            if i >= payload_len { break; }
+            let mb: i64 = _lb_byte_at(out, header_len + (i & 3));
+            let pb: i64 = _lb_byte_at(payload, i);
+            memset(_lb_ptr_off(out, header_len + 4 + i), (pb ^ mb) as i32, 1 as usize);
+            i = i + 1;
+        }
+    } else {
+        if payload_len > 0 {
+            memcpy(_lb_ptr_off(out, header_len), payload, payload_len as usize);
+        }
+    }
+    let ok: bool = _lb_send_all(fd, out, total);
+    free(out);
+    return ok;
+}
+
+// Send ONLY a frame header declaring an oversized 64-bit length (no mask,
+// no payload). `_ws_frame_read` rejects on the length check before it reads
+// the mask, so it never blocks on the un-sent payload — it replies with
+// close `1009` (message too big). The declared length is 4 GiB (2^32), well
+// over the server's frame cap and positive as an i64.
+fn _lb_send_oversize_header(fd: i32) -> bool {
+    let hdr: * u8 = malloc(16 as usize);
+    if hdr as i64 == 0 { return false; }
+    memset(_lb_ptr_off(hdr, 0), (128 | 1) as i32, 1 as usize);
+    memset(_lb_ptr_off(hdr, 1), (128 | 127) as i32, 1 as usize);
+    let mut k: i64 = 0;
+    loop {
+        if k >= 8 { break; }
+        memset(_lb_ptr_off(hdr, 2 + k), 0, 1 as usize);
+        k = k + 1;
+    }
+    // Big-endian byte index 3 of the 8-byte length (buffer offset 5) holds
+    // 2^32 = 4 GiB.
+    memset(_lb_ptr_off(hdr, 5), 1, 1 as usize);
+    let ok: bool = _lb_send_all(fd, hdr, 10);
+    free(hdr);
+    return ok;
+}
+
+// Read one UNMASKED server frame's opcode and, when it is a CLOSE carrying a
+// 2-byte status code, that code. Writes the opcode through `out_opcode` and
+// the code (0 when absent) through `out_code`. Short-length only — every
+// server reply these tests read is <= 125 bytes.
+fn _lb_read_close(fd: i32, out_opcode: * i64, out_code: * i64) -> bool {
+    let hdr: * u8 = malloc(8 as usize);
+    if hdr as i64 == 0 { return false; }
+    if !_lb_recv_exact(fd, hdr, 2) {
+        free(hdr);
+        return false;
+    }
+    let byte0: i64 = _lb_byte_at(hdr, 0);
+    let byte1: i64 = _lb_byte_at(hdr, 1);
+    let opcode: i64 = byte0 & 15;
+    let len: i64 = byte1 & 127;
+    free(hdr);
+    atomic_store(out_opcode, opcode);
+    atomic_store(out_code, 0);
+    if len <= 0 { return true; }
+    let payload: * u8 = malloc((len + 4) as usize);
+    if payload as i64 == 0 { return false; }
+    if !_lb_recv_exact(fd, payload, len) {
+        free(payload);
+        return false;
+    }
+    if len >= 2 {
+        let code: i64 = (_lb_byte_at(payload, 0) << 8) | _lb_byte_at(payload, 1);
+        atomic_store(out_code, code);
+    }
+    free(payload);
+    return true;
+}
+
 // Lay out a consumer capsule whose `main` calls `websocket.serve(<port>)`.
 fn _app_root() -> string { return "build/websocket-serve-loopback-e2e"; }
 
@@ -537,4 +658,189 @@ test "websocket.serve loopback: two clients served concurrently" ![io] {
     // Best-effort cleanup of the consumer tree (the timeout reaps the
     // server process).
     let _rm = process.run(["rm", "-rf", _app_root2()]);
+}
+
+// ── RFC 6455 protocol-completeness cases (#1924) ───────────────────────
+// A third fixed port + consumer tree, independent of the two above so the
+// protocol test spawns its own server and never collides under `--jobs N`.
+fn _lb_port3() -> i64 { return 18793; }
+
+fn _lb_port3_str() -> string { return "18793"; }
+
+fn _app_root3() -> string { return "build/websocket-serve-protocol-e2e"; }
+
+fn _write_server3(port_str: string) -> string ![io] {
+    let root = _app_root3();
+    fs.createDirectory(root + "/src", true);
+    fs.writeFile(root + "/capsule.toml", "[capsule]\n"
+        + "name = \"sfn/websocket-serve-protocol-e2e-app\"\n"
+        + "version = \"0.0.1\"\n"
+        + "description = \"websocket.serve protocol e2e consumer\"\n"
+        + "\n"
+        + "[capabilities]\n"
+        + "required = [\"io\", \"net\"]\n"
+        + "\n"
+        + "[build]\n"
+        + "entry = \"src/main.sfn\"\n"
+        + "kind = \"library\"\n");
+    fs.writeFile(root + "/src/main.sfn", "fn main() ![io, net] {\n"
+        + "    websocket.serve("
+        + port_str
+        + ");\n"
+        + "}\n");
+    return root + "/src/main.sfn";
+}
+
+// Open a fresh connection and complete the RFC 6455 handshake, returning the
+// upgraded fd (or -1). Effect-free (only the plain socket/libc externs), the
+// same shape as `_lb_connect`.
+fn _lb_open_ready(port: i64) -> i32 {
+    let fd: i32 = _lb_connect(port);
+    if fd < 0 { return 0 - 1; }
+    let req: string = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    if !_lb_send_all(fd, req as * u8, strlen(req as * u8) as i64) {
+        close(fd);
+        return 0 - 1;
+    }
+    let cap: i64 = 1024;
+    let buf: * u8 = malloc((cap + 4) as usize);
+    if buf as i64 == 0 {
+        close(fd);
+        return 0 - 1;
+    }
+    let n: i64 = _lb_recv_some(fd, buf, cap);
+    free(buf);
+    if n <= 0 {
+        close(fd);
+        return 0 - 1;
+    }
+    return fd;
+}
+
+test "websocket.serve loopback: ping/pong, fragmentation, close-code, protocol errors" ![io] {
+    // Same teardown constraint as the tests above: without a reaper the
+    // spawned server would orphan the fixed port and poison later runs.
+    if _timeout_cmd().length == 0 {
+        print.info("[websocket-serve-protocol] SKIP: no timeout/gtimeout to reap the blocking server");
+        return;
+    }
+
+    let port = _lb_port3();
+    let main_path = _write_server3(_lb_port3_str());
+    let server_bin = _build_bin(main_path, _app_root3() + "/server-bin");
+    assert server_bin.length > 0;
+    let _handle = _spawn_server(server_bin);
+
+    let ready = _await_ready(port);
+    print.info("[websocket-serve-protocol] ready: " + ready);
+    assert ready.length > 0;
+    assert contains(ready, "101");
+
+    // Case 1: a PING is answered with a PONG carrying the same payload, and
+    // the connection stays open for subsequent data frames.
+    let fd1: i32 = _lb_open_ready(port);
+    assert fd1 >= 0;
+    assert _lb_send_frame_raw(fd1, 1, 9, true, "pingdata" as * u8, 8);
+    let mut op_pong: i64 = 0 - 1;
+    let pong = _lb_read_frame(fd1, & op_pong);
+    print.info("[websocket-serve-protocol] pong opcode=" + op_pong + " payload="
+        + pong);
+    assert op_pong == 10;
+    assert pong == "pingdata";
+    assert _lb_send_frame_raw(fd1, 1, 1, true, "still-here" as * u8, 10);
+    let mut op_after: i64 = 0 - 1;
+    let after = _lb_read_frame(fd1, & op_after);
+    assert op_after == 1;
+    assert after == "still-here";
+    close(fd1);
+
+    // Case 2: a fragmented message (initial TEXT FIN=0 + continuation FIN=1)
+    // is reassembled and echoed back as a single message.
+    let fd2: i32 = _lb_open_ready(port);
+    assert fd2 >= 0;
+    assert _lb_send_frame_raw(fd2, 0, 1, true, "Hello" as * u8, 5);
+    assert _lb_send_frame_raw(fd2, 1, 0, true, "World" as * u8, 5);
+    let mut op_frag: i64 = 0 - 1;
+    let frag = _lb_read_frame(fd2, & op_frag);
+    print.info("[websocket-serve-protocol] reassembled opcode=" + op_frag
+        + " payload="
+        + frag);
+    assert op_frag == 1;
+    assert frag == "HelloWorld";
+    close(fd2);
+
+    // Case 3: a client CLOSE carrying a 2-byte status code round-trips that
+    // code (not a bare empty CLOSE).
+    let fd3: i32 = _lb_open_ready(port);
+    assert fd3 >= 0;
+    let code_buf: * u8 = malloc(8 as usize);
+    assert code_buf as i64 != 0;
+    memset(_lb_ptr_off(code_buf, 0), 3, 1 as usize);
+    memset(_lb_ptr_off(code_buf, 1), 232, 1 as usize);
+    assert _lb_send_frame_raw(fd3, 1, 8, true, code_buf, 2);
+    free(code_buf);
+    let mut op_close: i64 = 0 - 1;
+    let mut code_close: i64 = 0 - 1;
+    assert _lb_read_close(fd3, & op_close, & code_close);
+    print.info("[websocket-serve-protocol] close-echo opcode=" + op_close
+        + " code="
+        + code_close);
+    assert op_close == 8;
+    assert code_close == 1000;
+    close(fd3);
+
+    // Case 4: an unmasked client frame is a protocol error — refused with a
+    // CLOSE carrying code 1002.
+    let fd4: i32 = _lb_open_ready(port);
+    assert fd4 >= 0;
+    assert _lb_send_frame_raw(fd4, 1, 1, false, "nomask" as * u8, 6);
+    let mut op_1002: i64 = 0 - 1;
+    let mut code_1002: i64 = 0 - 1;
+    assert _lb_read_close(fd4, & op_1002, & code_1002);
+    print.info("[websocket-serve-protocol] unmasked-reject opcode=" + op_1002
+        + " code="
+        + code_1002);
+    assert op_1002 == 8;
+    assert code_1002 == 1002;
+    close(fd4);
+
+    // Case 5: an over-large single frame (declared length only, no payload)
+    // is refused with CLOSE 1009 before any allocation — the DoS floor.
+    let fd5: i32 = _lb_open_ready(port);
+    assert fd5 >= 0;
+    assert _lb_send_oversize_header(fd5);
+    let mut op_1009a: i64 = 0 - 1;
+    let mut code_1009a: i64 = 0 - 1;
+    assert _lb_read_close(fd5, & op_1009a, & code_1009a);
+    print.info("[websocket-serve-protocol] oversize-frame opcode=" + op_1009a
+        + " code="
+        + code_1009a);
+    assert op_1009a == 8;
+    assert code_1009a == 1009;
+    close(fd5);
+
+    // Case 6: an oversize REASSEMBLY (two in-cap fragments whose sum exceeds
+    // the message cap) is refused with CLOSE 1009 — the buffer is bounded,
+    // not grown without limit.
+    let fd6: i32 = _lb_open_ready(port);
+    assert fd6 >= 0;
+    let frag_len: i64 = 525000;
+    let big: * u8 = malloc((frag_len + 4) as usize);
+    assert big as i64 != 0;
+    memset(big, 65, frag_len as usize);
+    assert _lb_send_frame_raw(fd6, 0, 1, true, big, frag_len);
+    assert _lb_send_frame_raw(fd6, 1, 0, true, big, frag_len);
+    free(big);
+    let mut op_1009b: i64 = 0 - 1;
+    let mut code_1009b: i64 = 0 - 1;
+    assert _lb_read_close(fd6, & op_1009b, & code_1009b);
+    print.info("[websocket-serve-protocol] oversize-reassembly opcode="
+        + op_1009b
+        + " code="
+        + code_1009b);
+    assert op_1009b == 8;
+    assert code_1009b == 1009;
+    close(fd6);
+
+    let _rm = process.run(["rm", "-rf", _app_root3()]);
 }

--- a/compiler/tests/e2e/websocket_serve_loopback_test.sfn
+++ b/compiler/tests/e2e/websocket_serve_loopback_test.sfn
@@ -262,6 +262,9 @@ fn _lb_read_frame(fd: i32, out_opcode: * i64) -> string {
 // mask key is fine for a directed test vehicle (the production client uses
 // `RAND_bytes`).
 fn _lb_send_frame_raw(fd: i32, fin: i64, opcode: i64, masked: bool, payload: * u8, payload_len: i64) -> bool {
+    // Guard against a negative length underflowing `total` into a huge
+    // `as usize` allocation if a future caller mis-passes it.
+    if payload_len < 0 { return false; }
     let byte0: i64 = (fin << 7) | (opcode & 15);
     let mut header_len: i64 = 2;
     if payload_len >= 126 && payload_len <= 65535 { header_len = 4; } else {
@@ -319,9 +322,11 @@ fn _lb_send_frame_raw(fd: i32, fin: i64, opcode: i64, masked: bool, payload: * u
     return ok;
 }
 
-// Send ONLY a frame header declaring an oversized 64-bit length (no mask,
-// no payload). `_ws_frame_read` rejects on the length check before it reads
-// the mask, so it never blocks on the un-sent payload — it replies with
+// Send ONLY a frame header declaring an oversized 64-bit length: the MASK
+// bit is set (so the server reaches the length-cap check and replies `1009`
+// rather than taking the unmasked-frame `1002` path) but no masking key or
+// payload follows. `_ws_frame_read` rejects on the length check before it
+// reads the mask, so it never blocks on the un-sent bytes — it replies with
 // close `1009` (message too big). The declared length is 4 GiB (2^32), well
 // over the server's frame cap and positive as an i64.
 fn _lb_send_oversize_header(fd: i32) -> bool {

--- a/docs/status.md
+++ b/docs/status.md
@@ -194,9 +194,12 @@ here.
   `sfn_websocket_unbridged` metadata-only sentinel is gone for this family, so
   the calls lower, link, and self-host like any other member-call bridge (e.g.
   `http.*`). Client (#1876): `ws://` connect + a single masked TEXT send
-  + close. Server (#1877, v0): `websocket.serve(port)` binds/listens/accepts and
-  runs an RFC 6455 echo loop — single connection at a time, blocking, unmasked
-  server frames, no fragmentation/ping-pong, no `wss://`. `![net]` is enforced
+  + close. Server (#1877): `websocket.serve(port)` binds/listens/accepts,
+  dispatching each connection to a shared worker pool (#1923) that runs an
+  RFC 6455 echo loop with unmasked server frames, ping/pong keepalive,
+  bounded fragmented-message reassembly, and a status-code close handshake
+  (#1924); an unmasked or over-large (> 1 MiB) client frame is refused with
+  the matching close code (`1002`/`1009`). No `wss://`. `![net]` is enforced
   via the registry rows (single source of truth since #1601); `websocket.send`
   additionally requires `![io]` — any `.send(...)` member call trips the
   checker's pre-existing conservative, receiver-agnostic channel-op rule
@@ -204,11 +207,9 @@ here.
   convention: a registry-driven member-call bridge marshals scalar arguments
   only — `websocket.serve(8080)` is the canonical call shape; an object literal
   (`websocket.serve({ port })`) is unreachable without bespoke lowering.
-  Follow-ups tracked under epic #1180: concurrency-pool dispatch (#1923),
-  ping/pong + fragmentation + close-code completeness (#1924), `wss://`/TLS
-  (#1925), a per-client handler API — `server.clients()`/`onMessage`/per-client
-  send (#1926), typed message channels/backpressure (#1927), and client-side
-  receive.
+  Follow-ups tracked under epic #1180: `wss://`/TLS (#1925), a per-client
+  handler API — `server.clients()`/`onMessage`/per-client send (#1926), typed
+  message channels/backpressure (#1927), and client-side receive.
 - **Undefined free-function rejection** (`E0420`, #616/#812): unresolvable
   bare-identifier callees fail typecheck.
 - **Function references**: a bare fn name in value position lowers to the

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -1283,6 +1283,10 @@ fn _ws_conn_worker(ctx: * u8) -> * u8 {
             if len > 0 {
                 memcpy(_ws_ptr_off(grown, frag_len), payload_addr as * u8, len as usize);
             }
+            // Keep the module's payload-buffer invariant: NUL-terminate at the
+            // new end (the +4 slack in `new_len + 4` covers it) so the buffer
+            // stays safe for any `_ws_byte_at`-style tail read.
+            memset(_ws_ptr_off(grown, new_len), 0, 1 as usize);
             free(payload_addr as * u8);
             frag_len = new_len;
             if fin == 1 {

--- a/runtime/sfn/adapters/websocket.sfn
+++ b/runtime/sfn/adapters/websocket.sfn
@@ -12,8 +12,10 @@
 // Scope: `ws://` only (no TLS/`wss://`). Client: connect, send a single
 // masked TEXT frame, close. Server: bind/listen/accept, dispatching each
 // connection to a shared worker pool (#1923), echo TEXT/BINARY frames back
-// unmasked, reply to CLOSE. Neither half implements fragmentation or
-// ping/pong.
+// unmasked, reply to PING with PONG, absorb PONG, reassemble fragmented
+// messages (bounded), and complete the RFC 6455 close handshake (echo the
+// client's close code; reject an unmasked or over-large frame with the
+// matching close code, #1924).
 //
 // ABI. `compiler/src/llvm/runtime_helpers.sfn` points the websocket
 // registry rows at the exports below (owned by the orchestrator, not
@@ -49,6 +51,11 @@ extern fn free(ptr: * u8) -> void;
 extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
 
 extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+// `realloc` grows the fragment-reassembly buffer in place across
+// continuation frames (`_ws_conn_worker`); returns null on failure
+// without freeing the original block (standard C semantics).
+extern fn realloc(ptr: * u8, size: usize) -> * u8;
 
 extern fn strlen(s: * u8) -> usize;
 
@@ -924,46 +931,84 @@ fn _ws_server_frame_send(fd: i32, opcode: i64, payload: * u8, payload_len: i64) 
     return ok;
 }
 
-// `_ws_frame_read(fd, out_opcode, out_payload_slot, out_len_slot)` —
-// read exactly one CLIENT frame and unmask it. Writes the opcode, the
-// `i64` bit-pattern of a freshly `malloc`'d NUL-terminated payload
-// buffer (the caller casts back with `as * u8` and owns/frees it — the
-// same slot-write idiom as `_ws_parse_url`), and the payload length
-// through the three out-params. Returns false on a protocol error
-// (an unmasked "client" frame) or any `recv` failure.
-fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_slot: * i64) -> bool {
+// `_ws_max_frame_len()` — maximum accepted single-frame payload length
+// (bytes). A client frame declaring more is rejected with close `1009`
+// (message too big) instead of allocated, so a malicious extended-length
+// header cannot force an unbounded `malloc` on the un-memory-capped compiled
+// server (#1924). Mirrors the HTTP server's 1 MiB request-body cap
+// (`serve.sfn`).
+fn _ws_max_frame_len() -> i64 { return 1048576; }
+
+// `_ws_max_message_len()` — maximum reassembled message length across a
+// fragmented sequence (bytes). Bounds the continuation-frame reassembly
+// buffer so a stream of fragments cannot grow it without limit (#1924); an
+// over-cap reassembly is rejected with close `1009`. Held equal to the
+// single-frame cap so no reassembled message exceeds what one frame may
+// carry.
+fn _ws_max_message_len() -> i64 { return 1048576; }
+
+// `_ws_server_close_send(fd, code)` — send an UNMASKED CLOSE frame (opcode
+// 0x8) carrying `code` as the RFC 6455 2-byte big-endian status code, used
+// for the protocol-error (`1002`) and message-too-big (`1009`) teardown
+// paths. malloc(4), not 2: keeps the module's content+slack over-allocation
+// invariant even though only the first 2 bytes are sent.
+fn _ws_server_close_send(fd: i32, code: i64) -> bool {
+    let body: * u8 = malloc(4 as usize);
+    if body as i64 == 0 { return false; }
+    memset(_ws_ptr_off(body, 0), ((code >> 8) & 255) as i32, 1 as usize);
+    memset(_ws_ptr_off(body, 1), (code & 255) as i32, 1 as usize);
+    let ok: bool = _ws_server_frame_send(fd, 8, body, 2);
+    free(body);
+    return ok;
+}
+
+// `_ws_frame_read(fd, out_fin, out_opcode, out_payload_slot, out_len_slot)` —
+// read exactly one CLIENT frame and unmask it. Writes the FIN bit (0/1),
+// the opcode, the `i64` bit-pattern of a freshly `malloc`'d NUL-terminated
+// payload buffer (the caller casts back with `as * u8` and owns/frees it —
+// the same slot-write idiom as `_ws_parse_url`), and the payload length
+// through the four out-params. Returns a status code rather than a bool so
+// the caller can pick the right close-handshake reply:
+//   0 = OK (out-params filled).
+//   1 = I/O failure / EOF / OOM — the peer is gone; just close.
+//   2 = protocol error (an unmasked "client" frame) — reply close `1002`.
+//   3 = frame length exceeds `_ws_max_frame_len()` — reply close `1009`.
+// On any non-zero status the out-params are untouched (no payload to free).
+fn _ws_frame_read(fd: i32, out_fin: * i64, out_opcode: * i64, out_payload_slot: * i64, out_len_slot: * i64) -> i64 {
     // malloc(12), not 8: the `len7 == 127` path fills 8 content bytes and
     // reads them with `_ws_byte_at`, whose 4-byte load at offset 7 touches
     // bytes 7..10 — so 8 content + 4 tail-load slack, matching this module's
     // content+4 over-allocation invariant (the 2-byte header read needs less,
     // but the buffer is reused for the widest read).
     let hdr: * u8 = malloc(12 as usize);
-    if hdr as i64 == 0 { return false; }
+    if hdr as i64 == 0 { return 1; }
     if !_ws_recv_exact(fd, hdr, 2) {
         free(hdr);
-        return false;
+        return 1;
     }
     let byte0: i64 = _ws_byte_at(hdr, 0);
     let byte1: i64 = _ws_byte_at(hdr, 1);
+    let fin: i64 = (byte0 >> 7) & 1;
     let opcode: i64 = byte0 & 15;
     if (byte1 & 128) == 0 {
-        // RFC 6455: client-to-server frames MUST be masked.
+        // RFC 6455 §5.1: client-to-server frames MUST be masked. Signal a
+        // protocol error so the caller replies with close `1002`.
         free(hdr);
-        return false;
+        return 2;
     }
     let len7: i64 = byte1 & 127;
     let mut len: i64 = len7;
     if len7 == 126 {
         if !_ws_recv_exact(fd, hdr, 2) {
             free(hdr);
-            return false;
+            return 1;
         }
         len = (_ws_byte_at(hdr, 0) << 8) | _ws_byte_at(hdr, 1);
     } else {
         if len7 == 127 {
             if !_ws_recv_exact(fd, hdr, 8) {
                 free(hdr);
-                return false;
+                return 1;
             }
             let mut v: i64 = 0;
             let mut k: i64 = 0;
@@ -977,24 +1022,21 @@ fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_s
     }
     free(hdr);
 
-    // v0 frame-length guard: reject a negative length (a 64-bit extended
-    // length with the MSB set, which would wrap the `len + 4` allocation
-    // request) and cap the payload at a generous v0 maximum so a malicious
-    // `127`-length frame cannot force an unbounded `malloc` (remote DoS) —
-    // the compiled server is not memory-capped, only the toolchain self-caps.
-    // The full configurable cap + RFC 6455 close `1009` (message too big) is
-    // tracked in #1924; this is the minimal safety floor. The client half
-    // never sends frames anywhere near this size.
-    let max_frame: i64 = 16777216;
-    if len < 0 || len > max_frame { return false; }
+    // Frame-length guard: reject a negative length (a 64-bit extended length
+    // with the MSB set, which would wrap the `len + 4` allocation request) or
+    // one over `_ws_max_frame_len()` so a malicious `127`-length frame cannot
+    // force an unbounded `malloc` (remote DoS) — the compiled server is not
+    // memory-capped, only the toolchain self-caps. Signal message-too-big so
+    // the caller replies with close `1009` (#1924).
+    if len < 0 || len > _ws_max_frame_len() { return 3; }
 
     // malloc(8), not 4: `_ws_byte_at`'s 4-byte tail load at key[3] needs the
     // slack, matching `_ws_frame_send`'s identical over-allocation.
     let key: * u8 = malloc(8 as usize);
-    if key as i64 == 0 { return false; }
+    if key as i64 == 0 { return 1; }
     if !_ws_recv_exact(fd, key, 4) {
         free(key);
-        return false;
+        return 1;
     }
 
     // +4, not +1: the NUL terminator needs the same `_ws_byte_at` tail-load
@@ -1002,13 +1044,13 @@ fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_s
     let payload: * u8 = malloc((len + 4) as usize);
     if payload as i64 == 0 {
         free(key);
-        return false;
+        return 1;
     }
     if len > 0 {
         if !_ws_recv_exact(fd, payload, len) {
             free(key);
             free(payload);
-            return false;
+            return 1;
         }
     }
     let mut i: i64 = 0;
@@ -1022,10 +1064,11 @@ fn _ws_frame_read(fd: i32, out_opcode: * i64, out_payload_slot: * i64, out_len_s
     memset(_ws_ptr_off(payload, len), 0, 1 as usize);
     free(key);
 
+    atomic_store(out_fin, fin);
     atomic_store(out_opcode, opcode);
     atomic_store(out_payload_slot, payload as i64);
     atomic_store(out_len_slot, len);
-    return true;
+    return 0;
 }
 
 // `_ws_srv_handshake(fd)` — read the client's HTTP GET upgrade request
@@ -1106,13 +1149,20 @@ fn _ws_srv_handshake(fd: i32) -> bool {
 // 8-byte cell `[client_fd: i64]` (freed here up front — no handler slot,
 // unlike `serve.sfn`'s 16-byte pair, since `websocket.serve` has no user
 // handler surface yet). Arms the socket timeouts, completes the RFC 6455
-// handshake, then loops reading single-frame (FIN=1) client frames and
-// echoing TEXT/BINARY payloads back unmasked; a CLOSE frame gets an
-// unmasked CLOSE reply before the connection closes. PING/PONG and any
-// other opcode are silently drained (#1877). Returns null (serve is
-// fire-and-forget; the `Task` result is unused). Calls only effect-free
-// externs and effect-erased helpers, so it carries no effect annotation —
-// matching `serve.sfn::_serve_conn_worker` and `future.sfn`'s trampolines.
+// handshake, then loops reading client frames and driving the RFC 6455
+// protocol (#1924):
+//   - TEXT/BINARY (0x1/0x2): echoed back unmasked; a FIN=0 frame opens a
+//     fragmented message that continuation frames (0x0) grow until FIN=1,
+//     bounded by `_ws_max_message_len()`.
+//   - PING (0x9): answered with a PONG carrying the same payload.
+//   - PONG (0xA): silently absorbed.
+//   - CLOSE (0x8): the client's close code (+ optional reason) is echoed,
+//     completing the close handshake, then the connection closes.
+//   - An unmasked or over-large frame is refused with close `1002` / `1009`.
+// Returns null (serve is fire-and-forget; the `Task` result is unused).
+// Calls only effect-free externs and effect-erased helpers, so it carries no
+// effect annotation — matching `serve.sfn::_serve_conn_worker` and
+// `future.sfn`'s trampolines.
 fn _ws_conn_worker(ctx: * u8) -> * u8 {
     if ctx as i64 == 0 { return null; }
     let fd_slot: * i64 = ctx as * i64;
@@ -1125,21 +1175,130 @@ fn _ws_conn_worker(ctx: * u8) -> * u8 {
         close(fd);
         return null;
     }
+
+    // Fragment-reassembly state (RFC 6455 §5.4). The initial data frame
+    // (FIN=0, opcode 0x1/0x2) seeds `frag_buf` and records its `frag_opcode`;
+    // continuation frames (0x0) grow the buffer via `realloc` until FIN=1,
+    // at which point the reassembled message is echoed with `frag_opcode`.
+    // `frag_buf` holds the buffer's i64 bit-pattern (0 when inactive).
+    let mut frag_active: bool = false;
+    let mut frag_opcode: i64 = 0;
+    let mut frag_buf: i64 = 0;
+    let mut frag_len: i64 = 0;
+
     loop {
+        let mut fin: i64 = 0;
         let mut opcode: i64 = 0;
         let mut payload_addr: i64 = 0;
         let mut len: i64 = 0;
-        if !_ws_frame_read(fd, & opcode, & payload_addr, & len) { break; }
+        let status: i64 = _ws_frame_read(fd, & fin, & opcode, & payload_addr, & len);
+        if status == 1 { break; }
+        if status == 2 {
+            // Unmasked client frame: close the handshake with `1002`.
+            _ws_server_close_send(fd, 1002);
+            break;
+        }
+        if status == 3 {
+            // Declared length over the cap: close with `1009` (too big).
+            _ws_server_close_send(fd, 1009);
+            break;
+        }
+
         if opcode == 8 {
-            _ws_server_frame_send(fd, 8, null, 0);
+            // CLOSE: echo the client's status code (+ optional reason) rather
+            // than a bare empty CLOSE, clamped to the 125-byte control-frame
+            // limit (RFC 6455 §5.5) so the reply stays a valid short-length
+            // control frame. An empty client CLOSE round-trips as empty.
+            let mut close_len: i64 = len;
+            if close_len > 125 { close_len = 125; }
+            _ws_server_frame_send(fd, 8, payload_addr as * u8, close_len);
             free(payload_addr as * u8);
             break;
         }
-        if opcode == 1 || opcode == 2 {
-            _ws_server_frame_send(fd, opcode, payload_addr as * u8, len);
+        if opcode == 9 {
+            // PING -> PONG with the same application data (clamped to the
+            // 125-byte control-frame limit).
+            let mut ping_len: i64 = len;
+            if ping_len > 125 { ping_len = 125; }
+            _ws_server_frame_send(fd, 10, payload_addr as * u8, ping_len);
             free(payload_addr as * u8);
-        } else { free(payload_addr as * u8); }
+            continue;
+        }
+        if opcode == 10 {
+            // PONG: heartbeat acknowledgement, silently absorbed.
+            free(payload_addr as * u8);
+            continue;
+        }
+        if opcode == 1 || opcode == 2 {
+            if frag_active {
+                // A new data frame while a fragmented message is open is a
+                // protocol violation (RFC 6455 §5.4).
+                free(payload_addr as * u8);
+                free(frag_buf as * u8);
+                frag_active = false;
+                _ws_server_close_send(fd, 1002);
+                break;
+            }
+            if fin == 1 {
+                // Complete single-frame message: echo it unchanged.
+                _ws_server_frame_send(fd, opcode, payload_addr as * u8, len);
+                free(payload_addr as * u8);
+                continue;
+            }
+            // Start of a fragmented message: adopt the payload buffer as the
+            // reassembly buffer (ownership transfers here — not freed).
+            frag_active = true;
+            frag_opcode = opcode;
+            frag_buf = payload_addr;
+            frag_len = len;
+            continue;
+        }
+        if opcode == 0 {
+            if !frag_active {
+                // Continuation with no message in progress: protocol error.
+                free(payload_addr as * u8);
+                _ws_server_close_send(fd, 1002);
+                break;
+            }
+            let new_len: i64 = frag_len + len;
+            if new_len > _ws_max_message_len() {
+                // Reassembled message exceeds the cap: refuse rather than grow
+                // the buffer without bound (#1924).
+                free(payload_addr as * u8);
+                free(frag_buf as * u8);
+                frag_active = false;
+                _ws_server_close_send(fd, 1009);
+                break;
+            }
+            let grown: * u8 = realloc(frag_buf as * u8, (new_len + 4) as usize);
+            if grown as i64 == 0 {
+                // realloc failed; the original block is still live. Free it and
+                // tear the connection down.
+                free(payload_addr as * u8);
+                free(frag_buf as * u8);
+                frag_active = false;
+                break;
+            }
+            frag_buf = grown as i64;
+            if len > 0 {
+                memcpy(_ws_ptr_off(grown, frag_len), payload_addr as * u8, len as usize);
+            }
+            free(payload_addr as * u8);
+            frag_len = new_len;
+            if fin == 1 {
+                // Final fragment: echo the reassembled message as one frame.
+                _ws_server_frame_send(fd, frag_opcode, frag_buf as * u8, frag_len);
+                free(frag_buf as * u8);
+                frag_active = false;
+                frag_buf = 0;
+                frag_len = 0;
+            }
+            continue;
+        }
+        // Any other (reserved) opcode: drain and ignore.
+        free(payload_addr as * u8);
     }
+    if frag_active { free(frag_buf as * u8); }
     close(fd);
     return null;
 }


### PR DESCRIPTION
## Summary
- Brings the Sailfin-native `websocket.serve` echo server up to RFC 6455 correctness for the control-frame and framing cases the v0 bridge (#1877) deferred: **ping/pong**, **fragmentation reassembly**, and the **close handshake**, plus a **bounded frame/message cap**.
- `_ws_frame_read` now returns an `i64` status (OK / IO / unmasked / too-big) and exposes the FIN bit, so `_ws_conn_worker` drives the protocol and picks the correct close reply.
- Runtime-only (`runtime/sfn/adapters/websocket.sfn`) — no `compiler/src` changes, so the self-hosting invariant is untouched.

Closes #1924

## Acceptance Criteria
- [x] A PING from the client receives a matching PONG; the connection stays open. *(reply PONG with same payload; PONG absorbed)*
- [x] A fragmented client message (2+ frames) is reassembled and echoed as one message; an oversize reassembly is rejected, not unbounded. *(FIN=0 + continuation `0x0` buffered via `realloc` until FIN=1; 1 MiB reassembly cap → close `1009`)*
- [x] A client CLOSE with a status code round-trips that code; an unmasked client frame is rejected with `1002`. *(close code echoed, clamped to the 125-byte control-frame limit; unmasked → close `1002`)*
- [x] e2e coverage for each case; `make compile` self-hosts; `make test` passes. *(6-case loopback test; targeted `websocket_serve_loopback_test.sfn` green; full `make test-e2e` run)*

Also folds in the owner's issue-comment addition: a **maximum inbound frame-length cap** — a client frame declaring `> 1 MiB` (mirroring the HTTP server's request-body cap) is refused with close `1009` (message too big) before any allocation, defusing the extended-length memory-amplification DoS on the un-memory-capped compiled server.

## Design notes
- Two caps, both 1 MiB: `_ws_max_frame_len()` (single frame) and `_ws_max_message_len()` (reassembled message), the latter held equal so no reassembled message exceeds what one frame may carry.
- Close/PING replies clamp their echoed payload to 125 bytes so the reply is always a valid short-length control frame.
- `_ws_frame_read` status contract: on any non-zero status the out-params are left untouched (no payload to free); the caller frees nothing.

## Map reconciliation
None — the advisory `## Files Affected` (`runtime/sfn/adapters/websocket.sfn` + the loopback test) matched the tree. `docs/status.md` additionally synced to reflect the shipped protocol completeness (the paragraph still described the pre-#1923/#1924 v0 server).

## Verification
```bash
# targeted e2e — all 3 tests pass, including the new 6-case protocol test
build/native/sailfin test compiler/tests/e2e/websocket_serve_loopback_test.sfn
#   PASS  (all 3 tests passed)

sfn fmt --check runtime/sfn/adapters/websocket.sfn compiler/tests/e2e/websocket_serve_loopback_test.sfn   # clean
sfn check      compiler/tests/e2e/websocket_serve_loopback_test.sfn                                        # ok
make compile   # self-hosts (runtime-only change; compiler unaffected)
make test-e2e  # full suite
```

## Files Changed
- `runtime/sfn/adapters/websocket.sfn` — control-frame handling, `realloc`-grown fragment reassembly, close-code handshake, frame/message caps; `_ws_frame_read` status/FIN rework; new `_ws_server_close_send` / `_ws_max_frame_len` / `_ws_max_message_len` helpers.
- `compiler/tests/e2e/websocket_serve_loopback_test.sfn` — raw-frame client helpers (`_lb_send_frame_raw`, `_lb_send_oversize_header`, `_lb_read_close`, `_lb_open_ready`) + a 6-case protocol test.
- `docs/status.md` — `websocket.*` server description synced to the shipped state.

## Follow-up (out of scope for #1924)
Code review flagged three RFC §5.5 *conformance* gaps that are all memory-safe and beyond this issue's scope: control frames with payload > 125 or FIN=0 are accepted rather than failed with `1002`; reserved opcodes are drained rather than rejected; a 1-byte CLOSE payload is echoed rather than treated as malformed. Worth a small hardening follow-up before marketing full RFC 6455 conformance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H74X7DLyCtuEU4o3c6WGZu)_