### PR TITLE
docs(sfep): reconcile epic↔SFEP back-links

### DIFF
--- a/docs/proposals/0010-test-infra/00-overview.md
+++ b/docs/proposals/0010-test-infra/00-overview.md
@@ -4,7 +4,7 @@ title: Sailfin-Native Test Infrastructure
 status: Accepted
 type: tooling
 created: 2026-05-06
-updated: 2026-07-06
+updated: 2026-05-06
 author: "agent:compiler-architect"
 tracking: "#965, #839, #842, #840"
 supersedes:

--- a/docs/proposals/0010-test-infra/00-overview.md
+++ b/docs/proposals/0010-test-infra/00-overview.md
@@ -4,9 +4,9 @@ title: Sailfin-Native Test Infrastructure
 status: Accepted
 type: tooling
 created: 2026-05-06
-updated: 2026-05-06
+updated: 2026-07-06
 author: "agent:compiler-architect"
-tracking: "#965, #842, #840"
+tracking: "#965, #839, #842, #840"
 supersedes:
 superseded-by:
 graduates-to: reference/spec/11-testing.md

--- a/docs/proposals/0011-ci-test-speed.md
+++ b/docs/proposals/0011-ci-test-speed.md
@@ -4,9 +4,9 @@ title: "CI Test-Speed Plan"
 status: Accepted
 type: tooling
 created: 2026-05-01
-updated: 2026-07-01
+updated: 2026-07-06
 author: "agent:compiler-architect"
-tracking: "#1012"
+tracking: "#1012, #843"
 supersedes:
 superseded-by:
 graduates-to:

--- a/docs/proposals/0016-capability-sealed-runtime.md
+++ b/docs/proposals/0016-capability-sealed-runtime.md
@@ -4,9 +4,9 @@ title: The Capability-Sealed Runtime
 status: Accepted
 type: runtime
 created: 2026-06-07
-updated: 2026-06-26
+updated: 2026-07-06
 author: "agent:compiler-architect; project owner (repositioning)"
-tracking: "#1639"
+tracking: "#1639, #934, #1642, #1643"
 supersedes:
 superseded-by:
 graduates-to:

--- a/docs/proposals/0021-windows-native-selfhost.md
+++ b/docs/proposals/0021-windows-native-selfhost.md
@@ -4,9 +4,9 @@ title: Native Windows Self-Host (MSVC ABI)
 status: Accepted
 type: runtime
 created: 2026-06-22
-updated: 2026-06-22
+updated: 2026-07-06
 author: "agent:compiler-architect"
-tracking:
+tracking: ["#1485"]
 supersedes:
 superseded-by:
 graduates-to:

--- a/docs/proposals/0021-windows-native-selfhost.md
+++ b/docs/proposals/0021-windows-native-selfhost.md
@@ -6,7 +6,7 @@ type: runtime
 created: 2026-06-22
 updated: 2026-07-06
 author: "agent:compiler-architect"
-tracking: ["#1485"]
+tracking: "#1485"
 supersedes:
 superseded-by:
 graduates-to:

--- a/docs/proposals/0023-capsule-decorators.md
+++ b/docs/proposals/0023-capsule-decorators.md
@@ -4,9 +4,9 @@ title: Capsule-Defined Decorators
 status: Draft
 type: language
 created: 2026-06-15
-updated: 2026-06-15
+updated: 2026-07-06
 author: "agent:compiler-architect"
-tracking:
+tracking: ["#1557"]
 supersedes:
 superseded-by:
 graduates-to:

--- a/docs/proposals/0023-capsule-decorators.md
+++ b/docs/proposals/0023-capsule-decorators.md
@@ -6,7 +6,7 @@ type: language
 created: 2026-06-15
 updated: 2026-07-06
 author: "agent:compiler-architect"
-tracking: ["#1557"]
+tracking: "#1557"
 supersedes:
 superseded-by:
 graduates-to:

--- a/docs/proposals/0036-tls-runtime.md
+++ b/docs/proposals/0036-tls-runtime.md
@@ -4,9 +4,9 @@ title: "TLS termination + upstream TLS for the native runtime (OpenSSL)"
 status: Implemented
 type: runtime
 created: 2026-06-29
-updated: 2026-07-06
+updated: 2026-07-05
 author: "agent:compiler-architect; human review"
-tracking: "#1820, #1821, #1822"
+tracking: "#1540, #1820, #1821, #1822"
 supersedes:
 superseded-by:
 graduates-to: reference/standard-library.md

--- a/docs/proposals/0036-tls-runtime.md
+++ b/docs/proposals/0036-tls-runtime.md
@@ -4,9 +4,9 @@ title: "TLS termination + upstream TLS for the native runtime (OpenSSL)"
 status: Implemented
 type: runtime
 created: 2026-06-29
-updated: 2026-07-05
+updated: 2026-07-06
 author: "agent:compiler-architect; human review"
-tracking: "#1540, #1820, #1821, #1822"
+tracking: "#1820, #1821, #1822"
 supersedes:
 superseded-by:
 graduates-to: reference/standard-library.md


### PR DESCRIPTION
## Summary

Epic↔SFEP linkage audit found **19 of 22 open epics don't cite their SFEP**, though the design records mostly *exist* — a back-linking gap, not a design vacuum (many epics predate the SFEP process). This reconciles both directions.

## SFEP `tracking:` front-matter (this PR)

| SFEP | Change |
|---|---|
| 0010 test-infra | `+#839` (parent epic) |
| 0011 CI test-speed | `+#843` (Phase 4) |
| 0016 capability seal | `+#934, #1642, #1643` (child epics the SFEP text already named) |
| 0021 Windows self-host | `= #1485` (was **empty**) |
| 0023 capsule-decorators | `= #1557` (was **empty**) |

`tracking:` uses the scalar `"#N, #M"` form throughout (per review). SFEPs are Markdown — no `sfn fmt` / self-host gate.

> **Correction (post-review):** an earlier commit dropped `#1540` from SFEP-0036's `tracking:` as "stale." It is **not** stale — 0036's body scopes the TLS work as "Gap B1 of epic #1540 (MCP-proxy enablement)," so the link is legitimate. Reverted; 0036 is unchanged by this PR.

## Epic bodies (applied live via `gh`, not in this diff)

Added a `## Design: SFEP-NNNN` section to 14 epics: #1639→0016, #1640→0015, #1641→0015+0016, #1642→0016, #1643→0016, #934→0016, #1180→0017, #1485→0021, #1609→0030+0042, #1557→0023, #345→0020, #839→0010, #842→0010, #843→0011.

## Not in scope (follow-ups)

- New SFEPs for #513 (Makefile slim-down), #1503 (`sfn bench`); #1540/#1556 (MCP-proxy) — #1540's TLS gap already has SFEP-0036, but the epic may still want an umbrella SFEP.
- Epic closures (#1867, #842) handled separately.