### PR TITLE
docs: codify Linear Initiative→Project→Issue workflow; retire GitHub epic issues

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -127,15 +127,16 @@ Wait for user approval. The user may:
 
 ## Phase 4: CREATE ISSUES
 
-For each approved issue, create it via `gh`. Titles follow
-`docs/conventions/issue-naming.md`:
+Create **only session-sized leaf issues** on GitHub — one per approved item.
+The epic itself is **not** a GitHub issue: it is the Linear **Project** created
+in the *Reflect in Linear* step below (`linear-workflow.md`). Do **not** open a
+GitHub `Epic:` / `Tracking:` issue or apply the `epic` / `tracking` label — those
+shapes are retired (`docs/conventions/issue-naming.md` § Title taxonomy).
 
-- Sub-tasks: `<type>(<scope>): <imperative verb phrase>` (Conventional Commit shape).
-- Epics: `Epic: <track-id>: <noun phrase>` — also apply the `epic` label.
-- Tracking issues: `Tracking: <topic> (<YYYY-MM-DD>)` — also apply the `tracking` label.
-
-Labels come from `.github/labels.yml` (canonical registry). Use lowercase
-prefixes (`type:bug` not `bug`, `size:m` not `medium`).
+Leaf titles follow `docs/conventions/issue-naming.md`: `<type>(<scope>):
+<imperative verb phrase>` (Conventional Commit shape). Labels come from
+`.github/labels.yml` (canonical registry); use lowercase prefixes (`type:bug`
+not `bug`, `size:m` not `medium`).
 
 ```bash
 gh issue create \
@@ -304,12 +305,17 @@ Examples:
 agent has decided the issue does not need a fresh seed; getting that
 wrong is the failure mode this gate exists to prevent.
 
-### Attach issues to the parent epic as native sub-issues
+### Grouping: Linear Project for the epic; GitHub sub-issues only for leaf splits
 
-If the grooming target was an **existing epic issue** (e.g. `/groom 450`), every
-created issue must be attached as a GitHub-native sub-issue of that epic — body
-references alone do not populate the parent's "Sub-issues" panel and break the
-roadmap UI. Use the REST API (the `gh` CLI has no first-class command yet):
+Epic grouping is **not** a GitHub parent — it is the Linear **Project** the leaves
+are associated to in the *Reflect in Linear* step below. Do not create a GitHub
+`Epic:` parent to hang leaves off.
+
+GitHub-native sub-issue nesting is still used in **one** case: when a single
+session-sized leaf is split into smaller GitHub children (steps of one piece of
+work). Attach each child as a sub-issue of its **leaf parent** — body references
+alone do not populate the parent's "Sub-issues" panel. Use the REST API (the `gh`
+CLI has no first-class command yet):
 
 ```bash
 # Look up the parent's internal node id (NOT the issue number) once:
@@ -333,38 +339,36 @@ gh api /repos/SailfinIO/sailfin/issues/$PARENT/sub_issues \
 Skip this step only when the grooming target was a roadmap section, a free-form
 prompt, or a document — i.e. when no parent epic issue exists.
 
-### Phased epics: use a two-level phase-tracker structure
+### Phased epics: one Linear Project per phase, groomed wave-by-wave
 
 When an epic is **inherently multi-phase** — sequential phases where later phases
 depend on earlier ones (e.g. SFEP-0027's Phase A → B → C → D, where B can't start
-until A's modules land) — do **not** attach leaf issues directly to the epic and
-groom them in undocumented "waves." That is the structure that lost #351's Phase 3
-(it went 8/13-done with no sub-issues ever filed). Use two levels instead:
+until A's modules land) — do **not** dump all leaves into one Project and groom
+them in undocumented "waves." That is the structure that lost #351's Phase 3 (it
+went 8/13-done with no sub-issues ever filed). Model the phases in Linear instead:
 
-1. **One `tracking` sub-issue per phase, all attached to the epic up front.** Title
-   `Tracking: <epic-id> Phase <X> — <noun phrase>`; label `tracking` (never `epic`
-   — they are mutually exclusive). The phase you are grooming leaves for now is a
-   bare `tracking` issue; **every future phase also gets `needs-grooming`** (its
-   leaves don't exist yet). Body = that phase's checklist + the SFEP `## Design`
-   cite; leaves attach **under the phase tracker, not the epic**.
-2. **Groom each phase's leaf issues wave-by-wave under its phase tracker** — attach
-   the leaves as native sub-issues of the *phase tracker*, and only when that
-   phase's wave is actually being opened.
+1. **One Linear Project per phase, all created up front** under the shared
+   Initiative, named `<Epic> Phase <X> — <noun phrase>` (as the existing
+   *Concurrency Maturity Phase 1 / Phase 2* Projects do). Give each future phase's
+   Project a `Planned`/`Backlog` state and put its checklist + `Design: SFEP-NNNN`
+   in the Project description. Leaves attach to the **current** phase's Project;
+   future phases hold no leaves yet.
+2. **Groom each phase's leaf issues wave-by-wave**, filing them (GitHub → Linear)
+   into that phase's Project only when the wave is actually being opened. The empty
+   next-phase Project is the visible *"groom me next"* card.
 
-Why this is load-bearing (not bookkeeping): `/sweep` Phase 2c recommends closing a
-parent from its **native sub-issue rollup** (`completed == total`), and ignores the
-markdown `## Phases` checklist entirely. With leaves attached directly to the epic,
-the rollup hits 100% the moment Phase A's wave closes and `/sweep` recommends
-**closing the whole epic** before B/C/D are even groomed. With phase trackers
-attached up front, the epic rollup reads "phases-complete / total-phases" — it
-**cannot** reach 100% until every phase is groomed and done, and the open
-`needs-grooming` next-phase tracker is the visible *"groom me next"* card. Each
-phase is also independently focusable and closable, which a single epic issue is
-not.
+Why one-Project-per-phase (not one Project for the whole epic): a Project rolls up
+its own issues' state. If every phase's leaves lived in a single Project, that
+Project would read ~100% the moment Phase A's wave closed — hiding that B/C/D
+aren't even groomed. Separate phase Projects keep each phase independently
+plannable, focusable, and completable, and the Initiative view shows the phase
+sequence at a glance. (`/sweep` Phase 2c still uses GitHub **leaf** sub-issue
+rollups to recommend closing a leaf-parent — that is unchanged; it never closes a
+Linear Project.)
 
 **When NOT to use this:** a single-phase epic, or a flat bag of genuinely
-independent issues with no phase ordering — attach the leaves directly to the epic
-as above. The two-level structure is for *sequential, wave-groomed* phases only.
+independent issues with no phase ordering — one Project, leaves filed directly.
+The per-phase Project structure is for *sequential, wave-groomed* phases only.
 
 ---
 
@@ -387,9 +391,9 @@ Suggest: `/pickup` to start working the queue, or `/triage` to verify hygiene.
 - **Always set the `claude-ready` label** on issues that are ready to pick up. Use `needs-grooming` for issues that exist as placeholders but need refinement.
 - **Always set the `type:*` and `size:*` labels** so `/pickup` can filter correctly. Apply `area:*` labels when the touched subsystem is unambiguous.
 - **Use only labels defined in `.github/labels.yml`** — never invent new ones in this command. If you think a new label is warranted, edit `labels.yml` in a separate PR first.
-- **Title format follows `docs/conventions/issue-naming.md`** — Conventional Commit shape for sub-tasks, `Epic:` prefix for epics, `Tracking:` for trackers.
+- **Title format follows `docs/conventions/issue-naming.md`** — Conventional Commit shape for leaf sub-tasks. Never open an `Epic:`/`Tracking:` GitHub issue or apply the `epic`/`tracking` label; epics are Linear Projects (see *Reflect in Linear*).
 - **Don't create issues for work that's already in progress** — check `gh issue list` first to avoid duplicates.
-- **When grooming an existing epic issue, attach every created issue as a native sub-issue of that epic** via the REST `/sub_issues` endpoint. Body cross-references do not populate the parent's Sub-issues panel and leave the roadmap UI incomplete. Use `-F sub_issue_id=<int>` (not `-f`) — the field must be typed.
+- **When splitting one leaf into GitHub children, attach each child as a native sub-issue of its leaf parent** via the REST `/sub_issues` endpoint (epic grouping is the Linear Project, not a GitHub parent). Body cross-references do not populate the parent's Sub-issues panel. Use `-F sub_issue_id=<int>` (not `-f`) — the field must be typed.
 - **Labels are the source of truth.** There is no derived board to sync.
 - **Set the GitHub native Type field** with
   `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` (best-effort; it

--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -336,8 +336,10 @@ gh api /repos/SailfinIO/sailfin/issues/$PARENT/sub_issues \
   --jq '.[] | "#\(.number) \(.title)"'
 ```
 
-Skip this step only when the grooming target was a roadmap section, a free-form
-prompt, or a document — i.e. when no parent epic issue exists.
+This applies **only** to the leaf-split case above. The default groom output —
+independent leaves associated to the epic's Linear Project — needs no GitHub
+sub-issue attachment at all; skip this step unless you actually split one leaf
+into GitHub children.
 
 ### Phased epics: one Linear Project per phase, groomed wave-by-wave
 

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -172,11 +172,16 @@ gh issue comment <N> --body "Auto-triage: in-progress label was set but no activ
 gh issue comment <N> --body "Auto-triage: claude-ready for 30+ days without pickup. Likely stale — review priority or close."
 ```
 
-### OVERSIZED — L-sized → epic
+### OVERSIZED — L-sized → needs grooming (epic scope = a Linear Project)
+
+An L-sized issue is epic-scale. Do **not** apply the `epic` label (retired —
+epics are Linear Projects, not GitHub issues; see `docs/conventions/linear-workflow.md`).
+Flag it for grooming; `/groom` decomposes it into XS/S/M leaves under a Linear
+Project.
 
 ```bash
-gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming" --add-label "epic"
-gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking \`epic\` + \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M children."
+gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming"
+gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M leaves under a Linear Project (epics are Projects, not GitHub issues)."
 ```
 
 ### TYPE-FIX — null GitHub native Type field (silent, always)

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -156,10 +156,10 @@ labels:
   # --- Special markers -------------------------------------------------
   - name: epic
     color: "d4c5f9"
-    description: "Roadmap-scale parent ticket; tracks child issues"
+    description: "Legacy — epics are now Linear Projects; do not apply to new issues"
   - name: tracking
     color: "a371f7"
-    description: "Cross-cutting tracker (status, sequencing); not directly implementable"
+    description: "Legacy — trackers are now Linear Projects/Initiatives; do not apply to new issues"
   - name: seed-blocker
     color: "b60205"
     description: "Must close before the next seed binary is cut"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -159,7 +159,7 @@ labels:
     description: "Legacy — epics are now Linear Projects; do not apply to new issues"
   - name: tracking
     color: "a371f7"
-    description: "Legacy — trackers are now Linear Projects/Initiatives; do not apply to new issues"
+    description: "Legacy — trackers are now Linear Projects/Initiatives; do not apply to new issues except the Release: vX.Y.Z cadence tracker"
   - name: seed-blocker
     color: "b60205"
     description: "Must close before the next seed binary is cut"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,14 +322,17 @@ earn their cost on open-ended investigation and cross-cutting analysis.
 
 ## Task Tracking
 
-The roadmap (`site/src/pages/roadmap.astro`, [sailfin.dev/roadmap](https://sailfin.dev/roadmap))
-is strategic — epics, not session-sized work. Day-to-day work lives in **GitHub
-Issues**, scoped so a single session takes an issue from open to merged PR.
+Work is organised in three tiers — **Linear Initiative → Linear Project →
+GitHub Issue** (full playbook: `docs/conventions/linear-workflow.md`). An
+**epic is a Linear Project** under an Initiative (a theme); **never open a
+GitHub `Epic:`/`Tracking:` issue** (retired 2026-07-07). GitHub Issues are
+session-sized leaf work only, scoped so a single session takes an issue from
+open to merged PR, and are mirrored into Linear by the integration.
 
 ```
-roadmap (epics) ──/groom──▶ Issues (claude-ready) ──/triage──▶ pickable
-                                   │
-                                   └──/pickup [#N]──▶ PR opened, issue auto-closed on merge
+Initiative (theme) ─▶ Project (epic) ─▶ Issue (leaf, claude-ready) ──/triage──▶ pickable
+     [Linear]            [Linear]        [GitHub → mirrored]  │
+                                              └──/pickup [#N]──▶ PR opened, issue auto-closed on merge
 ```
 
 **Issue contract** (template: `.github/ISSUE_TEMPLATE/claude-task.md`): Goal,
@@ -347,7 +350,8 @@ the session-sized *what*.
 **Labels** are registered in `.github/labels.yml`; conventions and the lifecycle
 diagram are in `docs/conventions/issue-naming.md`. Key ones: `claude-ready`,
 `needs-grooming`, `in-progress`, `blocked`, `type:*`, `size:*`, `priority:*`,
-`area:*`, `epic`/`tracking`. **Labels are the source of truth** and there is no
+`area:*` (`epic`/`tracking` are **legacy** — epics/trackers are Linear Projects
+now, not labels on new issues). **Labels are the source of truth** and there is no
 derived GitHub board to keep in sync: the former *Sailfin Tracker* project
 (org project SailfinIO/4) and its `sync-project.yml` label→board workflow have
 been **retired**. Epic and roadmap-level grouping now lives in **Linear** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,8 @@ the session-sized *what*.
 diagram are in `docs/conventions/issue-naming.md`. Key ones: `claude-ready`,
 `needs-grooming`, `in-progress`, `blocked`, `type:*`, `size:*`, `priority:*`,
 `area:*` (`epic`/`tracking` are **legacy** — epics/trackers are Linear Projects
-now, not labels on new issues). **Labels are the source of truth** and there is no
+now, not labels on new issues; the one surviving use of `tracking` is the
+`Release: vX.Y.Z` cadence tracker). **Labels are the source of truth** and there is no
 derived GitHub board to keep in sync: the former *Sailfin Tracker* project
 (org project SailfinIO/4) and its `sync-project.yml` label→board workflow have
 been **retired**. Epic and roadmap-level grouping now lives in **Linear** —

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -72,9 +72,16 @@ review attached or required).
 
 ## Title taxonomy
 
-There are **four human-authored title shapes** (sub-task, epic, tracking,
-focus) plus **one reserved auto-generated prefix** (`[aw]`). Anything else
-is a bug.
+There are **two human-authored GitHub title shapes** (sub-task, focus) plus
+**one reserved auto-generated prefix** (`[aw]`). Anything else is a bug.
+
+> **Epics and trackers are not GitHub issues.** An epic is a Linear **Project**
+> (under an Initiative); a cross-cutting status thread is that Project itself.
+> The historical `Epic:` / `Tracking:` GitHub title shapes are **retired** — see
+> § 2 and § 3 below and the playbook in
+> [`linear-workflow.md`](./linear-workflow.md). The **one** surviving tracking
+> title is `Release: vX.Y.Z` (release automation owns it — see § *Release
+> tracking*).
 
 ### 1. Sub-task (the default — what most issues and PRs are)
 
@@ -112,49 +119,31 @@ The `<type>` prefix and the `type:<type>` label MUST agree:
 | `chore`      | `type:tech-debt` |
 | `docs`       | `type:docs`     |
 
-### 2. Epic (parent of multiple sub-tasks)
+### 2. Epic — **retired as a GitHub issue; use a Linear Project**
 
-```
-Epic: <track-id>: <noun phrase>
-```
+An epic is now a **Linear Project** under an Initiative, not a GitHub issue.
+See § *Linear structure & naming* below and the playbook in
+[`linear-workflow.md`](./linear-workflow.md). Name the Project for its outcome
+(`CLI Modularization`), drop the `Epic:` prefix and any track-id / `#N` /
+`SFEP-NNNN`, and put `GitHub: #N` + `Design: SFEP-NNNN` in the Project
+**description**.
 
-| Field | Definition |
-|-------|------------|
-| `<track-id>` | Stable identifier from the roadmap. Examples: `M0`, `M1.5`, `M2`, `T1`, `T7`, `SR` (syntax reform), `EFF` (effect system hardening). New track IDs are added to the roadmap first. |
-| `<noun phrase>` | Title-case, scope-positive description of the outcome. |
+Do **not** open a new `Epic:` GitHub issue and do **not** apply the `epic`
+label to new work. The label persists only on the historical epics that were
+closed during the 2026-07-07 Linear migration; `/groom` creates a Project and
+files only session-sized leaves.
 
-**Examples:**
+### 3. Tracking issue — **retired; the Project (or Initiative) is the tracker**
 
-```
-Epic: M2: Core Runtime in Sailfin
-Epic: M3: Capability Adapters in Sailfin + Delete C Runtime
-Epic: T1: Per-module memory budget under 800 MB
-Epic: T7: Compiler decomposition into sub-capsules
-Epic: SR: Pre-1.0 syntax reform
-```
+Cross-cutting status no longer lives in a GitHub `Tracking:` issue. The Linear
+Project rolls up its issues' state, and an Initiative groups related Projects —
+that *is* the coordination surface. Do not open new `Tracking:` issues or apply
+the `tracking` label to new work.
 
-Always paired with the `epic` label. Children link back via `Blocked by` /
-`Parent: #<N>` references in their bodies.
-
-### 3. Tracking issue (cross-cutting status, not directly implementable)
-
-```
-Tracking: <topic> (<YYYY-MM-DD>)
-```
-
-The date is when the tracker was opened (not when the work happens). Use a
-tracking issue when you want a single thread to coordinate multiple PRs but
-no single PR closes it.
-
-**Examples:**
-
-```
-Tracking: Runtime Rewrite Reassessment & Sequencing (2026-05-06)
-Tracking: Build Performance & Production-Readiness (2026-05-06)
-```
-
-Always paired with the `tracking` label. Tracking issues are explicitly
-**not** `claude-ready` — they are coordination surfaces, not work items.
+**One exception:** the per-cycle **`Release: vX.Y.Z`** issue survives, because
+release automation (`release.yml`, `/release-plan`) keys off it and the
+`release:*` labels. A release is a Linear **Cycle**, never a Project — see
+§ *Release tracking*.
 
 ### 4. Focus issue (planner output, weekly)
 
@@ -183,7 +172,7 @@ Leave the `[aw]` prefix in place; downstream tooling pattern-matches on it.
 | Every `claude-ready` issue carries exactly one `size:*` label | `/pickup` and `/sweep` rank by it |
 | Use `priority:*` only when prioritisation matters; default is no priority label | Avoids label inflation; absence ≠ low |
 | Apply `area:*` labels when the touched subsystem is unambiguous | Helps `/sweep` dedupe collisions |
-| `epic` and `tracking` are mutually exclusive | They mean different things |
+| `epic` / `tracking` are **legacy** — do not apply to new issues | Epics are Linear Projects, trackers are Projects/Initiatives (see `linear-workflow.md`) |
 | Never re-introduce a bare alias (`bug`, `runtime`, `medium`, …) | They are listed in `aliases:` of `labels.yml` and will be migrated away on the next sync |
 | Never invent a new label in a workflow or slash command | Add it to `labels.yml` in a separate PR first |
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -72,8 +72,10 @@ review attached or required).
 
 ## Title taxonomy
 
-There are **two human-authored GitHub title shapes** (sub-task, focus) plus
-**one reserved auto-generated prefix** (`[aw]`). Anything else is a bug.
+There are **two recurring GitHub issue title shapes** — the sub-task (default)
+and the planner-generated focus issue — plus the **`Release: vX.Y.Z`** cadence
+tracker and **one reserved auto-generated prefix** (`[aw]`). Anything else is a
+bug.
 
 > **Epics and trackers are not GitHub issues.** An epic is a Linear **Project**
 > (under an Initiative); a cross-cutting status thread is that Project itself.
@@ -172,7 +174,7 @@ Leave the `[aw]` prefix in place; downstream tooling pattern-matches on it.
 | Every `claude-ready` issue carries exactly one `size:*` label | `/pickup` and `/sweep` rank by it |
 | Use `priority:*` only when prioritisation matters; default is no priority label | Avoids label inflation; absence ≠ low |
 | Apply `area:*` labels when the touched subsystem is unambiguous | Helps `/sweep` dedupe collisions |
-| `epic` / `tracking` are **legacy** — do not apply to new issues | Epics are Linear Projects, trackers are Projects/Initiatives (see `linear-workflow.md`) |
+| `epic` / `tracking` are **legacy** — do not apply to new issues (sole exception: `tracking` on the `Release: vX.Y.Z` cadence tracker, see § *Release tracking*) | Epics are Linear Projects, trackers are Projects/Initiatives (see `linear-workflow.md`) |
 | Never re-introduce a bare alias (`bug`, `runtime`, `medium`, …) | They are listed in `aliases:` of `labels.yml` and will be migrated away on the next sync |
 | Never invent a new label in a workflow or slash command | Add it to `labels.yml` in a separate PR first |
 

--- a/docs/conventions/linear-workflow.md
+++ b/docs/conventions/linear-workflow.md
@@ -90,7 +90,8 @@ ordinary issues associated to that Project.
    reflects state into Linear. Each leaf cites the SFEP (`## Design`), it does not
    re-litigate the design.
 4. **Work the leaves:** `/pickup` drives each from branch → PR; the `Closes #N`
-   merge closes the GitHub issue, which the two-way sync rolls up to the Project.
+   merge closes the GitHub issue, and the GitHub↔Linear integration reflects that
+   closure onto the Linear mirror, rolling up the Project.
 5. **Graduate:** when the epic ships, flip its SFEP to `Implemented` and update
    `docs/status.md`.
 

--- a/docs/conventions/linear-workflow.md
+++ b/docs/conventions/linear-workflow.md
@@ -1,0 +1,112 @@
+# Linear Workflow — Initiatives, Projects, and Issues
+
+This is the human-facing playbook for how work is organised across **Linear**
+and **GitHub Issues**. It is the front door; the dense, agent-facing mechanics
+live in [`issue-naming.md`](./issue-naming.md) (§ *Linear structure & naming*,
+§ *Reflecting state into Linear*, § *Release tracking*) and this file links to
+them rather than restating them.
+
+If you only remember one thing: **an epic is a Linear Project, not a GitHub
+issue.** GitHub issues are session-sized leaf work — nothing bigger.
+
+---
+
+## The three tiers
+
+```
+Initiative        a pillar / durable theme          (Linear)      ~6, rarely added
+   └─ Project     one epic                           (Linear)      the roadmap unit
+        └─ Issue  one session-sized piece of work    (GitHub → mirrored to Linear)
+             └─ (sub-issue)  a split of one leaf, optional
+```
+
+| Tier | Is | Lives in | Who owns state |
+|------|----|----------|----------------|
+| **Initiative** | A pillar or durable workstream (e.g. *Structured Concurrency*, *Build & Toolchain*). A small, stable set. | Linear | Set by hand; changes rarely. |
+| **Project** | Exactly one epic — a deliverable with real surface area and a design record (SFEP). | Linear | Rolled up from its issues; the design/context lives in the project **description**. |
+| **Issue** | One session-sized leaf (XS/S/M, never L). A `claude-ready` issue is pickable by `/pickup`. | Authored on **GitHub**, mirrored into Linear by the GitHub↔Linear integration. | **GitHub labels are the source of truth**; Linear status is derived from them one-way. |
+
+A Project belongs to exactly one Initiative. A leaf Issue belongs to exactly one
+Project. Releases are a fourth, **orthogonal** axis — a Linear **Cycle**, never a
+Project (see below).
+
+---
+
+## The rules
+
+1. **Never open a GitHub `Epic:` or `Tracking:` issue.** An epic is a Linear
+   Project under an Initiative. A cross-cutting status thread is the Project
+   itself (or its Initiative). The old GitHub `Epic:` / `Tracking:` title shapes
+   are **retired** — see [`issue-naming.md`](./issue-naming.md) § *Title
+   taxonomy*.
+2. **GitHub issues are leaf work only.** If a would-be issue is too big for one
+   session (an `L`, or a "parent of many"), it is an epic → make it a Project and
+   `/groom` it into leaves.
+3. **Labels stay the source of truth** for issue state (`claude-ready`,
+   `in-progress`, `blocked`, `type:*`, `size:*`, `priority:*`, `area:*`). Linear
+   status is *derived* from them; never hand-edit a mirror's status to drive the
+   GitHub side.
+4. **Project names are scannable; links go in the description.** Name a project
+   for its outcome (`CLI Modularization`), not `Epic: CLI modularization
+   (SFEP-0027)`. Put `GitHub: #N` and `Design: SFEP-NNNN` in the description.
+5. **Releases are Cycles, not Projects.** A release cuts *across* epics; modeling
+   it as a Project would force it into one epic. Keep the `release:*` labels + the
+   per-cycle `Release: vX.Y.Z` GitHub tracking issue; `/release-plan` assigns the
+   gating issues to a Linear Cycle. (`Release:` is the **one** GitHub tracking
+   title that survives — release automation owns it.)
+
+### Sub-issues — allowed, but bounded
+
+Sub-issues are fine for **splitting one session-sized leaf** into smaller
+checkable steps (GitHub's native parent/child relationship carries the nesting,
+mirrored to Linear). They are **not** a mini-epic. Rule of thumb: if a parent has
+more than a handful of children, or the parent is not itself workable in a
+session, it is an epic — promote it to a **Project** and let the children be
+ordinary issues associated to that Project.
+
+---
+
+## "What work do I have?" — the daily views
+
+- **By epic (Linear):** the Sailfin team board grouped by Project shows every
+  epic and its live issues. Filter to an Initiative to see one theme.
+- **Pickable now (GitHub or Linear):** open issues with `claude-ready`, not
+  `blocked`, not `in-progress`, no unclosed `Blocked by`. This is exactly what
+  `/pickup` selects; `/pickup` with no argument picks the top one.
+- **Needs shaping:** `needs-grooming` → run `/groom`; `needs-design` → architect
+  queue; `needs-discussion` → parked for a human.
+
+---
+
+## Lifecycle of a new epic
+
+1. **Create the Project** in Linear under the right Initiative (create a new
+   Initiative only for a genuinely new pillar). Name it for the outcome.
+2. **Write the design as an SFEP** (`/sfep new <slug>` → `docs/proposals/`), and
+   put `Design: SFEP-NNNN` in the project description. See
+   [`.claude/rules/proposals.md`](../../.claude/rules/proposals.md).
+3. **Groom into leaves:** `/groom <epic>` decomposes it into session-sized GitHub
+   issues, ensures the Project exists, associates each leaf to the Project, and
+   reflects state into Linear. Each leaf cites the SFEP (`## Design`), it does not
+   re-litigate the design.
+4. **Work the leaves:** `/pickup` drives each from branch → PR; the `Closes #N`
+   merge closes the GitHub issue, which the two-way sync rolls up to the Project.
+5. **Graduate:** when the epic ships, flip its SFEP to `Implemented` and update
+   `docs/status.md`.
+
+---
+
+## How this was migrated (2026-07-07)
+
+The legacy model was GitHub `Epic:` issues with attached sub-issues, on the
+retired *Sailfin Tracker* GitHub Project board (org project #4). The migration:
+
+- Created the six Initiatives and one Linear **Project per epic**.
+- Folded each old GitHub epic's body into its Linear **Project description**, then
+  **canceled** the duplicate mirrored epic issue in Linear.
+- **Closed** the ~28 GitHub `Epic:`/`Tracking:` issues as *not planned*, each with
+  a comment pointing to its Linear Project. (The `Release: v0.8.0` / `v0.9.0`
+  trackers stayed open — release automation owns them.)
+
+From here, follow the rules above: epics are Projects, GitHub carries leaf work,
+and no new GitHub `Epic:`/`Tracking:` issues are opened.


### PR DESCRIPTION
## What & why

The prior migration (#1975) stood up the Linear side — 6 Initiatives and one Project per epic — but left two loose ends: the legacy GitHub `Epic:`/`Tracking:` issues stayed **open** (now duplicating the Projects), and the same epics were **mirrored into Linear as issues**, cluttering the backlog next to real leaf work. The authoring path (`/groom`, the title taxonomy) also still instructed opening GitHub epic issues, directly contradicting the new model.

This PR lands the **conventions half** and documents the **cleanup half** that was executed alongside it (via the Linear/GitHub MCP tools — not in this diff).

## Target model

**Linear Initiative (theme) → Linear Project (epic) → GitHub Issue (session-sized leaf).** Sub-issues remain legal for splitting one leaf. GitHub labels stay the source of truth for leaf state; releases are Linear **Cycles**, never Projects.

## Doc changes (this diff)

- **New `docs/conventions/linear-workflow.md`** — the human-facing playbook: the three-tier model, the rules (no new GitHub `Epic:`/`Tracking:` issues), the sub-issue policy, the "what work do I have?" daily views, and the lifecycle of a new epic.
- **`docs/conventions/issue-naming.md`** — retire the Epic (§2) and Tracking (§3) GitHub title shapes and the `epic`/`tracking` labels for new work; `Release: vX.Y.Z` is the one surviving tracker title.
- **`.github/labels.yml`** — mark `epic`/`tracking` labels legacy.
- **`CLAUDE.md`** Task Tracking — lead with the Initiative→Project→Issue tiers; "never open a GitHub Epic:/Tracking: issue."
- **`.claude/commands/groom.md`** — create only leaf issues; the epic is the Linear Project; phased epics use **one Project per phase** (matching the existing Concurrency Maturity Phase 1/2 Projects); GitHub sub-issues only for leaf splits.
- **`.claude/commands/triage.md`** — L-sized → `needs-grooming` only (no `epic` label).

## Cleanup executed alongside (not in this diff)

- **28 GitHub `Epic:`/`Tracking:` issues** closed as *not planned*, each with a comment linking its Linear Project. `Release: v0.8.0`/`v0.9.0` left open (release automation owns them).
- **~25 duplicate mirrored epic/tracking issues in Linear** folded into their Project descriptions (epic body → `description`, blurb → `summary`) and moved to **Canceled**. Issue bodies were left untouched to avoid clobbering the linked GitHub issues via two-way sync.

## Notes / follow-ups

- `.claude/commands/sweep.md` still contains epic-rollup logic that reads GitHub epic structure. It is now **inert** (no open epic issues) rather than harmful; a dedicated pass to re-point its rollup at Linear Projects is a sensible follow-up, kept out of this PR to avoid reworking intricate logic unreviewed.
- Docs/YAML only — no `.sfn` touched, so the self-host/`fmt` gates don't apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01THUrvKsZxgQrE54kJFLkq7)_