### PR TITLE
fix(emit): fail closed on return-path LLVM lowering fatals (#1954)

### DIFF
--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -39,7 +39,11 @@ fn _bool_to_string(value: boolean) -> string {
 }
 
 fn _abs(x: float) -> float {
-    if x < 0 { return 0 - x; }
+    // `x` is a float, so the negation must use a float literal: a bare `0`
+    // is an int literal, and Sailfin rejects int/float mixing in arithmetic
+    // (strict scalar coercion, spec §06-types). Write `0.0` so the operand
+    // kinds match (issue #1954).
+    if x < 0.0 { return 0.0 - x; }
     return x;
 }
 

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -329,6 +329,13 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
                 // scope-exit drop seam in `emit_llvm_function`.
                 current_locals = lowered.locals;
                 current_bindings = lowered.bindings;
+                // Issue #1954: thread the return expression's diagnostics so a
+                // `[fatal]` on a `return f()` path (e.g. an unresolved callee
+                // whose return type is unknown) reaches the emit-level
+                // `has_fatal_lowering_diagnostic` gate. Every sibling
+                // expression-carrying branch already does this; the Return
+                // branch dropped them, letting return-path fatals exit rc=0.
+                diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
                 collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
                 terminated = true;
                 index += 1;

--- a/compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
+++ b/compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
@@ -1,0 +1,93 @@
+// End-to-end regression for the emit-llvm fail-closed exit contract on a
+// `return f()` path (issue #1954, split from #1953).
+//
+// `sailfin emit ... llvm` must exit non-zero when LLVM lowering prints a
+// `[fatal]` — mirroring the `build` / `emit native` fail-closed contract
+// (#906/#631). The regression class: a `[fatal]` produced inside a
+// `return f()` expression (e.g. an unresolved callee whose return type is
+// unknown) was dropped because the Return branch in
+// `compiler/src/llvm/lowering/instructions.sfn` did not thread the return
+// expression's diagnostics into the emit-level `has_fatal_lowering_diagnostic`
+// gate — so the emit printed the `[fatal]` and still exited 0.
+//
+// Pins both directions: an unresolved-callee `return f()` exits non-zero on
+// both the `-o file` and stdout paths, and a valid file with a resolvable
+// `return f()` still emits and exits 0 (no success-path behavior change).
+//
+// Drives the compiler-under-test as a subprocess (the canonical e2e pattern —
+// `.claude/rules/no-bash-e2e.md`). The emitting child inherits the full parent
+// environment via `process.environ()` so its build-cache routes under the
+// runner's `SAILFIN_TEST_SCRATCH` (#1333) for parallel-pool isolation. The
+// `sfn/test` `expect_*` matchers are `![pure]` and cannot be called from an
+// `![io]` test, so output is asserted with `sfn/strings`.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+// Write `source` to `<scratch>/<name>` and return the path.
+fn _write_source(name: string, source: string) -> string ![io] {
+    let path = _scratch_dir() + "/" + name;
+    if fs.exists(path) { fs.deleteFile(path); }
+    fs.writeFile(path, source);
+    return path;
+}
+
+// A consumer with a `return f()` whose callee is unresolvable: the import
+// target does not exist, so the callee signature is unknown and lowering
+// emits `llvm lowering [fatal]: cannot resolve return type for call ...`.
+fn _unresolved_source() -> string {
+    return "import { helper_fn } from \"./sfn_missing_module_1954\";\n"
+        + "fn use_it() -> string { return helper_fn(1); }\n";
+}
+
+// A valid consumer with a `return f()` whose callee IS resolvable — proves
+// the diagnostics-threading fix does not regress the success path.
+fn _valid_source() -> string {
+    return "fn helper_fn(x: int) -> int { return x; }\n"
+        + "fn use_it() -> int { return helper_fn(1); }\n";
+}
+
+test "emit-llvm: unresolved-callee return path fails closed (-o file)" ![io] {
+    let src = _write_source("emit_llvm_1954_unresolved_ofile.sfn", _unresolved_source());
+    let out = _scratch_dir() + "/emit_llvm_1954_unresolved.ll";
+    if fs.exists(out) { fs.deleteFile(out); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", out, "llvm", src], process.environ());
+    let sout = process.capture_take_stdout();
+    let serr = process.capture_take_stderr();
+    // Fail-closed: a return-path `[fatal]` must produce a non-zero exit.
+    assert exit != 0;
+    assert find(sout + serr, "[fatal]", 0) >= 0;
+}
+
+test "emit-llvm: unresolved-callee return path fails closed (stdout)" ![io] {
+    let src = _write_source("emit_llvm_1954_unresolved_stdout.sfn", _unresolved_source());
+    let exit = process.run_capture([_sfn_bin(), "emit", "llvm", src], process.environ());
+    let sout = process.capture_take_stdout();
+    let serr = process.capture_take_stderr();
+    assert exit != 0;
+    assert find(sout + serr, "[fatal]", 0) >= 0;
+}
+
+test "emit-llvm: valid return-path file still emits and exits 0" ![io] {
+    let src = _write_source("emit_llvm_1954_valid.sfn", _valid_source());
+    let out = _scratch_dir() + "/emit_llvm_1954_valid.ll";
+    if fs.exists(out) { fs.deleteFile(out); }
+    let exit = process.run_capture([_sfn_bin(), "emit", "-o", out, "llvm", src], process.environ());
+    let _sout = process.capture_take_stdout();
+    let _serr = process.capture_take_stderr();
+    assert exit == 0;
+    assert fs.exists(out);
+    let ir = fs.readFile(out);
+    assert ir.length > 0;
+}

--- a/compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
+++ b/compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
@@ -61,13 +61,19 @@ fn _valid_source() -> string {
 test "emit-llvm: unresolved-callee return path fails closed (-o file)" ![io] {
     let src = _write_source("emit_llvm_1954_unresolved_ofile.sfn", _unresolved_source());
     let out = _scratch_dir() + "/emit_llvm_1954_unresolved.ll";
-    if fs.exists(out) { fs.deleteFile(out); }
+    // Seed a stale `.ll` so this pins the FULL fail-closed contract, not just
+    // the exit code: on a `[fatal]`, `lowering_core` deletes any prior output
+    // and refuses to write (lowering_core.sfn:482-486), so downstream tooling
+    // that only stats `out` cannot mistake a stale file for fresh IR.
+    fs.writeFile(out, "; stale IR from a prior successful build\n");
     let exit = process.run_capture([_sfn_bin(), "emit", "-o", out, "llvm", src], process.environ());
     let sout = process.capture_take_stdout();
     let serr = process.capture_take_stderr();
     // Fail-closed: a return-path `[fatal]` must produce a non-zero exit.
     assert exit != 0;
     assert find(sout + serr, "[fatal]", 0) >= 0;
+    // ...and leave no partial/stale `.ll` on disk.
+    assert ! fs.exists(out);
 }
 
 test "emit-llvm: unresolved-callee return path fails closed (stdout)" ![io] {


### PR DESCRIPTION
## Summary

- **Thread return-path diagnostics.** `emit llvm` scans `LoweredLLVMLinesResult.diagnostics` via `has_fatal_lowering_diagnostic`, but the Return branch (`_instr_tag == 0`) in `compiler/src/llvm/lowering/instructions.sfn` captured `temp_index`/`locals`/`bindings`/`string_constants` from `lower_return_instruction` and **dropped its `diagnostics`** — unlike every sibling expression-carrying branch. So a `[fatal]` inside `return f()` (e.g. an unresolved callee whose return type is unknown) was silently swallowed and `emit llvm` exited **0** while writing a partial `.ll`, violating the fail-closed contract `build` / `emit native` already hold (#906/#631). One-line thread fixes it.
- **Resolve the surfaced latent fatal (policy: keep strict int/float).** Un-dropping return-path fatals surfaces exactly one previously-swallowed site: `sfn/test`'s `_abs` did `return 0 - x;` (int literal minus float `x`), which Sailfin's **shipped** strict int↔float arithmetic refusal rejects (spec §06-types; `docs/status.md`). Cast the literals to float (`0.0`), per the documented `as`/explicit-float fix-it, rather than reversing shipped coercion policy.
- **Regression coverage.** New e2e pinning both halves of the contract.

Closes #1954

## Acceptance Criteria

- [x] `sailfin emit ... llvm` on an unresolved-callee `return f()` exits non-zero (both `-o file` and stdout paths).
- [x] A valid file still emits and exits 0 (no behavior change on success).
- [x] The int-literal/float policy is decided (**keep strict refusal** — matches shipped spec §06-types + `draft-sized-integer-types`'s "explicit `as`-cast" direction) and every return-path `[fatal]` the full suite surfaces is resolved (sole site: `_abs`).
- [x] `make compile` self-hosts (rc=0). Full `make test` runs clean through the previously-failing int/float section; CI runs the authoritative full gate.
- [x] Regression test covering fail-closed exit + valid-emit-still-0.

## Policy decision (the issue's open grooming question)

The issue flagged an open policy fork: is `return 0 - x` a **real bug** (cast the sites) or a **false fatal** (loosen the ABI/coercion check)? Resolved as **real bug / cast the sites**:

- Strict int↔float arithmetic refusal is **shipped and spec'd** (`06-types.md`, `docs/status.md` marks it *Shipped* with an `as` fix-it), and `docs/proposals/draft-sized-integer-types.md` points *tighter* ("explicit `as`-cast, no implicit widening").
- A coercion fix would **reverse documented policy** and touch the spec's coercion table — SFEP-level and cross-cutting, out of scope for a diagnostics-plumbing bug PR.
- Blast radius of the cast: **one site** (`_abs`), confirmed by both a static sweep and the full suite (every other `0 - var` in the tree is int-typed).

There is a genuine *positional asymmetry* worth fixing separately — `x - 0` already silently coerces the literal to float, while `0 - x` fatals — but that is a deliberate design decision (literal-context propagation is currently left→right only) and belongs in its own issue/SFEP. Filed as a follow-up.

## Map reconciliation

None — advisory `## Files Affected` matched the tree (`instructions.sfn`, `capsules/sfn/test/src/mod.sfn`, and the new e2e test all landed as listed).

## Verification

```
# Repro before fix (baseline binary, original source):
$ sailfin emit -o /tmp/out.ll llvm consumer.sfn   # return helper_fn(1), missing import
llvm lowering [fatal]: cannot resolve return type for call to `helper_fn` ...
$ echo $?  → 0        # BUG: partial .ll written, exit 0

# After fix:
$ sailfin emit -o /tmp/out.ll llvm consumer.sfn ; echo $?   → 1   [fatal] present
$ sailfin emit llvm consumer.sfn ; echo $?                  → 1   [fatal] present
# (proves the fatal is the dropped Return-branch lowering diagnostic, not a
#  typecheck E0420 — pre-fix exit was 0 despite the [fatal] printing.)

# New regression:
$ sailfin test compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
  PASS  (all 3 tests passed)

# _abs fix emits clean (0.0 - x):  exit 0, 0 fatals
# make compile:  self-hosts, rc=0
# sfn fmt --check:  clean on all 3 touched files
# make test:  runs clean through the previously-failing int/float section
#             (0 arithmetic ABI fatals, 0 resolver failures, 0 FAILs)
```

## Files Changed

- `compiler/src/llvm/lowering/instructions.sfn` — thread `lowered.diagnostics` in the Return branch (matches sibling Expression branch).
- `capsules/sfn/test/src/mod.sfn` — `_abs`: `0 - x` → `0.0 - x` (and `x < 0` → `x < 0.0` for consistency within the float helper).
- `compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn` — new fail-closed regression (both emit paths + valid-emit-still-0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hr34AxM5BpC7mVzc14ht68)_