### PR TITLE
perf(build): in-process SHA-256 for text artifacts — retire popen hashing on the hot path

### DIFF
--- a/compiler/src/build/fs.sfn
+++ b/compiler/src/build/fs.sfn
@@ -4,6 +4,7 @@
 // relocated from `cli_commands_utils` (SFEP-0027 §3.5); leave the
 // `compiler-common` boundary to #345.
 import { substring } from "../string_utils";
+import { sha256_hex_of_string } from "./hash";
 
 fn _ends_with_cmd(value: string, suffix: string) -> boolean {
     if suffix.length == 0 { return true; }
@@ -238,6 +239,35 @@ fn _sha256_of_file_cmd(file_path: string) -> string ![io] {
     return _shell_read_cmd(cmd);
 }
 
+// Compute the SHA-256 hex digest of a NUL-free text file in-process,
+// without spawning a subprocess. Returns `""` when the file does not
+// exist or cannot be read, preserving the `_sha256_of_file_cmd`
+// failure contract (empty digest → not content-addressable → recompile).
+//
+// SOUND ONLY for NUL-free text artifacts: .sfn source, .ll LLVM IR,
+// .toml manifests, .h/.c headers, layout manifests. `fs.readFile`
+// coerces the `i8*` return to a Sailfin string via `strlen`
+// (core_operands.sfn:1013–1043), which truncates at the first NUL byte.
+// Binary artifacts (compiled binaries, tarballs, archives) MUST use
+// `_sha256_of_file_cmd`. When #1999 lands a binary-safe `fs.readBinary`
+// builtin, this split can be collapsed: replace `_sha256_of_text_file`
+// with a single in-process path over `fs.readBinary` and retire
+// `_sha256_of_file_cmd` from all hashing callers (#1995, #1999).
+fn _sha256_of_text_file(file_path: string) -> string ![io] {
+    if !fs.exists(file_path) { return ""; }
+    let contents = fs.readFile(file_path);
+    if contents.length == 0 {
+        // Distinguish "empty file" from "read error": an empty file has
+        // the well-known empty-string digest; an unreadable file should
+        // return "" to signal the caller. fs.readFile returns "" on read
+        // failure, so we treat zero-length as a miss (recompile). Files
+        // with real zero-byte content produce the same cache-miss outcome
+        // as they would under _sha256_of_file_cmd ("" on failure).
+        return "";
+    }
+    return sha256_hex_of_string(contents);
+}
+
 export {
     _dirname_cmd,
     _path_join_cmd,
@@ -253,5 +283,6 @@ export {
     _toml_trim_cmd,
     _shell_read_cmd,
     _shell_single_quote_arg,
-    _sha256_of_file_cmd
+    _sha256_of_file_cmd,
+    _sha256_of_text_file
 };

--- a/compiler/src/build/fs.sfn
+++ b/compiler/src/build/fs.sfn
@@ -253,9 +253,23 @@ fn _sha256_of_file_cmd(file_path: string) -> string ![io] {
 // builtin, this split can be collapsed: replace `_sha256_of_text_file`
 // with a single in-process path over `fs.readBinary` and retire
 // `_sha256_of_file_cmd` from all hashing callers (#1995, #1999).
+//
+// Inputs larger than 64 KiB fall back to the subprocess pipeline: the
+// vendored hasher's byte loop collapses under -O0 compiler builds (the
+// CI shard configuration) — hashing multi-hundred-KB .ll files
+// in-process pushed the linux int-caps shard from ~6 min to ~23 min and
+// drove selfhost_diff_test.sfn into its 300 s per-file kill (PR #2000
+// triage). One popen (~30 ms) beats seconds of -O0 hashing; the
+// in-process win is the many small .sfn/.toml sources, which stay under
+// the threshold. Retire the threshold together with the split (#1999),
+// or earlier if CI shard builds move off -O0.
 fn _sha256_of_text_file(file_path: string) -> string ![io] {
     if !fs.exists(file_path) { return ""; }
     let contents = fs.readFile(file_path);
+    let inprocess_max = 65536;
+    if contents.length > inprocess_max {
+        return _sha256_of_file_cmd(file_path);
+    }
     if contents.length == 0 {
         // Distinguish "empty file" from "read error": an empty file has
         // the well-known empty-string digest; an unreadable file should

--- a/compiler/src/build/hash.sfn
+++ b/compiler/src/build/hash.sfn
@@ -1,0 +1,169 @@
+// compiler/src/build/hash.sfn
+//
+// In-process SHA-256 for the build driver. Vendored from
+// `capsules/sfn/crypto/src/mod.sfn` (#1995,
+// `docs/proposals/draft-test-runner-invocation-cache.md` §3-B).
+// Vendoring avoids adding `sfn/crypto` to the compiler's dependency
+// closure while keeping the algorithm identical — both copies are
+// cross-checked against `sha256sum` by
+// `compiler/tests/e2e/build_hash_matches_sha256sum_test.sfn`.
+//
+// `sha256_hex_of_string` is the sole public export. It hashes the raw
+// bytes of its input using the Sailfin string's length field (not a
+// NUL scan), so it is safe for any in-memory string — including strings
+// that contain embedded NUL bytes. It is NOT safe to use on content
+// loaded via `fs.readFile`, whose `i8* → {i8*, i64}` coercion computes
+// the length with `strlen` and therefore truncates at the first NUL
+// (core_operands.sfn NUL-truncation, diagnosed in #1995). Use
+// `_sha256_of_text_file` (./fs.sfn) for NUL-free text artifacts, or
+// keep `_sha256_of_file_cmd` for binary artifacts.
+// Rotate a 32-bit word right by `n` bits. All intermediate values are
+// masked to 32 bits because `>>` lowers to LLVM `ashr` (arithmetic
+// shift); masking keeps every value non-negative so `ashr` behaves as
+// the logical shift SHA-256 requires.
+fn _sha256_rotr(x: int, n: int) -> int {
+    return ((x >> n) | (x << (32 - n))) & 4294967295;
+}
+
+// Render a 32-bit word as exactly 8 lowercase hex characters.
+fn _sha256_word_hex(x: int) -> string {
+    let digits: string[] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f",];
+    let mut out: string = "";
+    let mut shift: int = 28;
+    loop {
+        if shift < 0 { break; }
+        out = out + digits[(x >> shift) & 15];
+        shift -= 4;
+    }
+    return out;
+}
+
+// sha256_hex_of_string — compute the SHA-256 digest of `s` (FIPS 180-4)
+// and return the bare 64-character lowercase hex string.
+//
+// Iterates over bytes using `s.length` (length-based, not NUL-terminated),
+// so embedded NUL bytes are hashed correctly. Digests match `sha256sum`
+// on the same byte sequence.
+//
+// Hex literals are unavailable in Sailfin source, so round constants and
+// the initial hash state are written in decimal.
+fn sha256_hex_of_string(s: string) -> string {
+    let mask: int = 4294967295;
+
+    let mut bytes: int[] = [];
+    let mut bi: int = 0;
+    loop {
+        if bi >= s.length { break; }
+        bytes.push(char_code(s[bi]) & 255);
+        bi += 1;
+    }
+    let bit_len: int = bytes.length * 8;
+
+    // Pad: 0x80, then zeros until length ≡ 56 (mod 64), then the
+    // 64-bit big-endian message-length in bits.
+    bytes.push(128);
+    loop {
+        if (bytes.length % 64) == 56 { break; }
+        bytes.push(0);
+    }
+    let hi: int = (bit_len >> 32) & mask;
+    let lo: int = bit_len & mask;
+    bytes.push((hi >> 24) & 255);
+    bytes.push((hi >> 16) & 255);
+    bytes.push((hi >> 8) & 255);
+    bytes.push(hi & 255);
+    bytes.push((lo >> 24) & 255);
+    bytes.push((lo >> 16) & 255);
+    bytes.push((lo >> 8) & 255);
+    bytes.push(lo & 255);
+
+    // Round constants K[0..63].
+    let k: int[] = [1116352408, 1899447441, 3049323471, 3921009573, 961987163, 1508970993, 2453635748, 2870763221, 3624381080, 310598401, 607225278, 1426881987, 1925078388, 2162078206, 2614888103, 3248222580, 3835390401, 4022224774, 264347078, 604807628, 770255983, 1249150122, 1555081692, 1996064986, 2554220882, 2821834349, 2952996808, 3210313671, 3336571891, 3584528711, 113926993, 338241895, 666307205, 773529912, 1294757372, 1396182291, 1695183700, 1986661051, 2177026350, 2456956037, 2730485921, 2820302411, 3259730800, 3345764771, 3516065817, 3600352804, 4094571909, 275423344, 430227734, 506948616, 659060556, 883997877, 958139571, 1322822218, 1537002063, 1747873779, 1955562222, 2024104815, 2227730452, 2361852424, 2428436474, 2756734187, 3204031479, 3329325298,];
+
+    // Initial hash state H[0..7].
+    let mut h0: int = 1779033703;
+    let mut h1: int = 3144134277;
+    let mut h2: int = 1013904242;
+    let mut h3: int = 2773480762;
+    let mut h4: int = 1359893119;
+    let mut h5: int = 2600822924;
+    let mut h6: int = 528734635;
+    let mut h7: int = 1541459225;
+
+    let num_blocks: int = bytes.length / 64;
+    let mut block: int = 0;
+    loop {
+        if block >= num_blocks { break; }
+        let base: int = block * 64;
+
+        let mut w: int[] = [];
+        let mut t: int = 0;
+        loop {
+            if t >= 16 { break; }
+            let j: int = base + t * 4;
+            let word: int = ((bytes[j] << 24) | (bytes[j + 1] << 16) | (bytes[j
+                + 2] << 8) | bytes[j
+                + 3]) & mask;
+            w.push(word);
+            t += 1;
+        }
+        t = 16;
+        loop {
+            if t >= 64 { break; }
+            let w15: int = w[t - 15];
+            let w2: int = w[t - 2];
+            let s0: int = (_sha256_rotr(w15, 7) ^ _sha256_rotr(w15, 18) ^ ((w15 >> 3) & mask)) & mask;
+            let s1: int = (_sha256_rotr(w2, 17) ^ _sha256_rotr(w2, 19) ^ ((w2 >> 10) & mask)) & mask;
+            w.push((w[t - 16] + s0 + w[t - 7] + s1) & mask);
+            t += 1;
+        }
+
+        let mut a: int = h0;
+        let mut b: int = h1;
+        let mut c: int = h2;
+        let mut d: int = h3;
+        let mut e: int = h4;
+        let mut f: int = h5;
+        let mut g: int = h6;
+        let mut h: int = h7;
+
+        let mut r: int = 0;
+        loop {
+            if r >= 64 { break; }
+            let big_s1: int = (_sha256_rotr(e, 6) ^ _sha256_rotr(e, 11) ^ _sha256_rotr(e, 25)) & mask;
+            let ch: int = ((e & f) ^ ((mask ^ e) & g)) & mask;
+            let temp1: int = (h + big_s1 + ch + k[r] + w[r]) & mask;
+            let big_s0: int = (_sha256_rotr(a, 2) ^ _sha256_rotr(a, 13) ^ _sha256_rotr(a, 22)) & mask;
+            let maj: int = ((a & b) ^ (a & c) ^ (b & c)) & mask;
+            let temp2: int = (big_s0 + maj) & mask;
+            h = g;
+            g = f;
+            f = e;
+            e = (d + temp1) & mask;
+            d = c;
+            c = b;
+            b = a;
+            a = (temp1 + temp2) & mask;
+            r += 1;
+        }
+
+        h0 = (h0 + a) & mask;
+        h1 = (h1 + b) & mask;
+        h2 = (h2 + c) & mask;
+        h3 = (h3 + d) & mask;
+        h4 = (h4 + e) & mask;
+        h5 = (h5 + f) & mask;
+        h6 = (h6 + g) & mask;
+        h7 = (h7 + h) & mask;
+        block += 1;
+    }
+
+    return _sha256_word_hex(h0) + _sha256_word_hex(h1) + _sha256_word_hex(h2)
+        + _sha256_word_hex(h3)
+        + _sha256_word_hex(h4)
+        + _sha256_word_hex(h5)
+        + _sha256_word_hex(h6)
+        + _sha256_word_hex(h7);
+}
+
+export { sha256_hex_of_string };

--- a/compiler/src/build/runtime_objs.sfn
+++ b/compiler/src/build/runtime_objs.sfn
@@ -27,6 +27,7 @@ import {
     _atomic_rename_into_place,
     _mktemp_sibling_cmd,
     _sha256_of_file_cmd,
+    _sha256_of_text_file,
     _shell_read_cmd,
     _shell_single_quote_arg
 } from "./fs";
@@ -326,7 +327,7 @@ fn _runtime_obj_key_with_sibling_deps(base_key: string, ctx_root: string, slug: 
     let mut i: int = 0;
     loop {
         if i >= deps.length { break; }
-        let dep_hash = _sha256_of_file_cmd(deps[i]);
+        let dep_hash = _sha256_of_text_file(deps[i]);
         if dep_hash.length == 0 { return ""; }
         key = key + "\n" + dep_hash;
         i += 1;

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -75,10 +75,12 @@ import {
     _ensure_dir_recursive_cmd,
     _sanitize_filename_cmd,
     _sha256_of_file_cmd,
+    _sha256_of_text_file,
     _shell_read_cmd,
     _shell_single_quote_arg,
     _write_text_cmd
 } from "./build/fs";
+import { sha256_hex_of_string } from "./build/hash";
 import { _get_env_cmd } from "./build_flags";
 import { char_code_at_text, find_last_index_of_char, substring } from "./string_utils";
 
@@ -842,47 +844,13 @@ fn cache_store_artifact(root: string, key: CacheKey, kind: string, src_path: str
 // ----------------------------------------------------------------
 // Hashing helpers
 // ----------------------------------------------------------------
-// Hash a string by writing it to a tmp file and sha256ing.
-// `unique_suffix` is sanitized through `_sanitize_filename_cmd`
-// before being concatenated into the tmp path so a stray slash
-// or shell metacharacter cannot escape `/tmp/.sfn_build_cache_*`
-// or break the downstream `sha256sum '<path>'` shell invocation.
-//
-// Cross-process race fix: two parallel workers calling this with the
-// same sanitized suffix used to collide on the single fixed tmp path
-// `/tmp/.sfn_build_cache_hash_<suffix>` — one worker `rm -f`'d the file
-// out from under another's `sha256sum`, surfacing as
-// `sha256sum: /tmp/.sfn_build_cache_hash_…: No such file or directory`
-// and a roaming build-and-run failure under the parallel test pool /
-// `make check --jobs N` (macOS nightly self-host check). The runtime
-// object cache-key path (`runtime_object_entry_key_from_str`) hashes a
-// per-source `hash_suffix` (`cap_prefix + basename + opt_flag`) that is
-// IDENTICAL across concurrent builds of the same runtime source, so the
-// collision is process-global — independent of `SAILFIN_TEST_SCRATCH`.
-//
-// Fix: derive a per-process-unique tmp path via `mktemp` (same pattern
-// as `_cache_atomic_copy`). `mktemp` guarantees a fresh, exclusively
-// created file, so no two workers ever share the path. Falls back to the
-// legacy fixed path when `mktemp` is unavailable (degrades to the prior
-// single-process behaviour rather than failing the hash).
+// Hash a string in-process via the vendored SHA-256 (#1995,
+// `docs/proposals/draft-test-runner-invocation-cache.md` §3-B).
+// `unique_suffix` is accepted for API compatibility but is unused:
+// the in-process path has no shared tmp file and therefore no race
+// (the mktemp workaround is now moot).
 fn _sha256_of_string(input: string, unique_suffix: string) -> string ![io] {
-    let safe_suffix = _sanitize_filename_cmd(unique_suffix);
-    let template = _shell_single_quote_arg("/tmp/.sfn_build_cache_hash_"
-        + safe_suffix
-        + ".XXXXXX");
-    let tmp = _shell_read_cmd("mktemp " + template + " 2>/dev/null");
-    if tmp.length == 0 {
-        // mktemp unavailable — degrade to the legacy fixed path.
-        let fixed = "/tmp/.sfn_build_cache_hash_" + safe_suffix;
-        _write_text_cmd(fixed, input);
-        let fixed_digest = _sha256_of_file_cmd(fixed);
-        process.run(["rm", "-f", fixed]);
-        return fixed_digest;
-    }
-    _write_text_cmd(tmp, input);
-    let digest = _sha256_of_file_cmd(tmp);
-    process.run(["rm", "-f", tmp]);
-    return digest;
+    return sha256_hex_of_string(input);
 }
 
 // ----------------------------------------------------------------
@@ -985,16 +953,20 @@ fn canonicalize_flags(flags: string[]) -> string {
 // ----------------------------------------------------------------
 // Content-hash primitive (shared)
 // ----------------------------------------------------------------
-// Public wrapper over the private `_sha256_of_file_cmd` so callers
-// outside this module can content-address their own artifacts
-// without reaching into `build/fs.sfn` internals. Promoted to
-// a single exported helper per #514's plan; the runtime C-object
-// cache (#632) is the first external consumer. Returns "" if the
-// file can't be hashed (missing source, sha tool absent) — callers
-// must treat an empty hash as "not content-addressable" and fall
-// back to recompile rather than risk a stale hit.
+// Content-address a NUL-free text artifact (`.sfn` source, `.ll` LLVM IR,
+// `.toml` manifest, `.layout.manifest`, `.h`/`.c` header). Delegates to
+// `_sha256_of_text_file`, which reads via `fs.readFile`; that call coerces
+// the `i8*` return to a Sailfin string via `strlen`
+// (core_operands.sfn:1013–1043) and therefore truncates at the first NUL
+// byte. Binary artifacts (compiled binaries, tarballs, archives) MUST NOT
+// use this wrapper — route them through `_sha256_of_file_cmd` in
+// `build/fs.sfn` instead. When #1999 lands a binary-safe read builtin, the
+// two paths can be collapsed. Returns "" if the file does not exist or
+// cannot be read — callers must treat an empty hash as "not
+// content-addressable" and fall back to recompile rather than risk a stale
+// hit (#514, #632).
 fn sha256_of_file(file_path: string) -> string ![io] {
-    return _sha256_of_file_cmd(file_path);
+    return _sha256_of_text_file(file_path);
 }
 
 // Content-addressed cache key for a runtime C / LL object compile.
@@ -1125,13 +1097,13 @@ fn runtime_object_entry_key_from_str(key_str: string, hash_suffix: string) -> Ca
 // carry distinct slugs, which incidentally keeps the `sha256sum` temp
 // filenames below from colliding across concurrent workers.
 fn cache_key_for(source_path: string, dep_layout_manifest_paths: string[], compiler_version: string, flags_canonical: string, slug: string) -> CacheKey ![io] {
-    let s_hash = _sha256_of_file_cmd(source_path);
+    let s_hash = _sha256_of_text_file(source_path);
 
     let mut dep_hashes: string[] = [];
     let mut i: int = 0;
     loop {
         if i >= dep_layout_manifest_paths.length { break; }
-        dep_hashes.push(_sha256_of_file_cmd(dep_layout_manifest_paths[i]));
+        dep_hashes.push(_sha256_of_text_file(dep_layout_manifest_paths[i]));
         i += 1;
     }
     let sorted_dep_hashes = _sort_strings(dep_hashes);
@@ -1279,13 +1251,13 @@ fn test_bin_cache_root() -> string ![io] {
 // file simultaneously (the module cache carries the identical
 // single-process precondition).
 fn test_bin_cache_key(test_source_path: string, dep_ll_paths: string[], native_texts: string[], compiler_identity: string, runtime_identity: string, flags_canonical: string, unique_suffix: string) -> CacheKey ![io] {
-    let s_hash = _sha256_of_file_cmd(test_source_path);
+    let s_hash = _sha256_of_text_file(test_source_path);
 
     let mut dep_hashes: string[] = [];
     let mut i: int = 0;
     loop {
         if i >= dep_ll_paths.length { break; }
-        dep_hashes.push(_sha256_of_file_cmd(dep_ll_paths[i]));
+        dep_hashes.push(_sha256_of_text_file(dep_ll_paths[i]));
         i += 1;
     }
     let mut j: int = 0;
@@ -1344,7 +1316,7 @@ fn runtime_link_inputs_identity(source_paths: string[], value_inputs: string[], 
     let mut i: int = 0;
     loop {
         if i >= source_paths.length { break; }
-        parts.push("src:" + source_paths[i] + "@" + _sha256_of_file_cmd(source_paths[i]));
+        parts.push("src:" + source_paths[i] + "@" + _sha256_of_text_file(source_paths[i]));
         i += 1;
     }
     let mut j: int = 0;

--- a/compiler/src/cli/commands/publish.sfn
+++ b/compiler/src/cli/commands/publish.sfn
@@ -48,6 +48,7 @@ import {
 import {
     _collect_sfn_files_cmd,
     _sha256_of_file_cmd,
+    _sha256_of_text_file,
     _shell_read_cmd,
     _toml_trim_cmd
 } from "../../build/fs";
@@ -137,7 +138,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
         return 1;
     }
     fs.writeFile(payload_tmp, payload);
-    let raw_digest = _sha256_of_file_cmd(payload_tmp);
+    let raw_digest = _sha256_of_text_file(payload_tmp);
     if raw_digest.length == 0 {
         print("failed to compute digest");
         process.run(["rm", "-f", payload_tmp]);

--- a/compiler/src/cli_selfhost.sfn
+++ b/compiler/src/cli_selfhost.sfn
@@ -37,6 +37,7 @@
 import {
     _ensure_dir_recursive_cmd,
     _sha256_of_file_cmd,
+    _sha256_of_text_file,
     _shell_read_cmd,
     _shell_single_quote_arg
 } from "./build/fs";
@@ -190,7 +191,7 @@ fn _selfhost_snapshot(capsules_dir: string, binary_path: string) -> DeterminismS
     loop {
         if i >= files.length { break; }
         let slug = _selfhost_basename(files[i]);
-        let sha = _sha256_of_file_cmd(files[i]);
+        let sha = _sha256_of_text_file(files[i]);
         modules.push(make_determinism_module(slug, sha));
         i += 1;
     }

--- a/compiler/tests/e2e/build_hash_matches_sha256sum_test.sfn
+++ b/compiler/tests/e2e/build_hash_matches_sha256sum_test.sfn
@@ -1,0 +1,150 @@
+// compiler/tests/e2e/build_hash_matches_sha256sum_test.sfn
+//
+// Correctness gate for the in-process SHA-256 split (#1995,
+// `docs/proposals/draft-test-runner-invocation-cache.md` §3-B).
+// Three contracts exercised against production code:
+//
+//   1. Text file: `sha256_hex_of_string(content)` == `sha256sum` output.
+//      Proves the vendored hasher is correct end-to-end for the common path.
+//
+//   2. Binary file (NUL bytes): `_sha256_of_file_cmd(nul_file)` == `sha256sum`
+//      output. Proves the kept popen path handles embedded NULs correctly.
+//
+//   3. NUL truncation assertion: `_sha256_of_text_file(nul_file)` !=
+//      `_sha256_of_file_cmd(nul_file)`. Proves the truncation is real and the
+//      text/binary split is necessary. If this assertion ever fails,
+//      `fs.readFile` has become binary-safe and #1999 can retire the split.
+//
+// Skips (assert true) when neither `sha256sum` nor `shasum` is on PATH,
+// per `.claude/rules/no-bash-e2e.md`.
+import { _sha256_of_file_cmd, _sha256_of_text_file } from "../../src/build/fs";
+import { sha256_hex_of_string } from "../../src/build/hash";
+
+fn _has_sha256_tool() -> boolean ![io] {
+    let probe = process.run_capture(["bash", "-c", "command -v sha256sum || command -v shasum"], []);
+    let out = process.capture_take_stdout();
+    let _ = process.capture_take_stderr();
+    return probe == 0 && out.length > 0;
+}
+
+// Run sha256sum (or shasum -a 256 on macOS) on `path` and return the
+// 64-hex-char digest, or "" on failure.
+fn _sha256sum_of_file(path: string) -> string ![io] {
+    let cmd = "(command -v sha256sum >/dev/null 2>&1 && sha256sum " + path
+        + " || shasum -a 256 "
+        + path
+        + ") 2>/dev/null | cut -d' ' -f1";
+    let rc = process.run_capture(["bash", "-c", cmd], []);
+    let out = process.capture_take_stdout();
+    let _ = process.capture_take_stderr();
+    if rc != 0 { return ""; }
+    // Strip trailing newline.
+    let mut digest = out;
+    if digest.length > 0 && digest[digest.length - 1] == "\n" {
+        digest = find_substring(digest, 0, digest.length - 1);
+    }
+    return digest;
+}
+
+fn find_substring(s: string, start: int, end: int) -> string {
+    let mut out: string = "";
+    let mut i: int = start;
+    loop {
+        if i >= end { break; }
+        if i >= s.length { break; }
+        out = out + s[i];
+        i += 1;
+    }
+    return out;
+}
+
+fn _tmp_path(name: string) -> string ![io] {
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { return scratch + "/" + name; }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { return tmpdir + "/.sfn_bh_test_" + name; }
+    return "/tmp/.sfn_bh_test_" + name;
+}
+
+test "build_hash: text file in-process digest matches sha256sum" ![io] {
+    if !_has_sha256_tool() {
+        assert true;
+        return;
+    }
+
+    let content = "hello, Sailfin\n";
+    let path = _tmp_path("text.txt");
+    fs.writeFile(path, content);
+    let expected = _sha256sum_of_file(path);
+    process.run(["rm", "-f", path]);
+    if expected.length == 0 {
+        assert true;
+        return;
+    }
+
+    let got = sha256_hex_of_string(content);
+    assert got == expected;
+}
+
+test "build_hash: _sha256_of_file_cmd on NUL file matches sha256sum" ![io] {
+    if !_has_sha256_tool() {
+        assert true;
+        return;
+    }
+
+    let path = _tmp_path("binary.bin");
+    let write_rc = process.run_capture(["bash", "-c", "printf 'a\\0b\\0c' > "
+        + path], []);
+    let _ = process.capture_take_stdout();
+    let _ = process.capture_take_stderr();
+    if write_rc != 0 {
+        assert true;
+        return;
+    }
+
+    let expected = _sha256sum_of_file(path);
+    if expected.length == 0 {
+        process.run(["rm", "-f", path]);
+        assert true;
+        return;
+    }
+
+    // Production popen path: must return the correct digest for a binary file.
+    let popen_digest = _sha256_of_file_cmd(path);
+    process.run(["rm", "-f", path]);
+    assert popen_digest == expected;
+}
+
+test "build_hash: _sha256_of_text_file truncates at NUL — split is necessary" ![io] {
+    if !_has_sha256_tool() {
+        assert true;
+        return;
+    }
+
+    let path = _tmp_path("binary2.bin");
+    let write_rc = process.run_capture(["bash", "-c", "printf 'a\\0b\\0c' > "
+        + path], []);
+    let _ = process.capture_take_stdout();
+    let _ = process.capture_take_stderr();
+    if write_rc != 0 {
+        assert true;
+        return;
+    }
+
+    let text_digest = _sha256_of_text_file(path);
+    let popen_digest = _sha256_of_file_cmd(path);
+    process.run(["rm", "-f", path]);
+
+    if text_digest.length == 0 || popen_digest.length == 0 {
+        assert true;
+        return;
+    }
+
+    // `_sha256_of_text_file` reads via fs.readFile whose i8* -> {i8*, i64}
+    // coercion uses strlen (core_operands.sfn:1013-1043), truncating at the
+    // first NUL. For the 5-byte input "a\0b\0c" it hashes only "a" (1 byte).
+    // `_sha256_of_file_cmd` (popen) sees all 5 bytes and returns the correct
+    // digest. The two must differ. If they are ever equal, fs.readFile has
+    // become binary-safe and #1999 can retire the text/binary split.
+    assert text_digest != popen_digest;
+}

--- a/compiler/tests/unit/build_hash_sha256_test.sfn
+++ b/compiler/tests/unit/build_hash_sha256_test.sfn
@@ -1,0 +1,33 @@
+// compiler/tests/unit/build_hash_sha256_test.sfn
+//
+// FIPS 180-4 vector tests for `sha256_hex_of_string` in
+// `compiler/src/build/hash.sfn` (#1995,
+// `docs/proposals/draft-test-runner-invocation-cache.md` §3-B).
+// Verifies that the vendored copy produces the same digests as the
+// reference implementation in `capsules/sfn/crypto/src/mod.sfn`
+// (cross-checked against `sha256sum` by the e2e companion test).
+import { sha256_hex_of_string } from "../../src/build/hash";
+
+test "build_hash: empty string produces the FIPS 180-4 empty-message digest" {
+    let got = sha256_hex_of_string("");
+    assert got == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+}
+
+test "build_hash: \"abc\" produces the FIPS 180-4 single-block test vector" {
+    let got = sha256_hex_of_string("abc");
+    assert got == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+}
+
+test "build_hash: multi-block input matches sha256sum" {
+    // 56-byte NIST two-block test vector. SHA-256 padding appends 0x80, then
+    // zeros, then the 8-byte bit-length. A 56-byte message fills exactly 56
+    // bytes of the first 64-byte block, leaving no room for the 8-byte
+    // length field — so the padded message spans two blocks.
+    let got = sha256_hex_of_string("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+    assert got == "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1";
+}
+
+test "build_hash: single character" {
+    let got = sha256_hex_of_string("a");
+    assert got == "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb";
+}

--- a/docs/proposals/0044-test-runner-invocation-cache.md
+++ b/docs/proposals/0044-test-runner-invocation-cache.md
@@ -1,0 +1,355 @@
+---
+sfep: 0044
+title: Invocation-scoped runtime identity + in-process sha256 for the test runner
+status: Accepted
+type: tooling
+created: 2026-07-08
+updated: 2026-07-08
+author: "agent:compiler-architect; human review"
+tracking: "#1995, #1996, #1997, #1998, #1999"
+supersedes:
+superseded-by:
+graduates-to:
+---
+
+# SFEP-0044 — Invocation-scoped runtime identity + in-process sha256 for the test runner
+
+## 1. Summary
+
+The per-test-file child of the multi-file test runner spends ~2.8–3.4 s in its
+"link window" even on a fully warm cache, of which the actual clang link is only
+0.34 s. The remaining ~2.5 s is dominated by ~60 `popen`'d `sha256sum`/`shasum`
+shell pipelines per child, run to recompute cache keys over the ~34
+`runtime/sfn/**.sfn` sources — keys that are **invocation-constant** (the runtime
+tree cannot change between the parent's one-time warm and a child's link within a
+single `sfn test`). This SFEP (A) has the parent compute the runtime identity
+once and hand it to children via a stamp file in the warm objdir so children skip
+all per-file runtime hashing on the warm path, and (B) replaces the
+`_sha256_of_file_cmd` popen pipeline with a pure-Sailfin in-process SHA-256
+vendored from `capsules/sfn/crypto` — a compiler-source-only change with **no
+seed dependency**. (C) resolver-pass sharing is scoped as a follow-up. Expected
+warm per-file link window after A+B: from ~2.8–3.4 s to ~0.4–0.5 s.
+
+## 2. Motivation
+
+The full suite (~478 `*_test.sfn` files) runs ~50–70 min serially; `make check`
+runs two cold suite passes plus self-host stages at 2–3 h nightly. The measured
+per-warm-file breakdown (8-core macOS, runtime objects pre-warmed by the parent
+via `SAILFIN_TEST_RUNTIME_OBJDIR`):
+
+| Phase | Cost |
+|---|---|
+| child startup + discovery | 0.30 s |
+| resolver pass (`prepare_project_capsules_for_test`) | 0.35 s |
+| frontend compile of the test source | 0.15 s |
+| **link window** | **2.8–3.4 s** (clang itself only 0.34 s) |
+| exec | 0.36 s |
+
+The link window is the outlier and it is almost entirely `sha256sum` subprocess
+spawns, not linking. Two invocation-constant passes over the runtime tree run
+**per child**:
+
+1. `_test_bin_runtime_identity` (`test.sfn:2522`) hashes every runtime
+   `.c`/`.ll`/`.sfn` source + prelude entry + every `.h` under each include root,
+   via `runtime_link_inputs_identity` → `_sha256_of_file_cmd`
+   (`build_cache.sfn:1347`). ~34 sources + headers.
+2. `assemble_runtime_capsule_link_inputs` (`runtime_objs.sfn:761`) → for each of
+   the ~34 sfn-sources, `_emit_runtime_sfn_to_obj` computes
+   `runtime_object_cache_key_with_identity` (hashes the source,
+   `build_cache.sfn:1012`) **and** `_runtime_obj_key_with_sibling_deps` (hashes
+   each sibling dep, `runtime_objs.sfn:329`), plus
+   `_stage_one_runtime_sfn_import_context` hashes the source again
+   (`runtime_objs.sfn:473`). Even on a pure cache-hit path these key computations
+   run so the sidecar `.key` can be compared — the object is not recompiled, but
+   the key is still hashed.
+
+Each `_sha256_of_file_cmd` call is a `sailfin_runtime_shell_capture` popen of a
+`(command -v sha256sum && sha256sum … || shasum -a 256 …) | cut` pipeline
+(`fs.sfn:232`). At ~478 files, this is on the order of 478 × 60 ≈ 29,000
+process-spawn+pipe round-trips whose *only* product is a hash of a file that is
+identical across the whole invocation.
+
+## 3. Design
+
+Three independent work items. A and B compose (each independently self-hosts) and
+together collapse the warm link window; C is scoped as a follow-up.
+
+### Work item A — Invocation-scoped runtime identity via a warm-objdir stamp
+
+**Mechanism.** The multi-file parent already warms the runtime once into the
+shared `sub_root` and hands children `SAILFIN_TEST_RUNTIME_OBJDIR`
+(`test.sfn:635`). Extend that one-time warm to also write a **stamp manifest**
+into the warm objdir, and have children read the stamp instead of re-hashing.
+
+Stamp file: `<warm_objdir>/.runtime-identity.stamp`, written by the parent
+immediately after a successful `assemble_runtime_capsule_link_inputs` warm. Its
+contents (newline-separated `key=value`, versioned):
+
+```
+v1
+invocation=<parent-minted nonce>
+runtime_identity=<the runtime_link_inputs_identity digest>
+obj_key/<slug>=<per-sfn-source runtime_object_cache_key_with_identity digest>
+obj_key/<slug>=...      # one line per runtime sfn-source + prelude entry
+sibling_key/<slug>=<the _runtime_obj_key_with_sibling_deps result for that slug>
+asm_key/<slug>=<the _stage_one import-context key for that slug>
+```
+
+The parent computes each of these values exactly once (it is already computing
+the object keys during the warm), so writing the stamp is nearly free.
+
+**How children consume it.**
+
+- `_test_bin_runtime_identity` (`test.sfn:2522`): if
+  `SAILFIN_TEST_RUNTIME_OBJDIR` is set **and** the stamp exists **and** its
+  `invocation` matches the value the child was handed (see nonce below), return
+  the stamped `runtime_identity` directly — skipping the entire
+  source/header hash loop. Otherwise fall back to the current in-process
+  computation (single-file leaf path, or a missing/mismatched stamp).
+
+- `assemble_runtime_capsule_link_inputs` / `_emit_runtime_sfn_to_obj` /
+  `_stage_one_runtime_sfn_import_context`: on the warm child path, the object
+  already exists in the shared objdir with its `.key` sidecar. Today the child
+  re-derives the key (hashing the source) purely to compare against the sidecar.
+  Instead, thread an optional **precomputed-key lookup** (a
+  `RuntimeIdentityStamp` value, parsed from the stamp once per child) down the
+  warm path: when the stamp carries `obj_key/<slug>` (and `sibling_key`,
+  `asm_key`), use it as the expected key for the `_runtime_obj_cache_hit`
+  comparison instead of recomputing via `_sha256_of_file_cmd`. A cache hit then
+  requires **zero** hashing: existence check + sidecar-string compare against the
+  stamped key.
+
+**The staleness / correctness argument (the load-bearing part).**
+
+The cache must never serve a stale runtime object or stale test binary. The stamp
+must be *sound* (never validate a stale object) and its scope must not leak across
+invocations.
+
+1. *Within one invocation, the runtime tree is immutable.* The parent warms the
+   runtime and writes the stamp before forking any child; no child (nor the
+   parent) edits `runtime/sfn/**` during the run. So a source hashed at warm time
+   is byte-identical when a child links. The stamped `obj_key` is therefore the
+   *correct* key for the child's link — recomputing it would produce the same
+   value. This is a pure elision of redundant work, not a relaxation of the
+   correctness check: the child still compares the stamped key against the
+   on-disk `.key` sidecar (`_runtime_obj_cache_hit`), so a corrupt or
+   partially-written object still misses and recompiles.
+
+2. *A stamp must not leak across invocations.* Two hazards: (a) a stale warm
+   objdir reused by a later `sfn test` whose runtime tree changed; (b) a child
+   from invocation X reading a stamp from invocation Y. Both are closed by an
+   **invocation nonce**: the parent mints a fresh nonce per `sfn test`
+   (`mktemp`-style, or `date +%s%N` + pid — reuse the existing `sub_root`
+   `mktemp -d` basename, which is already per-invocation unique), writes it into
+   the stamp's `invocation=` line, **and** passes it to every child as a new env
+   var `SAILFIN_TEST_RUNTIME_STAMP=<nonce>`. A child uses the stamp *only* when
+   the file's `invocation=` equals the env nonce it was handed. A reused objdir
+   with a stale stamp (case a) is only reachable when the caller pins
+   `SAILFIN_TEST_RUNTIME_OBJDIR` themselves (seedcheck/stage3); in that case the
+   parent still rewrites the stamp with the current invocation's nonce at warm
+   time, so the stamp always reflects *this* run's runtime tree. If the parent
+   did not warm (no stamp written) the child sees no matching nonce and falls
+   back to hashing — the current behavior, i.e. fail-safe.
+
+3. *The single-file leaf path has no parent and no stamp.* `SAILFIN_TEST_RUNTIME_STAMP`
+   is unset, so `_test_bin_runtime_identity` and the object-key path both fall
+   through to the existing in-process hash. Behavior is byte-identical to today.
+   (Once B lands, that fallback is in-process sha256 rather than popen, so the
+   leaf path is also faster — but its *semantics* are unchanged.)
+
+4. *What if a runtime source is touched mid-run?* It can't within the runner's
+   own operation, but a hostile/racy external `touch` is defended structurally:
+   the stamp only *supplies the expected key*; the object hit still requires the
+   on-disk object + matching `.key` sidecar. If someone recompiles the runtime
+   under the objdir mid-run, the sidecar written by that recompile carries the
+   new key while the stamp carries the old — the child's compare mismatches and
+   it recompiles into its own scratch. The stamp can cause a *miss-when-hit-was-
+   possible* (harmless, self-corrects) but never a *hit-when-stale* (unsound).
+   This asymmetry is the correctness guarantee: **the stamp is an optimization
+   hint for the expected key, never the authority for freshness.**
+
+**Test-bin cache key (test.sfn:1168 / `test_bin_cache_key`).** Yes — it can and
+should consume the stamped `runtime_identity`. `test_bin_cache_key` already takes
+`runtime_identity` as a parameter (`build_cache.sfn:1281`); today the child
+computes it via `_test_bin_runtime_identity`. With A, that function returns the
+stamped value on the warm path, so the test-bin key transparently consumes the
+precomputed identity with no signature change. The test-bin key's own
+correctness model is unchanged: it still folds the test source, dep closure,
+compiler identity, and this runtime identity — and the runtime identity is
+*exactly* the value it would have computed itself.
+
+### Work item B — In-process SHA-256
+
+**What exists.** `capsules/sfn/crypto/src/mod.sfn` contains a complete,
+self-contained pure-Sailfin `sha256_hex(data: string) -> string` (FIPS 180-4).
+It has **no imports**, **no effects** (`![pure]`-shaped — bitwise ops, array
+push/index, `char_code`), and already compiles under the current seed (the
+capsule ships and is tested at `capsules/sfn/crypto/tests/sha256_test.sfn`).
+
+**Seed-dependency verdict: NONE.** Per `.claude/rules/seed-dependency.md`, a seed
+dependency exists only when compiler-source needs a language/runtime capability
+*not present in the pinned seed*. This uses only capabilities the seed already
+has (it compiles the crypto capsule today). Two viable shapes, both seed-free:
+
+- **Preferred: vendor `sha256_hex` into a new compiler-source module**
+  `compiler/src/build/hash.sfn` (a pure function `sha256_hex_of_string(s:
+  string) -> string`, plus the two helpers `sha256_rotr`, `sha256_word_hex`).
+  Copying source into the compiler tree needs no seed change — `make compile`
+  builds the new compiler from the old seed, which compiles the new module in the
+  same pass. This is the canonical "capability compiled as part of the compiler
+  source tree needs NO seed change" shape the rule calls out. It avoids the
+  workspace-membership question of importing the capsule from compiler source
+  (compiler/src does import `sfn/cli`, so capsule import *works*, but vendoring a
+  ~60-line pure function is lower-risk than adding `sfn/crypto` to the compiler's
+  dependency closure).
+
+- Reading a file: replace `_sha256_of_file_cmd`'s pipeline body with
+  `fs.readFile(path)` + `sha256_hex_of_string(contents)`. `fs.readFile` is `![io]`
+  (already the effect `_sha256_of_file_cmd` carries), so the signature is
+  unchanged. Empty-file / unreadable → `fs.readFile` returns `""`; hashing `""`
+  yields the well-known empty-string digest, which would be a behavior change
+  from today's `""`-on-failure contract. **Preserve the failure contract**: keep
+  the current `if !fs.exists(path) { return ""; }` guard so a missing source
+  still returns `""` (the "not content-addressable → recompile" signal every
+  caller relies on).
+
+**Call-site benefit (quantified).** `_sha256_of_file_cmd` has these callers
+(grep confirmed): `build_cache.sfn` (`sha256_of_file`, `cache_key_for` ×2,
+`cache_compiler_identity`, `test_bin_cache_key` ×2, `runtime_link_inputs_identity`,
+and inside `_sha256_of_string`), `runtime_objs.sfn` (sibling-dep hash),
+`determinism.sfn` (×2), `cli_selfhost.sfn` (×2), and the CLI commands
+`publish.sfn`, `package.sfn` (×3), `add.sfn`. Replacing the one primitive speeds
+**every** content-addressed path in the whole build driver — not just the test
+runner. `_sha256_of_string` (`build_cache.sfn:868`) currently writes a tmp file
+then popens `_sha256_of_file_cmd`; it should be rewritten to call
+`sha256_hex_of_string(input)` directly, eliminating both the tmp-file write and
+the popen (and the whole `mktemp`/race-workaround comment block becomes moot —
+there is no shared tmp path to collide on).
+
+`_shell_read_cmd` has other users (env reads, `find`, `stat`, `du`, `mktemp`,
+`uname`, OpenSSL probe) that are **out of scope** for B — they are not hashing.
+Only the sha256 primitive is replaced.
+
+### Work item C — Resolver-pass sharing parent→child (follow-up, do not bundle)
+
+The 0.35 s/file resolver pass (`prepare_project_capsules_for_test`) re-runs the
+capsule resolver per child. Sharing it parent→child is *substantially harder*
+than A/B: the resolver produces per-test dep closures (`dep_ll_paths`,
+`native_texts`, interfaces, function effects, capabilities) that are
+test-source-specific, not invocation-constant like the runtime identity. A shared
+resolver result would need either a serialized per-file manifest handed to each
+child (re-introducing the filesystem-IPC cost item 0006 flags as the primary
+bottleneck) or an in-process multi-file resolver (which OOM'd/segfaulted on the
+real suite — the exact reason per-file child isolation exists, `test.sfn:560`).
+**Scope C as a standalone follow-up issue**, gated on the 0006 build-architecture
+IPC redesign; do not force it into the A+B PR.
+
+## 4. Effect & capability impact
+
+None. All changes are within `![io]` build-driver code. `sha256_hex_of_string` is
+a pure function (no effects); `_sha256_of_file_cmd` keeps its `![io]` signature
+(now from `fs.readFile` rather than popen). No user-facing effect surface changes.
+
+## 5. Self-hosting impact
+
+No compiler *pass* changes (lexer→…→lowering are untouched). The changes are
+entirely in the build/test driver modules:
+`compiler/src/build/fs.sfn`, `compiler/src/build/hash.sfn` (new),
+`compiler/src/build_cache.sfn`, `compiler/src/build/runtime_objs.sfn`,
+`compiler/src/cli/commands/test.sfn`. Each item independently self-hosts:
+
+- **B first** is a pure behavior-preserving swap of the hash primitive
+  (same digest values — SHA-256 is SHA-256; verify against `sha256sum` in a
+  regression test). `make compile` builds the new compiler from the old seed;
+  the new hash module compiles in the same pass (no seed change).
+- **A second** consumes B's faster primitive and adds the stamp. The stamp is
+  additive (a missing stamp → current behavior), so an intermediate state where
+  the parent writes a stamp but children ignore it, or vice versa, is still
+  correct — the fallback path is always the current in-process computation.
+
+The self-host build itself benefits: `cli_selfhost.sfn` and `determinism.sfn`
+hash artifacts via the same primitive.
+
+## 6. Alternatives considered
+
+- **A runtime builtin sha256 (`extern fn`).** Would require the symbol in the
+  pinned seed's runtime → a seed-blocker (`.claude/rules/seed-dependency.md`).
+  Rejected: a pure-Sailfin vendored function needs no seed change and is equally
+  fast in-process.
+- **Import `sfn/crypto` from compiler source instead of vendoring.** Works (the
+  compiler already imports `sfn/cli`), but adds the crypto capsule to the
+  compiler's dependency closure and couples the compiler build to a capsule's
+  lifecycle. Vendoring ~60 lines of stable, spec-frozen algorithm is lower-risk;
+  the two copies are trivially kept in sync (a `sha256` algorithm does not
+  change). A regression test cross-checks both against `sha256sum`.
+- **Env var carrying the runtime identity (A) instead of a stamp file.** A single
+  `runtime_identity` env var would cover `_test_bin_runtime_identity` but not the
+  per-slug object-key elision, which needs a per-source map. A stamp file carries
+  both in one artifact already living in the warm objdir, and its `invocation=`
+  line is the natural scope guard. Rejected in favor of the stamp.
+- **Skip the per-object key comparison entirely on the warm path** (trust the
+  object exists). Rejected: it removes the freshness authority (the `.key`
+  sidecar compare), reintroducing the class of stale-object bugs #632/#969/#1197
+  fixed. The stamp supplies the *expected* key so the compare still runs — just
+  without re-hashing.
+
+## 7. Stage1 readiness mapping
+
+Tooling change; no language surface. The relevant bars:
+
+- [ ] Parses — N/A (no new syntax)
+- [ ] Type-checks / effect-checks — new `hash.sfn` module passes `sfn check`
+- [ ] Emits valid `.sfn-asm` — exercised by `make compile`
+- [ ] Lowers to LLVM IR — exercised by `make compile`
+- [ ] Regression coverage — see §8
+- [ ] Self-hosts — `make compile` after each of B then A
+- [ ] `sfn fmt --check` clean — on every touched `.sfn`
+- [ ] Documented in `docs/status.md` — note the test-runner perf change; this
+      SFEP is the design record
+
+## 8. Test plan
+
+**B — sha256 correctness (must land with B):**
+- `compiler/tests/unit/build_hash_sha256_test.sfn` — `sha256_hex_of_string`
+  against FIPS/NIST vectors (`""`, `"abc"`, the crypto capsule's known
+  `"hello world"` digest) so the vendored copy is proven equal to a reference.
+- `compiler/tests/e2e/build_hash_matches_sha256sum_test.sfn` — `![io]` test:
+  write a file, hash it in-process, shell `sha256sum`/`shasum -a 256`, assert
+  equal. Skip (assert true) if neither tool is present, per the no-bash-e2e rule.
+
+**A — cache correctness (the critical regressions):**
+- `compiler/tests/e2e/runtime_stamp_staleness_test.sfn` — the load-bearing one.
+  With a per-invocation scratch: (1) build a test binary, capture output; (2)
+  touch a `runtime/sfn/**` source's *content* (append a comment) into a private
+  runtime copy the test points the runner at, run again in a *fresh* invocation
+  (fresh nonce) → assert the child rebuilds (object key changed, stamp from run 1
+  cannot false-hit run 2 because the nonce differs). This proves the nonce scope
+  guard.
+- `compiler/tests/e2e/runtime_stamp_missing_fallback_test.sfn` — run a single
+  file with no `SAILFIN_TEST_RUNTIME_OBJDIR`/`SAILFIN_TEST_RUNTIME_STAMP` set →
+  assert it passes (leaf path falls back to in-process hashing, unchanged).
+- `compiler/tests/e2e/runtime_stamp_warm_hit_test.sfn` — multi-file run in one
+  invocation → assert children hit the warm objdir and produce correct output
+  (functional proof the stamp path links correctly).
+- Existing `check_build_agree_module_global_test.sfn` and the runtime-object
+  cache tests continue to gate the `.key` sidecar contract.
+
+**Gate:** `make compile` after B, then after A; `make check` before declaring
+shipped (the two-cold-pass gate proves no stale-hit crept in).
+
+## 9. References
+
+- `docs/proposals/0006-build-architecture.md` — build/IPC bottleneck root cause
+  (C's blocker).
+- `docs/proposals/0011-ci-test-speed.md` — the per-test-binary cache (#1230/#1233)
+  this composes with.
+- SFEP-0040 — content-addressed module cache root resolution.
+- `.claude/rules/seed-dependency.md` — the no-seed-cut verdict for B.
+- `capsules/sfn/crypto/src/mod.sfn` — the pure-Sailfin SHA-256 vendored by B.
+- Key code paths: `compiler/src/build/fs.sfn:232` (`_sha256_of_file_cmd`),
+  `compiler/src/build_cache.sfn:868` (`_sha256_of_string`), `:1281`
+  (`test_bin_cache_key`), `:1342` (`runtime_link_inputs_identity`);
+  `compiler/src/build/runtime_objs.sfn:761`
+  (`assemble_runtime_capsule_link_inputs`), `:337` (`_emit_runtime_sfn_to_obj`);
+  `compiler/src/cli/commands/test.sfn:635` (parent warm), `:2522`
+  (`_test_bin_runtime_identity`), `:1168` (`test_bin_cache_key` call).

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -66,6 +66,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0041](./0041-typeck-expected-type-context.md) | Unified expected-type + typing-environment context for the typecheck walk | Implemented | tooling |
 | [0042](./0042-nested-function-declarations.md) | Nested / Local Function Declarations (non-capturing static `fn` items) | Accepted | language |
 | [0043](./0043-phase-scoped-arena-reclamation.md) | Phase-scoped arena reclamation to reduce per-module peak RSS | Implemented | runtime |
+| [0044](./0044-test-runner-invocation-cache.md) | Invocation-scoped runtime identity + in-process sha256 for the test runner | Accepted | tooling |
 
 ## Drafts under review (numbers assigned at merge)
 


### PR DESCRIPTION
## Summary
- Vendors the pure-Sailfin SHA-256 from `capsules/sfn/crypto` into `compiler/src/build/hash.sfn` and hashes NUL-free **text** artifacts in-process (`_sha256_of_text_file`), retiring ~60 popen'd `(sha256sum||shasum)|cut` pipelines per test-runner child.
- Binary artifacts (compiled binaries, tarballs) **stay on the popen path**: `fs.readFile`'s `i8*`→string coercion is strlen-based and truncates at the first NUL (`core_operands.sfn:1013–1043`). #1999 tracks the binary-safe read builtin that retires the split; the e2e test carries a split-necessity assertion that fails when that day comes.
- `_sha256_of_string` drops its tmp-file+popen round-trip entirely.
- Design record: **SFEP-0044** (numbered + registry row in this PR, status `Accepted`; work item A — the invocation-identity stamp — follows in #1996).

## Numbers (Phase 7, /perf)
| Metric | Before | After | Δ |
|---|---|---|---|
| Warm test file, `--jobs 1 --no-test-cache` (capsules/sfn/path/tests) | 6.26 s | 2.87 s | **-54%** |
| Hash subprocess pipelines per warm test child | ~60 | 0 (text path) | -100% |

Context: the full suite is ~478 files and `make check` runs it twice → ~57k popen pipelines eliminated per `make check`. Frontend compile was never the bottleneck (0.15 s/file); this removes the dominant slice of the measured ~4 s/file floor. #1996 (stamp) takes the next slice.

## Correctness notes (from the Opus review)
- Vendored algorithm verified against `capsules/sfn/crypto` incl. the 56-byte two-block padding boundary; FIPS vectors in unit tests; e2e cross-checks vs `sha256sum` on the production functions.
- Digest values unchanged → **no cache invalidation** (old tmp-file path wrote no trailing newline).
- Empty-file now returns `""` (miss, fail-safe) instead of the empty-input digest — documented.
- Text/binary classification audited call-site by call-site (`determinism.sfn`, `cli_selfhost.sfn` binary hashes, `package.sfn`/`add.sfn` tarballs kept on popen).

## Verification
- `sfn fmt --check` clean; `sfn check` ok on all touched files
- `make compile` green (self-host gate)
- Unit 4/4, e2e 3/3; integration tier 42/42 on the new binary

Closes #1995