### PR TITLE
fix(lowering): value-position dispatch for expression-bodied lambdas

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -806,7 +806,25 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     // a regular identifier or member-access expression. Capturing
     // lambdas (#687) use the same prefix with an extended env_alloc
     // payload — handled by `lower_closure_pair_marker`.
+    //
+    // Inline IIFE (#1949): `(fn (n) => n + 1)(5)` lifts to
+    // `<closure_pair @sfn_lambda_<N> ...>(5)` — the marker's closing `>` is
+    // followed by a `(args)` call suffix. Route it through the call path (which
+    // materialises the pair via `try_resolve_closure_callee` and emits the
+    // closure dispatch) rather than the bare-marker lowering below, which would
+    // drop the call and return the pair itself. This must happen HERE, before
+    // the generic operator dispatch, because the marker's own `<`/`>` would
+    // otherwise be mis-read as comparison operators by `find_comparison_operator`.
     if starts_with(stripped, "<closure_pair ") {
+        let call_at = find_call_site(stripped);
+        if call_at > 0 && ends_with(stripped, ")") {
+            let marker_only = trim_text(substring(stripped, 0, call_at));
+            if ends_with(marker_only, ">") {
+                let args_text = substring(stripped, call_at + 1, stripped.length - 1);
+                let arg_entries = split_call_arguments(args_text);
+                return lower_call_expression(marker_only, arg_entries, bindings, locals, temp_index, lines, functions, context);
+            }
+        }
         let pair_result = lower_closure_pair_marker(stripped, functions, context, bindings, locals, temp_index, lines);
         let mut _ci_pair: int = 0;
         loop {

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -37,7 +37,7 @@ import {
     trim_text
 } from "../../utils";
 import { array_pointer_element_type } from "../arrays";
-import { lower_expression } from "./core";
+import { lower_closure_pair_marker, lower_expression } from "./core";
 import { collect_parameter_types } from "./core_helpers";
 import { load_local_operand } from "./core_operands";
 import { parse_member_access } from "./core_parse";
@@ -263,9 +263,65 @@ fn _strip_env_parameter(parameter_types: string[]) -> string[] {
     return out;
 }
 
+// Extract the lifted-lambda function name (no leading `@`) from a
+// `<closure_pair @sfn_lambda_<N> ...>` marker, or "" if malformed. Mirrors the
+// symbol parse in `lower_closure_pair_marker` (core.sfn) so the two agree on
+// which function the marker names.
+fn _closure_pair_symbol(marker: string) -> string {
+    let prefix = "<closure_pair ";
+    let mut cursor: int = prefix.length;
+    let mut symbol: string = "";
+    loop {
+        if cursor >= marker.length { break; }
+        let ch = marker[cursor];
+        if ch == " " { break; }
+        symbol = symbol + ch;
+        cursor += 1;
+    }
+    if symbol.length == 0 { return ""; }
+    if substring(symbol, 0, 1) == "@" {
+        return substring(symbol, 1, symbol.length);
+    }
+    return symbol;
+}
+
 fn try_resolve_closure_callee(target: string, bindings: ParameterBinding[], locals: LocalBinding[], functions: NativeFunction[], context: TypeContext, temp_index: int, lines: string[]) -> _ClosureCalleeInfo? ![io] {
     let name = trim_text(target);
     if name.length == 0 { return null; }
+
+    // Inline IIFE (#1949): the callee is a lifted-lambda closure-pair marker
+    // (`<closure_pair @sfn_lambda_<N> ...>`) rather than a named binding — e.g.
+    // `(fn (n) => n + 1)(5)`. Materialise the `{i8*, i8*}` pair inline (reusing
+    // `lower_closure_pair_marker`) and resolve the lifted function's user-facing
+    // signature, so the call routes through the same closure-dispatch branch as
+    // a `__closure__`-typed local. Without this the marker is not a simple
+    // identifier and dispatch falls through to a silent zero return. The trailing
+    // space in the prefix excludes the `<closure_pair_fatal_mutable ...>` marker.
+    if starts_with(name, "<closure_pair ") {
+        let symbol = _closure_pair_symbol(name);
+        if symbol.length == 0 { return null; }
+        let marker_fn = find_function_by_name(functions, symbol);
+        if marker_fn != null {
+            let pair = lower_closure_pair_marker(name, functions, context, bindings, locals, temp_index, lines);
+            if pair.operand != null {
+                let materialized: LLVMOperand = pair.operand;
+                let lifted_params = collect_parameter_types(context, marker_fn.parameters, marker_fn.name);
+                let user_params = _strip_env_parameter(lifted_params);
+                let return_type = map_return_type(context, marker_fn.return_type);
+                let mut effective_return: string = return_type;
+                if effective_return.length == 0 { effective_return = "void"; }
+                return _ClosureCalleeInfo {
+                    operand: materialized,
+                    lines: pair.lines,
+                    temp_index: pair.temp_index,
+                    return_type: effective_return,
+                    parameter_types: user_params
+                };
+            }
+        }
+        return null;
+    }
+
     if !is_simple_identifier(name) { return null; }
 
     // Locals win over parameters when both bind the same name (the

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -66,6 +66,7 @@ import {
     BindingEntry,
     FnSigEntry,
     backfill_call_argument,
+    backfill_lambda_return_from_body,
     build_binding_table,
     build_fn_signature_table
 } from "./lambda_param_inference";
@@ -952,7 +953,16 @@ fn _rewrite_expression(ctx: LiftContext, expression: Expression) -> ExpressionRe
     return ExpressionRewriteResult { ctx: ctx, expression: expression };
 }
 
-fn _rewrite_lambda(ctx: LiftContext, lambda: Expression, owned_env: boolean) -> ExpressionRewriteResult {
+fn _rewrite_lambda(ctx: LiftContext, lambda_in: Expression, owned_env: boolean) -> ExpressionRewriteResult {
+    // Fill a `null` return type from the body before matching the capture
+    // record and synthesising the lifted function (#1949). Argument-position
+    // lambdas are already backfilled from the callee's expected `fn(...) -> R`
+    // (`backfill_call_argument`) before reaching here, so this only affects
+    // `let`-bound / IIFE lambdas that have no expected type — otherwise the
+    // synthesised `sfn_lambda_<N>` lowers as `void` and the value-position call
+    // silently returns 0. The body object is preserved, so the `body.tokens[0]`
+    // capture-record key is unchanged.
+    let lambda = backfill_lambda_return_from_body(lambda_in);
     let record = _find_capture_record(ctx.records, lambda);
     if record == null {
         // No record means `analyze_lambda_captures` did not see this

--- a/compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn
@@ -236,6 +236,13 @@ fn backfill_lambda_return_from_body(lambda: Expression) -> Expression {
     };
 }
 
+// Running state for the body-return scan below: whether any value-returning
+// `return` was seen, and the last literal-inferable return type ("" if none).
+struct _BodyReturnScan {
+    has_value_return: boolean;
+    inferred: string;
+}
+
 // Infer a lambda body's return type text from its `return <expr>` statements.
 // A body with a value-returning `return` whose type is not literal-inferable
 // falls back to the untyped-lambda `int` ABI (#766); the last inferable `return`
@@ -243,27 +250,93 @@ fn backfill_lambda_return_from_body(lambda: Expression) -> Expression {
 // `fn () { print.info("x"); }`) keeps `void` — the ABI it lifted with before
 // #1949 — so this backfill never turns an ordinary void closure into a
 // value-returning function (which would emit a spurious `missing return`
-// lowering diagnostic and `ret i64 0`).
+// lowering diagnostic and `ret i64 0`). The scan recurses into nested blocks
+// (`if`/`match`/`try`/loops/etc.) so a lambda whose only value-returning
+// `return` lives inside a branch is still typed, not mis-lowered to `void`.
 fn _infer_body_return_text(body: Block) -> string {
-    let mut inferred: string = "";
-    let mut has_value_return: boolean = false;
+    let scan = _scan_block_returns(_BodyReturnScan {
+        has_value_return: false, inferred: ""
+    }, body);
+    if !scan.has_value_return { return "void"; }
+    if scan.inferred.length == 0 { return "int"; }
+    return scan.inferred;
+}
+
+fn _scan_block_returns(scan: _BodyReturnScan, block: Block) -> _BodyReturnScan {
+    let mut out: _BodyReturnScan = scan;
     let mut index: int = 0;
     loop {
-        if index >= body.statements.length { break; }
-        let statement = body.statements[index];
-        if statement.variant == "ReturnStatement" {
-            if statement.expression != null {
-                has_value_return = true;
-                let value: Expression = statement.expression;
-                let text = infer_expression_type(value);
-                if text.length > 0 { inferred = text; }
-            }
-        }
+        if index >= block.statements.length { break; }
+        out = _scan_statement_returns(out, block.statements[index]);
         index += 1;
     }
-    if !has_value_return { return "void"; }
-    if inferred.length == 0 { return "int"; }
-    return inferred;
+    return out;
+}
+
+// Recurse over the block-bearing statement variants (mirrors the traversal in
+// `_collect_statement_bindings`) so a `return <expr>` at any depth is counted.
+fn _scan_statement_returns(scan: _BodyReturnScan, statement: Statement) -> _BodyReturnScan {
+    let mut out: _BodyReturnScan = scan;
+    if statement.variant == "ReturnStatement" {
+        if statement.expression != null {
+            let value: Expression = statement.expression;
+            let text = infer_expression_type(value);
+            let mut new_inferred: string = out.inferred;
+            if text.length > 0 { new_inferred = text; }
+            out = _BodyReturnScan {
+                has_value_return: true,
+                inferred: new_inferred
+            };
+        }
+        return out;
+    }
+    if statement.variant == "IfStatement" {
+        out = _scan_block_returns(out, statement.then_block);
+        if statement.else_branch != null {
+            let branch = statement.else_branch;
+            if branch.body != null {
+                out = _scan_block_returns(out, branch.body);
+            } else if branch.statement != null {
+                out = _scan_statement_returns(out, branch.statement);
+            }
+        }
+        return out;
+    }
+    if statement.variant == "BlockStatement" {
+        return _scan_block_returns(out, statement.body);
+    }
+    if statement.variant == "WithStatement" {
+        return _scan_block_returns(out, statement.body);
+    }
+    if statement.variant == "ForStatement" {
+        return _scan_block_returns(out, statement.body);
+    }
+    if statement.variant == "LoopStatement" {
+        return _scan_block_returns(out, statement.body);
+    }
+    if statement.variant == "RoutineStatement" {
+        return _scan_block_returns(out, statement.body);
+    }
+    if statement.variant == "MatchStatement" {
+        let mut c: int = 0;
+        loop {
+            if c >= statement.cases.length { break; }
+            out = _scan_block_returns(out, statement.cases[c].body);
+            c += 1;
+        }
+        return out;
+    }
+    if statement.variant == "TryStatement" {
+        out = _scan_block_returns(out, statement.try_block);
+        if statement.catch_block != null {
+            out = _scan_block_returns(out, statement.catch_block);
+        }
+        if statement.finally_block != null {
+            out = _scan_block_returns(out, statement.finally_block);
+        }
+        return out;
+    }
+    return out;
 }
 
 // ── Case A: callee signature table ───────────────────────────────────

--- a/compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn
@@ -35,6 +35,7 @@ import {
     Statement,
     TypeAnnotation
 } from "../../../ast";
+import { infer_expression_type } from "../../../emit_native_format";
 import { index_of, substring } from "../../../string_utils";
 import { ends_with, starts_with, trim_text } from "../../utils";
 
@@ -206,6 +207,63 @@ fn _lambda_is_fully_typed(lambda: Expression) -> boolean {
         i += 1;
     }
     return true;
+}
+
+// ── Backfill a lambda's return type from its body (#1949) ────────────
+//
+// A short-form `fn(...) => expr` (or untyped block-form) lambda reaching the
+// lift choke point OUTSIDE call-argument position — `let`-bound and called by
+// name, or an inline IIFE — has no expected `fn(...) -> R` to backfill from, so
+// its `return_type` stays `null`, the synthesised `sfn_lambda_<N>` is declared
+// `void`, and a value-position call silently yields `0`. Fill a `null` return
+// type from the body's returned expression: a literal / struct / array return
+// whose type `infer_expression_type` recognises uses that; anything else (a
+// `Binary` like `n + 1`, an identifier, or a call — not covered by literal
+// inference) falls back to the untyped-lambda `int` ABI (#766), matching what
+// the call-argument backfill already emits for the array-builtin path. Only ever
+// fills a `null` return type, so a typed lambda (explicit `-> T`, or already
+// backfilled from an expected fn-type in argument position) is returned
+// unchanged — zero regression surface.
+fn backfill_lambda_return_from_body(lambda: Expression) -> Expression {
+    if lambda.variant != "Lambda" { return lambda; }
+    if lambda.return_type != null { return lambda; }
+    let inferred = _infer_body_return_text(lambda.body);
+    return Expression.Lambda {
+        parameters: lambda.parameters,
+        body: lambda.body,
+        return_type: TypeAnnotation { text: inferred },
+        captures: lambda.captures
+    };
+}
+
+// Infer a lambda body's return type text from its `return <expr>` statements.
+// A body with a value-returning `return` whose type is not literal-inferable
+// falls back to the untyped-lambda `int` ABI (#766); the last inferable `return`
+// wins. A body with NO value-returning `return` (a `void` closure such as
+// `fn () { print.info("x"); }`) keeps `void` — the ABI it lifted with before
+// #1949 — so this backfill never turns an ordinary void closure into a
+// value-returning function (which would emit a spurious `missing return`
+// lowering diagnostic and `ret i64 0`).
+fn _infer_body_return_text(body: Block) -> string {
+    let mut inferred: string = "";
+    let mut has_value_return: boolean = false;
+    let mut index: int = 0;
+    loop {
+        if index >= body.statements.length { break; }
+        let statement = body.statements[index];
+        if statement.variant == "ReturnStatement" {
+            if statement.expression != null {
+                has_value_return = true;
+                let value: Expression = statement.expression;
+                let text = infer_expression_type(value);
+                if text.length > 0 { inferred = text; }
+            }
+        }
+        index += 1;
+    }
+    if !has_value_return { return "void"; }
+    if inferred.length == 0 { return "int"; }
+    return inferred;
 }
 
 // ── Case A: callee signature table ───────────────────────────────────
@@ -572,6 +630,7 @@ export {
     array_builtin_expected_fn_type,
     backfill_call_argument,
     backfill_lambda_from_fn_type,
+    backfill_lambda_return_from_body,
     build_binding_table,
     build_fn_signature_table,
     declared_binding_type,

--- a/compiler/tests/e2e/short_lambda_closure_pair_test.sfn
+++ b/compiler/tests/e2e/short_lambda_closure_pair_test.sfn
@@ -84,3 +84,13 @@ test "lambda: value-less let-bound closure keeps the void ABI and runs clean" ![
     let exit = _build_and_run(src);
     assert exit == 0;
 }
+
+// The return-type inference must recurse into nested blocks: an untyped
+// `let`-bound closure whose only value-returning `return`s live inside `if`
+// branches (no top-level `return`) must still lift to a value-returning
+// function, not `void`. Guards against a top-level-only scan (#1949 review).
+test "lambda: untyped closure with only nested returns lifts to a value ABI" ![io] {
+    let src = "fn main() -> int {\n    let f = fn (n: int) { if n > 0 { return 7; } else { return 0; } };\n    return f(5);\n}\n";
+    let exit = _build_and_run(src);
+    assert exit == 7;
+}

--- a/compiler/tests/e2e/short_lambda_closure_pair_test.sfn
+++ b/compiler/tests/e2e/short_lambda_closure_pair_test.sfn
@@ -1,0 +1,86 @@
+// End-to-end regression for #1949: an expression-bodied short-form lambda
+// (`fn(...) => expr`, SFEP-0029) that is `let`-bound and called by name, or
+// invoked inline as an IIFE, silently returned 0 instead of its body value.
+//
+// Root cause: the lambda-lift pass only backfilled a `null` return type for
+// lambdas in call-ARGUMENT position (`backfill_call_argument`, #1683). A
+// `let`-bound / IIFE short-form lambda has no expected `fn(...) -> R` to
+// backfill from, so it kept `return_type: null`, the synthesised
+// `sfn_lambda_<N>` lowered as `void`, and the value-position call yielded 0.
+// `backfill_lambda_return_from_body` now fills the return type at the lift
+// choke point (`_rewrite_lambda`). The block form (`fn() -> T { return e; }`)
+// was never affected because it carries an explicit return type.
+//
+// Build-and-run shape: each fixture returns the lambda value as its process
+// exit code (6/7), so a `void`-lowered regression re-surfaces as exit 0.
+//
+// Parallel-runner isolation (load-bearing): the nested `sfn build` inherits the
+// full environment — PATH for `clang`/`ld`, and `SAILFIN_TEST_SCRATCH` so the
+// compiler routes the `program.ll` build-cache dir per-invocation (#1333)
+// instead of colliding on the fixed `build/sailfin` under the `--jobs N` pool.
+// See `.claude/rules/no-bash-e2e.md`.
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+// Build `source` to a binary in a temp dir and run it; returns the run exit
+// code, or -100 if the build itself failed (kept distinct so a build break does
+// not masquerade as the miscompile this test guards).
+fn _build_and_run(source: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let srcpath = dir + "/probe.sfn";
+        fs.writeFile(srcpath, source);
+        let binpath = dir + "/probe";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env());
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+        let run_exit = process.run_capture([binpath], []);
+        let _ro = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        return run_exit;
+    });
+}
+
+test "short-lambda: let-bound `fn(n) => n + 1` called by name returns its body value" ![io] {
+    let src = "fn main() -> int {\n    let f = fn (n: int) => n + 1;\n    return f(5);\n}\n";
+    let exit = _build_and_run(src);
+    assert exit == 6;
+}
+
+test "short-lambda: inline IIFE `(fn(n) => n + 1)(5)` returns its body value" ![io] {
+    let src = "fn main() -> int {\n    return (fn (n: int) => n + 1)(5);\n}\n";
+    let exit = _build_and_run(src);
+    assert exit == 6;
+}
+
+test "short-lambda: let-bound no-arg `fn() => 7` returns its body value" ![io] {
+    let src = "fn main() -> int {\n    let f = fn () => 7;\n    return f();\n}\n";
+    let exit = _build_and_run(src);
+    assert exit == 7;
+}
+
+// The inline-IIFE dispatch fix (`try_resolve_closure_callee`'s marker branch)
+// is body-form-agnostic — it also repairs the block-form IIFE, which shared the
+// same silent-drop path. Guard that path too so it cannot regress.
+test "lambda: inline block-form IIFE `(fn(n) -> int { return n + 1; })(5)` returns its body value" ![io] {
+    let src = "fn main() -> int {\n    return (fn (n: int) -> int { return n + 1; })(5);\n}\n";
+    let exit = _build_and_run(src);
+    assert exit == 6;
+}
+
+// A value-less `let`-bound closure must keep the `void` ABI it lifted with
+// before #1949: the return-type backfill only touches value-returning bodies,
+// so this builds and runs cleanly (exit 0) rather than lifting to a spurious
+// `-> int` function that falls off its end.
+test "lambda: value-less let-bound closure keeps the void ABI and runs clean" ![io] {
+    let src = "fn main() -> int {\n    let log = fn () { };\n    log();\n    return 0;\n}\n";
+    let exit = _build_and_run(src);
+    assert exit == 0;
+}


### PR DESCRIPTION
## Summary
- Fixes a silent wrong-answer miscompile where an expression-bodied short-form lambda (`fn(...) => expr`, SFEP-0029) returned `0` instead of its body value when `let`-bound and called by name, or invoked inline as an IIFE.
- Two distinct root causes fixed (bundled, as they share the lambda-invocation surface):
  - **Missing return-type inference.** The lift pass only backfilled a `null` lambda `return_type` in call-*argument* position (`backfill_call_argument`). A `let`-bound / no-arg lambda had no expected `fn(...) -> R`, so `return_type` stayed `null`, the synthesised `sfn_lambda_<N>` lowered as `void`, and the value-position call yielded `0`. `backfill_lambda_return_from_body` now infers the return type from the body's `return <expr>` at the lift choke point (`_rewrite_lambda`), via the existing `infer_expression_type`, defaulting to the untyped-lambda `int` ABI (#766) when the expression is not literal-inferable. Value-less (void) closures keep their `void` ABI unchanged.
  - **Inline IIFE dispatch.** `(fn (n) => n + 1)(5)` lifts to `<closure_pair ...>(5)`, which `lower_expression` caught as a *bare* marker and dropped the `(5)`. It now detects the trailing `(args)` call suffix and routes through the call path; `try_resolve_closure_callee` materialises the `{i8*, i8*}` pair inline and resolves the lifted function's signature. This also repairs the **block-form** inline IIFE, which shared the silent-drop path.

Closes #1949

## Acceptance Criteria
- [x] `let f = fn (n: int) => n + 1; return f(5);` returns 6.
- [x] `return (fn (n: int) => n + 1)(5);` returns 6.
- [x] `let f = fn () => 7; return f();` returns 7.
- [x] Regression test (e2e build-and-run) covering let-bound and inline short-form invocation; `make compile` self-hosts; `sfn fmt --check` clean.

## Investigation notes (worth recording for future grooming)
- The issue's leading hypothesis (synthetic `{`-token position not matching the capture-record key) was **refuted** — producer and consumer read the same `body.tokens[0]` off the same node. The actual cause was the argument-only return-type backfill.
- The inline IIFE turned out to be a **separate, pre-existing defect** in call dispatch (block-form and explicitly-typed IIFEs failed identically), not specific to the short form. Bundled here per maintainer direction so all three acceptance criteria land together.

## Map reconciliation
None — the advisory `## Files Affected` pointed at `parser/expressions.sfn` + `lambda_lowering.sfn`; the real fix locus was the lowering layer (`lambda_param_inference.sfn`, `lambda_lowering.sfn`, `core.sfn`, `core_call_resolution.sfn`), all within the `In:` "`=>` desugar and its interaction with lambda lifting" semantic unit plus the bundled call-dispatch surface. No parser change was needed.

## Verification
```
make compile                 # self-hosts (status: pass)
make check                   # unit 199/199, integration 42/42, capsules 38/38;
                             # e2e 194/196 — the 2 failures (websocket_serve_loopback,
                             # work_dir_parity) are parallel-pool flakiness: both PASS
                             # cleanly in isolation and are unrelated to lambda lowering.
build/native/sailfin test compiler/tests/e2e/short_lambda_closure_pair_test.sfn  # 5/5 PASS

# Manual repros (exit code == returned value):
let f = fn (n: int) => n + 1; return f(5);        -> 6
return (fn (n: int) => n + 1)(5);                 -> 6
let f = fn () => 7; return f();                   -> 7
return (fn (n:int) -> int { return n+1; })(5);    -> 6  (block-form IIFE, bonus)
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/lambda_param_inference.sfn` — `backfill_lambda_return_from_body` + `_infer_body_return_text` (return-type inference; void-body preserves `void`).
- `compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn` — call the backfill at the `_rewrite_lambda` choke point (body object preserved so the capture-record key is unchanged).
- `compiler/src/llvm/expression_lowering/native/core.sfn` — route a called `<closure_pair ...>(args)` marker through the call path before generic operator dispatch.
- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — `try_resolve_closure_callee` materialises a direct closure-pair callee; `_closure_pair_symbol` helper.
- `compiler/tests/e2e/short_lambda_closure_pair_test.sfn` — new build-and-run regression (let-bound, no-arg, short + block IIFE, void-closure guard).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfPFVKj8RT2XNL98yq3rPu)_