### PR TITLE
feat(cli): emit a machine-readable command tree via `--help --json`

### DIFF
--- a/capsules/sfn/cli/src/help.sfn
+++ b/capsules/sfn/cli/src/help.sfn
@@ -75,6 +75,148 @@ fn render_help_tree(cmd: Command) -> HelpNode {
     };
 }
 
+fn render_help_json(node: HelpNode) -> string {
+    // Render the complete command tree as a stable machine-readable JSON
+    // envelope. The text help path continues to consume the same HelpNode, so
+    // `--help` and `--help --json` cannot drift in command/flag coverage.
+    return "{" + _json_number_field("schema_version", 1) + "," + _json_field("command", _render_help_node_json(node))
+        + "}";
+}
+
+fn _render_help_node_json(node: HelpNode) -> string {
+    let mut parts: string[] = [];
+    parts.push(_json_string_field("name", node.name));
+    parts.push(_json_string_field("description", node.description));
+    parts.push(_json_string_field("version", node.version));
+    parts.push(_json_field("flags", _render_help_flags_json(node.flags)));
+    parts.push(_json_field("positionals", _render_help_positionals_json(node.positionals)));
+    parts.push(_json_field("subcommands", _render_help_nodes_json(node.subcommands)));
+    return "{" + _json_join(parts, ",") + "}";
+}
+
+fn _render_help_nodes_json(nodes: HelpNode[]) -> string {
+    let mut parts: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= nodes.length { break; }
+        parts.push(_render_help_node_json(nodes[i]));
+        i += 1;
+    }
+    return "[" + _json_join(parts, ",") + "]";
+}
+
+fn _render_help_flags_json(flags: HelpFlag[]) -> string {
+    let mut parts: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= flags.length { break; }
+        let f = flags[i];
+        let mut fields: string[] = [];
+        fields.push(_json_string_field("name", f.long_name));
+        fields.push(_json_string_field("short", f.short_name));
+        fields.push(_json_bool_field("takes_value", f.takes_value));
+        fields.push(_json_string_field("description", f.description));
+        fields.push(_json_bool_field("required", f.required));
+        fields.push(_json_string_field("env", f.env_var));
+        parts.push("{" + _json_join(fields, ",") + "}");
+        i += 1;
+    }
+    return "[" + _json_join(parts, ",") + "]";
+}
+
+fn _render_help_positionals_json(args: HelpPositional[]) -> string {
+    let mut parts: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= args.length { break; }
+        let a = args[i];
+        let mut fields: string[] = [];
+        fields.push(_json_string_field("name", a.name));
+        fields.push(_json_string_field("description", a.description));
+        fields.push(_json_bool_field("optional", a.is_optional));
+        fields.push(_json_bool_field("variadic", a.is_variadic));
+        fields.push(_json_string_field("default", a.default_value));
+        parts.push("{" + _json_join(fields, ",") + "}");
+        i += 1;
+    }
+    return "[" + _json_join(parts, ",") + "]";
+}
+
+fn _json_escape_string(s: string) -> string {
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
+            out = out + "\\\\";
+        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
+            out = out + "\\r";
+        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+fn _json_quote(s: string) -> string {
+    return "\"" + _json_escape_string(s) + "\"";
+}
+
+fn _json_field(name: string, value: string) -> string {
+    return _json_quote(name) + ":" + value;
+}
+
+fn _json_string_field(name: string, value: string) -> string {
+    return _json_field(name, _json_quote(value));
+}
+
+fn _json_bool_field(name: string, value: boolean) -> string {
+    if value { return _json_field(name, "true"); }
+    return _json_field(name, "false");
+}
+
+fn _json_number_field(name: string, value: int) -> string {
+    return _json_field(name, _json_number_to_string(value));
+}
+
+fn _json_number_to_string(value: int) -> string {
+    if value == 0 { return "0"; }
+    let digits = "0123456789";
+    let mut working = value;
+    let mut negative = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let mut out = "";
+    loop {
+        if working <= 0 { break; }
+        let mut temp = working;
+        let mut quotient = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        out = substring(digits, temp, temp + 1) + out;
+        working = quotient;
+    }
+    if negative { out = "-" + out; }
+    return out;
+}
+
+fn _json_join(parts: string[], sep: string) -> string {
+    if parts.length == 0 { return ""; }
+    let mut out = parts[0];
+    let mut i: int = 1;
+    loop {
+        if i >= parts.length { break; }
+        out = out + sep + parts[i];
+        i += 1;
+    }
+    return out;
+}
+
 fn render_help_text(node: HelpNode) -> string {
     // Render a `HelpNode` into the `--help` string. Pure (no `![io]`).
     // The usage-line program name is `node.name`.

--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -127,6 +127,7 @@ export {
     help,
     print_help,
     render_help_tree,
+    render_help_json,
     render_help_text
 } from "./help";
 

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -31,6 +31,8 @@ import {
     ParseResult,
     command,
     parse,
+    render_help_json,
+    render_help_tree,
     subcommand,
     subcommand_path,
     with_subcommand
@@ -143,6 +145,20 @@ fn _v2_trace_argv(argv: string[]) ![io] {
     }
 }
 
+fn _is_help_json_args(args: string[]) -> boolean {
+    if args.length != 2 { return false; }
+    if strings_equal(args[0], "--help") {
+        return strings_equal(args[1], "--json");
+    }
+    if strings_equal(args[0], "-h") {
+        return strings_equal(args[1], "--json");
+    }
+    if strings_equal(args[0], "help") {
+        return strings_equal(args[1], "--json");
+    }
+    return false;
+}
+
 fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // Parse the driver-injected `--runtime-root` / `--binary-dir` prefix
     // (Issue 2.2) so `binary_dir` is available for version resolution
@@ -196,6 +212,15 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     root = with_subcommand(root, check_command_def());
     root = with_subcommand(root, build_command_def());
     root = with_subcommand(root, run_command_def());
+
+    // Machine-readable top-level help for tools and agents. This bypasses
+    // `parse()` intentionally: `--json` is a modifier for root help, not a
+    // root command flag, so the human-readable `sfn --help` path below stays
+    // byte-for-byte unchanged.
+    if _is_help_json_args(args) {
+        print(render_help_json(render_help_tree(root)));
+        return 0;
+    }
 
     // Preserve the legacy `--emit` long-flag alias (`sfn --emit llvm x.sfn`):
     // the legacy dispatch treated `--emit` as the first token identically to

--- a/compiler/tests/e2e/cli_help_json_test.sfn
+++ b/compiler/tests/e2e/cli_help_json_test.sfn
@@ -1,0 +1,54 @@
+// End-to-end coverage for `sfn --help --json` command-tree introspection.
+//
+// The JSON is emitted from the live `sfn/cli` HelpNode derived from the root
+// command tree, not a hand-maintained fixture. This test pins discoverability,
+// top-level command coverage, and deterministic output across runs.
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    return e;
+}
+
+fn _assert_top_command(out: string, name: string) {
+    assert contains(out, "\"name\":\"" + name + "\"");
+}
+
+test "cli help json: stable envelope includes registered top-level commands" ![io] {
+    let exit1 = process.run_capture([_sfn_bin(), "--help", "--json"], _child_env());
+    let out1 = process.capture_take_stdout();
+    let err1 = process.capture_take_stderr();
+    assert exit1 == 0;
+    assert err1.length == 0;
+
+    let exit2 = process.run_capture([_sfn_bin(), "--help", "--json"], _child_env());
+    let out2 = process.capture_take_stdout();
+    let err2 = process.capture_take_stderr();
+    assert exit2 == 0;
+    assert err2.length == 0;
+    assert strings_equal(out1, out2);
+
+    assert contains(out1, "\"schema_version\":1");
+    assert contains(out1, "\"command\":{");
+    _assert_top_command(out1, "build");
+    _assert_top_command(out1, "run");
+    _assert_top_command(out1, "check");
+    _assert_top_command(out1, "test");
+    _assert_top_command(out1, "fmt");
+    _assert_top_command(out1, "add");
+    assert contains(out1, "\"flags\":[");
+    assert contains(out1, "\"takes_value\":");
+    assert contains(out1, "\"description\":");
+}


### PR DESCRIPTION
### Motivation

- Provide a stable, machine-readable JSON dump of the live `sfn/cli` command tree so tools and agents can introspect commands/flags without scraping human-readable help. 
- Reuse the existing help tree (`HelpNode`) as the single source of truth so text and JSON renderers cannot drift. 
- Expose the dump via a discoverable invocation that does not change the existing human-readable `sfn --help` behavior.

### Description

- Added a JSON renderer in `capsules/sfn/cli/src/help.sfn` (`render_help_json` and helper encoders) that serializes `HelpNode` (commands, subcommands, flags, positionals) into a stable schema-versioned envelope. 
- Exported `render_help_json` from the `sfn/cli` capsule in `capsules/sfn/cli/src/mod.sfn`. 
- Wired top-level argument detection in `compiler/src/cli/main.sfn` via `_is_help_json_args(args)` to print the JSON envelope on `sfn --help --json`, `sfn -h --json`, and `sfn help --json` while leaving the human-readable `--help` path unchanged. 
- Added end-to-end regression test `compiler/tests/e2e/cli_help_json_test.sfn` that asserts deterministic output across runs and verifies presence of known top-level commands and expected JSON fields.

### Testing

- Ran `make compile` and the native compiler build step, which succeeded. 
- Ran formatter and checks with `build/native/sailfin fmt --write capsules/sfn/cli/src/help.sfn capsules/sfn/cli/src/mod.sfn compiler/src/cli/main.sfn compiler/tests/e2e/cli_help_json_test.sfn` and `build/native/sailfin fmt --check ...`, both succeeded. 
- Verified runtime JSON emission and basic parsing with `build/native/sailfin --help --json > /tmp/sfn-help.json && python3 -m json.tool /tmp/sfn-help.json`, and validated required top-level command names with a small Python check, which succeeded. 
- Executed the new e2e test with `build/native/sailfin test compiler/tests/e2e/cli_help_json_test.sfn`, which passed (1 test, all assertions passed). 

Environment notes: the verification required a working `build/native/sailfin` (the repository's seed fetch + native build ran during checks), so CI or local verification must either provide the built `sailfin` binary or allow the seed/native build steps to run; no agent errors occurred during these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4db02b6bd483249a6b0df00d26dbb3)