### PR TITLE
[codex] Migrate issue tracking conventions to Linear

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -31,7 +31,7 @@ which can duplicate hook execution and produce startup warnings.
 
 ## Web setup
 
-Codex web should be given the same repository context plus one of the prompts in `prompts/`. For the closest equivalent to Claude's `/pickup`, paste `prompts/pickup.md` and optionally append an issue number. For SFEP lifecycle work, paste `prompts/sfep.md` with the desired mode.
+Codex web should be given the same repository context plus one of the prompts in `prompts/`. For the closest equivalent to Claude's `/pickup`, paste `prompts/pickup.md` and optionally append a Linear identifier such as `SFN-123` or a GitHub issue number. For SFEP lifecycle work, paste `prompts/sfep.md` with the desired mode.
 
 ## Safety behavior
 
@@ -55,9 +55,10 @@ The remaining guardrail is time, not caller memory: wrap direct single-file comp
 
 Use `prompts/pickup.md` for autonomous issue work. It instructs Codex to:
 
-1. Query `claude-ready` issues and rank them with the same priority order as Claude's `/pickup` command.
+1. Query Linear `Ready` issues first, falling back to GitHub `claude-ready` labels only when Linear is unavailable, and rank them with the same priority order as Claude's `/pickup` command.
 2. Verify pinned-seed freshness only when a compiler-source capability must already be present in the pinned seed.
-3. Claim the issue, sync the project board with the existing repository helper, and branch as `codex/<issue>-<slug>`.
-4. Implement, verify, commit, and open a PR with `Closes #<issue>`.
+3. Claim the Linear issue, best-effort sync any GitHub mirror, and branch as `codex/SFN-123-<slug>` for Linear pickup.
+4. File out-of-scope bugs or obvious gaps as Sailfin Linear follow-ups using the templates in `docs/conventions/linear-templates.md`.
+5. Implement, verify, commit, and open a PR with the Linear issue link plus `Closes #<issue>` when a GitHub mirror exists.
 
 The GitHub/project scripts remain in `.claude/scripts/` for now because they are repository automation rather than Claude-only logic.

--- a/.codex/prompts/pickup.md
+++ b/.codex/prompts/pickup.md
@@ -5,17 +5,18 @@ Use this prompt in Codex web or CLI when you want the Claude `/pickup` experienc
 ```text
 Pick up the next Sailfin issue and drive it to a pull request.
 
-Follow this repository's AGENTS.md and use the Sailfin pickup workflow in .codex/skills/sailfin-pickup/SKILL.md. If I provide an issue number, use that issue; otherwise select the highest-priority pickable `claude-ready` issue.
+Follow this repository's AGENTS.md and use the Sailfin pickup workflow in .codex/skills/sailfin-pickup/SKILL.md. If I provide `SFN-123`, use that Linear issue. If I provide a bare number, use that GitHub issue and resolve its Linear mirror. Otherwise select the highest-priority pickable issue in Linear's native `Ready` status, falling back to GitHub `claude-ready` labels only when Linear is unreachable.
 
 Required workflow:
-1. Query GitHub issues with `gh` and choose/validate the issue.
+1. Query Linear `Ready` issues for the Sailfin team and choose/validate the issue; fall back to `gh` for GitHub-only issues.
 2. Read any referenced SFEP/design note before planning; do not redesign an accepted SFEP in the issue body.
 3. Apply the seed-dependency policy: bundle a single tightly-coupled compiler-source capability with its consumer by default; verify `## Required in pinned seed` only when the issue explicitly requires a predecessor in the pinned seed.
-4. Claim the issue, sync the project status, and create a `codex/<issue>-<slug>` branch.
+4. Claim the Linear issue, best-effort sync any GitHub mirror, and create a `codex/SFN-123-<slug>` branch for Linear pickup or `codex/<issue>-<slug>` for GitHub-only fallback.
 5. Restate the issue goal, scope, acceptance criteria, files affected, design references, and verification plan.
 6. Implement the smallest focused change that satisfies the issue.
-7. Run the issue's verification commands plus the Sailfin safety checks from .codex/skills/sailfin-check/SKILL.md.
-8. Commit the changes and open a PR with `Closes #<issue>`.
+7. If you discover a real bug or obvious gap outside the claimed scope, search Linear for duplicates and file a Sailfin (`SFN`) follow-up using Linear-native status, priority, estimate, Project, blocker, and relation fields. Use only canonical `type:*` and `area:*` labels, and follow `docs/conventions/linear-templates.md`.
+8. Run the issue's verification commands plus the Sailfin safety checks from .codex/skills/sailfin-check/SKILL.md.
+9. Commit the changes and open a PR with the Linear issue link plus `Closes #<issue>` when a GitHub mirror exists.
 
 The compiler self-caps memory at 8 GiB on Linux; do not use a `ulimit` prefix. Wrap direct single-file compiler invocations with `timeout 60`.
 ```

--- a/.codex/skills/sailfin-pickup/SKILL.md
+++ b/.codex/skills/sailfin-pickup/SKILL.md
@@ -1,29 +1,42 @@
 ---
 name: sailfin-pickup
-description: Pick up a ready Sailfin GitHub issue and drive it through branch, implementation, verification, and PR handoff.
+description: Pick up a ready Sailfin Linear or GitHub issue and drive it through branch, implementation, verification, and PR handoff.
 ---
 
 # Sailfin Pickup Skill
 
-Use this skill when the user asks Codex to pick up an issue, work the next item, or emulate Claude's `/pickup` flow.
+Use this skill when the user asks Codex to pick up an issue, work the next item,
+or emulate Claude's `/pickup` flow.
 
 ## Issue selection
 
-1. Query ready issues:
+Issue identifiers are accepted in two forms:
+
+- `SFN-123` selects the Linear issue directly.
+- `123` selects GitHub issue `#123`, then looks up the Linear mirror when the
+  Linear tools are reachable.
+
+With no explicit issue, prefer Linear. Query Sailfin (`SFN`) Linear issues in
+the native `Ready` status, then filter out any issue that is assigned to someone
+else, canceled, completed, or externally blocked. If Linear is unreachable, fall
+back to GitHub's public compatibility label:
+
    ```bash
    gh issue list --label "claude-ready" --state open --json number,title,labels,assignees,body --limit 50
    ```
-2. Filter out blocked, in-progress, assigned, or externally blocked work.
-3. Rank remaining issues by:
-   - Linear-native priority Urgent, then High (read from the issue's Linear
-     mirror — priority is no longer a GitHub label; skip this tier if Linear
-     isn't reachable)
+
+Rank remaining issues by:
+
+   - Linear-native priority Urgent, then High
    - `type:bug`
    - `type:perf`
    - smallest `size:*` (`XS` before `S` before `M`)
-   - lowest issue number
+   - lowest Linear identifier, then lowest GitHub issue number when tied
 
-If the user supplied an issue number, fetch it directly with `gh issue view <N> --json number,title,labels,assignees,body,state` and validate the same pickability rules.
+For a supplied `SFN-123`, resolve it with Linear first and validate the same
+pickability rules. For a supplied GitHub issue number, fetch it directly with
+`gh issue view <N> --json number,title,labels,assignees,body,state,url` and then
+try to resolve the Linear mirror by querying the issue number or URL.
 
 ## Seed dependency policy
 
@@ -33,16 +46,29 @@ If the user supplied an issue number, fetch it directly with `gh issue view <N> 
 - Split only when the capability has multiple consumers, is genuinely independent, or has a large blast radius.
 - When split, the predecessor should be labeled `seed-blocker`, the consumer should list it under `## Required in pinned seed`, and the seed bump queues against the normal cadence unless release-critical.
 
-Before claiming compiler/runtime work, read the issue body. If `## Required in pinned seed` lists predecessors, verify at least one closing/merge commit (or an explicit content expectation from the issue body) is present in the pinned seed tag. If not, comment on the issue and stop without claiming it.
+Before claiming compiler/runtime work, read the Linear description or GitHub
+issue body. If `## Required in pinned seed` lists predecessors, verify at least
+one closing/merge commit (or an explicit content expectation from the issue
+body) is present in the pinned seed tag. If not, comment on the Linear issue or
+GitHub issue and stop without claiming it.
 
 ## Claim and branch
 
+For Linear-native pickup, claim Linear first:
+
+- set state to `In Progress`;
+- assign to `me` when the Linear tools support it;
+- do not add Linear status labels such as `blocked` or `in-progress`; Linear has
+  native statuses for that.
+
+If a GitHub mirror exists, update it best-effort too:
+
 ```bash
 gh issue edit <N> --add-label "in-progress" --remove-label "claude-ready"
-git switch -c codex/<N>-<slug>
 ```
 
-Labels are the source of truth; there is no derived board to sync.
+Create the branch as `codex/SFN-123-<slug>` for Linear-native pickup, or
+`codex/<N>-<slug>` for GitHub-only fallback.
 
 ## Implementation rules
 
@@ -52,8 +78,47 @@ Labels are the source of truth; there is no derived board to sync.
 - Add or update Sailfin-native tests beside related coverage under `compiler/tests/`.
 - Use the Sailfin check skill for formatting and verification.
 
+## Follow-up issue filing
+
+During pickup, do not silently expand the current issue when you discover a
+real bug, missing acceptance criterion, or obvious gap outside the claimed
+scope. Search Linear first to avoid duplicates, then file a Sailfin (`SFN`)
+Linear issue when the work is concrete enough to track.
+
+Create follow-ups with Linear-native fields:
+
+- Team: `Sailfin` (`SFN`).
+- Status: `Triage` when the gap needs human shaping, `Backlog` when scoped but
+  not yet ready, `Blocked` when it depends on the current issue/PR or another
+  unresolved blocker, and `Ready` only when it is fully groomed, unblocked, and
+  pickable.
+- Project: reuse the current issue's Project when the follow-up belongs to the
+  same epic; otherwise leave it unprojected only when genuinely cross-cutting
+  and say why in the description.
+- Priority: inherit the current issue or Project priority unless the discovery
+  is a release, self-hosting, seed, or correctness blocker. Use Urgent only for
+  drop-everything blockers, High for critical-path work, Medium for enabling
+  current-milestone work, and Low for polish or post-milestone work.
+- Estimate: use the Sailfin Linear scale (`1` = XS, `2` = S, `3` = M). If the
+  work is larger than M, leave it in `Triage` or create a Project/design note
+  instead of filing an oversized leaf.
+- Labels: use only canonical `type:*` and `area:*` labels. Do not add Linear
+  labels for status, priority, estimate, release, blockers, assignee, or
+  project membership.
+- Relations: mark the follow-up `related to` the current issue; mark it
+  `blocked by` the current issue only when it cannot start before the current
+  PR lands.
+
+Use the repository template in `docs/conventions/linear-templates.md` for the
+issue description. The description must include the discovery source, expected
+acceptance criteria, verification commands or test expectations, and links to
+the current issue/PR or GitHub mirror when available.
+
 ## PR handoff
 
 - Run the verification commands from the issue body plus the Sailfin check ladder.
 - Commit atomically with a Conventional Commit style message, for example `fix(compiler): handle ...`.
-- Open a PR whose body includes scope, issue link (`Closes #N`), SFEP/design link when applicable, verification commands, and residual concerns.
+- Open a PR whose body includes scope, issue links, SFEP/design link when
+  applicable, verification commands, and residual concerns. Use `Closes #N`
+  when a GitHub mirror exists; always include the Linear issue link
+  (`Linear: SFN-123`).

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -14,7 +14,7 @@ reintroduce gh-aw workflow sources without a new design decision.
 For issue execution, use Linear plus the repo-local Codex/Claude workflows:
 
 - groom and prioritize work in Linear;
-- use labels such as `claude-ready`, `needs-grooming`, and `blocked` as human
-  triage hints, not autonomous GitHub workflow triggers;
+- use labels such as `claude-ready`, `needs-grooming`, and `blocked` only as
+  public GitHub fallback triage hints; Linear native status is primary;
 - use the repository prompts and skills under `.codex/` and `.claude/` for
   interactive pickup, implementation, and PR handoff.

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -7,7 +7,10 @@ assignees: []
 ---
 
 <!--
-This template defines the contract between issue authors and Claude.
+This template defines the contract between public GitHub issue authors and
+Claude/Codex. Maintainer- or agent-created implementation work should start as
+a Linear `SFN-NNN` issue and use the GitHub issue only as the public mirror when
+needed.
 
 A well-groomed issue is one Claude can complete in a single session and
 produce a mergeable PR. If you can't fill in every section concretely,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "dependencies"
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
     directory: "/site"
+    labels:
+      - "dependencies"
     schedule:
       interval: "weekly"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,7 +28,9 @@
 # for naming conventions and the lifecycle diagram.
 
 labels:
-  # --- Issue lifecycle (state machine) ---------------------------------
+  # --- Public issue triage hints ---------------------------------------
+  # Linear owns maintainer workflow state natively. These labels remain only
+  # for public GitHub issues, mirrors, and GitHub-only fallback flows.
   - name: needs-grooming
     color: "fbca04"
     description: "Placeholder issue: scope, criteria, or files-affected still missing"
@@ -38,18 +40,15 @@ labels:
   - name: needs-discussion
     color: "d93f0b"
     description: "Design blocked pending human input"
-  - name: design-approved
-    color: "0e8a16"
-    description: "Legacy approval marker; prefer claude-ready for current pickup"
   - name: claude-ready
     color: "0e8a16"
-    description: "Fully groomed and unblocked; eligible for /pickup"
+    description: "GitHub fallback: fully groomed and eligible for /pickup"
   - name: in-progress
     color: "1d76db"
-    description: "Currently being worked; do not pick up"
+    description: "GitHub fallback: currently being worked; do not pick up"
   - name: blocked
     color: "b60205"
-    description: "Has open dependencies; recheck after blocker closes"
+    description: "GitHub fallback: has open dependencies"
 
   # --- PR lifecycle ----------------------------------------------------
   - name: needs-review
@@ -67,17 +66,6 @@ labels:
   - name: security
     color: "d93f0b"
     description: "Security-relevant issue or PR; requires Security review"
-
-  # --- Focus (planner cycle) -------------------------------------------
-  - name: focus:proposed
-    color: "a371f7"
-    description: "Legacy weekly focus issue awaiting human approval"
-  - name: focus:approved
-    color: "0e8a16"
-    description: "Legacy weekly focus is live; prefer Linear planning state"
-  - name: focus:stale
-    color: "cccccc"
-    description: "Superseded legacy focus issue"
 
   # --- Type taxonomy (mirror Conventional Commit prefixes) -------------
   - name: type:feature
@@ -114,7 +102,7 @@ labels:
   # Priority is a Linear-native field, not a GitHub label. Set it in Linear
   # at groom/triage time (Urgent/High/Medium/Low). The former `priority:*`
   # labels are retired via the `delete:` list below. See
-  # docs/conventions/issue-naming.md § Reflecting state into Linear.
+  # docs/conventions/issue-naming.md § Reflecting state across Linear and GitHub.
 
   # --- Area (subsystem) ------------------------------------------------
   - name: area:compiler
@@ -144,11 +132,11 @@ labels:
   - name: area:dx
     color: "c5def5"
     description: "Diagnostics, error messages, ergonomics, tooling UX"
+  - name: area:capsules
+    color: "c5def5"
+    description: "capsules/* — standard library and package capsule surfaces"
 
   # --- Special markers -------------------------------------------------
-  - name: epic
-    color: "d4c5f9"
-    description: "Legacy — epics are now Linear Projects; do not apply to new issues"
   - name: tracking
     color: "a371f7"
     description: "Legacy — trackers are Linear Projects; only for Release: vX.Y.Z cadence tracker"
@@ -240,6 +228,18 @@ aliases:
     to: area:architecture
   - from: agentic-workflows
     to: area:agents
+  - from: "area:fmt"
+    to: "area:dx"
+  - from: "area:formatter"
+    to: "area:dx"
+  - from: "area:perf"
+    to: "area:build"
+  - from: "type:chore"
+    to: "type:tech-debt"
+  - from: "type:enhancement"
+    to: "type:feature"
+  - from: "type:test"
+    to: "type:tech-debt"
 
 # Labels to delete outright (no canonical replacement).
 delete:
@@ -253,3 +253,37 @@ delete:
     reason: "Priority is now a Linear-native field, not a GitHub label"
   - name: priority:low
     reason: "Priority is now a Linear-native field, not a GitHub label"
+  - name: "priority: critical"
+    reason: "Priority is now a Linear-native field, not a GitHub label"
+  - name: design-approved
+    reason: "Retired GitHub agentic approval marker; Linear Ready status is canonical"
+  - name: focus:proposed
+    reason: "Retired weekly-focus planner marker; Linear planning state replaced it"
+  - name: focus:approved
+    reason: "Retired weekly-focus planner marker; Linear planning state replaced it"
+  - name: focus:stale
+    reason: "Retired weekly-focus planner marker; Linear planning state replaced it"
+  - name: epic
+    reason: "Epics are Linear Projects; historical GitHub epic issues were migrated"
+  - name: size:l
+    reason: "L work must be broken down; size is Linear estimate plus XS/S/M only"
+  - name: large
+    reason: "Old T-shirt size label; use size:m or split the issue"
+  - name: small
+    reason: "Old T-shirt size label; use size:s"
+  - name: xtra large
+    reason: "Old T-shirt size label; split the issue"
+  - name: workstream
+    reason: "Workstreams are Linear Initiatives/Projects, not labels"
+  - name: codex
+    reason: "Assistant authorship is tracked by PR body/author; agent-authored is the canonical label"
+  - name: claude-ready-remove
+    reason: "Temporary migration helper; no canonical use"
+  - name: released on @beta
+    reason: "Old release automation label; release tracking uses release:* labels"
+  - name: github_actions
+    reason: "Dependabot ecosystem label; dependabot.yml now uses only dependencies"
+  - name: javascript
+    reason: "Dependabot ecosystem label; dependabot.yml now uses only dependencies"
+  - name: python
+    reason: "Dependabot ecosystem label; dependabot.yml now uses only dependencies"

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -7,11 +7,13 @@ to follow it.
 
 The label registry lives in `.github/labels.yml` and is auto-synced to GitHub
 by the `Sync Labels` workflow on every push to `main`. Maintainers can also
-run `scripts/setup-github-labels.sh` manually.
+run `scripts/setup-github-labels.sh` manually. Linear labels are intentionally
+smaller: use native Linear fields for status, priority, estimate, Project,
+Cycle, blockers, and assignee.
 
 ---
 
-## Lifecycle (issue state machine)
+## Lifecycle (Linear state machine; GitHub fallback labels mirror names)
 
 ```
                                        ┌────────────────┐
@@ -30,17 +32,12 @@ run `scripts/setup-github-labels.sh` manually.
                               │                 │
                               │                 ▼
                               │        ┌────────────────┐
-                              │        │ design-approved│  ── architect gate
+                              │        │     Ready      │  ── eligible for /pickup
                               │        └────────┬───────┘
                               │                 │
                               │                 ▼
                               │        ┌────────────────┐
-                              │        │  claude-ready  │  ── eligible for /pickup
-                              │        └────────┬───────┘
-                              │                 │
-                              │                 ▼
-                              │        ┌────────────────┐
-                              │        │   in-progress  │
+                              │        │  In Progress   │
                               │        └────────┬───────┘
                               │                 │
                               │                 ▼
@@ -51,7 +48,7 @@ run `scripts/setup-github-labels.sh` manually.
                               │        │  Closes #N)    │
                               │        └────────────────┘
                               │
-                  ── if blocker found anywhere above ──► `blocked`
+                  ── if blocker found anywhere above ──► Blocked
 ```
 
 ## PR lifecycle
@@ -130,10 +127,9 @@ See § *Linear structure & naming* below and the playbook in
 `SFEP-NNNN`, and put `GitHub: #N` + `Design: SFEP-NNNN` in the Project
 **description**.
 
-Do **not** open a new `Epic:` GitHub issue and do **not** apply the `epic`
-label to new work. The label persists only on the historical epics that were
-closed during the 2026-07-07 Linear migration; `/groom` creates a Project and
-files only session-sized leaves.
+Do **not** open a new `Epic:` GitHub issue. The legacy `epic` label is retired
+and deleted by `.github/labels.yml`; `/groom` creates a Linear Project and files
+only session-sized leaves.
 
 ### 3. Tracking issue — **retired; the Project (or Initiative) is the tracker**
 
@@ -170,10 +166,10 @@ four human-authored shapes. Do not create new `[aw]` issues manually.
 | Rule | Why |
 |------|-----|
 | Every active issue carries exactly one `type:*` label | `/pickup` routes by it |
-| Every `claude-ready` issue carries exactly one `size:*` label | `/pickup` and `/sweep` rank by it |
-| **Priority is a Linear-native field, not a GitHub label.** Set it in Linear (Urgent/High/Medium/Low) at groom/triage time; the `priority:*` labels are retired (see § *Reflecting state into Linear*) | One source of truth; Linear's board sorts on the native field |
+| Every GitHub `claude-ready` fallback issue carries exactly one `size:*` label | GitHub-only `/pickup` fallback ranks by it |
+| **Priority is a Linear-native field, not a GitHub label.** Set it in Linear (Urgent/High/Medium/Low) at groom/triage time; the `priority:*` labels are retired (see § *Reflecting state across Linear and GitHub*) | One source of truth; Linear's board sorts on the native field |
 | Apply `area:*` labels when the touched subsystem is unambiguous | Helps `/sweep` dedupe collisions |
-| `epic` / `tracking` are **legacy** — do not apply to new issues (sole exception: `tracking` on the `Release: vX.Y.Z` cadence tracker, see § *Release tracking*) | Epics are Linear Projects, trackers are Projects/Initiatives (see `linear-workflow.md`) |
+| `tracking` is **legacy** outside release automation — do not apply to new issues except the `Release: vX.Y.Z` cadence tracker (see § *Release tracking*) | Epics are Linear Projects; release automation still queries `tracking` |
 | Never re-introduce a bare alias (`bug`, `runtime`, `medium`, …) | They are listed in `aliases:` of `labels.yml` and will be migrated away on the next sync |
 | Never invent a new label in a workflow or slash command | Add it to `labels.yml` in a separate PR first |
 
@@ -185,9 +181,7 @@ historical issue interpretation:
 
 | Label | Gate |
 |-------|------|
-| `focus:approved` | Legacy focus marker; prefer Linear planning state for new work |
 | `needs-design` | Human/agent hint that an issue needs design grooming |
-| `design-approved` | Historical approval marker; `claude-ready` is the current pickup-ready signal |
 | `type:bug` | Bug classification |
 | `agent-authored` | PR originated from an autonomous or assistant-driven workflow |
 | `needs-changes` | PR needs author rework before merge |
@@ -263,39 +257,45 @@ required, that is real growth — pause for human input.
 
 ## Issue tracking
 
-**Labels are the source of truth for issue state.** The former GitHub Project board
-(*Sailfin Tracker*, org project #4) and its label→board sync workflow have been
-**retired**. Lifecycle state lives entirely in GitHub labels; the `size:*` label
-carries size (and drives the derived Linear estimate), and the GitHub native
-parent/child relationship carries sub-issue nesting. **Priority and estimate are
-Linear-native fields** — set them on the Linear mirror at groom/triage time (see
-§ *Reflecting state into Linear*); there is no `priority:*` GitHub label. Epic and roadmap-level grouping now lives
-in **Linear** — Linear Projects correspond to epics, while session-sized leaf
-work stays as GitHub issues mirrored into Linear by the GitHub↔Linear integration.
+**Linear is the maintainer planning source of truth for issue state.** The
+former GitHub Project board (*Sailfin Tracker*, org project #4) and its
+label→board sync workflow have been **retired**. Lifecycle status, priority,
+estimate, assignee, and Project membership live on the Linear issue. GitHub
+issues remain the public open-source surface and compatibility mirror; their
+labels use the same canonical taxonomy so release automation, public triage,
+and GitHub-only fallbacks keep working.
+
+On GitHub fallback issues, the `size:*` label carries size and drives the
+Linear estimate. **Priority and estimate are Linear-native fields** — set them
+in Linear at groom/triage time
+(see § *Reflecting state across Linear and GitHub*); there is no `priority:*`
+GitHub label. Epic and roadmap-level grouping lives in **Linear** — Linear
+Projects correspond to epics, while session-sized leaf work is a Linear issue
+with a GitHub public mirror when needed.
 
 ### Status semantics
 
-A single status is derived from issue state plus labels, first match wins. This
-precedence is the convention `/triage` and `/sweep` apply. The GitHub↔Linear
-integration mirrors the **labels** themselves into Linear; a Linear issue's
-board status is owned natively in Linear and was seeded from this same
-precedence — Linear does not continuously recompute status from the labels.
+A single status is selected from issue state plus labels, first match wins. This
+precedence is the convention `/triage`, `/sweep`, and `/pickup` apply when they
+need to reconcile a GitHub mirror or an older migrated issue. Linear status is
+owned natively in Linear; labels are compatibility hints, not a replacement for
+the Linear status field.
 
 | Signal | Status |
 |--------|--------|
 | Issue closed (or PR merged for linked PRs) | `Done` |
-| `in-progress` label | `In progress` |
+| `in-progress` label | `In Progress` |
 | `blocked` label | `Blocked` |
 | `claude-ready` label (no blocker) | `Ready` |
-| `needs-grooming` / `needs-design` / `design-approved` | `Backlog` |
-| No status-bearing label | `To triage` (implicit default) |
+| `needs-grooming` / `needs-design` | `Backlog` |
+| No status-bearing label | `To triage` or Linear `Triage`, depending on origin |
 
 Notable invariants:
 
-- **`To triage` is not a label.** It is the implicit default for an issue that
-  carries no status-bearing label (`in-progress` / `blocked` / `claude-ready` /
-  `needs-grooming` / `needs-design` / `design-approved`) — not a value written
-  anywhere on the issue.
+- **`To triage` is not a label.** It is the implicit default for a GitHub issue
+  that carries no status-bearing label (`in-progress` / `blocked` /
+  `claude-ready` / `needs-grooming` / `needs-design`) and
+  the explicit triage queue state for new Linear/GitHub integration intake.
 - **`blocked` beats `claude-ready`.** A blocked-but-groomed issue reads as
   `Blocked`, not `Ready`, so the ready set is always pickable.
 - **`In review` is intentionally not derived** for issues. An issue with
@@ -311,7 +311,7 @@ issues. Keep it consistent:
 |------|------------|--------|
 | **Initiative** | a pillar or durable workstream | Theme name in Title Case. A small, stable set (e.g. *Capability-Sealed Runtime*, *Structured Concurrency*, *Build & Toolchain*). Rarely added. |
 | **Project** | one epic | The deliverable as a concise Title-Case noun phrase, ≤ ~60 chars. Drop `Epic:` / `Tracking:` prefixes and any trailing `#N` / `SFEP-NNNN`. e.g. `CLI Modularization`, not `Epic: CLI modularization (SFEP-0027)`. |
-| **Issue** | a session-sized leaf | Unchanged — a GitHub issue with a Conventional-Commit title (above), mirrored into Linear. |
+| **Issue** | a session-sized leaf | A Linear `SFN-NNN` issue with a Conventional-Commit title (above), mirrored to GitHub when public tracking is needed; external GitHub issues mirror into Linear triage. |
 
 **Cross-links go in the project description, not the name.** Each Linear project's
 description carries the traceability the name omits:
@@ -325,43 +325,49 @@ issue belongs to exactly one project.
 
 When an epic is groomed, `/groom` creates (or reuses) a Linear Project under the
 right initiative following this convention, files the session-sized leaves as
-GitHub issues that mirror into it, and reflects their state per **§ Reflecting
-state into Linear** below. The skills are the primary reflection path; the
+Linear issues, and attaches or creates GitHub public mirrors when needed. The
+skills are the primary reflection path; the
 `Linear Priority Sync` GitHub Action (`.github/workflows/linear-priority-sync.yml`,
 using the Actions `LINEAR_API_KEY`) is a scheduled safety net that backfills the
 Linear-native **priority and estimate** on mirrors the skills didn't reach —
 notably the CI-auto-filed regression issues, whose mirror is created
 asynchronously after `gh issue create` (see the note in step 3 below).
 
-## Reflecting state into Linear
+## Reflecting state across Linear and GitHub
 
-Linear mirrors GitHub issues (via the GitHub↔Linear integration) and holds the
-epic/roadmap grouping (Linear Projects = epics). GitHub labels stay the **source
-of truth**; Linear status and project membership are **derived from them, one
-direction only** — never read Linear state back onto a GitHub issue.
+Linear holds maintainer planning state and epic/roadmap grouping (Linear
+Projects = epics). GitHub issues remain the public mirror and the close target
+for PRs that should use `Closes #N`.
 
-When a workflow (`/groom`, `/triage`, `/sweep`) creates an issue or flips a
-status-bearing label, it reflects the change into Linear with the Linear MCP
-tools (`list_issues`, `save_issue`, `list_projects`, `save_project`). This is
-**best-effort**: if the Linear MCP tools are not connected in the session, skip
-the reflection with a one-line note — never fail or block the GitHub-side work
-on it (the same posture the skills take when `gh` is unavailable).
+When a workflow (`/groom`, `/triage`, `/sweep`, `/pickup`) creates or claims
+work, it should update Linear first with the Linear MCP tools (`list_issues`,
+`save_issue`, `list_projects`, `save_project`). If a GitHub mirror exists, it
+also updates the mirror labels best-effort. If the Linear MCP tools are not
+connected in the session, fall back to GitHub and leave a one-line note; if
+GitHub is unavailable but Linear is available, continue with Linear and link the
+Linear issue in the PR.
 
-1. **Find the mirror.** A GitHub issue's Linear mirror is located with
+1. **Find or create the work item.** Maintainer/agent-created work starts as a
+   Linear issue under the Sailfin (`SFN`) team and uses native status, priority,
+   estimate, Project, Cycle, blocker, and assignee fields. The GitHub
+   integration creates or attaches a public mirror when needed. External
+   contributor issues start in GitHub and mirror into Linear triage.
+2. **Find the mirror.** A GitHub issue's Linear mirror is located with
    `list_issues` querying the issue's number or URL (the integration records the
    GitHub link on the mirror). A newly-created issue mirrors in
    **asynchronously** — allow a brief lag and retry a few times; if the mirror
    still isn't present, record it and let the next `/triage`/`/sweep` pass
    reconcile it. Never block on it.
-2. **Set issue status from labels** using the § Status semantics precedence
-   (first match wins). **Never** write `Done`, `Canceled`, or any terminal
-   status onto a mirror whose GitHub issue is still open — the two-way sync would
-   close the GitHub issue. Only the non-terminal statuses (In Progress, Blocked,
-   Ready, To triage, Backlog, Todo) are ever written.
-3. **Set priority and estimate on the mirror** (Linear-native fields — there is
-   no GitHub label for either). Priority is a judgement call carried from
-   grooming; estimate is derived mechanically from the `size:*` label. Use
-   `save_issue` with the numeric `priority` and `estimate`:
+3. **Set Linear issue status from the intended workflow state** using the
+   § Status semantics precedence when reconciling GitHub labels. **Never** write
+   `Done`, `Canceled`, or any terminal status onto a mirror whose GitHub issue
+   is still open — the two-way sync would close the GitHub issue. Only the
+   non-terminal statuses (In Progress, Blocked, Ready, To triage, Backlog, Todo)
+   are ever written by agent workflows.
+4. **Set priority and estimate in Linear** (Linear-native fields — there is no
+   GitHub label for either). Priority is a judgement call carried from grooming;
+   estimate is derived mechanically from the `size:*` label. Use `save_issue`
+   with the numeric `priority` and `estimate`:
 
    | Size label | Estimate |
    |---|---|
@@ -378,7 +384,7 @@ on it (the same posture the skills take when `gh` is unavailable).
    | Low | `4` |
 
    The estimate scale is the Sailfin team's **Linear (1–5)** scale. Every
-   `claude-ready` leaf gets both an estimate and a priority; if grooming set no
+   Linear `Ready` leaf gets both an estimate and a priority; if grooming set no
    explicit priority, default the leaf to its Project's priority. Never leave a
    promoted leaf at `No priority` / no estimate.
 
@@ -389,10 +395,10 @@ on it (the same posture the skills take when `gh` is unavailable).
    `size:*`, and priority for the regression classes
    (`build-quality-regression` → Urgent, `perf-regression` → Medium). It only
    fills unset values, so an interactively-set priority/estimate always wins.
-4. **Assign the issue to its epic's Project** if it isn't already, resolving the
-   Project from the epic (`epic`/parent reference) and creating it per § Linear
+5. **Assign the issue to its epic's Project** if it isn't already, resolving the
+   Project from the Linear Project or parent reference and creating it per § Linear
    structure & naming when it doesn't exist yet.
-5. **Roll up the Project status** from its issues: any issue In Progress →
+6. **Roll up the Project status** from its issues: any issue In Progress →
    Project `started`; else any Ready → `planned`; else `backlog`. Never
    `completed`/`canceled` from a workflow.
 
@@ -643,9 +649,9 @@ workflow that reads `.seed-version`.
 
 ## Milestones
 
-Milestones are phase markers, not calendar deadlines. Every `epic` issue
-should carry exactly one milestone; sub-task issues inherit the milestone
-of their parent epic via the GitHub parent/child link.
+Milestones are phase markers, not calendar deadlines. Epics are Linear Projects;
+session-sized issues inherit the relevant milestone from their Project or parent
+context.
 
 | Milestone | Track IDs | Captures |
 |-----------|-----------|----------|

--- a/docs/conventions/linear-templates.md
+++ b/docs/conventions/linear-templates.md
@@ -1,0 +1,171 @@
+# Linear Templates
+
+These templates are the source of truth for Sailfin Linear work. Linear's native
+issue, Project, and document template slots may be empty; agents should still
+follow this file when creating or updating Linear records.
+
+## Issue template
+
+Use this for maintainer-created work and pickup follow-ups.
+
+**Title**
+
+Use Conventional Commit shape when it helps scanning:
+
+```text
+<type>(<scope>): <imperative verb phrase>
+```
+
+Examples: `fix(parser): reject unterminated type effects`,
+`docs(sfep): record capsule import staging`.
+
+**Fields**
+
+| Field | Value |
+|---|---|
+| Team | `Sailfin` (`SFN`) |
+| Status | `Triage` for unclear intake, `Backlog` for scoped but not ready, `Ready` for fully groomed and unblocked leaves, `Blocked` when a blocker relation exists, `In Progress` only when claimed |
+| Project | Same Project as the current issue when the work belongs to the same epic |
+| Priority | Urgent = release/self-host/seed blocker; High = critical path; Medium = current-milestone enabling work; Low = polish or post-milestone work |
+| Estimate | `1` = XS, `2` = S, `3` = M; split or triage anything larger |
+| Labels | Canonical `type:*` and `area:*` labels only |
+| Relations | `related to` the source issue; `blocked by` only when work cannot start yet |
+
+Do not create or apply Linear labels for status, priority, estimate, release,
+blockers, assignee, cycle, or Project membership.
+
+**Description**
+
+```markdown
+## Goal
+
+One or two sentences describing the user-visible or maintainer-visible outcome.
+
+## Context
+
+- Found during: SFN-NNN / PR #NNN / GitHub #NNN
+- Project: <Linear Project or "unprojected: <reason>">
+- Design: SFEP-NNNN / design note / none
+
+## Scope
+
+In:
+- <concrete behavior, file family, or workflow>
+
+Out:
+- <nearby work intentionally left alone>
+
+## Acceptance criteria
+
+- <observable condition>
+- <test/docs/status expectation>
+
+## Verification
+
+- `<command>`
+- `<command>`
+
+## Links
+
+- Linear: SFN-NNN
+- GitHub: #NNN
+- PR: #NNN
+```
+
+## Project template
+
+Use a Linear Project for an epic: a deliverable with meaningful surface area,
+usually backed by an SFEP or design note. Do not use a Linear issue or GitHub
+issue as an epic.
+
+**Name**
+
+Use an outcome name, not a tracker label:
+
+```text
+Capsule Import Resolution
+```
+
+**Fields**
+
+| Field | Value |
+|---|---|
+| Team | `Sailfin` (`SFN`) |
+| Initiative | One existing durable pillar whenever possible |
+| Status | `Backlog` before grooming, `Planned` when leaves exist, `Started` when a leaf is in progress |
+| Priority | Highest priority of its current gating leaves |
+| Target | Release Cycle only when the epic gates that release |
+
+**Description**
+
+```markdown
+## Outcome
+
+The concrete capability this Project ships.
+
+## Design
+
+- SFEP: SFEP-NNNN / draft / none
+- Status doc impact: yes/no
+
+## Scope
+
+In:
+- <major capability>
+
+Out:
+- <explicit non-goal>
+
+## Leaf issue criteria
+
+- Leaves are XS/S/M.
+- Each Ready leaf has priority and estimate.
+- No leaf re-litigates an accepted SFEP.
+
+## Links
+
+- Docs/status:
+- GitHub mirror/tracker, if any:
+- Related Projects:
+```
+
+## Document template
+
+Use a Linear document for working notes, project briefings, and agent-readable
+context that should live beside Linear planning.
+
+**Title**
+
+```text
+<Project or topic>: <decision/context name>
+```
+
+**Body**
+
+```markdown
+## Purpose
+
+Why this document exists and what decision or context it preserves.
+
+## Current state
+
+The facts an agent or maintainer needs before acting.
+
+## Decisions
+
+- <decision, date, owner/source>
+
+## Open questions
+
+- <question and next owner>
+
+## Follow-ups
+
+- SFN-NNN: <title>
+
+## References
+
+- SFEP/design:
+- GitHub/PR:
+- Docs:
+```

--- a/docs/conventions/linear-workflow.md
+++ b/docs/conventions/linear-workflow.md
@@ -3,11 +3,15 @@
 This is the human-facing playbook for how work is organised across **Linear**
 and **GitHub Issues**. It is the front door; the dense, agent-facing mechanics
 live in [`issue-naming.md`](./issue-naming.md) (§ *Linear structure & naming*,
-§ *Reflecting state into Linear*, § *Release tracking*) and this file links to
+§ *Reflecting state across Linear and GitHub*, § *Release tracking*) and this file links to
 them rather than restating them.
 
 If you only remember one thing: **an epic is a Linear Project, not a GitHub
-issue.** GitHub issues are session-sized leaf work — nothing bigger.
+issue.** Issues are session-sized leaf work — nothing bigger.
+
+Repo-side Linear issue, Project, and document templates live in
+[`linear-templates.md`](./linear-templates.md). Use those templates when Linear's
+native template slots are empty or unavailable to an agent.
 
 ---
 
@@ -16,7 +20,7 @@ issue.** GitHub issues are session-sized leaf work — nothing bigger.
 ```
 Initiative        a pillar / durable theme          (Linear)      ~6, rarely added
    └─ Project     one epic                           (Linear)      the roadmap unit
-        └─ Issue  one session-sized piece of work    (GitHub → mirrored to Linear)
+        └─ Issue  one session-sized piece of work    (Linear ↔ GitHub public mirror)
              └─ (sub-issue)  a split of one leaf, optional
 ```
 
@@ -24,7 +28,7 @@ Initiative        a pillar / durable theme          (Linear)      ~6, rarely add
 |------|----|----------|----------------|
 | **Initiative** | A pillar or durable workstream (e.g. *Structured Concurrency*, *Build & Toolchain*). A small, stable set. | Linear | Set by hand; changes rarely. |
 | **Project** | Exactly one epic — a deliverable with real surface area and a design record (SFEP). | Linear | Rolled up from its issues; the design/context lives in the project **description**. |
-| **Issue** | One session-sized leaf (XS/S/M, never L). A `claude-ready` issue is pickable by `/pickup`. | Authored on **GitHub**, mirrored into Linear by the GitHub↔Linear integration. | **GitHub labels are the source of truth**; Linear status is derived from them one-way. |
+| **Issue** | One session-sized leaf (XS/S/M, never L). A Linear `Ready` issue is pickable by `/pickup`. | Authored in **Linear** for maintainer/agent work, mirrored to GitHub when public tracking is needed; external GitHub issues mirror into Linear triage. | **Linear owns status, priority, estimate, project, and assignee**. GitHub labels remain the public compatibility taxonomy. |
 
 A Project belongs to exactly one Initiative. A leaf Issue belongs to exactly one
 Project. Releases are a fourth, **orthogonal** axis — a Linear **Cycle**, never a
@@ -39,16 +43,15 @@ Project (see below).
    itself (or its Initiative). The old GitHub `Epic:` / `Tracking:` title shapes
    are **retired** — see [`issue-naming.md`](./issue-naming.md) § *Title
    taxonomy*.
-2. **GitHub issues are leaf work only.** If a would-be issue is too big for one
-   session (an `L`, or a "parent of many"), it is an epic → make it a Project and
+2. **Issues are leaf work only.** If a would-be issue is too big for one session
+   (an `L`, or a "parent of many"), it is an epic → make it a Project and
    `/groom` it into leaves.
-3. **Labels stay the source of truth** for issue state (`claude-ready`,
-   `in-progress`, `blocked`, `type:*`, `size:*`, `area:*`). Linear status is
-   *derived* from them; never hand-edit a mirror's status to drive the GitHub
-   side. **Priority and estimate are the exception — they are Linear-native
-   fields**, not labels: set them on the mirror at groom/triage time (priority
-   is a judgement call; estimate derives from `size:*`, xs/s/m → 1/2/3). There
-   is no `priority:*` GitHub label.
+3. **Linear is the maintainer planning source of truth.** Status, priority,
+   estimate, project, assignee, blockers, and cycle live on the Linear issue.
+   Do not create Linear labels that duplicate native Linear fields
+   (`blocked`, `in-progress`, `claude-ready`, `size:*`, `priority:*`,
+   `release:*`). GitHub labels stay as the public compatibility taxonomy for
+   external contributors, release automation, and GitHub-only fallbacks.
 4. **Project names are scannable; links go in the description.** Name a project
    for its outcome (`CLI Modularization`), not `Epic: CLI modularization
    (SFEP-0027)`. Put `GitHub: #N` and `Design: SFEP-NNNN` in the description.
@@ -73,9 +76,10 @@ ordinary issues associated to that Project.
 
 - **By epic (Linear):** the Sailfin team board grouped by Project shows every
   epic and its live issues. Filter to an Initiative to see one theme.
-- **Pickable now (GitHub or Linear):** open issues with `claude-ready`, not
-  `blocked`, not `in-progress`, no unclosed `Blocked by`. This is exactly what
-  `/pickup` selects; `/pickup` with no argument picks the top one.
+- **Pickable now (Linear first):** open Sailfin (`SFN`) issues in the native
+  `Ready` status, no unclosed `Blocked by`.
+  This is exactly what `/pickup` selects; `/pickup` with no argument picks the
+  top one, and `/pickup SFN-123` targets a specific Linear issue.
 - **Needs shaping:** `needs-grooming` → run `/groom`; `needs-design` → architect
   queue; `needs-discussion` → parked for a human.
 
@@ -88,13 +92,14 @@ ordinary issues associated to that Project.
 2. **Write the design as an SFEP** (`/sfep new <slug>` → `docs/proposals/`), and
    put `Design: SFEP-NNNN` in the project description. See
    [`.claude/rules/proposals.md`](../../.claude/rules/proposals.md).
-3. **Groom into leaves:** `/groom <epic>` decomposes it into session-sized GitHub
-   issues, ensures the Project exists, associates each leaf to the Project, and
-   reflects state into Linear. Each leaf cites the SFEP (`## Design`), it does not
-   re-litigate the design.
-4. **Work the leaves:** `/pickup` drives each from branch → PR; the `Closes #N`
-   merge closes the GitHub issue, and the GitHub↔Linear integration reflects that
-   closure onto the Linear mirror, rolling up the Project.
+3. **Groom into leaves:** `/groom <epic>` decomposes it into session-sized
+   Linear issues, ensures the Project exists, associates each leaf to the
+   Project, and lets the GitHub integration create or attach the public mirror
+   when needed. Each leaf cites the SFEP (`## Design`), it does not re-litigate
+   the design.
+4. **Work the leaves:** `/pickup` drives each from Linear issue → branch → PR.
+   If a GitHub mirror exists, the PR uses `Closes #N`; otherwise the PR links
+   `Linear: SFN-NNN` and the mirror can be attached later.
 5. **Graduate:** when the epic ships, flip its SFEP to `Implemented` and update
    `docs/status.md`.
 
@@ -112,5 +117,27 @@ retired *Sailfin Tracker* GitHub Project board (org project #4). The migration:
   a comment pointing to its Linear Project. (The `Release: v0.8.0` / `v0.9.0`
   trackers stayed open — release automation owns them.)
 
-From here, follow the rules above: epics are Projects, GitHub carries leaf work,
-and no new GitHub `Epic:`/`Tracking:` issues are opened.
+From here, follow the rules above: epics are Projects, Linear carries maintainer
+leaf work, GitHub remains the public mirror, and no new GitHub
+`Epic:`/`Tracking:` issues are opened.
+
+## Linear labels
+
+Linear team labels should be smaller than the GitHub label registry. Use them
+only for dimensions Linear does not already model natively, mainly `type:*` and
+`area:*` classification. Use native Linear fields for status, priority,
+estimate, Project, Cycle, blockers, assignee, and duplicate/canceled state.
+
+The Linear MCP tools available to Codex can create labels, but they do not
+currently expose label edit/delete. Clean up stale Linear labels in the Linear
+UI when convenient:
+
+- Delete or archive native-field duplicates: `blocked`, `in-progress`,
+  `claude-ready`, `size:xs`, `size:s`, `size:m`, `size:l`, `release:*`,
+  `priority:critical`, `priority:high`, `priority:medium`, `priority:low`.
+- Delete or archive non-canonical migrated labels when no issue still needs
+  them: `type:enhancement`, `type:chore`, `workstream`, `agentic-workflows`,
+  `area:perf`, plus the default `Bug`/`Feature`/`Improvement` labels if they are
+  unused.
+- Delete `epic` and `tracking` from Linear labels. Epics are Projects; releases
+  are Cycles. The GitHub `tracking` label remains only for release automation.


### PR DESCRIPTION
## Summary

- Make Linear the maintainer source of truth for issue status, priority, estimate, project membership, blockers, and pickup selection.
- Update Codex pickup docs/skill to accept `SFN-123`, prefer Linear `Ready` issues, claim Linear first, and file out-of-scope follow-ups as Linear issues with native fields.
- Clean up the GitHub label registry for public compatibility only, including retired aliases/deletions and Dependabot label simplification.
- Add repo-backed Linear issue, project, and document templates, plus a matching Linear team document for agent/human reference.

## Validation

- `git diff --cached --check`
- `git diff --check`
- `./scripts/setup-github-labels.sh --repo SailfinIO/sailfin --dry-run`
- `gh label list --repo SailfinIO/sailfin --limit 200 --json name --jq 'length'`

## Notes

Linear native template slots still need to be populated manually in the Linear UI if we want them to appear in the template picker. The Linear connector can create normal documents but does not expose native template CRUD.