### PR TITLE
fix(compiler): scope-aware keying for nested-fn shadowing by value bindings

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -749,12 +749,57 @@ fn required_effects(body: Block, imports: ImportSymbolTable) -> EffectRequiremen
     return collect_effects_from_block(body, imports);
 }
 
+// Augment the effect table with the nested `fn`s declared DIRECTLY in this
+// block (SFEP-0042, #1940), each shadowing any same-named enclosing entry
+// (`append_local_function` is last-write-wins). This keys nested-fn effect
+// resolution by block scope: a call to `h` resolves to the `fn h` in the
+// nearest enclosing block, so two same-named nested fns in sibling blocks no
+// longer collide on one flat routine-wide row (over-/under-approximating the
+// caller's requirement). A block with no direct nested fn returns the table
+// unchanged (no copy), so non-nested code is untouched.
+fn _hoist_block_local_fns(imports: ImportSymbolTable, block: Block) -> ImportSymbolTable {
+    let mut has_nested: boolean = false;
+    let mut p: int = 0;
+    loop {
+        if p >= block.statements.length { break; }
+        if block.statements[p].variant == "FunctionDeclaration" {
+            has_nested = true;
+            break;
+        }
+        p += 1;
+    }
+    if !has_nested { return imports; }
+    // Deep-copy the functions array before appending — `append_local_function`
+    // mutates it in place and the array is reference-shared on struct copy, so
+    // appending onto `imports` directly would corrupt the shared table (the same
+    // aliasing hazard `_local_effect_table` guards against).
+    let mut copied: ImportedFunctionSignature[] = [];
+    let mut k: int = 0;
+    loop {
+        if k >= imports.functions.length { break; }
+        copied.push(imports.functions[k]);
+        k += 1;
+    }
+    let mut merged = ImportSymbolTable { functions: copied };
+    let mut i: int = 0;
+    loop {
+        if i >= block.statements.length { break; }
+        let s = block.statements[i];
+        if s.variant == "FunctionDeclaration" {
+            merged = append_local_function(merged, s.signature.name, s.signature.effects);
+        }
+        i += 1;
+    }
+    return merged;
+}
+
 fn collect_effects_from_block(block: Block, imports: ImportSymbolTable) -> EffectRequirement[] {
+    let scoped = _hoist_block_local_fns(imports, block);
     let mut required: EffectRequirement[] = [];
     let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
-        required = merge_requirements(required, collect_effects_from_statement(block.statements[index], imports));
+        required = merge_requirements(required, collect_effects_from_statement(block.statements[index], scoped));
         index += 1;
     }
     return required;

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -270,6 +270,62 @@ fn _lookup_nested_rename(renames: NestedRename[], name: string) -> string {
     return "";
 }
 
+// Look up the DEFINITION rename (the lifted symbol name) for a nested fn,
+// skipping shadow-suppression sentinels (`to == ""`, appended by
+// `_shadow_nested_rename` when a value binding / parameter shadows the name).
+// A real hoist rename always carries a non-empty mangled `to`, so scanning
+// innermost-first for the first non-shadow match yields this block's lifted
+// symbol even when a same-named `let` later shadowed the call path (#1940).
+fn _lookup_nested_mangled(renames: NestedRename[], name: string) -> string {
+    let mut _i: int = renames.length - 1;
+    loop {
+        if _i < 0 { break; }
+        if renames[_i].from == name {
+            if renames[_i].to.length > 0 { return renames[_i].to; }
+        }
+        _i -= 1;
+    }
+    return "";
+}
+
+// Append a shadow-suppression sentinel for `name` (#1940). A value binding
+// (`let`/parameter) that shadows a same-named nested `fn` must call the binding,
+// not the lifted nested symbol. The sentinel (`to == ""`) sits at a higher index
+// than the hoist rename, so `_lookup_nested_rename` (innermost-first) returns ""
+// for a call to `name` from this point on and `_rename_call_callee` leaves the
+// call untouched. Block-scoped like every rename: `_rewrite_block` restores the
+// incoming list on exit, so the shadow lapses outside the binding's block.
+fn _shadow_nested_rename(renames: NestedRename[], name: string) -> NestedRename[] {
+    let mut out: NestedRename[] = [];
+    let mut _i: int = 0;
+    loop {
+        if _i >= renames.length { break; }
+        out.push(renames[_i]);
+        _i += 1;
+    }
+    out.push(NestedRename { from: name, to: "" });
+    return out;
+}
+
+// Seed shadow sentinels for a nested-fn / lambda body's OWN parameters (#1940).
+// Inside such a body a parameter is highest priority (typecheck's
+// `_build_nested_fn_scope` step 4), so a parameter sharing a name with a sibling
+// nested `fn` shadows it — a call to that name invokes the parameter value, not
+// the lifted sibling. Only params that actually collide with an active rename
+// are shadowed; the rest already resolve to no rename.
+fn _shadow_parameters(renames: NestedRename[], parameters: Parameter[]) -> NestedRename[] {
+    let mut out: NestedRename[] = renames;
+    let mut _i: int = 0;
+    loop {
+        if _i >= parameters.length { break; }
+        if _lookup_nested_rename(out, parameters[_i].name).length > 0 {
+            out = _shadow_nested_rename(out, parameters[_i].name);
+        }
+        _i += 1;
+    }
+    return out;
+}
+
 // Type-text sentinel assigned to the let binding whose initializer
 // is a lifted lambda. Maps to the `{i8*, i8*}` closure-pair LLVM
 // type via `map_type_annotation` and is intentionally a string the
@@ -457,7 +513,12 @@ fn _synthesize_lifted_function_rewritten(ctx: LiftContext, lambda: Expression, l
     };
 
     let parsed_body = _reparse_lambda_body(lambda.body);
-    let rewritten = _rewrite_block(ctx, parsed_body);
+    // Seed the lambda body with its OWN parameter shadows (#1940): a lambda
+    // parameter sharing a name with a sibling nested fn shadows it, so a call to
+    // that name invokes the parameter, not the lifted sibling. Callers reset
+    // `renames` from their own `ctx`, so the seed never leaks past this body.
+    let seeded_ctx = _with_renames(ctx, _shadow_parameters(ctx.renames, lambda.parameters));
+    let rewritten = _rewrite_block(seeded_ctx, parsed_body);
     let body_with_prologue = _prepend_capture_prologue(rewritten.block, lambda_id, captures);
     let no_decorators: Decorator[] = [];
     let lifted_fn = Statement.FunctionDeclaration {
@@ -569,10 +630,16 @@ fn _rewrite_block(ctx: LiftContext, block: Block) -> _BlockRewriteResult {
             // Hoist: rewrite the body with renames active (so self- and
             // sibling-calls resolve to lifted symbols), rename the fn to its
             // lifted symbol, collect it as a top-level function, and drop it
-            // from this block.
-            let body_result = _rewrite_block(current_ctx, stmt.body);
-            current_ctx = body_result.ctx;
-            let mangled = _lookup_nested_rename(current_ctx.renames, stmt.signature.name);
+            // from this block. The body is seeded with its OWN parameter shadows
+            // (#1940) so a parameter that shares a name with a sibling nested fn
+            // calls the parameter; the outer rename scope (without those param
+            // shadows) is restored afterward, keeping accumulated counter+lifted.
+            let body_seed = _with_renames(current_ctx, _shadow_parameters(current_ctx.renames, stmt.signature.parameters));
+            let body_result = _rewrite_block(body_seed, stmt.body);
+            current_ctx = _with_renames(body_result.ctx, current_ctx.renames);
+            // Definition rename skips shadow sentinels so the lifted symbol name
+            // is the real mangled name even if a same-named `let` shadowed it.
+            let mangled = _lookup_nested_mangled(current_ctx.renames, stmt.signature.name);
             let lifted_fn = Statement.FunctionDeclaration {
                 signature: _rename_signature(stmt.signature, mangled),
                 body: body_result.block,
@@ -585,6 +652,17 @@ fn _rewrite_block(ctx: LiftContext, block: Block) -> _BlockRewriteResult {
         } else {
             let result = _rewrite_statement(current_ctx, stmt);
             current_ctx = result.ctx;
+            // A value binding that shadows a same-named nested fn suppresses the
+            // call rename from its declaration point onward (#1940), matching
+            // typecheck's sequential-`let` resolution (the `let` out-prioritizes
+            // the block-hoisted fn). The sentinel is appended AFTER the
+            // initializer is rewritten, so the initializer itself still sees the
+            // nested fn.
+            if stmt.variant == "VariableDeclaration" {
+                if _lookup_nested_rename(current_ctx.renames, stmt.name).length > 0 {
+                    current_ctx = _with_renames(current_ctx, _shadow_nested_rename(current_ctx.renames, stmt.name));
+                }
+            }
             new_statements.push(result.statement);
         }
         index += 1;

--- a/compiler/tests/e2e/nested_function_declaration_test.sfn
+++ b/compiler/tests/e2e/nested_function_declaration_test.sfn
@@ -148,3 +148,56 @@ test "nested fn: inner-scope nested fn shadows a same-named outer one" ![io] {
     }
     assert exit == 2;
 }
+
+// Regression (#1940, SFEP-0042 §3.4 gap 1): a `let` value binding that shadows a
+// same-named nested `fn` must call the binding, not the lifted nested symbol.
+// typecheck resolves the call to the sequential `let` (highest index); the emit
+// rename previously rewrote `helper(5)` to the lifted nested symbol anyway
+// (`n * 10` → 50). With the shadow-suppression fix the call reaches the `let`
+// closure (`n + 1` → 6). Block-form lambda: an expression-bodied `fn(n) => …`
+// bound to a `let` and called by name miscompiles independently of #1940.
+test "nested fn: a let shadowing a nested fn calls the let, not the lifted fn" ![io] {
+    let marker = _marker("let-shadow");
+    let source = "fn main() -> int { fn helper(n: int) -> int { return n * 10; } let helper = fn (n: int) -> int { return n + 1; }; return helper(5); }";
+    let exit = _build_and_run(marker, source);
+    if exit == -100 {
+        let details = fs.readFile(marker);
+        print.error(details);
+        assert false;
+    }
+    assert exit == 6;
+}
+
+// Regression (#1940, SFEP-0042 §3.4 gap 1): the shadow is position-sensitive.
+// A call BEFORE the shadowing `let` still resolves to the block-hoisted nested
+// fn (`helper(5)` → 50); a call AFTER resolves to the `let` closure (→ 6). The
+// sentinel is appended only when the `let` is walked, so both halves coexist:
+// 50 + 6 == 56.
+test "nested fn: a nested-fn call before its shadowing let still hits the fn" ![io] {
+    let marker = _marker("shadow-before-after");
+    let source = "fn main() -> int { fn helper(n: int) -> int { return n * 10; } let before = helper(5); let helper = fn (n: int) -> int { return n + 1; }; let after = helper(5); return before + after; }";
+    let exit = _build_and_run(marker, source);
+    if exit == -100 {
+        let details = fs.readFile(marker);
+        print.error(details);
+        assert false;
+    }
+    assert exit == 56;
+}
+
+// Regression (#1940, SFEP-0042 §3.4 gap 1): a parameter that shadows a same-named
+// sibling nested `fn` must call the parameter. Inside `apply`, `dbl` is the
+// `fn(int) -> int` parameter (highest priority), so `dbl(5)` invokes the passed
+// lambda (`x + 1` → 6), not the sibling nested `fn dbl` (`n * 2` → 10). The emit
+// rename previously rewrote it to the lifted sibling symbol.
+test "nested fn: a parameter shadowing a sibling nested fn calls the parameter" ![io] {
+    let marker = _marker("param-shadow");
+    let source = "fn main() -> int { fn dbl(n: int) -> int { return n * 2; } fn apply(dbl: fn (int) -> int) -> int { return dbl(5); } return apply(fn (x: int) -> int { return x + 1; }); }";
+    let exit = _build_and_run(marker, source);
+    if exit == -100 {
+        let details = fs.readFile(marker);
+        print.error(details);
+        assert false;
+    }
+    assert exit == 6;
+}

--- a/compiler/tests/unit/nested_function_effect_test.sfn
+++ b/compiler/tests/unit/nested_function_effect_test.sfn
@@ -79,3 +79,28 @@ test "effects: an effectful nested fn inside a lambda body is effect-checked" ![
     let violations = _violations_for(source);
     assert _has_violation_for(violations, "logit");
 }
+
+// Soundness regression (#1940, SFEP-0042 §3.4 gap 2): same-named nested fns in
+// SIBLING blocks of one routine must resolve to the correct per-block effect
+// row. The flat routine-wide table folded both `h`s by bare name
+// (last-write-wins), so the pure `h` collected last masked the effectful `h`.
+// The effectful `h` is CALLED in the first block; `run` declares no effect, so
+// the call must be flagged — under the old flat table it silently passed
+// (under-approximation defeating capability enforcement).
+test "effects: sibling-block nested fn call resolves to its own effectful row" ![io] {
+    let source = "fn run() -> int { { fn h() ![io] { print.info(\"x\"); } h(); } { fn h() -> int { return 1; } } return 0; }";
+    let violations = _violations_for(source);
+    assert _has_violation_for(violations, "run");
+}
+
+// Soundness regression (#1940, SFEP-0042 §3.4 gap 2), reverse direction: a call
+// to a PURE nested `h` must NOT inherit a same-named effectful sibling's row.
+// The effectful `h` is declared (uncalled) in the second block, so it is
+// collected last and won the flat table — over-approximating the first block's
+// pure `h()` call and falsely flagging `run`. Block-scoped keying resolves the
+// call to the pure `h`, so `run` is not flagged.
+test "effects: sibling-block pure nested fn call is not tainted by an effectful sibling" ![io] {
+    let source = "fn run() -> int { { fn h() -> int { return 1; } let r = h(); } { fn h() ![io] { print.info(\"x\"); } } return 0; }";
+    let violations = _violations_for(source);
+    assert ! _has_violation_for(violations, "run");
+}


### PR DESCRIPTION
## Summary
Closes the two v0 same-name nested-function shadowing gaps from **SFEP-0042 §3.4**, both rooted in keying nested-fn resolution by bare source name.

- **Area 1 — emit rename (`lambda_lowering.sfn`):** a `let`/parameter that shadows a same-named nested `fn` was still rewritten to the lifted nested symbol at the call site, even though typecheck resolves the call to the value binding — a **miscompile**. The block-scoped rename list now carries shadow-suppression sentinels (`to == ""`): a value binding appends one *after* its initializer is rewritten (so the shadow is position-sensitive, matching sequential-`let` scoping), and a nested-fn/lambda body seeds sentinels for its own parameters (highest priority per typecheck's `_build_nested_fn_scope`). `_rename_call_callee` then leaves the shadowed call untouched, while the definition rename uses a shadow-skipping lookup (`_lookup_nested_mangled`) so the lifted symbol name is unaffected.
- **Area 2 — routine-local effect table (`effect_checker.sfn`):** the table flattened all of a routine's nested fns by bare name (last-write-wins), so two same-named nested fns in sibling blocks collided → a call could resolve to the wrong effect row (under- or over-approximating the caller's requirement). `collect_effects_from_block` now hoists each block's own direct nested fns into a block-scoped, deep-copied effect table, so a call resolves to the `fn` in the nearest enclosing block.

Closes #1940

## Acceptance Criteria
- [x] A `let`/param shadowing a nested fn name calls the value binding, not the lifted nested fn.
- [x] Same-named nested fns in sibling blocks resolve to the correct per-block effect row.
- [x] Regression tests; `make compile` self-hosts; `sfn fmt --check` clean.

## Map reconciliation
None — the advisory `## Files Affected` (`lambda_lowering.sfn`, `effect_checker.sfn`) matched the tree.

## Verification
```
make compile                               # self-hosts (status: pass)
sfn fmt --check <touched .sfn>             # clean
build/native/sailfin check <touched src>  # checked 2 files: ok

# Targeted regression tests (against the rebuilt compiler)
sailfin test compiler/tests/unit/nested_function_effect_test.sfn        # PASS (9 tests)
sailfin test compiler/tests/e2e/nested_function_declaration_test.sfn     # PASS (9 tests)

# Before/after behavior (manual fixtures)
let-shadow:            6  (was 50 — nested symbol)
param-shadow:          6  (was 10 — sibling symbol)
before/after position: 56 (50 before the shadowing let + 6 after)
```

Code review (correctness / self-host / effect soundness): **approved** — no leakage, aliasing/deep-copy handling correct in both files, no new unsoundness.

## Files Changed
- `compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn` — shadow-suppression sentinels + shadow-skipping definition lookup + param seeding
- `compiler/src/effect_checker.sfn` — block-scoped nested-fn effect table (`_hoist_block_local_fns`)
- `compiler/tests/e2e/nested_function_declaration_test.sfn` — let-shadow, param-shadow, position-sensitivity regressions
- `compiler/tests/unit/nested_function_effect_test.sfn` — sibling-block under-/over-approximation regressions

## Notes / follow-ups
- Found an **orthogonal pre-existing bug** while writing fixtures: an expression-bodied short-form lambda (`fn(n) => …`) bound to a `let` and called by name returns `0` (no nested fn involved — unrelated to #1940). The tests use the block form to isolate this fix; worth filing separately.
- Two residual, pre-existing gaps noted by review for the SFEP-0042 residual list (not blockers): (a) deferred nested-fn analysis resolves *siblings* via the flat table (cross-scope same-name collision), and (b) the effect checker over-approximates a call to a `let` that shadows a nested fn (the effect-side mirror of the Area 1 fix; only ever a spurious diagnostic, never unsound).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZfz7F7Uq1NQyDQP5TkLHP)_