### PR TITLE
chore(process): make priority/estimate Linear-native; retire priority:* labels

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -113,10 +113,15 @@ the next cadence bump rather than cutting reactively.
 
 Present the proposed issue list as a table:
 
-| # | Title | Type | Size | Blocked by |
-|---|---|---|---|---|
-| 1 | ... | Performance | S | — |
-| 2 | ... | Refactor | M | #1 |
+| # | Title | Type | Size | Priority | Blocked by |
+|---|---|---|---|---|---|
+| 1 | ... | Performance | S | High | — |
+| 2 | ... | Refactor | M | Medium | #1 |
+
+Priority is one of Urgent / High / Medium / Low — the architect assigns it from
+the epic's place on the 1.0 critical path (default a leaf to its Project's
+priority unless it's a genuine outlier). It becomes the Linear-native priority in
+the *Reflect in Linear* step; it is **not** a GitHub label.
 
 Wait for user approval. The user may:
 - Approve as-is → proceed to Phase 4
@@ -252,9 +257,14 @@ skip with a one-line note if the Linear MCP tools aren't connected):
    named per § Linear structure & naming (concise Title-Case deliverable; no
    `Epic:` prefix or trailing `#N`/`SFEP-NNNN`), with `GitHub: #<epic>` and any
    `Design: SFEP-NNNN` placed in the project **description**, not the name.
-2. **Assign each created leaf** to that Project and set its status from its
-   labels. The mirror syncs in asynchronously — retry briefly, and let a later
-   `/triage`/`/sweep` pass reconcile any leaf whose mirror hasn't appeared yet.
+2. **Assign each created leaf** to that Project, set its status from its labels,
+   and set its **Linear-native priority and estimate** per
+   `docs/conventions/issue-naming.md` § Reflecting state into Linear (step 3):
+   estimate from the `size:*` label (xs/s/m → 1/2/3 on the team's Linear 1–5
+   scale), priority from the Phase 3 table (Urgent/High/Medium/Low → 1/2/3/4,
+   defaulting to the Project's priority). The mirror syncs in asynchronously —
+   retry briefly, and let a later `/triage`/`/sweep` pass reconcile any leaf
+   whose mirror (or priority/estimate) hasn't appeared yet.
 3. **Roll up the Project status** from its issues (any In Progress → `started`;
    else any Ready → `planned`; else `backlog`).
 
@@ -392,6 +402,7 @@ Suggest: `/pickup` to start working the queue, or `/triage` to verify hygiene.
 - **Never create issues without acceptance criteria.** The criteria are the contract.
 - **Always set the `claude-ready` label** on issues that are ready to pick up. Use `needs-grooming` for issues that exist as placeholders but need refinement.
 - **Always set the `type:*` and `size:*` labels** so `/pickup` can filter correctly. Apply `area:*` labels when the touched subsystem is unambiguous.
+- **Always set a Linear-native priority and estimate** on each leaf's mirror (see *Reflect in Linear*). Priority is not a GitHub label; estimate derives from `size:*`. Never leave a groomed leaf at `No priority` / no estimate.
 - **Use only labels defined in `.github/labels.yml`** — never invent new ones in this command. If you think a new label is warranted, edit `labels.yml` in a separate PR first.
 - **Title format follows `docs/conventions/issue-naming.md`** — Conventional Commit shape for leaf sub-tasks. Never open an `Epic:`/`Tracking:` GitHub issue or apply the `epic`/`tracking` label; epics are Linear Projects (see *Reflect in Linear*).
 - **Don't create issues for work that's already in progress** — check `gh issue list` first to avoid duplicates.

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -33,12 +33,13 @@ gh issue view <N> --json number,title,labels,assignees,body,state
 ```
 
 **Priority order** (highest first):
-1. `priority:critical` label
-2. `priority:high` label
-3. `type:bug` (bugs first)
-4. `type:perf` (perf next — compounds future work)
-5. Smallest `size:*` first within the same type (XS → S → M)
-6. Lowest issue number as tiebreaker (FIFO)
+1. **Linear-native priority** — Urgent, then High (read from the issue's Linear
+   mirror; priority is no longer a GitHub label). Best-effort: if the Linear MCP
+   tools aren't connected, skip this tier and rank by the signals below.
+2. `type:bug` (bugs first)
+3. `type:perf` (perf next — compounds future work)
+4. Smallest `size:*` first within the same type (XS → S → M)
+5. Lowest issue number as tiebreaker (FIFO)
 
 If no pickable issue exists, report: "No claude-ready issues available. Run `/triage` to audit, or `/groom <epic>` to add work."
 

--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -324,10 +324,11 @@ write a terminal issue status):
    cycle whose window covers the intended cut (the current cycle, or the next
    when the current is closing). Its `endsAt` is the visible target date.
 2. **Assign the must-close set to that Cycle.** For every open `release:<gate>`
-   issue on the tracker, set its Linear mirror's `cycle` to the target cycle and
-   its `priority` from the issue's `priority:*` label (critical→1/Urgent,
-   high→2, medium→3, low→4). This is what yields the dated, burndown-tracked
-   "what's in vX.Y.Z" view.
+   issue on the tracker, set its Linear mirror's `cycle` to the target cycle.
+   Its `priority` is already a Linear-native field (set at groom/triage) — leave
+   it; only backfill a priority if the mirror is still at `No priority` (default
+   a gating issue to High/2, or Urgent/1 for a correctness regression). This is
+   what yields the dated, burndown-tracked "what's in vX.Y.Z" view.
 3. **Assign the tracking issue** to the same Cycle and set its priority, so the
    coordination issue rides along.
 

--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -356,8 +356,10 @@ record every reason; it strengthens the rationale):
 
 **Gate-label candidates (open only):**
 
-1. **Priority.** Open `priority:critical` and `priority:high` issues with
-   no `release:*` label.
+1. **Priority.** Open issues at Linear-native priority Urgent or High with
+   no `release:*` label (priority is a Linear field, read via the mirror — not
+   a GitHub label). Best-effort: if the Linear MCP tools aren't connected, skip
+   this source and rely on the others below.
 2. **Correctness regressions.** Open `type:bug` issues (any priority) with
    no `release:*` label — a shipped-feature defect is a strong stable gate.
 3. **SFEP-targeted.** Read the SFEP registry (`docs/proposals/README.md`)
@@ -404,13 +406,13 @@ record every reason; it strengthens the rationale):
 Classify each candidate as a recommendation, then **present the full set
 and stop for the user's decision** — do not apply anything yet:
 
-- **IN** — should gate this release (correctness regressions,
-  `priority:critical`, SFEP items explicitly targeting this version).
+- **IN** — should gate this release (correctness regressions, Linear-native
+  priority Urgent, SFEP items explicitly targeting this version).
   **Open issues only** — a merged/closed item is never IN; it belongs to
   MANIFEST (see the open-only rule in 4.1).
 - **ROLL-FORWARD** — defer to a later release (epics/themes, speculative
-  or unscoped `priority:high`, anything whose landing this cycle is
-  uncertain).
+  or unscoped Linear-native priority High, anything whose landing this cycle
+  is uncertain).
 - **MANIFEST** — merged-but-unreleased work; informational only, never
   labeled (rendered into the tracker's manifest section).
 
@@ -424,7 +426,7 @@ Proposed scope — Release: vX.Y.Z (gate: release:<gate>)
 
 IN (apply release:<gate> — open issues only):
   #N — <title>   [type:bug · shipped-feature miscompile]
-  #M — <title>   [priority:critical · SFEP-00NN target]
+  #M — <title>   [priority:Urgent · SFEP-00NN target]
 
 ROLL-FORWARD (no label / defer):
   #P — <title>   [epic, milestone-tracked — not a single-cut gate]

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -319,8 +319,8 @@ For each pickable `claude-ready` issue (exclude any with `in-progress` or assign
 
    | Signal | Weight |
    |---|---|
-   | `priority:critical` label | +100 |
-   | `priority:high` label | +50 |
+   | Linear-native priority Urgent | +100 |
+   | Linear-native priority High | +50 |
    | Closes an epic on merge | +30 |
    | Unblocks ≥2 downstream issues | +20 per |
    | `size:xs` | +10 |

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -115,8 +115,12 @@ a size entirely (no label AND no `## Size`).
 Every label change below is also **reflected into Linear** per
 `docs/conventions/issue-naming.md` § Reflecting state into Linear: after the
 `gh issue edit`, find the issue's mirror, set its status from the new labels, and
-roll up its Project status. Best-effort — skip with a one-line note if the Linear
-MCP tools aren't connected, and never write a terminal status onto an open issue.
+roll up its Project status. On a PROMOTE, also set the mirror's **Linear-native
+priority and estimate** if they're unset — estimate from the `size:*` label
+(xs/s/m → 1/2/3), priority defaulting to the issue's Project priority (see
+§ Reflecting state into Linear step 3). Best-effort — skip with a one-line note
+if the Linear MCP tools aren't connected, and never write a terminal status onto
+an open issue.
 
 ### PROMOTE — move a groomed issue to Ready
 

--- a/.codex/skills/sailfin-pickup/SKILL.md
+++ b/.codex/skills/sailfin-pickup/SKILL.md
@@ -15,8 +15,9 @@ Use this skill when the user asks Codex to pick up an issue, work the next item,
    ```
 2. Filter out blocked, in-progress, assigned, or externally blocked work.
 3. Rank remaining issues by:
-   - `priority:critical`
-   - `priority:high`
+   - Linear-native priority Urgent, then High (read from the issue's Linear
+     mirror — priority is no longer a GitHub label; skip this tier if Linear
+     isn't reachable)
    - `type:bug`
    - `type:perf`
    - smallest `size:*` (`XS` before `S` before `M`)

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -214,10 +214,12 @@ The labels the agentic pipeline depends on:
 | `security` | Security | Security-relevant issue or PR |
 | `blocked` | Triage | Waiting on another issue to close |
 
-Type / size / priority / area labels follow the prefix scheme (`type:bug`,
-`size:m`, `priority:high`, `area:runtime`, …). Bare aliases (`bug`, `runtime`,
-`medium`, …) are retired by the `aliases:` list in `.github/labels.yml`; do
-not reintroduce them in workflows or templates.
+Type / size / area labels follow the prefix scheme (`type:bug`, `size:m`,
+`area:runtime`, …). **Priority is a Linear-native field, not a GitHub label**
+(the `priority:*` labels are retired via the `delete:` list in
+`.github/labels.yml`); set it on the Linear mirror at groom/triage. Bare aliases
+(`bug`, `runtime`, `medium`, …) are retired by the `aliases:` list in
+`.github/labels.yml`; do not reintroduce them in workflows or templates.
 
 ## Focus artifact
 

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -16,13 +16,21 @@ the issue is too big or too vague — break it down further.
 Title format (see docs/conventions/issue-naming.md):
   - Sub-tasks:  <type>(<scope>): <imperative verb phrase>
                 e.g.  feat(typecheck): register extern fn declarations
-  - Epics:      Epic: <track-id>: <noun phrase>          + apply `epic` label
-  - Trackers:   Tracking: <topic> (<YYYY-MM-DD>)         + apply `tracking` label
+
+GitHub issues are session-sized leaf work only. Epics and trackers are NOT
+GitHub issues — an epic is a Linear Project, a tracker is a Project/Initiative
+(see docs/conventions/linear-workflow.md). The `Release: vX.Y.Z` cadence
+tracker is the sole surviving GitHub tracking title.
 
 Labels come from .github/labels.yml — never invent new ones here. The
 template defaults to `needs-grooming`. Once scope, criteria, and files
 are filled in, swap it for `claude-ready` (and add `type:*`, `size:*`,
 optional `area:*`).
+
+Priority and estimate are Linear-native fields, not GitHub labels. Record
+the intended priority in the `## Priority` section below; the groomer sets
+the Linear priority from it and the Linear estimate from the `## Size` /
+`size:*` value.
 -->
 
 ## Goal
@@ -81,11 +89,25 @@ timeout 60 build/native/sailfin run path/to/example.sfn
 
 ## Size
 
-<!-- Pick one. If L, this issue is too big — break it down. -->
+<!-- Pick one. If L, this issue is too big — break it down. Drives the Linear estimate: XS→1, S→2, M→3. -->
 - [ ] **XS** — single file, < 1 hour
 - [ ] **S** — few files, 1-3 hours
 - [ ] **M** — multi-file, 3-6 hours
 - [ ] **L** — > 6 hours (NEEDS BREAKDOWN — remove `claude-ready` label and add `needs-grooming`)
+
+## Priority
+
+<!--
+Pick one. This sets the Linear-native priority field (not a GitHub label) —
+the groomer carries it onto the Linear mirror (Urgent/High/Medium/Low → 1/2/3/4).
+Default to the parent epic/Project's priority unless this leaf is a genuine
+outlier. Judge by the 1.0 critical path: pillars & GA blockers rank higher,
+product/post-1.0 polish lower.
+-->
+- [ ] **Urgent** — actively blocking; drop-everything
+- [ ] **High** — a pillar / 1.0 critical-path item
+- [ ] **Medium** — enabling infra; lands this milestone
+- [ ] **Low** — nice to have; post-1.0 or product polish
 
 ## Type
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -111,18 +111,10 @@ labels:
     description: "3-6 hours, multi-file. Larger items must be groomed into smaller issues."
 
   # --- Priority --------------------------------------------------------
-  - name: priority:critical
-    color: "b60205"
-    description: "Blocks self-hosting or release; drop everything"
-  - name: priority:high
-    color: "d93f0b"
-    description: "Should land this week"
-  - name: priority:medium
-    color: "fbca04"
-    description: "Should land this milestone"
-  - name: priority:low
-    color: "fef2c0"
-    description: "Nice to have; pick when nothing else is ready"
+  # Priority is a Linear-native field, not a GitHub label. Set it in Linear
+  # at groom/triage time (Urgent/High/Medium/Low). The former `priority:*`
+  # labels are retired via the `delete:` list below. See
+  # docs/conventions/issue-naming.md § Reflecting state into Linear.
 
   # --- Area (subsystem) ------------------------------------------------
   - name: area:compiler
@@ -253,3 +245,11 @@ aliases:
 delete:
   - name: enhancement
     reason: "GitHub default never adopted; type:feature is canonical"
+  - name: priority:critical
+    reason: "Priority is now a Linear-native field, not a GitHub label"
+  - name: priority:high
+    reason: "Priority is now a Linear-native field, not a GitHub label"
+  - name: priority:medium
+    reason: "Priority is now a Linear-native field, not a GitHub label"
+  - name: priority:low
+    reason: "Priority is now a Linear-native field, not a GitHub label"

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -428,8 +428,9 @@ jobs:
   #   1. Open or append a dedup'd regression issue tagged
   #      `area:architecture` and the stable marker
   #      `build-quality-regression` (a build-quality regression is
-  #      inherently release-critical; priority is set on the Linear mirror
-  #      at triage — it is no longer a GitHub label). Title prefix
+  #      inherently release-critical; priority is a Linear-native field, not
+  #      a GitHub label — `linear-priority-sync.yml` backfills the mirror's
+  #      priority to Urgent from this marker). Title prefix
   #      `build-quality regression:` + gate-name suffix lets later runs
   #      append a comment rather than open a duplicate.
   #   2. On `push: main` only, look up the merging PR (`/commits/{sha}/

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -426,8 +426,10 @@ jobs:
   #
   # Responsibilities:
   #   1. Open or append a dedup'd regression issue tagged
-  #      `priority:critical`, `area:architecture`, and the stable marker
-  #      `build-quality-regression`. Title prefix
+  #      `area:architecture` and the stable marker
+  #      `build-quality-regression` (a build-quality regression is
+  #      inherently release-critical; priority is set on the Linear mirror
+  #      at triage — it is no longer a GitHub label). Title prefix
   #      `build-quality regression:` + gate-name suffix lets later runs
   #      append a comment rather than open a duplicate.
   #   2. On `push: main` only, look up the merging PR (`/commits/{sha}/
@@ -565,7 +567,6 @@ jobs:
             new_number="$(gh issue create \
               --repo "$REPO" \
               --title "$title" \
-              --label "priority:critical" \
               --label "area:architecture" \
               --label "build-quality-regression" \
               --body-file regression-new-body.md \

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -94,10 +94,12 @@ Key terminology: capsule (package), fleet (workspace), generation card (model pr
    | Security concern | `security` | Security reviewer will assess |
    | Question / discussion | `question` | |
 
-5. **Assess priority** based on:
-   - Does it block self-hosting? (`make compile` broken) -> `priority:critical`
-   - Does it affect first impressions? (broken examples, confusing errors) -> `priority:high`
-   - Is there a workaround? -> `priority:medium` or `priority:low`
+5. **Assess priority** and record it as a **suggested priority** in the analysis
+   comment (step 8) — priority is a Linear-native field set at groom/triage, not
+   a GitHub label, so do **not** apply a `priority:*` label:
+   - Does it block self-hosting? (`make compile` broken) -> suggest **Urgent**
+   - Does it affect first impressions? (broken examples, confusing errors) -> suggest **High**
+   - Is there a workaround? -> suggest **Medium** or **Low**
 
 6. **Check for duplicates**: Search open issues for similar problems. If you find a match, add a `duplicate` label and reference the original issue.
 

--- a/.github/workflows/linear-priority-sync.yml
+++ b/.github/workflows/linear-priority-sync.yml
@@ -1,0 +1,39 @@
+name: Linear Priority Sync
+
+# Backfills Linear-native priority + estimate on the Sailfin team's issue
+# mirrors (scripts/linear-priority-sync.sh; see
+# docs/conventions/issue-naming.md § Reflecting state into Linear). Priority
+# and estimate are Linear-native fields, so the GitHub-side regression filers
+# (build-quality.yml, perf-history.yml) can't set them at create time — the
+# Linear mirror of a new GitHub issue is created asynchronously by the
+# GitHub<->Linear integration. This scheduled sweep fills the gap: it sets an
+# estimate from the `size:*` label, and a priority for the auto-filed
+# regression classes (build-quality -> Urgent, perf -> Medium). It never
+# overrides an already-set value, so grooming/triage stays authoritative.
+#
+# Requires the LINEAR_API_KEY Actions secret (write scope). Without it the
+# script is a no-op.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linear-priority-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # Scheduled runs only make sense on the canonical repo, never on forks.
+    if: github.repository == 'SailfinIO/sailfin'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Backfill Linear priority + estimate
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: bash scripts/linear-priority-sync.sh

--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -311,7 +311,6 @@ jobs:
               new_number="$(gh issue create --repo "$REPO" \
                 --title "$title" \
                 --label "type:perf" \
-                --label "priority:medium" \
                 --label "perf-regression" \
                 --body-file perf-new-body.md \
                 | awk -F/ '/^https:/{print $NF}')"

--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -308,6 +308,9 @@ jobs:
                 echo ""
                 cat perf-body.md
               } > perf-new-body.md
+              # Priority is a Linear-native field (not a GitHub label);
+              # linear-priority-sync.yml backfills the mirror's priority to
+              # Medium from the perf-regression marker.
               new_number="$(gh issue create --repo "$REPO" \
                 --title "$title" \
                 --label "type:perf" \

--- a/.github/workflows/planner.md
+++ b/.github/workflows/planner.md
@@ -90,7 +90,7 @@ over creating a new one.
 2. **Status** — `docs/status.md`. What ships today vs. what's partial vs. what's deferred.
 3. **Build performance** — `docs/proposals/0006-build-architecture.md` (Build performance section). Current vs. target build times.
 4. **Runtime audit** — `docs/status.md` (Runtime Migration table). C → Sailfin migration tracker.
-5. **Issue queue** — open issues grouped by label (`priority:critical`, `priority:high`, `needs-design`, `design-approved`, `blocked`, `type:bug`).
+5. **Issue queue** — open issues grouped by label (`needs-design`, `design-approved`, `blocked`, `type:bug`) and by Linear-native priority (Urgent/High, read from the mirror — priority is no longer a GitHub label).
 6. **Recent merges** — PRs merged in the last 7 days. Use the titles + PR bodies to infer what's progressed.
 7. **Previous focus** — the most recent `focus:approved` or `focus:proposed` issue. Continuity matters; don't redirect the ship every week.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,10 +349,12 @@ the session-sized *what*.
 
 **Labels** are registered in `.github/labels.yml`; conventions and the lifecycle
 diagram are in `docs/conventions/issue-naming.md`. Key ones: `claude-ready`,
-`needs-grooming`, `in-progress`, `blocked`, `type:*`, `size:*`, `priority:*`,
-`area:*` (`epic`/`tracking` are **legacy** — epics/trackers are Linear Projects
-now, not labels on new issues; the one surviving use of `tracking` is the
-`Release: vX.Y.Z` cadence tracker). **Labels are the source of truth** and there is no
+`needs-grooming`, `in-progress`, `blocked`, `type:*`, `size:*`, `area:*`
+(`epic`/`tracking` are **legacy** — epics/trackers are Linear Projects now, not
+labels on new issues; the one surviving use of `tracking` is the `Release:
+vX.Y.Z` cadence tracker. **Priority and estimate are Linear-native fields, not
+GitHub labels** — the `priority:*` labels are retired; set them on the Linear
+mirror at groom/triage). **Labels are the source of truth** for issue state and there is no
 derived GitHub board to keep in sync: the former *Sailfin Tracker* project
 (org project SailfinIO/4) and its `sync-project.yml` label→board workflow have
 been **retired**. Epic and roadmap-level grouping now lives in **Linear** —

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -360,12 +360,19 @@ on it (the same posture the skills take when `gh` is unavailable).
    grooming; estimate is derived mechanically from the `size:*` label. Use
    `save_issue` with the numeric `priority` and `estimate`:
 
-   | Size label | Estimate | | Priority tier | `priority` value |
-   |---|---|---|---|---|
-   | `size:xs` | `1` | | Urgent | `1` |
-   | `size:s` | `2` | | High | `2` |
-   | `size:m` | `3` | | Medium | `3` |
-   | (body `## Size`, no label) | map XS/S/M → 1/2/3 | | Low | `4` |
+   | Size label | Estimate |
+   |---|---|
+   | `size:xs` | `1` |
+   | `size:s` | `2` |
+   | `size:m` | `3` |
+   | (body `## Size`, no label) | map XS/S/M → 1/2/3 |
+
+   | Priority tier | `priority` value |
+   |---|---|
+   | Urgent | `1` |
+   | High | `2` |
+   | Medium | `3` |
+   | Low | `4` |
 
    The estimate scale is the Sailfin team's **Linear (1–5)** scale. Every
    `claude-ready` leaf gets both an estimate and a priority; if grooming set no

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -172,7 +172,7 @@ Leave the `[aw]` prefix in place; downstream tooling pattern-matches on it.
 |------|-----|
 | Every active issue carries exactly one `type:*` label | `/pickup` routes by it |
 | Every `claude-ready` issue carries exactly one `size:*` label | `/pickup` and `/sweep` rank by it |
-| Use `priority:*` only when prioritisation matters; default is no priority label | Avoids label inflation; absence ≠ low |
+| **Priority is a Linear-native field, not a GitHub label.** Set it in Linear (Urgent/High/Medium/Low) at groom/triage time; the `priority:*` labels are retired (see § *Reflecting state into Linear*) | One source of truth; Linear's board sorts on the native field |
 | Apply `area:*` labels when the touched subsystem is unambiguous | Helps `/sweep` dedupe collisions |
 | `epic` / `tracking` are **legacy** — do not apply to new issues (sole exception: `tracking` on the `Release: vX.Y.Z` cadence tracker, see § *Release tracking*) | Epics are Linear Projects, trackers are Projects/Initiatives (see `linear-workflow.md`) |
 | Never re-introduce a bare alias (`bug`, `runtime`, `medium`, …) | They are listed in `aliases:` of `labels.yml` and will be migrated away on the next sync |
@@ -263,11 +263,13 @@ required, that is real growth — pause for human input.
 
 ## Issue tracking
 
-**Labels are the sole source of truth.** The former GitHub Project board
+**Labels are the source of truth for issue state.** The former GitHub Project board
 (*Sailfin Tracker*, org project #4) and its label→board sync workflow have been
-**retired**. Issue state lives entirely in GitHub labels; `priority:*`/`size:*`
-labels carry priority and size directly, and the GitHub native parent/child
-relationship carries sub-issue nesting. Epic and roadmap-level grouping now lives
+**retired**. Lifecycle state lives entirely in GitHub labels; the `size:*` label
+carries size (and drives the derived Linear estimate), and the GitHub native
+parent/child relationship carries sub-issue nesting. **Priority and estimate are
+Linear-native fields** — set them on the Linear mirror at groom/triage time (see
+§ *Reflecting state into Linear*); there is no `priority:*` GitHub label. Epic and roadmap-level grouping now lives
 in **Linear** — Linear Projects correspond to epics, while session-sized leaf
 work stays as GitHub issues mirrored into Linear by the GitHub↔Linear integration.
 
@@ -353,10 +355,26 @@ on it (the same posture the skills take when `gh` is unavailable).
    status onto a mirror whose GitHub issue is still open — the two-way sync would
    close the GitHub issue. Only the non-terminal statuses (In Progress, Blocked,
    Ready, To triage, Backlog, Todo) are ever written.
-3. **Assign the issue to its epic's Project** if it isn't already, resolving the
+3. **Set priority and estimate on the mirror** (Linear-native fields — there is
+   no GitHub label for either). Priority is a judgement call carried from
+   grooming; estimate is derived mechanically from the `size:*` label. Use
+   `save_issue` with the numeric `priority` and `estimate`:
+
+   | Size label | Estimate | | Priority tier | `priority` value |
+   |---|---|---|---|---|
+   | `size:xs` | `1` | | Urgent | `1` |
+   | `size:s` | `2` | | High | `2` |
+   | `size:m` | `3` | | Medium | `3` |
+   | (body `## Size`, no label) | map XS/S/M → 1/2/3 | | Low | `4` |
+
+   The estimate scale is the Sailfin team's **Linear (1–5)** scale. Every
+   `claude-ready` leaf gets both an estimate and a priority; if grooming set no
+   explicit priority, default the leaf to its Project's priority. Never leave a
+   promoted leaf at `No priority` / no estimate.
+4. **Assign the issue to its epic's Project** if it isn't already, resolving the
    Project from the epic (`epic`/parent reference) and creating it per § Linear
    structure & naming when it doesn't exist yet.
-4. **Roll up the Project status** from its issues: any issue In Progress →
+5. **Roll up the Project status** from its issues: any issue In Progress →
    Project `started`; else any Ready → `planned`; else `backlog`. Never
    `completed`/`canceled` from a workflow.
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -326,9 +326,12 @@ issue belongs to exactly one project.
 When an epic is groomed, `/groom` creates (or reuses) a Linear Project under the
 right initiative following this convention, files the session-sized leaves as
 GitHub issues that mirror into it, and reflects their state per **§ Reflecting
-state into Linear** below. A Linear-sync GitHub Action (using the Actions
-`LINEAR_API_KEY`) can later make the same reflection fire on label changes made
-outside the skills; until then the skills are the reflection path.
+state into Linear** below. The skills are the primary reflection path; the
+`Linear Priority Sync` GitHub Action (`.github/workflows/linear-priority-sync.yml`,
+using the Actions `LINEAR_API_KEY`) is a scheduled safety net that backfills the
+Linear-native **priority and estimate** on mirrors the skills didn't reach —
+notably the CI-auto-filed regression issues, whose mirror is created
+asynchronously after `gh issue create` (see the note in step 3 below).
 
 ## Reflecting state into Linear
 
@@ -378,6 +381,14 @@ on it (the same posture the skills take when `gh` is unavailable).
    `claude-ready` leaf gets both an estimate and a priority; if grooming set no
    explicit priority, default the leaf to its Project's priority. Never leave a
    promoted leaf at `No priority` / no estimate.
+
+   **CI-auto-filed issues** (the `build-quality.yml` / `perf-history.yml`
+   regression filers) can't set these inline — their Linear mirror is created
+   asynchronously by the integration, after `gh issue create` returns. The
+   scheduled `Linear Priority Sync` workflow backfills them: estimate from
+   `size:*`, and priority for the regression classes
+   (`build-quality-regression` → Urgent, `perf-regression` → Medium). It only
+   fills unset values, so an interactively-set priority/estimate always wins.
 4. **Assign the issue to its epic's Project** if it isn't already, resolving the
    Project from the epic (`epic`/parent reference) and creating it per § Linear
    structure & naming when it doesn't exist yet.

--- a/docs/conventions/linear-workflow.md
+++ b/docs/conventions/linear-workflow.md
@@ -43,9 +43,12 @@ Project (see below).
    session (an `L`, or a "parent of many"), it is an epic → make it a Project and
    `/groom` it into leaves.
 3. **Labels stay the source of truth** for issue state (`claude-ready`,
-   `in-progress`, `blocked`, `type:*`, `size:*`, `priority:*`, `area:*`). Linear
-   status is *derived* from them; never hand-edit a mirror's status to drive the
-   GitHub side.
+   `in-progress`, `blocked`, `type:*`, `size:*`, `area:*`). Linear status is
+   *derived* from them; never hand-edit a mirror's status to drive the GitHub
+   side. **Priority and estimate are the exception — they are Linear-native
+   fields**, not labels: set them on the mirror at groom/triage time (priority
+   is a judgement call; estimate derives from `size:*`, xs/s/m → 1/2/3). There
+   is no `priority:*` GitHub label.
 4. **Project names are scannable; links go in the description.** Name a project
    for its outcome (`CLI Modularization`), not `Epic: CLI modularization
    (SFEP-0027)`. Put `GitHub: #N` and `Design: SFEP-NNNN` in the description.

--- a/docs/runbooks/build-quality.md
+++ b/docs/runbooks/build-quality.md
@@ -102,8 +102,6 @@ Once the offending commit is identified, file a fix issue with these
 labels:
 
 - `type:bug`
-- Set the Linear-native priority to **Urgent** on the mirror (priority is no
-  longer a GitHub label).
 - `area:compiler` (for emit-pipeline / lowering regressions),
   `area:build` (for cache-key drift), or `area:runtime` (rare —
   runtime-shape changes that perturb emitted IR).
@@ -111,6 +109,9 @@ labels:
   `/release` to refuse to cut anything beyond an alpha prerelease
   until the issue closes (see `docs/conventions/issue-naming.md` →
   "Release tracking" + "Seed pinning").
+
+Then set the fix issue's **Linear-native priority to Urgent** on its mirror
+(priority is a Linear field, not a GitHub label).
 
 The fix issue's body should `Closes` the regression issue
 (`build-quality regression: <gate>`) so the dedup anchor closes

--- a/docs/runbooks/build-quality.md
+++ b/docs/runbooks/build-quality.md
@@ -10,10 +10,11 @@ on every `push` to `main` and every nightly cron at 05:00 UTC:
    `cache.hit_rate >= 0.95`.
 
 When either gate fails, the `notify-failure` job (issue #782) opens a
-deduplicated regression issue labeled `priority:critical`,
-`area:architecture`, and `build-quality-regression`. If the failing
-event is `push: main`, the merging PR also gets a comment linking the
-regression issue and the failing job.
+deduplicated regression issue labeled `area:architecture` and
+`build-quality-regression` (build-quality regressions are inherently
+release-critical; priority is set on the Linear mirror at triage — it is no
+longer a GitHub label). If the failing event is `push: main`, the merging PR
+also gets a comment linking the regression issue and the failing job.
 
 This page is the triage runbook for those regressions.
 
@@ -101,7 +102,8 @@ Once the offending commit is identified, file a fix issue with these
 labels:
 
 - `type:bug`
-- `priority:critical`
+- Set the Linear-native priority to **Urgent** on the mirror (priority is no
+  longer a GitHub label).
 - `area:compiler` (for emit-pipeline / lowering regressions),
   `area:build` (for cache-key drift), or `area:runtime` (rare —
   runtime-shape changes that perturb emitted IR).

--- a/scripts/linear-priority-sync.sh
+++ b/scripts/linear-priority-sync.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/linear-priority-sync.sh
+#
+# Backfills Linear-native priority and estimate on the Sailfin team's issue
+# mirrors — the CI-side complement to the /groom and /triage skills, which set
+# these fields interactively. Priority and estimate are Linear-native fields,
+# not GitHub labels (see docs/conventions/issue-naming.md § Reflecting state
+# into Linear), so the GitHub-side regression filers (build-quality.yml,
+# perf-history.yml) cannot set them at `gh issue create` time: the Linear
+# mirror of a new GitHub issue is created asynchronously by the GitHub<->Linear
+# integration. This sweep runs on a schedule and fills that gap.
+#
+# What it sets (conservative and deterministic — it never guesses a human
+# priority, and never overrides an already-set value):
+#   * estimate — from the `size:*` label when the mirror has no estimate
+#                (size:xs -> 1, size:s -> 2, size:m -> 3, on the team's
+#                Linear 1-5 scale).
+#   * priority — only for the auto-filed regression classes while they sit at
+#                No priority: `build-quality-regression` -> Urgent (1),
+#                `perf-regression` -> Medium (3).
+#
+# Because it acts only when estimate is unset or priority is 0-with-a-known
+# regression-label, it is idempotent and safe to run repeatedly.
+#
+# Requires: LINEAR_API_KEY (write scope) in the environment; curl + jq.
+
+set -euo pipefail
+
+TEAM_ID="${SAILFIN_LINEAR_TEAM_ID:-dd644ba0-5c93-40a9-8c01-ceccae9dce7b}"
+API="https://api.linear.app/graphql"
+
+if [ -z "${LINEAR_API_KEY:-}" ]; then
+  echo "[linear-sync] LINEAR_API_KEY not set; skipping (no-op)."
+  exit 0
+fi
+
+gql() {
+  # $1 = JSON request body. Echoes the raw response.
+  curl -sS -X POST "$API" \
+    -H "Authorization: ${LINEAR_API_KEY}" \
+    -H "Content-Type: application/json" \
+    --data "$1"
+}
+
+# --- Fetch open issues (paginated) ------------------------------------------
+cursor="null"
+nodes_file="$(mktemp)"
+: > "$nodes_file"
+page=0
+while :; do
+  page=$((page + 1))
+  if [ "$page" -gt 40 ]; then
+    echo "[linear-sync] pagination guard hit at page $page; stopping."
+    break
+  fi
+  req="$(jq -n --arg t "$TEAM_ID" --argjson c "$cursor" '{
+    query: "query($t:String!,$c:String){ team(id:$t){ issues(first:100, after:$c, filter:{ state:{ type:{ nin:[\"completed\",\"canceled\"] } } }){ nodes{ id identifier priority estimate labels{ nodes{ name } } } pageInfo{ hasNextPage endCursor } } } }",
+    variables: { t: $t, c: $c }
+  }')"
+  resp="$(gql "$req")"
+  if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
+    echo "[linear-sync] query error:"
+    echo "$resp" | jq -c '.errors'
+    exit 1
+  fi
+  echo "$resp" | jq -c '.data.team.issues.nodes[]' >> "$nodes_file"
+  hasNext="$(echo "$resp" | jq -r '.data.team.issues.pageInfo.hasNextPage')"
+  endCur="$(echo "$resp" | jq -r '.data.team.issues.pageInfo.endCursor')"
+  if [ "$hasNext" = "true" ]; then
+    cursor="\"$endCur\""
+  else
+    break
+  fi
+done
+
+# --- Compute + apply changes ------------------------------------------------
+# jq emits one TSV row per issue that needs a change: id, identifier, priority
+# (number or "null"), estimate (number or "null"). "null" means leave that
+# field unchanged.
+changed=0
+failed=0
+while IFS=$'\t' read -r id ident prio est; do
+  [ -z "$id" ] && continue
+  input="$(jq -n --argjson p "$prio" --argjson e "$est" '
+    ({} + (if $p != null then {priority: $p} else {} end)
+        + (if $e != null then {estimate: $e} else {} end))')"
+  req="$(jq -n --arg id "$id" --argjson input "$input" '{
+    query: "mutation($id:String!,$input:IssueUpdateInput!){ issueUpdate(id:$id, input:$input){ success } }",
+    variables: { id: $id, input: $input }
+  }')"
+  resp="$(gql "$req")"
+  if echo "$resp" | jq -e '.data.issueUpdate.success == true' >/dev/null 2>&1; then
+    echo "[linear-sync] updated ${ident} <- ${input}"
+    changed=$((changed + 1))
+  else
+    echo "[linear-sync] FAILED ${ident}: $(echo "$resp" | jq -c '.errors // .')"
+    failed=$((failed + 1))
+  fi
+done < <(
+  jq -r -s '
+    .[] |
+    ([.labels.nodes[].name]) as $l |
+    (if .estimate == null then
+       (if   ($l | index("size:xs")) then 1
+        elif ($l | index("size:s"))  then 2
+        elif ($l | index("size:m"))  then 3
+        else null end)
+     else null end) as $e |
+    (if .priority == 0 then
+       (if   ($l | index("build-quality-regression")) then 1
+        elif ($l | index("perf-regression"))          then 3
+        else null end)
+     else null end) as $p |
+    select($e != null or $p != null) |
+    [.id, .identifier, ($p // "null"), ($e // "null")] | @tsv
+  ' "$nodes_file"
+)
+
+rm -f "$nodes_file"
+echo "[linear-sync] done; ${changed} updated, ${failed} failed."
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
## Goal

Make **priority** and **estimate** Linear-native fields set at groom/triage time, retire the GitHub `priority:*` labels, and wire a scheduled sweep so CI-auto-filed issues also get a priority. After the 2026-07-07 Linear migration, the `priority:*` labels disagreed with Linear's native priority field; this makes Linear's field the single source of truth for both priority and estimate.

## Context

Alongside this repo change, the Linear workspace was classified directly: all 31 Projects and 93 active leaf issues received a docs-driven priority (from CLAUDE.md's 1.0 critical path) and an estimate (derived from `size:*` on the team's Linear 1–5 scale), and the stale `priority:*` labels were stripped from 83 issue mirrors. This PR updates the repo's skills/rules/templates/workflows so future grooming and issue creation keep doing the same.

## What changed

**Convention & source of truth**
- `docs/conventions/issue-naming.md` — priority + estimate are Linear-native; added the `size→estimate` (xs/s/m → 1/2/3) and `tier→priority` (Urgent/High/Medium/Low → 1/2/3/4) mappings to the *Reflecting state into Linear* step (two clean 2-column tables); updated the label-rules table and the issue-tracking paragraph.
- `docs/conventions/linear-workflow.md`, `CLAUDE.md` — carve priority/estimate out of the label source-of-truth set as Linear-native fields.

**Label registry**
- `.github/labels.yml` — retire `priority:{critical,high,medium,low}` via the `delete:` list (no replacement — priority is a Linear field now). Size labels unchanged.

**Issue creation & skills**
- `.github/ISSUE_TEMPLATE/claude-task.md` — added a `## Priority` section; noted Size drives the Linear estimate; fixed the retired `Epic:`/`Tracking:` header notes.
- `.claude/commands/groom.md` — Phase 3 table gains a Priority column; the *Reflect in Linear* step and constraints set the Linear priority + estimate on each leaf.
- `.claude/commands/triage.md` — PROMOTE also sets Linear priority/estimate on the mirror if unset.
- `.claude/commands/{pickup,sweep,release-plan}.md`, `.codex/skills/sailfin-pickup/SKILL.md` — rank/select by Linear-native priority (best-effort). `release-plan.md` Phase 3c reflection no longer reads a `priority:*` label.

**Autonomous workflows (stop applying the deleted labels)**
- `.github/workflows/perf-history.yml`, `build-quality.yml` — regression filers drop the `priority:*` label (keep their `*-regression` marker; dedup anchor was never the priority label).
- `.github/workflows/issue-triage.md` — records a **suggested** priority in the analysis comment instead of applying a label.
- `.github/workflows/planner.md`, `.github/AGENTS.md`, `docs/runbooks/build-quality.md` — reference updates.

**New: scheduled Linear-write sweep**
- `.github/workflows/linear-priority-sync.yml` + `scripts/linear-priority-sync.sh` — a cron workflow (every 30 min) that backfills the Linear-native priority/estimate on mirrors the skills didn't reach. It closes the gap where the GitHub-side regression filers can't set these inline (the Linear mirror is created **asynchronously** after `gh issue create`):
  - **estimate** from `size:*` (xs/s/m → 1/2/3) when unset;
  - **priority** for the auto-filed regression classes at No priority (`build-quality-regression` → Urgent, `perf-regression` → Medium).
  - Idempotent; **never overrides an interactively-set value**, so grooming/triage stays authoritative. Reads `LINEAR_API_KEY` (write scope) via env, not the command line; no-op without the secret. Validated locally (bash `-n`, and the jq decision/mutation stages against sample mirror JSON).

## Notes

- Historical SFEP/proposal docs (`docs/proposals/0009`, `0010`, `0016`) still mention `priority:*` as prose design records from their authoring time; left as-is per the proposals rule (not label-appliers, no CI impact).
- No `.sfn` files touched — no self-host/format gate applies.
- The sweep needs the `LINEAR_API_KEY` Actions secret to have **write** scope (a personal API key inherits full access; a workspace/app key needs write enabled). Scheduled workflows only run from the default branch, so it activates on merge — not testable from the PR branch.
