### PR TITLE
docs(sfep): graduate SFEP-0043 to Implemented and number it

### DIFF
--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -1750,7 +1750,7 @@ Measured across 199 modules (rewind OFF vs ON, same binary):
 Global win across all pipeline stages; 2 known regressions (`capsule_resolver`
 +18%, `core_literals_lowering` +8%) — small front-half modules where the
 relocated-text copy exceeds reclaimed garbage; neither sets the new peak.
-Design record: `docs/proposals/draft-phase-scoped-arena-reclamation.md` (SFEP-0043).
+Design record: `docs/proposals/0043-phase-scoped-arena-reclamation.md` (SFEP-0043).
 
 ---
 

--- a/docs/proposals/0043-phase-scoped-arena-reclamation.md
+++ b/docs/proposals/0043-phase-scoped-arena-reclamation.md
@@ -1,21 +1,22 @@
 ---
-sfep: TBD
+sfep: 0043
 title: Phase-scoped arena reclamation to reduce per-module peak RSS
-status: Draft
+status: Implemented
 type: runtime            # language | runtime | tooling | process | informational
 created: 2026-07-07
 updated: 2026-07-07
 author: "agent:compiler-architect; human review"
-tracking:                # fill with the grooming epic / issue numbers
+tracking: "#1989"
 supersedes:
 superseded-by:
-graduates-to:
+graduates-to: "docs/status.md (Runtime Migration); docs/proposals/0006-build-architecture.md (perf section)"
 ---
 
-# SFEP-XXXX — Phase-scoped arena reclamation to reduce per-module peak RSS
+# SFEP-0043 — Phase-scoped arena reclamation to reduce per-module peak RSS
 
-> Draft. Number assigned at merge (next = registry max + 1 → **0043**). Filename
-> stays `draft-` until then.
+> Implemented in #1989 (merged). Self-hosts; byte-identical `.ll` with the
+> rewind on vs off, gated by the e2e test
+> `compiler/tests/e2e/arena_phase_rewind_ll_identity_test.sfn`.
 
 ## 1. Summary
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -65,6 +65,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0040](./0040-artifact-cache.md) | Global Artifact Cache Store and Garbage Collection | Accepted | tooling |
 | [0041](./0041-typeck-expected-type-context.md) | Unified expected-type + typing-environment context for the typecheck walk | Implemented | tooling |
 | [0042](./0042-nested-function-declarations.md) | Nested / Local Function Declarations (non-capturing static `fn` items) | Accepted | language |
+| [0043](./0043-phase-scoped-arena-reclamation.md) | Phase-scoped arena reclamation to reduce per-module peak RSS | Implemented | runtime |
 
 ## Drafts under review (numbers assigned at merge)
 


### PR DESCRIPTION
Housekeeping the SFEP-0043 design record that #1989 (phase-scoped arena reclamation, merged) deferred. Per `.claude/rules/proposals.md`, an SFEP that ships graduates to `Implemented` and gets numbered + a registry row in the merging PR — #1989 kept the `draft-` name, so this catches it up.

## Changes
- Rename `draft-phase-scoped-arena-reclamation.md` → `0043-phase-scoped-arena-reclamation.md`.
- Frontmatter: `sfep: TBD` → `0043`; `status: Draft` → `Implemented`; `tracking: "#1989"`; `graduates-to:` → status.md + 0006 perf section. H1 `SFEP-XXXX` → `SFEP-0043`; the "number assigned at merge" note replaced with the implemented/self-hosts note.
- Add the `0043` row to `docs/proposals/README.md` registry.
- Repoint the `0006-build-architecture.md` design-record link to the numbered filename.

## Why Implemented
Clears the Stage1 readiness bar end-to-end: parses/typechecks/emits/lowers, **self-hosts**, byte-identical `.ll` with rewind on vs off (e2e `arena_phase_rewind_ll_identity_test.sfn`), fmt-clean, documented (status.md + 0006). Shipped result: −16.7% peak / −22.5% mean per-module RSS at neutral wall.

Docs-only — no `.sfn` touched, no self-host gate needed.