### PR TITLE
fix(check): diagnose unresolved relative imports (E0430/E0431)

### DIFF
--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -40,7 +40,12 @@ import {
     render_summary,
     summarize
 } from "./tools/check";
-import { ImportedInterfaceLoadResult, load_imported_interfaces_from_paths } from "./typecheck_import_loader";
+import {
+    ClosureSymbolSet,
+    ImportedInterfaceLoadResult,
+    build_closure_symbol_set,
+    load_imported_interfaces_from_paths
+} from "./typecheck_import_loader";
 import { Diagnostic } from "./typecheck_types";
 
 // One distinct `(project_root, workspace_root)` resolution group. Every
@@ -63,6 +68,11 @@ struct CheckGroup {
     // `check_source_with_imports` so any function declaring an
     // effect outside the surface produces an `E0403` diagnostic.
     capabilities_required: string[];
+    // #1953: the set of every symbol name defined in this group's staged
+    // import closure. Threaded into `check_source_with_imports` so a
+    // relative import of a nonexistent module (E0430) or a symbol defined
+    // nowhere in the closure (E0431) is diagnosed.
+    closure_symbols: ClosureSymbolSet;
 }
 
 fn _emit_check_header(path: string, quiet: boolean) ![io] {
@@ -256,8 +266,13 @@ fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
             let empty_entries: string[] = [];
             let empty_interfaces: Statement[] = [];
             let empty_caps: string[] = [];
+            let empty_names: string[] = [];
+            let empty_closure = ClosureSymbolSet {
+                names: empty_names,
+                complete: false
+            };
             groups.push(CheckGroup {
-                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, function_effects: empty_import_symbols(), capabilities_required: empty_caps
+                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, function_effects: empty_import_symbols(), capabilities_required: empty_caps, closure_symbols: empty_closure
             });
             idx = groups.length - 1;
         }
@@ -313,6 +328,11 @@ fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
         // so any function declaring an effect outside the surface
         // produces an `E0403` diagnostic.
         groups[gi].capabilities_required = resolution.capabilities_required;
+        // #1953: build the global symbol set for this group's staged
+        // closure so the per-file loop can diagnose an import of a symbol
+        // defined nowhere in the closure (E0431). The nonexistent-module
+        // check (E0430) is an independent on-disk probe in the leaf.
+        groups[gi].closure_symbols = build_closure_symbol_set(resolution.asm_paths);
 
         let mut mi: int = 0;
         loop {
@@ -375,7 +395,7 @@ fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
         let path = files[fi];
         let group_idx = file_group_index[fi];
         let source = fs.readFile(path);
-        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects, groups[group_idx].capabilities_required, allow_bare_assert);
+        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects, groups[group_idx].capabilities_required, groups[group_idx].closure_symbols, allow_bare_assert);
         // Emit any diagnostic — error or warning — so contributors
         // running `sfn check` under Phase B (warning default) actually
         // see the effect-violation output. The summary line keys on

--- a/compiler/src/import_resolution_check.sfn
+++ b/compiler/src/import_resolution_check.sfn
@@ -15,7 +15,7 @@
 // are checked. Scoped/capsule imports (`sfn/...`), runtime imports
 // (`runtime/...`), and bare names resolve through other mechanisms and are
 // skipped entirely, so they can never false-positive here.
-import { Program, Statement } from "./ast";
+import { Program } from "./ast";
 import { strings_equal, substring } from "./string_utils";
 import { ClosureSymbolSet } from "./typecheck_import_loader";
 import {

--- a/compiler/src/import_resolution_check.sfn
+++ b/compiler/src/import_resolution_check.sfn
@@ -1,0 +1,171 @@
+// compiler/src/import_resolution_check.sfn
+//
+// `sfn check` import-resolution pass (#1953). Validates that every
+// relative `import { ... } from "./x"` / `"../x"` in a source resolves to
+// a real module on disk (else E0430) and that each named specifier is
+// defined somewhere in the staged import closure (else E0431). Sailfin
+// resolves imported symbols globally by name — a module may legally import
+// a symbol from a module that does not itself declare it, as long as some
+// module in the link defines it — so E0431 checks closure-wide existence,
+// not per-declaring-module export (see `ClosureSymbolSet`). Runs ONLY on
+// the `check_source_with_imports` path — never in the build / self-host
+// emit path — so it cannot affect self-hosting.
+//
+// Scope is deliberately narrow: only specs beginning with `./` or `../`
+// are checked. Scoped/capsule imports (`sfn/...`), runtime imports
+// (`runtime/...`), and bare names resolve through other mechanisms and are
+// skipped entirely, so they can never false-positive here.
+import { Program, Statement } from "./ast";
+import { strings_equal, substring } from "./string_utils";
+import { ClosureSymbolSet } from "./typecheck_import_loader";
+import {
+    Diagnostic,
+    make_cannot_find_module_diagnostic,
+    make_symbol_not_exported_diagnostic
+} from "./typecheck_types";
+
+// ---- Path helpers ----
+// Local mirrors of `capsule_resolver.sfn`'s `_cr_dirname` / `_cr_path_join`
+// / `_cr_ends_with` / `resolve_relative_import`. Kept local so this leaf
+// carries zero coupling to the large resolver module; they must stay in
+// sync with the resolver (#1953) so `check` resolves a relative spec to
+// exactly the path the build resolver stages.
+fn _irc_dirname(path: string) -> string {
+    let mut last_slash: int = -1;
+    let mut i: int = 0;
+    loop {
+        if i >= path.length { break; }
+        if substring(path, i, i + 1) == "/" { last_slash = i; }
+        i += 1;
+    }
+    if last_slash < 0 { return "."; }
+    if last_slash == 0 { return "/"; }
+    return substring(path, 0, last_slash);
+}
+
+fn _irc_path_join(base: string, name: string) -> string {
+    if base.length == 0 { return name; }
+    if substring(base, base.length - 1, base.length) == "/" {
+        return base + name;
+    }
+    return base + "/" + name;
+}
+
+fn _irc_ends_with(text: string, suffix: string) -> boolean {
+    if suffix.length > text.length { return false; }
+    let start = text.length - suffix.length;
+    return strings_equal(substring(text, start, text.length), suffix);
+}
+
+fn _irc_starts_with(text: string, prefix: string) -> boolean {
+    if prefix.length > text.length { return false; }
+    return strings_equal(substring(text, 0, prefix.length), prefix);
+}
+
+// Mirror of `resolve_relative_import`: strip leading `../`/`./` segments,
+// walking the base dir up for each `../`, then join and ensure a `.sfn`
+// suffix.
+fn _irc_resolve_relative_import(base_dir: string, spec: string) -> string {
+    let mut current_base = base_dir;
+    let mut remainder = spec;
+    loop {
+        if remainder.length >= 3 {
+            if substring(remainder, 0, 3) == "../" {
+                current_base = _irc_dirname(current_base);
+                remainder = substring(remainder, 3, remainder.length);
+                continue;
+            }
+        }
+        if remainder.length >= 2 {
+            if substring(remainder, 0, 2) == "./" {
+                remainder = substring(remainder, 2, remainder.length);
+                continue;
+            }
+        }
+        break;
+    }
+    let path = _irc_path_join(current_base, remainder);
+    if _irc_ends_with(path, ".sfn") { return path; }
+    return path + ".sfn";
+}
+
+fn _irc_names_contains(names: string[], target: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= names.length { break; }
+        if strings_equal(names[i], target) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _irc_is_relative(spec: string) -> boolean {
+    if _irc_starts_with(spec, "./") { return true; }
+    if _irc_starts_with(spec, "../") { return true; }
+    return false;
+}
+
+// Resolve a relative spec to a real file, applying the directory-import
+// fallback (`./dir` -> `dir/mod.sfn`) that the build resolver uses. Returns
+// "" when nothing on disk resolves.
+fn _irc_resolve_existing(base_dir: string, spec: string) -> string ![io] {
+    let dep = _irc_resolve_relative_import(base_dir, spec);
+    if fs.exists(dep) { return dep; }
+    if _irc_ends_with(dep, ".sfn") {
+        let mod_fallback = substring(dep, 0, dep.length - 4) + "/mod.sfn";
+        if fs.exists(mod_fallback) { return mod_fallback; }
+    }
+    return "";
+}
+
+// Walk a parsed program's `import` declarations and emit:
+//   - E0430 for a relative import whose `from "./x"` path resolves to no
+//     module on disk (independent of `closure` — a pure on-disk probe), and
+//   - E0431 for a named specifier that is defined NOWHERE in the staged
+//     import closure.
+// Sailfin resolves imported symbols globally by name (see
+// `ClosureSymbolSet`), so E0431 checks closure-wide existence, not
+// per-module export. It is suppressed unless `closure.complete` — an
+// incomplete closure (a missing/corrupt artifact, or a wildcard re-export)
+// might not list a genuinely-defined name, and a false positive is worse
+// than a missed one. E0430 always fires from the on-disk probe, so a
+// standalone single-file check (empty, incomplete closure) still catches a
+// nonexistent module path.
+fn collect_import_resolution_findings(program: Program, file_path: string, closure: ClosureSymbolSet) -> Diagnostic[] ![io] {
+    let mut out: Diagnostic[] = [];
+    let base_dir = _irc_dirname(file_path);
+    let mut i: int = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let statement = program.statements[i];
+        if statement.variant == "ImportDeclaration" {
+            let spec_path = statement.source;
+            if _irc_is_relative(spec_path) {
+                let resolved = _irc_resolve_existing(base_dir, spec_path);
+                if resolved.length == 0 {
+                    let mut d = make_cannot_find_module_diagnostic(spec_path);
+                    d.file_path = file_path;
+                    out.push(d);
+                } else {
+                    if closure.complete {
+                        let mut s: int = 0;
+                        loop {
+                            if s >= statement.import_specifiers.length { break; }
+                            let importer = statement.import_specifiers[s];
+                            if !_irc_names_contains(closure.names, importer.name) {
+                                let mut nd = make_symbol_not_exported_diagnostic(importer.name, spec_path);
+                                nd.file_path = file_path;
+                                out.push(nd);
+                            }
+                            s += 1;
+                        }
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    return out;
+}
+
+export { collect_import_resolution_findings };

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -212,12 +212,13 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
 
     // #1953: unresolved-import surfacing. A relative `import { ... } from
     // "./x"` that resolves to no module on disk (E0430), or a named
-    // specifier the resolved module does not export (E0431), used to pass
-    // `check` clean and only fail much later at LLVM lowering. Run the
-    // resolution pass here so the inner loop catches it. `module_exports`
-    // is empty for the standalone `check_source` path (single-file, no
-    // staged closure) — E0430 still fires from the on-disk probe; E0431 is
-    // simply skipped without a per-module export set. Always `error`.
+    // specifier defined nowhere in the staged import closure (E0431), used
+    // to pass `check` clean and only fail much later at LLVM lowering. Run
+    // the resolution pass here so the inner loop catches it. `closure_symbols`
+    // is empty and incomplete for the standalone `check_source` path
+    // (single-file, no staged closure) — E0430 still fires from the on-disk
+    // probe; E0431 is simply skipped when the closure is incomplete. Always
+    // `error`.
     let import_findings = collect_import_resolution_findings(program, file_path, closure_symbols);
     let mut ifi: int = 0;
     loop {

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -31,6 +31,7 @@ import {
 import { validate_capsule_capabilities, validate_effects_with_imports } from "../effect_checker";
 import { read_effect_enforcement_env, resolve_effect_enforcement } from "../effect_gate";
 import { ImportSymbolTable, empty_import_symbols } from "../effect_imports";
+import { collect_import_resolution_findings } from "../import_resolution_check";
 import { runtime_helper_call_names } from "../llvm/runtime_helpers";
 import { number_to_string } from "../num_format";
 import { parse_program } from "../parser/mod";
@@ -39,6 +40,7 @@ import { collect_reexport_violations } from "../reexport_check";
 import { substring } from "../string_utils";
 import { Token, TokenKind } from "../token";
 import { typecheck_diagnostics_with_import_symbols_prelude } from "../typecheck";
+import { ClosureSymbolSet } from "../typecheck_import_loader";
 import { Diagnostic, FixSuggestion } from "../typecheck_types";
 
 // -------------------------------------------------------------------
@@ -105,7 +107,11 @@ fn _parse_diagnostic_for_unknown(stmt: Statement, file_path: string) -> Diagnost
 fn check_source(source: string, file_path: string) -> CheckResult ![io] {
     let no_interfaces: Statement[] = [];
     let no_caps: string[] = [];
-    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols(), no_caps, false);
+    // Standalone single-file check: no staged closure, so mark it
+    // incomplete — E0431 (closure-wide symbol existence) is skipped, but
+    // E0430 (on-disk module-path probe) still fires.
+    let no_closure = ClosureSymbolSet { names: [], complete: false };
+    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols(), no_caps, no_closure, false);
 }
 
 // Cross-module-aware variant: `imported_interfaces` carries
@@ -134,7 +140,7 @@ fn check_source(source: string, file_path: string) -> CheckResult ![io] {
 // the manifest-allowed set. Empty list = no manifest in scope =
 // skip the cross-check (standalone .sfn files outside any capsule
 // keep working unchanged).
-fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable, capabilities_required: string[], allow_bare_assert: boolean) -> CheckResult ![io] {
+fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable, capabilities_required: string[], closure_symbols: ClosureSymbolSet, allow_bare_assert: boolean) -> CheckResult ![io] {
     let program = parse_program(source);
     let prelude_globals = load_prelude_global_names(runtime_helper_call_names());
     let type_diags = typecheck_diagnostics_with_import_symbols_prelude(program, imported_interfaces, function_effects, prelude_globals);
@@ -202,6 +208,26 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         rendered.push(render_diagnostic(rxdiag, source_lines, "reexport"));
         errors += 1;
         rxi += 1;
+    }
+
+    // #1953: unresolved-import surfacing. A relative `import { ... } from
+    // "./x"` that resolves to no module on disk (E0430), or a named
+    // specifier the resolved module does not export (E0431), used to pass
+    // `check` clean and only fail much later at LLVM lowering. Run the
+    // resolution pass here so the inner loop catches it. `module_exports`
+    // is empty for the standalone `check_source` path (single-file, no
+    // staged closure) — E0430 still fires from the on-disk probe; E0431 is
+    // simply skipped without a per-module export set. Always `error`.
+    let import_findings = collect_import_resolution_findings(program, file_path, closure_symbols);
+    let mut ifi: int = 0;
+    loop {
+        if ifi >= import_findings.length { break; }
+        let idiag = import_findings[ifi];
+        combined.push(idiag);
+        producers.push("import");
+        rendered.push(render_diagnostic(idiag, source_lines, "import"));
+        errors += 1;
+        ifi += 1;
     }
 
     // W0210 (#1173): soft-deprecate a bare `assert` inside a `test`

--- a/compiler/src/typecheck_import_loader.sfn
+++ b/compiler/src/typecheck_import_loader.sfn
@@ -118,6 +118,110 @@ fn interfaces_from_native_artifact(text: string) -> ArtifactInterfaceParse {
     };
 }
 
+// #1953: the set of every symbol name defined anywhere in `sfn check`'s
+// staged import closure, for the import-resolution pass's non-exported-
+// symbol check (E0431). Sailfin resolves imported symbols GLOBALLY by name
+// — a module may legally `import { X } from "./a"` even when `X` is
+// actually declared in `./b`, because the linker resolves `X` across the
+// whole program, not per-declaring-module (the compiler's own tree relies
+// on this). So the honest check that matches the language is "is this
+// imported name defined SOMEWHERE in the closure", not "does this exact
+// module export it". `names` is the union of every top-level name every
+// staged artifact declares — functions (incl. externs), structs,
+// interfaces, enums, bindings — plus every `.import`/`.export` specifier
+// name and alias (names re-exported through a barrel). `complete` is false
+// when any artifact is missing or failed to parse: the union is then a
+// subset of the real closure surface, so the check pass skips E0431
+// entirely rather than risk a false positive on a name defined in the
+// unreadable artifact. Over-accepting is a deliberate false-negative bias
+// — it can only make E0431 more permissive, never false-positive on valid
+// code.
+struct ClosureSymbolSet {
+    names: string[];
+    complete: boolean;
+}
+
+fn build_closure_symbol_set(asm_paths: string[]) -> ClosureSymbolSet ![io] {
+    let mut names: string[] = [];
+    let mut complete: boolean = true;
+    let mut i: int = 0;
+    loop {
+        if i >= asm_paths.length { break; }
+        let asm = asm_paths[i];
+        if !fs.exists(asm) {
+            complete = false;
+            i += 1;
+            continue;
+        }
+        let text = fs.readFile(asm);
+        let parsed = parse_native_artifact_for_import_context(text);
+        if parsed.diagnostics.length > 0 {
+            complete = false;
+            i += 1;
+            continue;
+        }
+        let mut fi: int = 0;
+        loop {
+            if fi >= parsed.functions.length { break; }
+            names.push(parsed.functions[fi].name);
+            fi += 1;
+        }
+        let mut si: int = 0;
+        loop {
+            if si >= parsed.structs.length { break; }
+            names.push(parsed.structs[si].name);
+            si += 1;
+        }
+        let mut ii: int = 0;
+        loop {
+            if ii >= parsed.interfaces.length { break; }
+            names.push(parsed.interfaces[ii].name);
+            ii += 1;
+        }
+        let mut ei: int = 0;
+        loop {
+            if ei >= parsed.enums.length { break; }
+            names.push(parsed.enums[ei].name);
+            ei += 1;
+        }
+        let mut bi: int = 0;
+        loop {
+            if bi >= parsed.bindings.length { break; }
+            names.push(parsed.bindings[bi].name);
+            bi += 1;
+        }
+        // Every `.import`/`.export` specifier name a module carries is a
+        // name reachable through that module (barrel re-exports pass
+        // imported names straight through), so fold them into the global
+        // set too. A wildcard-shaped re-export (`.export "src" { }` — empty
+        // specifier list) cannot be enumerated; treat the closure as
+        // incomplete so E0431 is skipped rather than false-firing.
+        let mut ni: int = 0;
+        loop {
+            if ni >= parsed.imports.length { break; }
+            let imp = parsed.imports[ni];
+            if imp.kind == "export" {
+                if imp.specifiers.length == 0 { complete = false; }
+            }
+            let mut spi: int = 0;
+            loop {
+                if spi >= imp.specifiers.length { break; }
+                let spec = imp.specifiers[spi];
+                names.push(spec.name);
+                let alias = spec.alias;
+                if alias != null {
+                    let alias_str: string? = alias;
+                    if alias_str.length > 0 { names.push(alias_str); }
+                }
+                spi += 1;
+            }
+            ni += 1;
+        }
+        i += 1;
+    }
+    return ClosureSymbolSet { names: names, complete: complete };
+}
+
 // Read each path, parse its artifact, and accumulate. Partitioning
 // follows the `ImportedInterfaceLoadResult` contract: missing files
 // surface in `missing_paths`, parse failures surface in
@@ -202,7 +306,9 @@ fn load_imported_native_texts_from_paths(paths: string[]) -> string[] ![io] {
 
 export {
     ArtifactInterfaceParse,
+    ClosureSymbolSet,
     ImportedInterfaceLoadResult,
+    build_closure_symbol_set,
     interfaces_from_native_artifact,
     load_imported_interfaces_from_paths,
     load_imported_native_texts_from_paths

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -2721,6 +2721,35 @@ fn make_undefined_function_diagnostic(name: string, span: SourceSpan?) -> Diagno
     };
 }
 
+// #1953: `sfn check` resolves each relative import against the staged
+// import closure. A `from "./x"` spec that resolves to no module on disk
+// mints E0430; a named specifier the resolved module does not export
+// mints E0431. Both carry no span — the `ImportDeclaration` AST node
+// carries none (see ast.sfn) — so `primary` is null and the renderer
+// falls back to a location-only line, matching the E0600 re-export
+// diagnostics.
+fn make_cannot_find_module_diagnostic(module_spec: string) -> Diagnostic {
+    return Diagnostic {
+        code: "E0430",
+        severity: "error",
+        message: "cannot find module `" + module_spec + "`",
+        file_path: "",
+        primary: null,
+        suggestion: null
+    };
+}
+
+fn make_symbol_not_exported_diagnostic(symbol: string, module_spec: string) -> Diagnostic {
+    return Diagnostic {
+        code: "E0431",
+        severity: "error",
+        message: "`" + symbol + "` is not exported by `" + module_spec + "`",
+        file_path: "",
+        primary: null,
+        suggestion: null
+    };
+}
+
 // A nested / local `fn` is a non-capturing static item (SFEP-0042): its
 // body may reference its own parameters, module-level items, and sibling
 // nested `fn`s — never an enclosing local or parameter. Capturing one is

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -2723,11 +2723,12 @@ fn make_undefined_function_diagnostic(name: string, span: SourceSpan?) -> Diagno
 
 // #1953: `sfn check` resolves each relative import against the staged
 // import closure. A `from "./x"` spec that resolves to no module on disk
-// mints E0430; a named specifier the resolved module does not export
-// mints E0431. Both carry no span — the `ImportDeclaration` AST node
-// carries none (see ast.sfn) — so `primary` is null and the renderer
-// falls back to a location-only line, matching the E0600 re-export
-// diagnostics.
+// mints E0430; a named specifier defined nowhere in the closure mints
+// E0431 (Sailfin resolves imports globally by name, so this is a
+// closure-wide existence check, not per-module export enforcement). Both
+// carry no span — the `ImportDeclaration` AST node carries none (see
+// ast.sfn) — so `primary` is null and the renderer falls back to a
+// location-only line, matching the E0600 re-export diagnostics.
 fn make_cannot_find_module_diagnostic(module_spec: string) -> Diagnostic {
     return Diagnostic {
         code: "E0430",
@@ -2743,7 +2744,8 @@ fn make_symbol_not_exported_diagnostic(symbol: string, module_spec: string) -> D
     return Diagnostic {
         code: "E0431",
         severity: "error",
-        message: "`" + symbol + "` is not exported by `" + module_spec + "`",
+        message: "`" + symbol + "` is imported from `" + module_spec
+            + "` but is not defined by any module in scope",
         file_path: "",
         primary: null,
         suggestion: null

--- a/compiler/tests/e2e/check_unresolved_import_test.sfn
+++ b/compiler/tests/e2e/check_unresolved_import_test.sfn
@@ -1,0 +1,124 @@
+// End-to-end regression tests for #1953 — `sfn check` diagnoses unresolved
+// imports instead of silently accepting them: a relative module path that
+// resolves to no file on disk is E0430 ("cannot find module"), and a symbol
+// imported from a module that never defines it is E0431.
+//
+// Native `*_test.sfn` per `.claude/rules/no-bash-e2e.md` — drives the
+// compiler subprocess via `process.run_capture`, mirroring the
+// `_sfn_bin`/subprocess pattern in `guillermo_test.sfn` and the
+// `_child_env`/`with_tmp_dir` fixture layout in `check_compiler_src_test.sfn`.
+//
+// NOTE on matchers: the `sfn/test` `expect_*` matchers are `![pure]` and
+// cannot be called from an `![io]` test. Assertions here use
+// `sfn/strings::find` on the captured combined stdout+stderr instead.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// `run_capture`'s empty array is the *empty* environment; thread the
+// variables the toolchain needs.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+// A fresh marker-file path under the runner's scratch dir (or `/tmp`), with
+// any stale value removed. Lives outside the `with_tmp_dir` tree so the
+// captured output survives temp-dir teardown.
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-check-unresolved-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// Run `sfn check <path>` and stash the combined stdout+stderr to
+// `out_marker`. Returns the process exit code.
+fn _check(path: string, out_marker: string) -> int ![io] {
+    let exit = process.run_capture([_sfn_bin(), "check", path], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    fs.writeFile(out_marker, out + err);
+    return exit;
+}
+
+test "check: nonexistent relative module path is E0430" ![io] {
+    let marker = _marker("missing-module");
+    let exit = with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/consumer.sfn";
+        fs.writeFile(srcpath, "import { helper_fn } from \"./missing_module\";\n"
+            + "fn use_it() -> string { return helper_fn(1); }\n");
+        return _check(srcpath, marker);
+    });
+    let combined = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert exit != 0;
+    assert find(combined, "E0430", 0) >= 0;
+    assert find(combined, "cannot find module", 0) >= 0;
+}
+
+test "check: symbol defined nowhere in closure is E0431" ![io] {
+    let marker = _marker("missing-symbol");
+    let exit = with_tmp_dir(fn (dir: string) -> int {
+        fs.writeFile(dir + "/helper.sfn", "fn helper_fn(x: int) -> string { return \"hi\"; }\n");
+        let srcpath = dir + "/consumer.sfn";
+        fs.writeFile(srcpath, "import { no_such_symbol } from \"./helper\";\n"
+            + "fn use_it() -> string { return no_such_symbol(1); }\n");
+        return _check(srcpath, marker);
+    });
+    let combined = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert exit != 0;
+    assert find(combined, "E0431", 0) >= 0;
+}
+
+test "check: valid relative import passes" ![io] {
+    let marker = _marker("valid-import");
+    let exit = with_tmp_dir(fn (dir: string) -> int {
+        fs.writeFile(dir + "/helper.sfn", "fn helper_fn(x: int) -> string { return \"hi\"; }\n");
+        let srcpath = dir + "/consumer.sfn";
+        fs.writeFile(srcpath, "import { helper_fn } from \"./helper\";\n"
+            + "fn use_it() -> string { return helper_fn(2); }\n");
+        return _check(srcpath, marker);
+    });
+    let _combined = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert exit == 0;
+}
+
+test "check: wrong import-path depth is caught (PR #1952 regression)" ![io] {
+    let marker = _marker("wrong-depth");
+    let exit = with_tmp_dir(fn (dir: string) -> int {
+        // `helper.sfn` lives at the tmp-dir root; the correct import from
+        // `sub/` is `../helper`. The consumer uses the wrong depth `./helper`,
+        // which resolves to `sub/helper.sfn` — reliably nonexistent INSIDE the
+        // controlled tmp dir (an `../../` overshoot would escape the tmp dir
+        // and could coincidentally hit a real file). This reproduces the
+        // #1952 class: a wrong-depth relative path that resolves to no module.
+        fs.writeFile(dir + "/helper.sfn", "fn helper_fn(x: int) -> string { return \"hi\"; }\n");
+        fs.createDirectory(dir + "/sub", true);
+        let srcpath = dir + "/sub/consumer.sfn";
+        fs.writeFile(srcpath, "import { helper_fn } from \"./helper\";\n"
+            + "fn use_it() -> string { return helper_fn(1); }\n");
+        return _check(srcpath, marker);
+    });
+    let combined = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    assert exit != 0;
+    assert find(combined, "E0430", 0) >= 0;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-07-05. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
+Updated: 2026-07-06. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -99,6 +99,14 @@ here.
   carry structured `FixSuggestion`/`TextEdit` for `sfn fix` / LSP (Track B).
   `sfn check` surfaces parse errors (`E0500`, #974) and implicit re-export
   bans (`E0600`) via the shared `reexport_check.sfn`.
+- **Import-resolution checking (#1953).** `sfn check` now diagnoses a
+  relative `import { ... } from "./x"`/`"../x"` that resolves to no module
+  on disk (`E0430`) and a named specifier defined nowhere in the staged
+  import closure (`E0431`, closure-wide "defined somewhere" — Sailfin
+  resolves imports globally by name, not per-declaring-module export).
+  Narrows the check≠build gap (#1389) for the wrong-import-depth class
+  (e.g. #1952). Scope: only `./`/`../` specs; `sfn/...` and runtime imports
+  are unaffected; checked only in `sfn check`, not the build path.
 - **Emit pipeline.** Parallel per-module emit fan-out (Stage E PR3, #278)
   with a shared retry + validator cascade (#515); driver `--work-dir` flag
   (#378); cross-Windows packaging leg (`ci-cross-windows`, #280).
@@ -313,7 +321,7 @@ here.
 | `unsafe` / `extern` | Boundary enforced (locally-declared externs) | `extern fn` declarations are fully shipped (see Runtime Migration); `unsafe { }` blocks and `unsafe fn` carry an `is_unsafe` AST marker (#1211). The ownership checker skips `unsafe` interiors and treats the boundary as load-bearing: a bare owned value escaping into an `extern fn` outside `unsafe` raises `E0906` (#1215). Scope at E6: only externs **declared in the same compilation unit** are recognized; implicitly-linked prelude/runtime externs (e.g. `memcpy`) are not yet matched — a deliberate, self-host-safe false negative widened in a follow-up. Raw-pointer ops *inside* `unsafe` stay author-asserted |
 | Policy decorators (`@policy`) | Parsed only | No compiler or runtime effect |
 | `sfn fmt` | **Shipped** | Zero-config token-stream formatter, `--check`/`--write`, CI-enforced; architecture + limitations in `docs/proposals/0007-fmt-architecture.md` |
-| `sfn check` | **Shipped** | Parse + typecheck + effect-check, no codegen; `--json` envelope; cross-module conformance; directory mode completes the full 156-file tree (~295 s — perf, not stability, is the open item) |
+| `sfn check` | **Shipped** | Parse + typecheck + effect-check, no codegen; `--json` envelope; cross-module conformance; directory mode completes the full 156-file tree (~295 s — perf, not stability, is the open item); relative-import resolution (`E0430`/`E0431`, #1953) |
 | `sfn test` | **Shipped** | Discovery, `-k`/`--tag` filtering (#849), lifecycle hooks (#975, ordering only), snapshots + `--update-snapshots` (#977), `--jobs N` parallel runner (#1236), per-test binary cache (#1230/#1233) |
 | `sfn vet` / `sfn lsp` / `sfn doc` / `sfn fix` | Planned | See `docs/proposals/0003-tooling.md` |
 | Package registry (`sfn init/add/publish`) | Shipped | Default registry `pkg.sfn.dev`; `SFN_REGISTRY` / `sfn config set registry` override |

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -214,7 +214,7 @@ relative to `compiler/src/`):
 |---|---|---|
 | `E00xx` | Names / generic resolution | `typecheck_types.sfn` |
 | `E03xx` | Duplicate symbols / type conflicts | `typecheck*.sfn` |
-| `E04xx` | Effect violations | `diagnostics_render.sfn`, `effect_checker.sfn` |
+| `E04xx` | Effect violations; relative-import resolution (`E0430` cannot find module, `E0431` symbol not defined in closure, #1953) | `diagnostics_render.sfn`, `effect_checker.sfn`, `typecheck_types.sfn` |
 | `E05xx`–`E06xx` | Build / check tooling | `tools/check.sfn` |
 | `E08xx` | `Result` / `?` operator; extern C-ABI (`E0801`–`E0805`); bare function-type annotation reject (`E0826`) | `typecheck_types.sfn` |
 | `E09xx` | Ownership / affine types | `ownership_checker.sfn` |


### PR DESCRIPTION
## Summary

- `sfn check` now diagnoses a relative `import { ... } from "./x"` / `"../x"` that resolves to **no module on disk** (`E0430 cannot find module`) — catching the wrong-import-depth class that previously passed `check` clean and only failed at `make compile` (e.g. #1952).
- It also diagnoses a named import of a **symbol defined nowhere in the staged import closure** (`E0431`). Sailfin resolves imported symbols globally by name (not per-declaring-module), so E0431 is a closure-wide existence check — not strict per-module export enforcement.
- Both run only in `sfn check` (never the build path), scoped to `./`/`../` relative imports; scoped/capsule (`sfn/...`) and runtime imports are untouched. Zero self-host risk by construction.

Closes #1953

## Design / policy notes

- **Global-by-name semantics (owner-decided).** Implementation revealed the compiler resolves imported symbols across the whole link, not per-module — the tree itself imports 5 symbols from modules that don't declare them. E0431 therefore checks "defined somewhere in the closure," which matches the language today and yields **zero false positives** on the compiler tree. Strict per-module export enforcement is a future tightening (would require cleaning up those imports first).
- **Secondary finding split to #1954.** The issue's secondary `emit llvm` exit-code false-green (prints `[fatal]`, exits 0) is a one-line diagnostic-propagation fix — but it *surfaces* pre-existing latent return-path fatals (e.g. an int-literal/float ABI mismatch in `sfn/test`'s `_abs`) that break the suite until resolved. That blast radius warrants its own PR; filed as #1954 with the full diagnosis.

## Acceptance Criteria

- [x] `sfn check` on an import from a nonexistent module path exits non-zero with `E0430` (with a diagnostic).
- [x] `sfn check` on a named import of a symbol not defined in the closure exits non-zero with `E0431` (closure-wide leniency documented; tests pin the envelope).
- [x] The PR #1952 wrong-import-depth failure mode is caught by `sfn check`, not only `make compile`.
- [x] Regression test under `compiler/tests/` covering nonexistent-module, non-defined-symbol, valid-import, and wrong-depth cases.
- [x] `make compile` self-hosts; `make check` passes.
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Map reconciliation

The issue's advisory `## Files Affected` named `cli_check.sfn` / `typecheck_imports.sfn` / `typecheck_import_loader.sfn` / `typecheck.sfn`. Reconciled at pickup: the check runs in a **new leaf** `compiler/src/import_resolution_check.sfn` invoked from `tools/check.sfn`'s `check_source_with_imports` (the same layer that already mints E0500/E0600); the closure symbol set is built in `typecheck_import_loader.sfn` and threaded via `cli_check.sfn`. `typecheck.sfn`'s unconditional import-symbol registration was intentionally **not** touched (it's load-bearing for E0420/E0402 and runs in the build path — editing it would risk self-hosting). Same semantic unit (import resolution in `check`), just a cleaner placement.

## Verification

```
# tree-wide false-positive gate — clean
build/native/sailfin check compiler/src/ runtime/    → checked 233 files: ok (0 E0430/E0431)

# repro cases
check <import from ./missing_module>   → rc=1, E0430 cannot find module
check <import no_such_symbol from ./helper>  → rc=1, E0431
check <valid ./helper import>          → rc=0

make compile   → pass (self-hosts)
make check     → pass (unit + integration + e2e 195/195 + capsules 38/38)
```

## Files Changed

- **new** `compiler/src/import_resolution_check.sfn` — the leaf pass (E0430/E0431), self-contained path helpers, `[io]`.
- `compiler/src/typecheck_import_loader.sfn` — `ClosureSymbolSet` + `build_closure_symbol_set` (global name union from staged artifacts).
- `compiler/src/typecheck_types.sfn` — `make_cannot_find_module_diagnostic` (E0430), `make_symbol_not_exported_diagnostic` (E0431).
- `compiler/src/tools/check.sfn` — thread the closure set into `check_source_with_imports`; emit findings.
- `compiler/src/cli_check.sfn` — build the closure set once per group.
- **new** `compiler/tests/e2e/check_unresolved_import_test.sfn` — 4 regression tests.
- `docs/status.md`, `docs/style-guide.md` — document E0430/E0431.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ok5PYcRYxeYCMRHcSXqgT)_