### PR TITLE
perf(check): test-pool jobs auto-detect + one-cold-suite make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,29 +151,27 @@ AGENT_REPORT := bash scripts/agent_report.sh
 # can never mask a test-compile regression.
 TEST_BIN_CACHE_FLAGS ?=
 
-# Parallel test execution (#843 / #1236). The unified runner accepts
+# Parallel test execution (#843 / #1236 / #1998). The unified runner accepts
 # `--jobs N` (per-file child processes run N at a time); every
-# `$(NATIVE_BIN) test ...` invocation below threads this knob. The
-# default stays 1 because each child carries its own RAM footprint
-# under the 8GB per-process cap — callers pick N for their RAM budget
-# (e.g. `make test TEST_JOBS=4` on a 4-core/16GB box, smaller on
-# 7GB CI runners). CI sharding (`make test-shard`) is unaffected.
-TEST_JOBS ?= 1
+# `$(NATIVE_BIN) test ...` invocation below threads this knob.
+#
+# Default: auto-detected from CPU count and total RAM via
+# scripts/detect_test_jobs.sh with a per-job budget of 384 MB (conservative
+# headroom over the measured ~150 MB child peak, because e2e build-spawner
+# tests fork nested compiler+clang trees). The 384 MB budget is ~5× lighter
+# than BUILD_JOBS' ~2 GB budget, which is sized for per-module emit.
+# Override with `TEST_JOBS=N` on the command line or in the environment;
+# an explicit value always wins. CI sharding (`make test-shard`) is
+# unaffected — it reads SAILFIN_TEST_JOBS directly from scripts/test_shards.sh.
+# See docs/proposals/0044-test-runner-invocation-cache.md and #1998.
+TEST_JOBS ?= $(shell bash scripts/detect_test_jobs.sh 2>/dev/null || echo 1)
 TEST_JOBS_FLAG = --jobs $(TEST_JOBS)
 
-# Test parallelism for `make check` specifically. `make check` runs the full
-# suite TWICE (once on the first-pass binary as an early gate, once on the
-# seedcheck binary), so a serial `TEST_JOBS=1` doubles down on the slowest part
-# of the gate. Unlike a bare `make test`, `make check` already pins peak build
-# concurrency via the RAM-budgeted `BUILD_JOBS` auto-detect, so it can safely
-# reuse that same per-job budget for its suite runs. An explicit `TEST_JOBS=N`
-# (command line or environment) always wins — set it to dial the suite down on
-# a tighter RAM budget, or to 1 to restore the old serial behaviour.
-ifeq ($(filter command line environment,$(origin TEST_JOBS)),)
-CHECK_TEST_JOBS ?= $(BUILD_JOBS)
-else
+# Test parallelism for `make check` specifically. CHECK_TEST_JOBS defaults
+# to the same auto-detected TEST_JOBS. An explicit `TEST_JOBS=N` on the
+# command line or in the environment always wins (the `?=` auto-detect
+# above already captures it, so no origin-check branch is needed here).
 CHECK_TEST_JOBS ?= $(TEST_JOBS)
-endif
 
 # Strict self-host gate (#1830). When SELFHOST_STRICT=1, `make check`
 # passes `--strict` to `sfn selfhost` so a stage2/stage3 fixed-point
@@ -560,9 +558,35 @@ check-impl:
 		echo "[check][error] missing $$seed (run: make compile)"; \
 		exit 1; \
 	fi
-	@echo "[check] running test suite on first-pass binary (early gate, jobs=$(CHECK_TEST_JOBS))..."
+	@# Pass1 smoke gate (#1998 / SFEP-0044): the first-pass binary only needs
+	@# to prove it can run and execute test binaries end-to-end. Running the
+	@# full suite twice (pass1 + seedcheck) doubled check wall-time without a
+	@# meaningful catch rate — real miscompilations surface in the seedcheck
+	@# fixed-point; the pass1 gate catches outright crashes. Two checks:
+	@#   (a) hello-world smoke (timeout 60): proves run works.
+	@#   (b) capsules/sfn/test/tests only (5 test files): proves the pass1
+	@#       binary can compile, link, and execute test binaries end-to-end.
+	@# The cold-suite backstop is the seedcheck full run below.
+	@# Set CHECK_FULL_PASS1=1 to restore the old two-full-suite behaviour
+	@# (escape hatch for bisect / pre-release double-check).
+ifeq ($(CHECK_FULL_PASS1),1)
+	@echo "[check] CHECK_FULL_PASS1=1: running full suite on first-pass binary (jobs=$(CHECK_TEST_JOBS))..."
 	@$(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
-	@echo "[check] first-pass tests passed — validating self-host (stage2/stage3 fixed point)..."
+else
+	@echo "[check] pass1 smoke gate: hello-world + sfn/test capsule tests (jobs=$(CHECK_TEST_JOBS))..."
+	@t60=""; \
+	if command -v timeout >/dev/null 2>&1; then t60="timeout 60"; \
+	elif command -v gtimeout >/dev/null 2>&1; then t60="gtimeout 60"; fi; \
+	$$t60 build/native/sailfin run examples/basics/hello-world.sfn
+	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		set -o pipefail; \
+		build/native/sailfin test capsules/sfn/test/tests --jobs $(CHECK_TEST_JOBS) --json | tee build/agent-test.check-pass1.jsonl || exit $$?; \
+	else \
+		build/native/sailfin test capsules/sfn/test/tests --jobs $(CHECK_TEST_JOBS) || exit $$?; \
+	fi
+endif
+	@echo "[check] pass1 smoke passed — validating self-host (stage2/stage3 fixed point)..."
 	@# #1502 (epic #513 Phase 1): the stage2/stage3 builds, per-stage `.ll`
 	@# scratch isolation (`SAILFIN_TEST_SCRATCH` so stage3 can't clobber
 	@# stage2's IR), `--no-cache` independence, the hello-world smoke gate,
@@ -587,7 +611,7 @@ check-impl:
 		--promote-to $(NATIVE_BIN) \
 		--smoke-timeout 10 \
 		$(SELFHOST_STRICT_FLAG)
-	@echo "[check] running test suite with seedcheck binary (no fallbacks, jobs=$(CHECK_TEST_JOBS))..."
+	@echo "[check] running full test suite with seedcheck binary (cold backstop, jobs=$(CHECK_TEST_JOBS))..."
 	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 
 # Fast PR-feedback gate: run `sfn check` against the compiler tree and

--- a/scripts/detect_test_jobs.sh
+++ b/scripts/detect_test_jobs.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# detect_test_jobs.sh — Pick a sensible TEST_JOBS default for the current host.
+#
+# Heuristic: min(cores, mem_mb / 384), floor 1, cap 16.
+#
+# The 384 MB-per-job budget is sized for test-runner child processes, not
+# compiler-module builds. Measured child-process peak at the time of #1998:
+#   * typical unit/integration test child   : ~50–80 MB RSS
+#   * e2e test that spawns a nested compiler : ~150 MB RSS (heaviest class)
+# The 384 MB budget gives ~2.5× headroom over the heaviest class to
+# absorb e2e tests that fork nested compiler+clang trees without
+# overcommitting the runner.
+#
+# This deliberately differs from detect_build_jobs.sh's ~2 GB-per-job budget,
+# which is sized for per-module emit (heaviest module: ~1.76 GB peak RSS).
+# Using BUILD_JOBS' budget for test children would under-report parallelism
+# by ~5×: a 7 GB macOS runner that allows BUILD_JOBS=2 allows TEST_JOBS≈18,
+# bounded further by core count.
+#
+# No macOS-specific ceiling: the 2-job cap in detect_build_jobs.sh exists
+# because two concurrent 1.6 GB module builds overcommit a 7 GB runner.
+# Test children are ~10× lighter, so the memory budget alone protects
+# the macOS CI runner (7168 / 384 ≈ 18 → naturally bounded by the 3-4
+# core count and the global cap of 16 anyway).
+#
+# Cap 16: the runner's --jobs parameter accepts [1, 256] but the
+# sliding-window pool has diminishing returns past core count; 16 matches
+# the workflow cap used elsewhere in CI.
+#
+# Falls back to 1 on:
+#   - hosts where nproc / sysctl / /proc/meminfo are not readable
+#   - Windows (MSYS / Cygwin / Git Bash) — xargs -P parallelism is unreliable
+#     under the various Windows shell wrappers
+#
+# Override by exporting TEST_JOBS=N before invoking make. The Makefile
+# honours `TEST_JOBS ?=` so an explicit env value always wins.
+# See #1998 and docs/proposals/0044-test-runner-invocation-cache.md.
+
+set -eu
+
+uname_s="$(uname -s 2>/dev/null || echo unknown)"
+cores=1
+mem_mb=0
+
+case "$uname_s" in
+    Linux*)
+        cores=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+        mem_kb=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)
+        mem_mb=$((mem_kb / 1024))
+        ;;
+    Darwin*)
+        cores=$(sysctl -n hw.ncpu 2>/dev/null || echo 1)
+        mem_b=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+        mem_mb=$((mem_b / 1024 / 1024))
+        ;;
+esac
+
+# Sanitize: a non-numeric or zero result falls back to safe defaults.
+[ "$cores" -gt 0 ] 2>/dev/null || cores=1
+[ "$mem_mb" -gt 0 ] 2>/dev/null || mem_mb=1536
+
+# Apply the per-job memory budget. 384 MB per job; see the header comment
+# for the per-child RSS data this divisor is sized against.
+by_mem=$((mem_mb / 384))
+[ "$by_mem" -lt 1 ] && by_mem=1
+
+jobs=$cores
+[ "$by_mem" -lt "$jobs" ] && jobs=$by_mem
+
+# Windows: xargs -P parallelism is unreliable under MSYS/Cygwin/Git Bash.
+case "$uname_s" in
+    MINGW*|MSYS*|CYGWIN*)
+        jobs=1
+        ;;
+esac
+
+# Global upper bound. 16 matches the workflow cap used elsewhere in CI.
+# The sliding-window pool has diminishing returns past core count, and
+# 16 exceeds all current CI runner core counts (Linux 4 vCPU, macOS 3).
+[ "$jobs" -gt 16 ] && jobs=16
+
+[ "$jobs" -lt 1 ] && jobs=1
+
+echo "$jobs"


### PR DESCRIPTION
## Summary
Two throughput knobs from SFEP-0044's adjacent verdicts (design lands with #2000; the structural per-file fix is #2000 + #1996):

1. **`TEST_JOBS` auto-detect** (`scripts/detect_test_jobs.sh`): 384 MB/job budget sized for test-runner children (measured peak ~150 MB; e2e build-spawners are the heaviest class) — not `BUILD_JOBS`' ~2 GB/job module-emit budget, which under-reported test parallelism ~5× and hard-capped macOS at 2. `min(cores, mem/384MB)`, cap 16, Windows→1, explicit `TEST_JOBS=N` always wins. CI shard legs (`SAILFIN_TEST_JOBS`) untouched.
2. **`make check` runs one cold full suite, not two**: the seedcheck leg keeps the full suite with `--no-test-cache` (the cold backstop — the merge gate still cold-builds every test binary once). The pass1 leg becomes a smoke gate: hello-world run + `capsules/sfn/test/tests` (proves the pass1 binary can compile, link, and execute test binaries end-to-end; real miscompiles surface in the selfhost fixed-point + seedcheck suite). `CHECK_FULL_PASS1=1` restores the old shape for bisects/pre-release double-checks.

## Numbers
| Metric | Before | After | Δ |
|---|---|---|---|
| `make test-capsules` (38 files) | ~4 min (`--jobs 1`) | **64 s** (`--jobs 8`, 307% CPU) | ~-73% |
| `make check` suite legs | 2 × full cold suite | 1 × full cold suite + smoke | -1 full suite (~50–70 min serial-equiv) |

## Verification
- `bash scripts/detect_test_jobs.sh` → 8 on an 8-core/16 GB box; budget math confirmed for 7 GB macOS CI (core-bound 3–4) and 4-vCPU Linux (4)
- `make -n check` shows pass1 smoke → selfhost → seedcheck full cold suite; with `CHECK_FULL_PASS1=1` shows the old double-suite shape
- `TEST_JOBS=1 make -n test` → `--jobs 1` (override wins)
- `make test-capsules`: 38/38 pass
- No `.sfn` files touched (no self-host surface)

Closes #1998