### PR TITLE
perf(ci): restore per-shard test-binary cache across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,6 +476,25 @@ jobs:
           [ -f build/native/.build-stamp ] && touch build/native/.build-stamp || true
           ls -lh build/native/sailfin
 
+      # Per-shard test-binary cache restore (#2008, SFEP-0044). The
+      # build-tree artifact deliberately excludes build/cache/test-bin;
+      # this restores each leg's slice from the most recent prior run of
+      # the same OS+shard (restore-keys prefix) and saves under this
+      # run's sha at job end. Safety is in the entry keys themselves:
+      # test_bin_cache_key folds test-source hash + dep closure +
+      # compiler identity + runtime identity (#1233), so a restored
+      # stale entry self-invalidates and a compiler-changing PR misses
+      # everything (correct cold start). The merge/seedcheck gate and
+      # nightly `make check` keep --no-test-cache — the cold backstop
+      # never consumes this cache.
+      - name: Restore per-shard test-binary cache
+        uses: actions/cache@v6
+        with:
+          path: build/cache/test-bin
+          key: test-bin-${{ runner.os }}-${{ matrix.shard }}-${{ github.sha }}
+          restore-keys: |
+            test-bin-${{ runner.os }}-${{ matrix.shard }}-
+
       - name: Test + package (via Makefile)
         uses: ./.github/actions/sailfin-build
         env:
@@ -824,6 +843,18 @@ jobs:
           touch build/native/sailfin
           [ -f build/native/.build-stamp ] && touch build/native/.build-stamp || true
           ls -lh build/native/sailfin
+
+      # Per-shard test-binary cache restore (#2008, SFEP-0044) — same
+      # contract as the Linux leg: prefix-restore from the latest prior
+      # run of this OS+shard, save under this run's sha; entry keys
+      # self-validate (#1233) so stale restores are safe by construction.
+      - name: Restore per-shard test-binary cache
+        uses: actions/cache@v6
+        with:
+          path: build/cache/test-bin
+          key: test-bin-${{ runner.os }}-${{ matrix.shard }}-${{ github.sha }}
+          restore-keys: |
+            test-bin-${{ runner.os }}-${{ matrix.shard }}-
 
       - name: Test + package (via Makefile)
         uses: ./.github/actions/sailfin-build


### PR DESCRIPTION
## Summary
The final CI lever from SFEP-0044's scope: shard legs restore `build/cache/test-bin` from the most recent prior run of the same OS+shard (`actions/cache` prefix restore), instead of cold-building all their test binaries every run. The ci.yml comment claiming legs "restore their own test-bin cache" now matches reality.

**Why it's safe:** correctness is enforced by the cache entry keys themselves — `test_bin_cache_key` folds test-source hash + dep closure + **compiler identity** + **runtime identity** (#1233). A restored stale entry can never serve a wrong binary; a PR that changes the compiler misses every entry (correct cold start). The merge/seedcheck gate and nightly `make check` keep `--no-test-cache` — the cold backstop invariant is untouched.

## Expected effect
- Docs/CI/non-compiler PRs: high `cache.test_bin_hit_rate` (visible in the `--json` summary), shard legs drop from minutes of building to mostly exec time. Compounds with #2007's per-file cut for the misses.
- Compiler PRs: no behavior change (identity miss ⇒ cold, as today).
- Cache growth: entries re-save per run under a sha-suffixed key; GitHub LRU-evicts at the repo cap.

## Verification
- YAML validated; no `--no-test-cache` in the shard path (only `make check`'s legs, by design); no `SAILFIN_BUILD_CACHE_DIR` override anywhere (path `build/cache/test-bin` is canonical).
- The proof lands with this PR's own *second* CI run (first run seeds the cache) — check `test_bin_hit_rate` and leg durations there.

Closes #2008