### PR TITLE
docs: graduate SFEP-0044 to Implemented + status.md test-perf sync

### DIFF
--- a/docs/proposals/0044-test-runner-invocation-cache.md
+++ b/docs/proposals/0044-test-runner-invocation-cache.md
@@ -1,12 +1,12 @@
 ---
 sfep: 0044
 title: Invocation-scoped runtime identity + in-process sha256 for the test runner
-status: Accepted
+status: Implemented
 type: tooling
 created: 2026-07-08
 updated: 2026-07-08
 author: "agent:compiler-architect; human review"
-tracking: "#1995, #1996, #1997, #1998, #1999"
+tracking: "#1995, #1996, #1997, #1998, #1999, #2008, #2010"
 supersedes:
 superseded-by:
 graduates-to:
@@ -29,6 +29,7 @@ all per-file runtime hashing on the warm path, and (B) replaces the
 vendored from `capsules/sfn/crypto` — a compiler-source-only change with **no
 seed dependency**. (C) resolver-pass sharing is scoped as a follow-up. Expected
 warm per-file link window after A+B: from ~2.8–3.4 s to ~0.4–0.5 s.
+Implemented via PRs #2000, #2001, #2007, #2009 (2026-07-08); work item C continues as #1997, dep-closure compile sharing as #2010.
 
 ## 2. Motivation
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -66,7 +66,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0041](./0041-typeck-expected-type-context.md) | Unified expected-type + typing-environment context for the typecheck walk | Implemented | tooling |
 | [0042](./0042-nested-function-declarations.md) | Nested / Local Function Declarations (non-capturing static `fn` items) | Accepted | language |
 | [0043](./0043-phase-scoped-arena-reclamation.md) | Phase-scoped arena reclamation to reduce per-module peak RSS | Implemented | runtime |
-| [0044](./0044-test-runner-invocation-cache.md) | Invocation-scoped runtime identity + in-process sha256 for the test runner | Accepted | tooling |
+| [0044](./0044-test-runner-invocation-cache.md) | Invocation-scoped runtime identity + in-process sha256 for the test runner | Implemented | tooling |
 
 ## Drafts under review (numbers assigned at merge)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-07-07. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
+Updated: 2026-07-08. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -322,7 +322,7 @@ here.
 | Policy decorators (`@policy`) | Parsed only | No compiler or runtime effect |
 | `sfn fmt` | **Shipped** | Zero-config token-stream formatter, `--check`/`--write`, CI-enforced; architecture + limitations in `docs/proposals/0007-fmt-architecture.md` |
 | `sfn check` | **Shipped** | Parse + typecheck + effect-check, no codegen; `--json` envelope; cross-module conformance; directory mode completes the full 156-file tree (~295 s — perf, not stability, is the open item); relative-import resolution (`E0430`/`E0431`, #1953) |
-| `sfn test` | **Shipped** | Discovery, `-k`/`--tag` filtering (#849), lifecycle hooks (#975, ordering only), snapshots + `--update-snapshots` (#977), `--jobs N` parallel runner (#1236), per-test binary cache (#1230/#1233) |
+| `sfn test` | **Shipped** | Discovery, `-k`/`--tag` filtering (#849), lifecycle hooks (#975, ordering only), snapshots + `--update-snapshots` (#977), `--jobs N` parallel runner (#1236), per-test binary cache (#1230/#1233). **Test-runner perf (SFEP-0044, 2026-07-08):** per warm test-file child (macOS 8-core): ~4 s → 2.9 s (in-process SHA-256 for text artifacts, #1995, PR #2000) → 1.75 s (invocation-scoped runtime-identity stamp, #1996, PR #2007); clang link window 2.9 s → 1.13 s. `make test` parallelism auto-detects via a test-child-sized 384 MB/job budget (`scripts/detect_test_jobs.sh`, #1998, PR #2001); `make check` runs ONE cold full suite (seedcheck leg, `--no-test-cache` backstop) + a pass1 smoke gate, `CHECK_FULL_PASS1=1` restores the old shape. CI shard legs restore a per-OS+shard test-binary cache across runs (#2008, PR #2009); safety is in the self-validating entry keys (#1233). Known residual: unit-tier cold cost dominated by per-child dep-closure compilation (~15 s CPU/file measured) — tracked as #2010; resolver sharing is #1997; binary-safe file read (retires the text/binary hash split) is #1999. |
 | `sfn vet` / `sfn lsp` / `sfn doc` / `sfn fix` | Planned | See `docs/proposals/0003-tooling.md` |
 | Package registry (`sfn init/add/publish`) | Shipped | Default registry `pkg.sfn.dev`; `SFN_REGISTRY` / `sfn config set registry` override |
 | `workspace.lock` (`sfn lock` write + resolver consume) | **Shipped** | Explicit `sfn lock` writes the root lockfile (#1070); `sfn lock --work-dir DIR` sets the workspace-discovery start dir so the command can run against a workspace without `cd`. Resolver prefers `workspace → workspace.lock → capsule.lock → cache → registry` for external deps, sibling-first untouched (#1071). Roots own lockfiles; library capsules don't commit them. Committing the root `workspace.lock` is #1050, gated on a seed embedding #1071 (satisfied at `v0.7.0-alpha.31`) |


### PR DESCRIPTION
Docs-only. Graduates SFEP-0044 to `Implemented` (shipped via #2000/#2001/#2007/#2009), flips the registry row, and syncs `docs/status.md` with the measured test-runner perf journey (per-file ~4 s → 2.9 s → 1.75 s; link window 2.9 s → 1.13 s) plus the residual trackers (#2010, #1997, #1999).