### PR TITLE
refactor(cli): migrate parse API to `Result<ParseResult, ParseError>`

### DIFF
--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -103,7 +103,14 @@ export {
 } from "./builder";
 
 // ---- Parsing ----
-export { parse, parse_with_env, run } from "./parser";
+export {
+    parse,
+    parse_with_env,
+    parse_is_ok,
+    parse_matches,
+    parse_error,
+    run
+} from "./parser";
 
 // ---- Match accessors ----
 export {

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -239,7 +239,13 @@ fn parse(cmd: Command, argv: string[]) -> Result<ParseResult, ParseError> {
                     // its required positionals/flags must be satisfied
                     // (and optional defaults filled) here, since the final
                     // post-loop validation only sees the leaf level.
-                    let _lr: ParseResult = _validate_level(cmd.name, path, active, pos_idx, pos_names, pos_values, fl_names, fl_values, fl_present)?;
+                    let level_result = _validate_level(cmd.name, path, active, pos_idx, pos_names, pos_values, fl_names, fl_values, fl_present);
+                    match level_result {
+                        Result.Ok { value } => { },
+                        Result.Err { error } => {
+                            return Result.Err { error: error };
+                        }
+                    }
                     path.push(token);
                     active = sub;
                     // Positionals are scoped per level; restart the
@@ -298,17 +304,11 @@ fn parse_with_env(cmd: Command, argv: string[]) -> Result<ParseResult, ParseErro
     // leaf level they were read from. The `env.get` read is the only
     // reason this entry carries `![io]` — `parse()` itself stays pure.
     let first_result = parse(cmd, argv);
-    let mut first_error: ParseError = _empty_parse_error();
-    let mut first_ok: boolean = true;
-    let mut first: ParseResult = ParseResult { matches: _empty_matches() };
-    match first_result {
-        Result.Ok { value } => { first = value; },
-        Result.Err { error } => {
-            first = ParseResult { matches: error.matches };
-            first_error = error;
-            first_ok = false;
-        }
-    }
+    let first_ok: boolean = parse_is_ok(first_result);
+    let first_error: ParseError = parse_error(first_result);
+    let first: ParseResult = ParseResult {
+        matches: parse_matches(first_result)
+    };
 
     // Help/version requests short-circuit identically on re-parse, so
     // skip the env reads entirely and return the pure result.
@@ -479,11 +479,8 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     // `parse_with_env()` is why env-bound flags resolve for real CLI entry
     // points while keeping the pure `parse()` available for embedding.
     let result = parse_with_env(cmd, argv);
-    let mut error: ParseError = _empty_parse_error();
-    match result {
-        Result.Ok { value } => { return value.matches; },
-        Result.Err { error: err } => { error = err; }
-    }
+    if parse_is_ok(result) { return parse_matches(result); }
+    let error: ParseError = parse_error(result);
 
     let path = error.matches.subcommand_path;
     let active = _resolve_active_path(cmd, path);

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -35,7 +35,7 @@ import {
     ParseResult
 } from "./types";
 
-fn parse(cmd: Command, argv: string[]) -> ParseResult {
+fn parse(cmd: Command, argv: string[]) -> Result<ParseResult, ParseError> {
     // Pure, non-exiting argv parser. Returns a ParseResult that
     // describes either successful matches or a structured error.
     let mut pos_names: string[] = [];
@@ -239,8 +239,7 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
                     // its required positionals/flags must be satisfied
                     // (and optional defaults filled) here, since the final
                     // post-loop validation only sees the leaf level.
-                    let lr = _validate_level(cmd.name, path, active, pos_idx, pos_names, pos_values, fl_names, fl_values, fl_present);
-                    if !lr.ok { return lr; }
+                    let _lr: ParseResult = _validate_level(cmd.name, path, active, pos_idx, pos_names, pos_values, fl_names, fl_values, fl_present)?;
                     path.push(token);
                     active = sub;
                     // Positionals are scoped per level; restart the
@@ -281,7 +280,7 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
     return _validate_level(cmd.name, path, active, pos_idx, pos_names, pos_values, fl_names, fl_values, fl_present);
 }
 
-fn parse_with_env(cmd: Command, argv: string[]) -> ParseResult ![io] {
+fn parse_with_env(cmd: Command, argv: string[]) -> Result<ParseResult, ParseError> ![io] {
     // Env-aware variant of `parse()`. Runs the pure parser first to
     // discover the matched (leaf) command level and which flags argv
     // supplied, then for each flag on that level bound via `flag_env`
@@ -298,13 +297,28 @@ fn parse_with_env(cmd: Command, argv: string[]) -> ParseResult ![io] {
     // injected tokens are appended to argv, so they validate at the same
     // leaf level they were read from. The `env.get` read is the only
     // reason this entry carries `![io]` — `parse()` itself stays pure.
-    let first = parse(cmd, argv);
+    let first_result = parse(cmd, argv);
+    let mut first_error: ParseError = _empty_parse_error();
+    let mut first_ok: boolean = true;
+    let mut first: ParseResult = ParseResult { matches: _empty_matches() };
+    match first_result {
+        Result.Ok { value } => { first = value; },
+        Result.Err { error } => {
+            first = ParseResult { matches: error.matches };
+            first_error = error;
+            first_ok = false;
+        }
+    }
 
     // Help/version requests short-circuit identically on re-parse, so
     // skip the env reads entirely and return the pure result.
-    if !first.ok {
-        if strings_equal(first.error.kind, "help_requested") { return first; }
-        if strings_equal(first.error.kind, "version_requested") { return first; }
+    if !first_ok {
+        if strings_equal(first_error.kind, "help_requested") {
+            return first_result;
+        }
+        if strings_equal(first_error.kind, "version_requested") {
+            return first_result;
+        }
     }
 
     let active = _resolve_active_path(cmd, first.matches.subcommand_path);
@@ -324,7 +338,7 @@ fn parse_with_env(cmd: Command, argv: string[]) -> ParseResult ![io] {
         i += 1;
     }
 
-    if extra.length == 0 { return first; }
+    if extra.length == 0 { return first_result; }
 
     // Rebuild argv with the env-supplied tokens appended. Copy
     // element-by-element rather than aliasing the caller's `argv`, so the
@@ -345,7 +359,7 @@ fn parse_with_env(cmd: Command, argv: string[]) -> ParseResult ![io] {
     return parse(cmd, aug);
 }
 
-fn _validate_level(cmd_name: string, path: string[], active: Command, pos_idx: int, pos_names: string[], pos_values: string[], fl_names: string[], fl_values: string[], fl_present: boolean[]) -> ParseResult {
+fn _validate_level(cmd_name: string, path: string[], active: Command, pos_idx: int, pos_names: string[], pos_values: string[], fl_names: string[], fl_values: string[], fl_present: boolean[]) -> Result<ParseResult, ParseError> {
     // Finalize a single command level: fill optional positional
     // defaults, enforce required positionals, and enforce required
     // flags. Mutates `pos_names`/`pos_values` in place to record filled
@@ -427,7 +441,9 @@ fn _validate_level(cmd_name: string, path: string[], active: Command, pos_idx: i
         flag_values: fl_values,
         flag_present: fl_present
     };
-    return ParseResult { ok: true, matches: matches, error: _ok_error() };
+    return Result.Ok {
+        value: ParseResult { matches: matches }
+    };
 }
 
 fn run(cmd: Command, argv: string[]) -> Matches ![io] {
@@ -439,12 +455,16 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     // `parse_with_env()` is why env-bound flags resolve for real CLI entry
     // points while keeping the pure `parse()` available for embedding.
     let result = parse_with_env(cmd, argv);
-    if result.ok { return result.matches; }
+    let mut error: ParseError = _empty_parse_error();
+    match result {
+        Result.Ok { value } => { return value.matches; },
+        Result.Err { error: err } => { error = err; }
+    }
 
-    let path = result.matches.subcommand_path;
+    let path = error.matches.subcommand_path;
     let active = _resolve_active_path(cmd, path);
     let label = _command_label(cmd.name, path);
-    let kind = result.error.kind;
+    let kind = error.kind;
 
     if strings_equal(kind, "help_requested") {
         print(_format_help(active, label));
@@ -469,25 +489,39 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     // suffix for every kind except `missing_value` (which historically
     // omits the hint), so a single stderr write reproduces the
     // pre-parse() stderr exactly.
-    print.err(result.error.message);
+    print.err(error.message);
     process.exit(EXIT_USAGE);
-    return result.matches;
+    return error.matches;
 }
 
 fn _with_hint(cmd_name: string, path: string[], first_line: string) -> string {
     return first_line + "\nrun '" + _help_hint(cmd_name, path) + "' for usage";
 }
 
-fn _ok_error() -> ParseError {
+fn _empty_matches() -> Matches {
+    return Matches {
+        command_name: "",
+        subcommand_name: "",
+        subcommand_path: [],
+        positional_names: [],
+        positional_values: [],
+        flag_names: [],
+        flag_values: [],
+        flag_present: []
+    };
+}
+
+fn _empty_parse_error() -> ParseError {
     return ParseError {
         kind: "ok",
         message: "",
         flag_name: "",
-        arg_name: ""
+        arg_name: "",
+        matches: _empty_matches()
     };
 }
 
-fn _err_result(command_name: string, path: string[], pos_names: string[], pos_values: string[], fl_names: string[], fl_values: string[], fl_present: boolean[], kind: string, message: string, flag_name: string, arg_name: string) -> ParseResult {
+fn _err_result(command_name: string, path: string[], pos_names: string[], pos_values: string[], fl_names: string[], fl_values: string[], fl_present: boolean[], kind: string, message: string, flag_name: string, arg_name: string) -> Result<ParseResult, ParseError> {
     let matches = Matches {
         command_name: command_name,
         subcommand_name: _leaf_name(path),
@@ -498,14 +532,13 @@ fn _err_result(command_name: string, path: string[], pos_names: string[], pos_va
         flag_values: fl_values,
         flag_present: fl_present
     };
-    return ParseResult {
-        ok: false,
-        matches: matches,
+    return Result.Err {
         error: ParseError {
             kind: kind,
             message: message,
             flag_name: flag_name,
-            arg_name: arg_name
+            arg_name: arg_name,
+            matches: matches
         }
     };
 }

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -446,6 +446,30 @@ fn _validate_level(cmd_name: string, path: string[], active: Command, pos_idx: i
     };
 }
 
+fn parse_is_ok(result: Result<ParseResult, ParseError>) -> boolean {
+    match result {
+        Result.Ok { value } => { return true; },
+        Result.Err { error } => { return false; }
+    }
+    return false;
+}
+
+fn parse_matches(result: Result<ParseResult, ParseError>) -> Matches {
+    match result {
+        Result.Ok { value } => { return value.matches; },
+        Result.Err { error } => { return error.matches; }
+    }
+    return _empty_matches();
+}
+
+fn parse_error(result: Result<ParseResult, ParseError>) -> ParseError {
+    match result {
+        Result.Ok { value } => { return _empty_parse_error(); },
+        Result.Err { error } => { return error; }
+    }
+    return _empty_parse_error();
+}
+
 fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     // Exiting wrapper around `parse_with_env()`. Prints help/version and
     // exits when --help/-h or --version/-V is given. Prints an error and

--- a/capsules/sfn/cli/src/types.sfn
+++ b/capsules/sfn/cli/src/types.sfn
@@ -138,18 +138,15 @@ struct ParseError {
     message: string;
     flag_name: string;
     arg_name: string;
+    matches: Matches;
 }
 
-// ParseResult is the non-exiting return shape of `parse()`. On success
-// `ok` is true and `matches` is the parsed `Matches`; on any other
-// outcome (including help/version requests) `ok` is false and `error`
-// describes what happened. `matches` still reflects whatever was
-// accumulated before the early exit so callers can inspect partial
-// state.
+// ParseResult is the successful return shape of `parse()`. Parse
+// failures, help, and version requests propagate as `Result.Err` with
+// `ParseError`; the error carries partial `Matches` so callers can
+// preserve legacy command-specific usage handling.
 struct ParseResult {
-    ok: boolean;
     matches: Matches;
-    error: ParseError;
 }
 
 // Style carries the resolved policy for emitting ANSI escape codes to

--- a/capsules/sfn/cli/tests/choice_flag_test.sfn
+++ b/capsules/sfn/cli/tests/choice_flag_test.sfn
@@ -13,6 +13,9 @@ import {
     flag_choice,
     get_choice,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     with_flag
 } from "../src/mod";
 
@@ -22,8 +25,8 @@ test "choice: flag_choice accepts an allowed value" {
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "Pick a color", choices));
     let argv: string[] = ["app", "--color", "green"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(get_choice(r.matches, "color"), "green");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get_choice(parse_matches(r), "color"), "green");
 }
 
 test "choice: flag_choice accepts the first allowed value" {
@@ -31,8 +34,8 @@ test "choice: flag_choice accepts the first allowed value" {
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "Pick a color", choices));
     let argv: string[] = ["app", "--color", "red"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(get_choice(r.matches, "color"), "red");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get_choice(parse_matches(r), "color"), "red");
 }
 
 // ---- invalid_choice: a value outside the set is rejected ----
@@ -41,9 +44,9 @@ test "choice: value outside the set yields invalid_choice" {
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "Pick a color", choices));
     let argv: string[] = ["app", "--color", "mauve"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "invalid_choice");
-    assert strings_equal(r.error.flag_name, "color");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "invalid_choice");
+    assert strings_equal(parse_error(r).flag_name, "color");
 }
 
 // ---- invalid_choice: message reports the allowed set and the value ----
@@ -52,8 +55,8 @@ test "choice: invalid_choice message lists the allowed set" {
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "Pick a color", choices));
     let argv: string[] = ["app", "--color", "mauve"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert string_starts_with(r.error.message, "error: flag --color expected one of {red, green, blue}, got 'mauve'");
+    assert parse_is_ok(r) == false;
+    assert string_starts_with(parse_error(r).message, "error: flag --color expected one of {red, green, blue}, got 'mauve'");
 }
 
 // ---- case-sensitivity: matching is exact (open question deferred) ----
@@ -62,8 +65,8 @@ test "choice: matching is case-sensitive" {
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "Pick a color", choices));
     let argv: string[] = ["app", "--color", "GREEN"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "invalid_choice");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "invalid_choice");
 }
 
 // ---- absent optional choice flag returns the documented sentinel ----
@@ -72,6 +75,6 @@ test "choice: get_choice returns empty sentinel when flag absent" {
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "Pick a color", choices));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(get_choice(r.matches, "color"), "");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get_choice(parse_matches(r), "color"), "");
 }

--- a/capsules/sfn/cli/tests/cli_test.sfn
+++ b/capsules/sfn/cli/tests/cli_test.sfn
@@ -22,6 +22,9 @@ import {
     has_flag,
     help,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     red,
     subcommand,
     with_arg,
@@ -136,14 +139,14 @@ test "cli: builders chain preserves all fields" {
 test "cli: parse single positional argument" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source file"));
     let argv: string[] = ["app", "hello.sfn"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "file"), "hello.sfn");
 }
 
 test "cli: parse multiple positional arguments" {
     let cmd = with_arg(with_arg(command("app", "desc"), arg("src", "Source")), arg("dst", "Destination"));
     let argv: string[] = ["app", "a.sfn", "b.sfn"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "src"), "a.sfn");
     assert strings_equal(get(m, "dst"), "b.sfn");
 }
@@ -151,49 +154,49 @@ test "cli: parse multiple positional arguments" {
 test "cli: parse optional positional uses default when missing" {
     let cmd = with_arg(command("app", "desc"), arg_optional("path", "Directory", "."));
     let argv: string[] = ["app"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "path"), ".");
 }
 
 test "cli: parse optional positional uses provided value" {
     let cmd = with_arg(command("app", "desc"), arg_optional("path", "Directory", "."));
     let argv: string[] = ["app", "src/"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "path"), "src/");
 }
 
 test "cli: parse long boolean flag" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "Verbose"));
     let argv: string[] = ["app", "--verbose"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert has_flag(m, "verbose") == true;
 }
 
 test "cli: parse long value flag" {
     let cmd = with_flag(command("app", "desc"), flag_value("output", "Out"));
     let argv: string[] = ["app", "--output", "build/out"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "output"), "build/out");
 }
 
 test "cli: parse short boolean flag" {
     let cmd = with_flag(command("app", "desc"), flag_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-v"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert has_flag(m, "verbose") == true;
 }
 
 test "cli: parse short value flag" {
     let cmd = with_flag(command("app", "desc"), flag_value_short("output", "o", "Out"));
     let argv: string[] = ["app", "-o", "build/out"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "output"), "build/out");
 }
 
 test "cli: parse mixed flags and positionals" {
     let cmd = with_flag(with_flag(with_arg(command("app", "desc"), arg("file", "Source")), flag("verbose", "Verbose")), flag_value_short("output", "o", "Output"));
     let argv: string[] = ["app", "--verbose", "-o", "out.bin", "main.sfn"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(get(m, "file"), "main.sfn");
     assert has_flag(m, "verbose") == true;
     assert strings_equal(get(m, "output"), "out.bin");
@@ -203,7 +206,7 @@ test "cli: parse subcommand" {
     let sub = with_arg(command("build", "Build"), arg("file", "Source"));
     let cmd = with_subcommand(command("app", "desc"), sub);
     let argv: string[] = ["app", "build", "main.sfn"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(subcommand(m), "build");
     assert strings_equal(get(m, "file"), "main.sfn");
 }
@@ -212,7 +215,7 @@ test "cli: parse subcommand with flags" {
     let sub = with_flag(with_arg(command("build", "Build"), arg("file", "Source")), flag_value_short("output", "o", "Output"));
     let cmd = with_subcommand(command("app", "desc"), sub);
     let argv: string[] = ["app", "build", "-o", "a.out", "main.sfn"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(subcommand(m), "build");
     assert strings_equal(get(m, "output"), "a.out");
     assert strings_equal(get(m, "file"), "main.sfn");
@@ -221,7 +224,7 @@ test "cli: parse subcommand with flags" {
 test "cli: no subcommand returns empty string" {
     let cmd = with_subcommand(command("app", "desc"), command("build", "Build"));
     let argv: string[] = ["app"];
-    let m = parse(cmd, argv).matches;
+    let m = parse_matches(parse(cmd, argv));
     assert strings_equal(subcommand(m), "");
 }
 
@@ -232,22 +235,22 @@ test "cli: unknown token treated as positional when no args defined" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "unknown"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unexpected_positional");
-    assert r.matches.positional_values.length == 0;
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unexpected_positional");
+    assert parse_matches(r).positional_values.length == 0;
 }
 
 // ---- Match accessor tests ----
 // These tests assert that accessors handle absent names correctly. An
-// `r.ok` precheck guards against parse() regressing to returning empty
+// `parse_is_ok(r)` precheck guards against parse() regressing to returning empty
 // matches alongside an error — which would silently satisfy assertions
 // like `get(..., "missing") == ""`.
 test "cli: get returns empty string for missing name" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert strings_equal(get(m, "nonexistent"), "");
 }
 
@@ -255,8 +258,8 @@ test "cli: get_or returns default for missing name" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert strings_equal(get_or(m, "missing", "fallback"), "fallback");
 }
 
@@ -264,8 +267,8 @@ test "cli: get_or returns actual value when present" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert strings_equal(get_or(m, "file", "fallback"), "test.sfn");
 }
 
@@ -295,8 +298,8 @@ test "cli: has_flag returns false for missing flag" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "V"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert has_flag(m, "verbose") == false;
 }
 
@@ -304,8 +307,8 @@ test "cli: has returns true for present positional" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "main.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert has(m, "file") == true;
 }
 
@@ -313,8 +316,8 @@ test "cli: has returns true for present flag" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "V"));
     let argv: string[] = ["app", "--verbose"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert has(m, "verbose") == true;
 }
 
@@ -322,8 +325,8 @@ test "cli: has returns false for missing name" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let m = r.matches;
+    assert parse_is_ok(r) == true;
+    let m = parse_matches(r);
     assert has(m, "anything") == false;
 }
 
@@ -385,8 +388,8 @@ test "cli: help hint without subcommand" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "--bogus"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert _contains(r.error.message, "run 'app --help' for usage") == true;
+    assert parse_is_ok(r) == false;
+    assert _contains(parse_error(r).message, "run 'app --help' for usage") == true;
 }
 
 test "cli: help hint with subcommand" {
@@ -394,8 +397,8 @@ test "cli: help hint with subcommand" {
     let cmd = with_subcommand(command("app", "desc"), sub);
     let argv: string[] = ["app", "build", "--bogus"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert _contains(r.error.message, "run 'app build --help' for usage") == true;
+    assert parse_is_ok(r) == false;
+    assert _contains(parse_error(r).message, "run 'app build --help' for usage") == true;
 }
 
 // ---- ANSI styling tests ----

--- a/capsules/sfn/cli/tests/env_flag_test.sfn
+++ b/capsules/sfn/cli/tests/env_flag_test.sfn
@@ -20,6 +20,9 @@ import {
     has_flag,
     help,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     parse_with_env,
     with_flag
 } from "../src/mod";
@@ -79,8 +82,8 @@ test "parse: pure parser ignores env binding (flag stays absent)" {
     let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "PATH"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert has_flag(r.matches, "token") == false;
+    assert parse_is_ok(r) == true;
+    assert has_flag(parse_matches(r), "token") == false;
 }
 
 // ---- parse_with_env: argv present (env must not override) ----
@@ -88,8 +91,8 @@ test "parse_with_env: argv present with unset env yields argv value" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), UNSET_VAR));
     let argv: string[] = ["app", "--token", "from-argv"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "token"), "from-argv");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "token"), "from-argv");
 }
 
 test "parse_with_env: argv value wins over env when both are present" ![io] {
@@ -98,9 +101,9 @@ test "parse_with_env: argv value wins over env when both are present" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "PATH"));
     let argv: string[] = ["app", "--token", "explicit"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "token"), "explicit");
-    assert ! strings_equal(get(r.matches, "token"), path_value);
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "token"), "explicit");
+    assert ! strings_equal(get(parse_matches(r), "token"), path_value);
 }
 
 // ---- parse_with_env: argv absent (env fills in) ----
@@ -110,9 +113,9 @@ test "parse_with_env: env value used when argv is absent" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "PATH"));
     let argv: string[] = ["app"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == true;
-    assert has_flag(r.matches, "token") == true;
-    assert strings_equal(get(r.matches, "token"), path_value);
+    assert parse_is_ok(r) == true;
+    assert has_flag(parse_matches(r), "token") == true;
+    assert strings_equal(get(parse_matches(r), "token"), path_value);
 }
 
 test "parse_with_env: boolean flag marked present from env" ![io] {
@@ -121,16 +124,16 @@ test "parse_with_env: boolean flag marked present from env" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_env(flag("debug", "Enable debug"), "PATH"));
     let argv: string[] = ["app"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == true;
-    assert has_flag(r.matches, "debug") == true;
+    assert parse_is_ok(r) == true;
+    assert has_flag(parse_matches(r), "debug") == true;
 }
 
 test "parse_with_env: unset env with argv absent leaves optional flag absent" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), UNSET_VAR));
     let argv: string[] = ["app"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == true;
-    assert has_flag(r.matches, "token") == false;
+    assert parse_is_ok(r) == true;
+    assert has_flag(parse_matches(r), "token") == false;
 }
 
 // ---- parse_with_env + flag_required ----
@@ -140,18 +143,18 @@ test "parse_with_env: required flag satisfied by env alone" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_required(flag_env(flag_value("token", "API token"), "PATH")));
     let argv: string[] = ["app"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
-    assert strings_equal(get(r.matches, "token"), path_value);
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
+    assert strings_equal(get(parse_matches(r), "token"), path_value);
 }
 
 test "parse_with_env: required env flag still fails when env unset and argv absent" ![io] {
     let cmd = with_flag(command("app", "desc"), flag_required(flag_env(flag_value("token", "API token"), UNSET_VAR)));
     let argv: string[] = ["app"];
     let r = parse_with_env(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.flag_name, "token");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).flag_name, "token");
 }
 
 // ---- Help annotation ----

--- a/capsules/sfn/cli/tests/equals_and_sentinel_test.sfn
+++ b/capsules/sfn/cli/tests/equals_and_sentinel_test.sfn
@@ -26,6 +26,9 @@ import {
     get_path,
     has,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     positionals,
     with_arg,
     with_flag
@@ -35,128 +38,128 @@ import {
 test "equals: string flag --out=FILE matches --out FILE" {
     let cmd = with_flag(command("app", "desc"), flag_value("out", "Output"));
     let r = parse(cmd, ["app", "--out=build/out.txt"]);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "out"), "build/out.txt");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "out"), "build/out.txt");
 }
 
 test "equals: int flag --count=42 parses to 42" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let r = parse(cmd, ["app", "--count=42"]);
-    assert r.ok == true;
-    assert get_int(r.matches, "count") == 42;
+    assert parse_is_ok(r) == true;
+    assert get_int(parse_matches(r), "count") == 42;
 }
 
 test "equals: int flag --delta=-7 parses a negative integer" {
     let cmd = with_flag(command("app", "desc"), flag_int("delta", "Offset"));
     let r = parse(cmd, ["app", "--delta=-7"]);
-    assert r.ok == true;
-    assert get_int(r.matches, "delta") == -7;
+    assert parse_is_ok(r) == true;
+    assert get_int(parse_matches(r), "delta") == -7;
 }
 
 test "equals: float flag --ratio=0.5 parses to 0.5" {
     let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
     let r = parse(cmd, ["app", "--ratio=0.5"]);
-    assert r.ok == true;
-    assert get_float(r.matches, "ratio") == 0.5;
+    assert parse_is_ok(r) == true;
+    assert get_float(parse_matches(r), "ratio") == 0.5;
 }
 
 test "equals: path flag --out=dir/x returns the path verbatim" {
     let cmd = with_flag(command("app", "desc"), flag_path("out", "Output"));
     let r = parse(cmd, ["app", "--out=dir/x"]);
-    assert r.ok == true;
-    assert strings_equal(get_path(r.matches, "out"), "dir/x");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get_path(parse_matches(r), "out"), "dir/x");
 }
 
 test "equals: choice flag --color=auto accepts a valid choice" {
     let choices: string[] = ["always", "auto", "never"];
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "When", choices));
     let r = parse(cmd, ["app", "--color=auto"]);
-    assert r.ok == true;
-    assert strings_equal(get_choice(r.matches, "color"), "auto");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get_choice(parse_matches(r), "color"), "auto");
 }
 
 test "equals: choice flag --color=bogus yields invalid_choice" {
     let choices: string[] = ["always", "auto", "never"];
     let cmd = with_flag(command("app", "desc"), flag_choice("color", "When", choices));
     let r = parse(cmd, ["app", "--color=bogus"]);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "invalid_choice");
-    assert strings_equal(r.error.flag_name, "color");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "invalid_choice");
+    assert strings_equal(parse_error(r).flag_name, "color");
 }
 
 // ---- `--key=` (empty value after `=`) ----
 test "equals: string flag --out= yields an empty string value" {
     let cmd = with_flag(command("app", "desc"), flag_value("out", "Output"));
     let r = parse(cmd, ["app", "--out="]);
-    assert r.ok == true;
-    assert has(r.matches, "out") == true;
-    assert strings_equal(get(r.matches, "out"), "");
+    assert parse_is_ok(r) == true;
+    assert has(parse_matches(r), "out") == true;
+    assert strings_equal(get(parse_matches(r), "out"), "");
 }
 
 test "equals: int flag --count= yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let r = parse(cmd, ["app", "--count="]);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "count");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "count");
 }
 
 test "equals: float flag --ratio= yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
     let r = parse(cmd, ["app", "--ratio="]);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "ratio");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "ratio");
 }
 
 test "equals: path flag --out= yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_path("out", "Output"));
     let r = parse(cmd, ["app", "--out="]);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "out");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "out");
 }
 
 // ---- `--key=a=b=c` splits on the first `=` only ----
 test "equals: value retains embedded equals (--out=a=b=c)" {
     let cmd = with_flag(command("app", "desc"), flag_value("out", "Output"));
     let r = parse(cmd, ["app", "--out=a=b=c"]);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "out"), "a=b=c");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "out"), "a=b=c");
 }
 
 // ---- non-value flags reject an inline value ----
 test "equals: boolean flag --verbose=x yields unexpected_value" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "Loud"));
     let r = parse(cmd, ["app", "--verbose=x"]);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unexpected_value");
-    assert strings_equal(r.error.flag_name, "verbose");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unexpected_value");
+    assert strings_equal(parse_error(r).flag_name, "verbose");
 }
 
 test "equals: counted flag --verbose=2 yields unexpected_value" {
     let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Loud"));
     let r = parse(cmd, ["app", "--verbose=2"]);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unexpected_value");
-    assert strings_equal(r.error.flag_name, "verbose");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unexpected_value");
+    assert strings_equal(parse_error(r).flag_name, "verbose");
 }
 
 // ---- the `--` sentinel stops flag parsing ----
 test "sentinel: -- makes a following --flag a positional" {
     let cmd = with_arg(command("app", "desc"), arg("target", "Target"));
     let r = parse(cmd, ["app", "--", "--flag"]);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "target"), "--flag");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "target"), "--flag");
     // `flag` was NOT recorded as a flag.
-    assert has(r.matches, "flag") == false;
+    assert has(parse_matches(r), "flag") == false;
 }
 
 test "sentinel: tokens after -- collect into a variadic positional" {
     let cmd = with_arg(command("app", "desc"), arg_variadic("rest", "Passthrough"));
     let r = parse(cmd, ["app", "--", "--in", "-x", "plain"]);
-    assert r.ok == true;
-    let rest = positionals(r.matches, "rest");
+    assert parse_is_ok(r) == true;
+    let rest = positionals(parse_matches(r), "rest");
     assert rest.length == 3;
     assert strings_equal(rest[0], "--in");
     assert strings_equal(rest[1], "-x");
@@ -167,16 +170,16 @@ test "sentinel: a known flag before -- still parses, value after does not" {
     let app = with_flag(command("app", "desc"), flag_value("out", "Output"));
     let cmd = with_arg(app, arg("target", "Target"));
     let r = parse(cmd, ["app", "--out=here", "--", "--out=ignored"]);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "out"), "here");
-    assert strings_equal(get(r.matches, "target"), "--out=ignored");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "out"), "here");
+    assert strings_equal(get(parse_matches(r), "target"), "--out=ignored");
 }
 
 test "sentinel: a second -- after the sentinel is a literal positional" {
     let cmd = with_arg(command("app", "desc"), arg_variadic("rest", "Passthrough"));
     let r = parse(cmd, ["app", "--", "--", "a"]);
-    assert r.ok == true;
-    let rest = positionals(r.matches, "rest");
+    assert parse_is_ok(r) == true;
+    let rest = positionals(parse_matches(r), "rest");
     assert rest.length == 2;
     assert strings_equal(rest[0], "--");
     assert strings_equal(rest[1], "a");

--- a/capsules/sfn/cli/tests/flag_groups_test.sfn
+++ b/capsules/sfn/cli/tests/flag_groups_test.sfn
@@ -12,6 +12,9 @@ import {
     flag_group_exclusive,
     flag_group_required_one,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     with_flag,
     with_flag_group
 } from "../src/mod";
@@ -46,8 +49,8 @@ test "parse: exclusive group with exactly one member present yields ok" {
     let cmd = with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_exclusive(members));
     let argv: string[] = ["app", "--json"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
 }
 
 test "parse: exclusive group with zero members present yields ok" {
@@ -56,7 +59,7 @@ test "parse: exclusive group with zero members present yields ok" {
     let cmd = with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_exclusive(members));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
+    assert parse_is_ok(r) == true;
 }
 
 // ---- Exclusive: violation ----
@@ -65,9 +68,9 @@ test "parse: exclusive group with two members present yields violation" {
     let cmd = with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_exclusive(members));
     let argv: string[] = ["app", "--json", "--yaml"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "flag_group_violation");
-    assert strings_equal(r.error.message, "flags json and yaml are mutually exclusive");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "flag_group_violation");
+    assert strings_equal(parse_error(r).message, "flags json and yaml are mutually exclusive");
 }
 
 // ---- Required-one: happy path ----
@@ -76,8 +79,8 @@ test "parse: required-one group with exactly one member present yields ok" {
     let cmd = with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_required_one(members));
     let argv: string[] = ["app", "--yaml"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
 }
 
 // ---- Required-one: violation ----
@@ -86,9 +89,9 @@ test "parse: required-one group with zero members present yields violation" {
     let cmd = with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_required_one(members));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "flag_group_violation");
-    assert strings_equal(r.error.message, "one of json, yaml is required");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "flag_group_violation");
+    assert strings_equal(parse_error(r).message, "one of json, yaml is required");
 }
 
 test "parse: required-one group with two members present yields ok" {
@@ -99,8 +102,8 @@ test "parse: required-one group with two members present yields ok" {
     let cmd = with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_required_one(members));
     let argv: string[] = ["app", "--json", "--yaml"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
 }
 
 // ---- Composition: exactly-one (exclusive + required_one) ----
@@ -111,9 +114,9 @@ test "parse: composed exclusive + required-one rejects two members" {
     let cmd = with_flag_group(with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_exclusive(members)), flag_group_required_one(members));
     let argv: string[] = ["app", "--json", "--yaml"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "flag_group_violation");
-    assert strings_equal(r.error.message, "flags json and yaml are mutually exclusive");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "flag_group_violation");
+    assert strings_equal(parse_error(r).message, "flags json and yaml are mutually exclusive");
 }
 
 test "parse: composed exclusive + required-one accepts exactly one" {
@@ -121,8 +124,8 @@ test "parse: composed exclusive + required-one accepts exactly one" {
     let cmd = with_flag_group(with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_exclusive(members)), flag_group_required_one(members));
     let argv: string[] = ["app", "--json"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
 }
 
 test "parse: composed exclusive + required-one rejects zero members" {
@@ -130,7 +133,7 @@ test "parse: composed exclusive + required-one rejects zero members" {
     let cmd = with_flag_group(with_flag_group(with_flag(with_flag(command("app", "desc"), flag("json", "JSON output")), flag("yaml", "YAML output")), flag_group_exclusive(members)), flag_group_required_one(members));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "flag_group_violation");
-    assert strings_equal(r.error.message, "one of json, yaml is required");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "flag_group_violation");
+    assert strings_equal(parse_error(r).message, "one of json, yaml is required");
 }

--- a/capsules/sfn/cli/tests/nested_subcommand_test.sfn
+++ b/capsules/sfn/cli/tests/nested_subcommand_test.sfn
@@ -15,6 +15,9 @@ import {
     get,
     has_flag,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     subcommand,
     subcommand_path,
     with_arg,
@@ -27,9 +30,9 @@ test "parse: no subcommand yields empty path" {
     let root = with_arg(command("app", "App"), arg("file", "Source"));
     let argv: string[] = ["app", "main.sfn"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    assert subcommand_path(r.matches).length == 0;
-    assert strings_equal(subcommand(r.matches), "");
+    assert parse_is_ok(r) == true;
+    assert subcommand_path(parse_matches(r)).length == 0;
+    assert strings_equal(subcommand(parse_matches(r)), "");
 }
 
 test "parse: single level path has one element" {
@@ -37,11 +40,11 @@ test "parse: single level path has one element" {
     let root = with_subcommand(command("app", "App"), build);
     let argv: string[] = ["app", "build"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    let p = subcommand_path(r.matches);
+    assert parse_is_ok(r) == true;
+    let p = subcommand_path(parse_matches(r));
     assert p.length == 1;
     assert strings_equal(p[0], "build");
-    assert strings_equal(subcommand(r.matches), "build");
+    assert strings_equal(subcommand(parse_matches(r)), "build");
 }
 
 test "parse: descends two subcommand levels" {
@@ -50,9 +53,9 @@ test "parse: descends two subcommand levels" {
     let root = with_subcommand(command("app", "Root"), mid);
     let argv: string[] = ["app", "a", "b"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    assert strings_equal(subcommand(r.matches), "b");
-    let p = subcommand_path(r.matches);
+    assert parse_is_ok(r) == true;
+    assert strings_equal(subcommand(parse_matches(r)), "b");
+    let p = subcommand_path(parse_matches(r));
     assert p.length == 2;
     assert strings_equal(p[0], "a");
     assert strings_equal(p[1], "b");
@@ -65,13 +68,13 @@ test "parse: descends three subcommand levels" {
     let root = with_subcommand(command("app", "Root"), a);
     let argv: string[] = ["app", "a", "b", "c"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    let p = subcommand_path(r.matches);
+    assert parse_is_ok(r) == true;
+    let p = subcommand_path(parse_matches(r));
     assert p.length == 3;
     assert strings_equal(p[0], "a");
     assert strings_equal(p[1], "b");
     assert strings_equal(p[2], "c");
-    assert strings_equal(subcommand(r.matches), "c");
+    assert strings_equal(subcommand(parse_matches(r)), "c");
 }
 
 // ---- leaf positional (`sfn config get <key>`) ----
@@ -81,13 +84,13 @@ test "parse: leaf positional after nested subcommands" {
     let root = with_subcommand(command("sfn", "Sailfin"), config);
     let argv: string[] = ["sfn", "config", "get", "mykey"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    assert strings_equal(subcommand(r.matches), "get");
-    let p = subcommand_path(r.matches);
+    assert parse_is_ok(r) == true;
+    assert strings_equal(subcommand(parse_matches(r)), "get");
+    let p = subcommand_path(parse_matches(r));
     assert p.length == 2;
     assert strings_equal(p[0], "config");
     assert strings_equal(p[1], "get");
-    assert strings_equal(get(r.matches, "key"), "mykey");
+    assert strings_equal(get(parse_matches(r), "key"), "mykey");
 }
 
 // ---- per-level flag scoping ----
@@ -97,10 +100,10 @@ test "parse: flags scoped per level both match" {
     let root = with_subcommand(command("app", "App"), config);
     let argv: string[] = ["app", "config", "--root", "get", "--leaf"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    assert has_flag(r.matches, "root") == true;
-    assert has_flag(r.matches, "leaf") == true;
-    assert strings_equal(subcommand(r.matches), "get");
+    assert parse_is_ok(r) == true;
+    assert has_flag(parse_matches(r), "root") == true;
+    assert has_flag(parse_matches(r), "leaf") == true;
+    assert strings_equal(subcommand(parse_matches(r)), "get");
 }
 
 test "parse: parent flag not visible in child level" {
@@ -109,8 +112,8 @@ test "parse: parent flag not visible in child level" {
     let root = with_subcommand(command("app", "App"), config);
     let argv: string[] = ["app", "config", "get", "--root"];
     let r = parse(root, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unknown_flag");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unknown_flag");
 }
 
 // ---- unknown subcommand at each level ----
@@ -119,8 +122,8 @@ test "parse: unknown subcommand at first level" {
     let root = with_subcommand(command("app", "App"), config);
     let argv: string[] = ["app", "bogus"];
     let r = parse(root, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unknown_subcommand");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unknown_subcommand");
 }
 
 test "parse: unknown subcommand at second level reports path" {
@@ -129,14 +132,14 @@ test "parse: unknown subcommand at second level reports path" {
     let root = with_subcommand(command("app", "App"), config);
     let argv: string[] = ["app", "config", "bogus"];
     let r = parse(root, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unknown_subcommand");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unknown_subcommand");
     // The path descended so far is recorded so run() targets the right
     // help level, and the usage hint reflects the full path.
-    let p = subcommand_path(r.matches);
+    let p = subcommand_path(parse_matches(r));
     assert p.length == 1;
     assert strings_equal(p[0], "config");
-    assert strings_equal(r.error.message, "error: unknown subcommand 'bogus'\nrun 'app config --help' for usage");
+    assert strings_equal(parse_error(r).message, "error: unknown subcommand 'bogus'\nrun 'app config --help' for usage");
 }
 
 // ---- parent-level required arguments are enforced on descent ----
@@ -148,9 +151,9 @@ test "parse: required flag on parent level is enforced before descent" {
     // required --root, which must still be reported.
     let argv: string[] = ["app", "config", "get"];
     let r = parse(root, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.flag_name, "root");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).flag_name, "root");
 }
 
 test "parse: required parent flag satisfied before subcommand" {
@@ -159,9 +162,9 @@ test "parse: required parent flag satisfied before subcommand" {
     let root = with_subcommand(command("app", "App"), config);
     let argv: string[] = ["app", "config", "--root", "r1", "get"];
     let r = parse(root, argv);
-    assert r.ok == true;
-    assert strings_equal(get(r.matches, "root"), "r1");
-    assert strings_equal(subcommand(r.matches), "get");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get(parse_matches(r), "root"), "r1");
+    assert strings_equal(subcommand(parse_matches(r)), "get");
 }
 
 test "parse: required positional on parent level is enforced on descent" {
@@ -172,7 +175,7 @@ test "parse: required positional on parent level is enforced on descent" {
     // so config's required <profile> is omitted and must be reported.
     let argv: string[] = ["app", "config", "get"];
     let r = parse(root, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.arg_name, "profile");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).arg_name, "profile");
 }

--- a/capsules/sfn/cli/tests/parser_test.sfn
+++ b/capsules/sfn/cli/tests/parser_test.sfn
@@ -20,6 +20,9 @@ import {
     flag_value,
     flag_value_short,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     with_arg,
     with_flag,
     with_subcommand
@@ -30,25 +33,25 @@ test "parse: success sets ok=true and error.kind=\"ok\"" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "main.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
-    assert strings_equal(r.error.message, "");
-    assert strings_equal(r.error.flag_name, "");
-    assert strings_equal(r.error.arg_name, "");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
+    assert strings_equal(parse_error(r).message, "");
+    assert strings_equal(parse_error(r).flag_name, "");
+    assert strings_equal(parse_error(r).arg_name, "");
 }
 
 test "parse: success matches struct mirrors run() shape" {
     let cmd = with_flag(with_arg(command("app", "desc"), arg("file", "Source")), flag_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-v", "main.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.matches.command_name, "app");
-    assert strings_equal(r.matches.subcommand_name, "");
-    assert r.matches.positional_names.length == 1;
-    assert strings_equal(r.matches.positional_names[0], "file");
-    assert strings_equal(r.matches.positional_values[0], "main.sfn");
-    assert r.matches.flag_names.length == 1;
-    assert strings_equal(r.matches.flag_names[0], "verbose");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_matches(r).command_name, "app");
+    assert strings_equal(parse_matches(r).subcommand_name, "");
+    assert parse_matches(r).positional_names.length == 1;
+    assert strings_equal(parse_matches(r).positional_names[0], "file");
+    assert strings_equal(parse_matches(r).positional_values[0], "main.sfn");
+    assert parse_matches(r).flag_names.length == 1;
+    assert strings_equal(parse_matches(r).flag_names[0], "verbose");
 }
 
 // ---- "help_requested" ----
@@ -56,18 +59,18 @@ test "parse: --help yields help_requested without printing" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "--help"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "help_requested");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "help_requested");
     // parse() must not produce a printable message — run() formats it.
-    assert strings_equal(r.error.message, "");
+    assert strings_equal(parse_error(r).message, "");
 }
 
 test "parse: -h yields help_requested" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "-h"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "help_requested");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "help_requested");
 }
 
 test "parse: subcommand --help records subcommand_name" {
@@ -75,10 +78,10 @@ test "parse: subcommand --help records subcommand_name" {
     let cmd = with_subcommand(command("app", "desc"), sub);
     let argv: string[] = ["app", "build", "--help"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "help_requested");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "help_requested");
     // run() relies on subcommand_name to pick the right help target.
-    assert strings_equal(r.matches.subcommand_name, "build");
+    assert strings_equal(parse_matches(r).subcommand_name, "build");
 }
 
 // ---- "version_requested" ----
@@ -86,17 +89,17 @@ test "parse: --version yields version_requested" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "--version"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "version_requested");
-    assert strings_equal(r.error.message, "");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "version_requested");
+    assert strings_equal(parse_error(r).message, "");
 }
 
 test "parse: -V yields version_requested" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "-V"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "version_requested");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "version_requested");
 }
 
 // ---- "unknown_flag" ----
@@ -104,21 +107,21 @@ test "parse: unknown long flag yields unknown_flag" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "--bogus"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unknown_flag");
-    assert strings_equal(r.error.message, "error: unknown flag --bogus\nrun 'app --help' for usage");
-    assert strings_equal(r.error.flag_name, "bogus");
-    assert strings_equal(r.error.arg_name, "");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unknown_flag");
+    assert strings_equal(parse_error(r).message, "error: unknown flag --bogus\nrun 'app --help' for usage");
+    assert strings_equal(parse_error(r).flag_name, "bogus");
+    assert strings_equal(parse_error(r).arg_name, "");
 }
 
 test "parse: unknown short flag yields unknown_flag" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "-x"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unknown_flag");
-    assert strings_equal(r.error.message, "error: unknown flag -x\nrun 'app --help' for usage");
-    assert strings_equal(r.error.flag_name, "x");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unknown_flag");
+    assert strings_equal(parse_error(r).message, "error: unknown flag -x\nrun 'app --help' for usage");
+    assert strings_equal(parse_error(r).flag_name, "x");
 }
 
 // ---- "missing_value" ----
@@ -127,20 +130,20 @@ test "parse: long flag missing value yields missing_value" {
     let cmd = with_flag(command("app", "desc"), flag_value("output", "Output path"));
     let argv: string[] = ["app", "--output"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_value");
-    assert strings_equal(r.error.message, "error: flag --output requires a value");
-    assert strings_equal(r.error.flag_name, "output");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_value");
+    assert strings_equal(parse_error(r).message, "error: flag --output requires a value");
+    assert strings_equal(parse_error(r).flag_name, "output");
 }
 
 test "parse: short flag missing value yields missing_value" {
     let cmd = with_flag(command("app", "desc"), flag_value_short("output", "o", "Out"));
     let argv: string[] = ["app", "-o"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_value");
-    assert strings_equal(r.error.message, "error: flag -o requires a value");
-    assert strings_equal(r.error.flag_name, "o");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_value");
+    assert strings_equal(parse_error(r).message, "error: flag -o requires a value");
+    assert strings_equal(parse_error(r).flag_name, "o");
 }
 
 // ---- "unexpected_positional" ----
@@ -148,11 +151,11 @@ test "parse: extra positional yields unexpected_positional" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app", "extra"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unexpected_positional");
-    assert strings_equal(r.error.message, "error: unexpected argument 'extra'\nrun 'app --help' for usage");
-    assert strings_equal(r.error.arg_name, "extra");
-    assert strings_equal(r.error.flag_name, "");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unexpected_positional");
+    assert strings_equal(parse_error(r).message, "error: unexpected argument 'extra'\nrun 'app --help' for usage");
+    assert strings_equal(parse_error(r).arg_name, "extra");
+    assert strings_equal(parse_error(r).flag_name, "");
 }
 
 // ---- "missing_required" ----
@@ -160,32 +163,32 @@ test "parse: omitted required positional yields missing_required" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.message, "error: missing required argument <file>\nrun 'app --help' for usage");
-    assert strings_equal(r.error.arg_name, "file");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).message, "error: missing required argument <file>\nrun 'app --help' for usage");
+    assert strings_equal(parse_error(r).arg_name, "file");
 }
 
 test "parse: omitted required positional after a flag yields missing_required" {
     let cmd = with_flag(with_arg(command("app", "desc"), arg("file", "Source")), flag("verbose", "Verbose"));
     let argv: string[] = ["app", "--verbose"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.arg_name, "file");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).arg_name, "file");
     // Partial matches should still reflect the flag we consumed before
     // the missing-required diagnostic — useful for richer recovery in
     // future callers.
-    assert r.matches.flag_names.length == 1;
-    assert strings_equal(r.matches.flag_names[0], "verbose");
+    assert parse_matches(r).flag_names.length == 1;
+    assert strings_equal(parse_matches(r).flag_names[0], "verbose");
 }
 
 test "parse: optional positional missing still ok" {
     let cmd = with_arg(command("app", "desc"), arg_optional("path", "Directory", "."));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
-    assert r.matches.positional_values.length == 1;
-    assert strings_equal(r.matches.positional_values[0], ".");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
+    assert parse_matches(r).positional_values.length == 1;
+    assert strings_equal(parse_matches(r).positional_values[0], ".");
 }

--- a/capsules/sfn/cli/tests/repeat_count_test.sfn
+++ b/capsules/sfn/cli/tests/repeat_count_test.sfn
@@ -15,6 +15,9 @@ import {
     flag_count_short,
     flag_repeat,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     repeated,
     with_flag
 } from "../src/mod";
@@ -46,8 +49,8 @@ test "repeated: absent flag yields an empty list" {
     let cmd = with_flag(command("app", "desc"), flag_repeat("include", "Include"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let vals = repeated(r.matches, "include");
+    assert parse_is_ok(r) == true;
+    let vals = repeated(parse_matches(r), "include");
     assert vals.length == 0;
 }
 
@@ -55,8 +58,8 @@ test "repeated: a single occurrence yields one value" {
     let cmd = with_flag(command("app", "desc"), flag_repeat("include", "Include"));
     let argv: string[] = ["app", "--include", "a"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let vals = repeated(r.matches, "include");
+    assert parse_is_ok(r) == true;
+    let vals = repeated(parse_matches(r), "include");
     assert vals.length == 1;
     assert strings_equal(vals[0], "a");
 }
@@ -65,8 +68,8 @@ test "repeated: three occurrences collected in argv order" {
     let cmd = with_flag(command("app", "desc"), flag_repeat("include", "Include"));
     let argv: string[] = ["app", "--include", "a", "--include", "b", "--include", "c"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let vals = repeated(r.matches, "include");
+    assert parse_is_ok(r) == true;
+    let vals = repeated(parse_matches(r), "include");
     assert vals.length == 3;
     assert strings_equal(vals[0], "a");
     assert strings_equal(vals[1], "b");
@@ -78,24 +81,24 @@ test "count_flag: absent flag yields zero" {
     let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Verbose"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert count_flag(r.matches, "verbose") == 0;
+    assert parse_is_ok(r) == true;
+    assert count_flag(parse_matches(r), "verbose") == 0;
 }
 
 test "count_flag: a single long occurrence yields one" {
     let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Verbose"));
     let argv: string[] = ["app", "--verbose"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert count_flag(r.matches, "verbose") == 1;
+    assert parse_is_ok(r) == true;
+    assert count_flag(parse_matches(r), "verbose") == 1;
 }
 
 test "count_flag: three long occurrences yield three" {
     let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Verbose"));
     let argv: string[] = ["app", "--verbose", "--verbose", "--verbose"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert count_flag(r.matches, "verbose") == 3;
+    assert parse_is_ok(r) == true;
+    assert count_flag(parse_matches(r), "verbose") == 3;
 }
 
 // ---- count_flag: short and clustered forms ----
@@ -103,24 +106,24 @@ test "count_flag: a single short occurrence yields one" {
     let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-v"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert count_flag(r.matches, "verbose") == 1;
+    assert parse_is_ok(r) == true;
+    assert count_flag(parse_matches(r), "verbose") == 1;
 }
 
 test "count_flag: three separate short occurrences yield three" {
     let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-v", "-v", "-v"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert count_flag(r.matches, "verbose") == 3;
+    assert parse_is_ok(r) == true;
+    assert count_flag(parse_matches(r), "verbose") == 3;
 }
 
 test "count_flag: clustered -vvv increments the count by three" {
     let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-vvv"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert count_flag(r.matches, "verbose") == 3;
+    assert parse_is_ok(r) == true;
+    assert count_flag(parse_matches(r), "verbose") == 3;
 }
 
 // ---- a cluster of an unknown short alias is still rejected ----
@@ -128,6 +131,6 @@ test "count_flag: clustered unknown short flag is rejected" {
     let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-xxx"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "unknown_flag");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "unknown_flag");
 }

--- a/capsules/sfn/cli/tests/required_flag_test.sfn
+++ b/capsules/sfn/cli/tests/required_flag_test.sfn
@@ -15,6 +15,9 @@ import {
     has_flag,
     help,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     with_flag
 } from "../src/mod";
 
@@ -66,17 +69,17 @@ test "parse: required boolean flag present yields ok" {
     let cmd = with_flag(command("app", "desc"), flag_required(flag("force", "Force")));
     let argv: string[] = ["app", "--force"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
-    assert has_flag(r.matches, "force") == true;
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
+    assert has_flag(parse_matches(r), "force") == true;
 }
 
 test "parse: required value flag present yields ok" {
     let cmd = with_flag(command("app", "desc"), flag_required(flag_value("output", "Output")));
     let argv: string[] = ["app", "--output", "out.txt"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(r.error.kind, "ok");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(parse_error(r).kind, "ok");
 }
 
 // ---- Parser: absent ----
@@ -84,27 +87,27 @@ test "parse: required flag absent yields missing_required with flag_name" {
     let cmd = with_flag(command("app", "desc"), flag_required(flag("force", "Force")));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.flag_name, "force");
-    assert strings_equal(r.error.arg_name, "");
-    assert strings_equal(r.error.message, "error: missing required flag --force\nrun 'app --help' for usage");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).flag_name, "force");
+    assert strings_equal(parse_error(r).arg_name, "");
+    assert strings_equal(parse_error(r).message, "error: missing required flag --force\nrun 'app --help' for usage");
 }
 
 test "parse: required value flag absent yields missing_required" {
     let cmd = with_flag(command("app", "desc"), flag_required(flag_value("output", "Output")));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.flag_name, "output");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
+    assert strings_equal(parse_error(r).flag_name, "output");
 }
 
 test "parse: non-required flag absent stays ok" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "Verbose"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
+    assert parse_is_ok(r) == true;
 }
 
 test "parse: required flag absent — get_or default does NOT satisfy required" {
@@ -114,12 +117,12 @@ test "parse: required flag absent — get_or default does NOT satisfy required" 
     let cmd = with_flag(command("app", "desc"), flag_required(flag_value("output", "Output")));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "missing_required");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "missing_required");
     // The partial matches do not contain the flag, so `get_or` would
     // fall back to its default — but the caller never reaches that
     // codepath because `ok` is false.
-    let fallback = get_or(r.matches, "output", "out.txt");
+    let fallback = get_or(parse_matches(r), "output", "out.txt");
     assert strings_equal(fallback, "out.txt");
 }
 

--- a/capsules/sfn/cli/tests/typed_flags_test.sfn
+++ b/capsules/sfn/cli/tests/typed_flags_test.sfn
@@ -16,6 +16,9 @@ import {
     get_int,
     get_path,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     with_flag
 } from "../src/mod";
 
@@ -24,24 +27,24 @@ test "typed: flag_int parses a positive integer" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let argv: string[] = ["app", "--count", "42"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert get_int(r.matches, "count") == 42;
+    assert parse_is_ok(r) == true;
+    assert get_int(parse_matches(r), "count") == 42;
 }
 
 test "typed: flag_int parses a negative integer" {
     let cmd = with_flag(command("app", "desc"), flag_int("delta", "Offset"));
     let argv: string[] = ["app", "--delta", "-7"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert get_int(r.matches, "delta") == -7;
+    assert parse_is_ok(r) == true;
+    assert get_int(parse_matches(r), "delta") == -7;
 }
 
 test "typed: flag_int accepts the i64 maximum" {
     let cmd = with_flag(command("app", "desc"), flag_int("big", "Max"));
     let argv: string[] = ["app", "--big", "9223372036854775807"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert get_int(r.matches, "big") == 9223372036854775807;
+    assert parse_is_ok(r) == true;
+    assert get_int(parse_matches(r), "big") == 9223372036854775807;
 }
 
 // ---- happy path: float ----
@@ -49,16 +52,16 @@ test "typed: flag_float parses a decimal value" {
     let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
     let argv: string[] = ["app", "--ratio", "0.5"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert get_float(r.matches, "ratio") == 0.5;
+    assert parse_is_ok(r) == true;
+    assert get_float(parse_matches(r), "ratio") == 0.5;
 }
 
 test "typed: flag_float parses a negative decimal value" {
     let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
     let argv: string[] = ["app", "--ratio", "-2.25"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert get_float(r.matches, "ratio") == -2.25;
+    assert parse_is_ok(r) == true;
+    assert get_float(parse_matches(r), "ratio") == -2.25;
 }
 
 // ---- happy path: path ----
@@ -66,8 +69,8 @@ test "typed: flag_path returns the path verbatim" {
     let cmd = with_flag(command("app", "desc"), flag_path("out", "Output"));
     let argv: string[] = ["app", "--out", "build/out.txt"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert strings_equal(get_path(r.matches, "out"), "build/out.txt");
+    assert parse_is_ok(r) == true;
+    assert strings_equal(get_path(parse_matches(r), "out"), "build/out.txt");
 }
 
 // ---- type_error: overflow ----
@@ -76,9 +79,9 @@ test "typed: flag_int overflow yields type_error" {
     // i64 max + 1.
     let argv: string[] = ["app", "--big", "9223372036854775808"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "big");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "big");
 }
 
 // ---- type_error: non-numeric int ----
@@ -86,9 +89,9 @@ test "typed: flag_int non-numeric input yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let argv: string[] = ["app", "--count", "twelve"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "count");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "count");
 }
 
 // ---- type_error: empty value ----
@@ -96,9 +99,9 @@ test "typed: flag_int empty value yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let argv: string[] = ["app", "--count", ""];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "count");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "count");
 }
 
 // ---- type_error: non-numeric float ----
@@ -106,9 +109,9 @@ test "typed: flag_float non-numeric input yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
     let argv: string[] = ["app", "--ratio", "1.2.3"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "ratio");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "ratio");
 }
 
 // ---- type_error: empty path ----
@@ -116,9 +119,9 @@ test "typed: flag_path empty value yields type_error" {
     let cmd = with_flag(command("app", "desc"), flag_path("out", "Output"));
     let argv: string[] = ["app", "--out", ""];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert strings_equal(r.error.kind, "type_error");
-    assert strings_equal(r.error.flag_name, "out");
+    assert parse_is_ok(r) == false;
+    assert strings_equal(parse_error(r).kind, "type_error");
+    assert strings_equal(parse_error(r).flag_name, "out");
 }
 
 // ---- parse() never exits: error carries a usage hint ----
@@ -126,8 +129,8 @@ test "typed: type_error message includes a usage hint" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let argv: string[] = ["app", "--count", "nope"];
     let r = parse(cmd, argv);
-    assert r.ok == false;
-    assert string_starts_with(r.error.message, "error: flag --count");
+    assert parse_is_ok(r) == false;
+    assert string_starts_with(parse_error(r).message, "error: flag --count");
 }
 
 // ---- absent optional typed flag returns the documented sentinel ----
@@ -135,6 +138,6 @@ test "typed: get_int returns 0 sentinel when flag absent" {
     let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    assert get_int(r.matches, "count") == 0;
+    assert parse_is_ok(r) == true;
+    assert get_int(parse_matches(r), "count") == 0;
 }

--- a/capsules/sfn/cli/tests/variadic_test.sfn
+++ b/capsules/sfn/cli/tests/variadic_test.sfn
@@ -12,6 +12,9 @@ import {
     command,
     help,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     positionals,
     with_arg
 } from "../src/mod";
@@ -45,8 +48,8 @@ test "variadic: zero matches yields an empty list" {
     let cmd = with_arg(command("app", "Test app"), arg_variadic("files", "Files"));
     let argv: string[] = ["app"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let files = positionals(r.matches, "files");
+    assert parse_is_ok(r) == true;
+    let files = positionals(parse_matches(r), "files");
     assert files.length == 0;
 }
 
@@ -54,8 +57,8 @@ test "variadic: one match yields a single-element list" {
     let cmd = with_arg(command("app", "Test app"), arg_variadic("files", "Files"));
     let argv: string[] = ["app", "a.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let files = positionals(r.matches, "files");
+    assert parse_is_ok(r) == true;
+    let files = positionals(parse_matches(r), "files");
     assert files.length == 1;
     assert strings_equal(files[0], "a.sfn");
 }
@@ -64,8 +67,8 @@ test "variadic: three matches collected in order" {
     let cmd = with_arg(command("app", "Test app"), arg_variadic("files", "Files"));
     let argv: string[] = ["app", "a.sfn", "b.sfn", "c.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let files = positionals(r.matches, "files");
+    assert parse_is_ok(r) == true;
+    let files = positionals(parse_matches(r), "files");
     assert files.length == 3;
     assert strings_equal(files[0], "a.sfn");
     assert strings_equal(files[1], "b.sfn");
@@ -77,11 +80,11 @@ test "variadic: a fixed positional before the tail is populated" {
     let cmd = with_arg(with_arg(command("app", "Test app"), arg("src", "Source")), arg_variadic("rest", "Remaining"));
     let argv: string[] = ["app", "main.sfn", "x", "y"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let src = positionals(r.matches, "src");
+    assert parse_is_ok(r) == true;
+    let src = positionals(parse_matches(r), "src");
     assert src.length == 1;
     assert strings_equal(src[0], "main.sfn");
-    let rest = positionals(r.matches, "rest");
+    let rest = positionals(parse_matches(r), "rest");
     assert rest.length == 2;
     assert strings_equal(rest[0], "x");
     assert strings_equal(rest[1], "y");
@@ -91,11 +94,11 @@ test "variadic: a required fixed positional before an empty tail still parses" {
     let cmd = with_arg(with_arg(command("app", "Test app"), arg("src", "Source")), arg_variadic("rest", "Remaining"));
     let argv: string[] = ["app", "main.sfn"];
     let r = parse(cmd, argv);
-    assert r.ok == true;
-    let src = positionals(r.matches, "src");
+    assert parse_is_ok(r) == true;
+    let src = positionals(parse_matches(r), "src");
     assert src.length == 1;
     assert strings_equal(src[0], "main.sfn");
-    let rest = positionals(r.matches, "rest");
+    let rest = positionals(parse_matches(r), "rest");
     assert rest.length == 0;
 }
 

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -28,11 +28,11 @@
 // numeric coercion.
 import {
     Command,
-    Matches,
-    ParseError,
-    ParseResult,
     command,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     render_help_json,
     render_help_tree,
     subcommand,
@@ -161,29 +161,6 @@ fn _is_help_json_args(args: string[]) -> boolean {
     return false;
 }
 
-fn _empty_cli_matches() -> Matches {
-    return Matches {
-        command_name: "",
-        subcommand_name: "",
-        subcommand_path: [],
-        positional_names: [],
-        positional_values: [],
-        flag_names: [],
-        flag_values: [],
-        flag_present: []
-    };
-}
-
-fn _empty_parse_error() -> ParseError {
-    return ParseError {
-        kind: "ok",
-        message: "",
-        flag_name: "",
-        arg_name: "",
-        matches: _empty_cli_matches()
-    };
-}
-
 fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // Parse the driver-injected `--runtime-root` / `--binary-dir` prefix
     // (Issue 2.2) so `binary_dir` is available for version resolution
@@ -264,27 +241,17 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     }
 
     let parse_result = parse(root, parse_argv);
-    let mut parse_error: ParseError = _empty_parse_error();
-    let mut parse_ok: boolean = true;
-    let mut result: ParseResult = ParseResult {
-        matches: _empty_cli_matches()
-    };
-    match parse_result {
-        Result.Ok { value } => { result = value; },
-        Result.Err { error } => {
-            result = ParseResult { matches: error.matches };
-            parse_error = error;
-            parse_ok = false;
-        }
-    }
+    let parse_ok: boolean = parse_is_ok(parse_result);
+    let matches = parse_matches(parse_result);
+    let parse_err = parse_error(parse_result);
 
     // `sfn guillermo` — the registered subcommand matched. Dispatch to
     // the guillermo command's `run` (it takes no input, so `matches` and
     // `ctx` are unused), reproducing the cold-path argv trace v2 owns.
     if parse_ok {
-        if strings_equal(subcommand(result.matches), "guillermo") {
+        if strings_equal(subcommand(matches), "guillermo") {
             if ctx.trace_argv { _v2_trace_argv(argv); }
-            return guillermo_run(result.matches, ctx);
+            return guillermo_run(matches, ctx);
         }
     }
 
@@ -298,9 +265,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // The literal `2` (not `sfn/cli`'s `EXIT_USAGE`) is deliberate: the
     // `EXIT_*` constants are module-level `let`s with no cross-capsule
     // import value path today, so they lower to 0 here (see `init.sfn`).
-    if strings_equal(subcommand(result.matches), "init") {
+    if strings_equal(subcommand(matches), "init") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return init_run(result.matches, ctx); }
+        if parse_ok { return init_run(matches, ctx); }
         print("usage: sfn init");
         return 2;
     }
@@ -313,9 +280,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // `args.length > 2` guard — the parser owns argument validation, so the
     // misuse never reaches `login.run`. The literal `2` mirrors the `init`
     // dispatch above (the `sfn/cli` `EXIT_*` constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "login") {
+    if strings_equal(subcommand(matches), "login") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return login_run(result.matches, ctx); }
+        if parse_ok { return login_run(matches, ctx); }
         print("usage: sfn login [token]");
         return 2;
     }
@@ -328,9 +295,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // parser owns argument validation, so the misuse never reaches `add.run`.
     // The literal `2` mirrors the `init` / `login` dispatches above (the
     // `sfn/cli` `EXIT_*` constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "add") {
+    if strings_equal(subcommand(matches), "add") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return add_run(result.matches, ctx); }
+        if parse_ok { return add_run(matches, ctx); }
         print("usage: sfn add [--dev] [--update] <capsule>");
         return 2;
     }
@@ -344,9 +311,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // misuse never reaches `publish.run`. The literal `2` mirrors the `init` /
     // `login` / `add` dispatches above (the `sfn/cli` `EXIT_*` constants lower
     // to 0 here).
-    if strings_equal(subcommand(result.matches), "publish") {
+    if strings_equal(subcommand(matches), "publish") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return publish_run(result.matches, ctx); }
+        if parse_ok { return publish_run(matches, ctx); }
         print("usage: sfn publish [path]");
         return 2;
     }
@@ -362,9 +329,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // misuse never reaches `lock.run`. The literal `2` mirrors the `init` /
     // `login` / `add` / `publish` dispatches above (the `sfn/cli` `EXIT_*`
     // constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "lock") {
+    if strings_equal(subcommand(matches), "lock") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return lock_run(result.matches, ctx); }
+        if parse_ok { return lock_run(matches, ctx); }
         print("usage: sfn lock [--work-dir DIR]");
         return 2;
     }
@@ -378,9 +345,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // `--help`) is a usage error (exit 2) — the parser owns argument
     // validation. The literal `2` mirrors the dispatches above (the `sfn/cli`
     // `EXIT_*` constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "package") {
+    if strings_equal(subcommand(matches), "package") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return package_run(result.matches, ctx); }
+        if parse_ok { return package_run(matches, ctx); }
         print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]");
         return 2;
     }
@@ -396,9 +363,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // usage error (exit 2) — the parser owns argument validation, replacing
     // the legacy `_usage()` branches. The literal `2` mirrors the dispatches
     // above (the `sfn/cli` `EXIT_*` constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "emit") {
+    if strings_equal(subcommand(matches), "emit") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return emit_run(result.matches, ctx); }
+        if parse_ok { return emit_run(matches, ctx); }
         print("usage: sfn emit [--timing] [-o OUTPUT] [--module-name SLUG] [--import-context DIR] [--attempts N] [--no-retry] [--validate] [--no-validate] [--no-resolve-gate] <llvm|sailfin|native> <file.sfn>");
         return 2;
     }
@@ -413,9 +380,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // the parser owns flag validation. The literal `2` mirrors the `init` /
     // `login` / `add` / `publish` dispatches above (the `sfn/cli` `EXIT_*`
     // constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "fmt") {
+    if strings_equal(subcommand(matches), "fmt") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return fmt_run(result.matches, ctx); }
+        if parse_ok { return fmt_run(matches, ctx); }
         print("usage: sfn fmt [--check] [--write] <path...>");
         return 2;
     }
@@ -432,9 +399,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // validation. The literal `2` mirrors the `init` / `login` / `add` /
     // `publish` / `fmt` dispatches above (the `sfn/cli` `EXIT_*` constants
     // lower to 0 here).
-    if strings_equal(subcommand(result.matches), "test") {
+    if strings_equal(subcommand(matches), "test") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return test_run(result.matches, ctx); }
+        if parse_ok { return test_run(matches, ctx); }
         print("usage: sfn test [--json] [-k NAME] [--tag TAG] [--update-snapshots] [--no-test-cache] [--jobs N] <suite...>");
         return 2;
     }
@@ -449,9 +416,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // `--help`) is a usage error (exit 2) — the parser owns flag validation.
     // The literal `2` mirrors the dispatches above (the `sfn/cli` `EXIT_*`
     // constants lower to 0 here).
-    if strings_equal(subcommand(result.matches), "check") {
+    if strings_equal(subcommand(matches), "check") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return check_run(result.matches, ctx); }
+        if parse_ok { return check_run(matches, ctx); }
         print("usage: sfn check [--quiet] [--json] [--allow-bare-assert] [path...]");
         return 2;
     }
@@ -470,14 +437,12 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // present; the help/version kinds (`--help` / `-h` / `--version`) carry
     // an empty message, so a fixed usage line is printed instead — never a
     // blank line. Either way the exit code is the legacy `2`.
-    let config_path: string[] = subcommand_path(result.matches);
+    let config_path: string[] = subcommand_path(matches);
     if config_path.length > 0 {
         if strings_equal(config_path[0], "config") {
             if ctx.trace_argv { _v2_trace_argv(argv); }
-            if parse_ok { return config_run(result.matches, ctx); }
-            if parse_error.message.length > 0 {
-                print(parse_error.message);
-            } else {
+            if parse_ok { return config_run(matches, ctx); }
+            if parse_err.message.length > 0 { print(parse_err.message); } else {
                 print("usage: sfn config <get|set|unset|list> [key] [value]");
             }
             return 2;
@@ -495,14 +460,14 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // is printed when present; otherwise a fixed usage line. The literal
     // `2` mirrors the dispatches above (the `sfn/cli` `EXIT_*` constants
     // lower to 0 here).
-    let cache_path: string[] = subcommand_path(result.matches);
+    let cache_path: string[] = subcommand_path(matches);
     if cache_path.length > 0 {
         if strings_equal(cache_path[0], "cache") {
             if ctx.trace_argv { _v2_trace_argv(argv); }
-            if parse_ok { return cache_run(result.matches, ctx); }
-            if parse_error.message.length > 0 {
-                print(parse_error.message);
-            } else { print("usage: sfn cache <info|prune|clean>"); }
+            if parse_ok { return cache_run(matches, ctx); }
+            if parse_err.message.length > 0 { print(parse_err.message); } else {
+                print("usage: sfn cache <info|prune|clean>");
+            }
             return 2;
         }
     }
@@ -510,12 +475,12 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     let mut handled_version: boolean = false;
     if parse_ok {
         // `sfn version` — the registered subcommand matched.
-        if strings_equal(subcommand(result.matches), "version") {
+        if strings_equal(subcommand(matches), "version") {
             handled_version = true;
         }
     } else {
         // `sfn --version` / `sfn -V` — the built-in version flag.
-        if strings_equal(parse_error.kind, "version_requested") {
+        if strings_equal(parse_err.kind, "version_requested") {
             handled_version = true;
         }
     }
@@ -528,7 +493,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         // `-V` flag path `parse_ok` is false, but `result.matches` still
         // reflects the accumulated parse state; `version.run` ignores it,
         // so passing it on both paths keeps the dispatch uniform.
-        return version_run(result.matches, ctx);
+        return version_run(matches, ctx);
     }
 
     // `sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace]
@@ -538,9 +503,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // against typed matches. A non-ok parse that still descended into `build`
     // (a value flag with no value, an unrecognized flag, or `--help`) is a
     // usage error (exit 2) — the parser owns argument validation.
-    if strings_equal(subcommand(result.matches), "build") {
+    if strings_equal(subcommand(matches), "build") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return build_run(result.matches, ctx); }
+        if parse_ok { return build_run(matches, ctx); }
         print("usage: sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)");
         return 2;
     }
@@ -552,9 +517,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // (an unrecognized flag, or `--help`) is a usage error (exit 2) — the
     // parser owns argument validation. Bare-file dispatch (`sfn foo.sfn`)
     // re-enters here as `["run", foo.sfn]` from the legacy fallthrough.
-    if strings_equal(subcommand(result.matches), "run") {
+    if strings_equal(subcommand(matches), "run") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if parse_ok { return run_run(result.matches, ctx); }
+        if parse_ok { return run_run(matches, ctx); }
         print("usage: sfn run [--no-cache] [--clean] [--cache-trace] <file.sfn>");
         return 2;
     }

--- a/compiler/src/cli/main.sfn
+++ b/compiler/src/cli/main.sfn
@@ -28,6 +28,8 @@
 // numeric coercion.
 import {
     Command,
+    Matches,
+    ParseError,
     ParseResult,
     command,
     parse,
@@ -159,6 +161,29 @@ fn _is_help_json_args(args: string[]) -> boolean {
     return false;
 }
 
+fn _empty_cli_matches() -> Matches {
+    return Matches {
+        command_name: "",
+        subcommand_name: "",
+        subcommand_path: [],
+        positional_names: [],
+        positional_values: [],
+        flag_names: [],
+        flag_values: [],
+        flag_present: []
+    };
+}
+
+fn _empty_parse_error() -> ParseError {
+    return ParseError {
+        kind: "ok",
+        message: "",
+        flag_name: "",
+        arg_name: "",
+        matches: _empty_cli_matches()
+    };
+}
+
 fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // Parse the driver-injected `--runtime-root` / `--binary-dir` prefix
     // (Issue 2.2) so `binary_dir` is available for version resolution
@@ -238,12 +263,25 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         j += 1;
     }
 
-    let result: ParseResult = parse(root, parse_argv);
+    let parse_result = parse(root, parse_argv);
+    let mut parse_error: ParseError = _empty_parse_error();
+    let mut parse_ok: boolean = true;
+    let mut result: ParseResult = ParseResult {
+        matches: _empty_cli_matches()
+    };
+    match parse_result {
+        Result.Ok { value } => { result = value; },
+        Result.Err { error } => {
+            result = ParseResult { matches: error.matches };
+            parse_error = error;
+            parse_ok = false;
+        }
+    }
 
     // `sfn guillermo` — the registered subcommand matched. Dispatch to
     // the guillermo command's `run` (it takes no input, so `matches` and
     // `ctx` are unused), reproducing the cold-path argv trace v2 owns.
-    if result.ok {
+    if parse_ok {
         if strings_equal(subcommand(result.matches), "guillermo") {
             if ctx.trace_argv { _v2_trace_argv(argv); }
             return guillermo_run(result.matches, ctx);
@@ -251,7 +289,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     }
 
     // `sfn init` — the registered subcommand matched. `init` declares no
-    // args, so a clean parse (`result.ok`) is the bare invocation and
+    // args, so a clean parse (`parse_ok`) is the bare invocation and
     // dispatches to `init.run` (exit 0 scaffolded / 1 already-exists).
     // Any trailing token makes the parse non-ok while still marking the
     // `init` subcommand as descended; that is a usage error (exit 2),
@@ -262,7 +300,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // import value path today, so they lower to 0 here (see `init.sfn`).
     if strings_equal(subcommand(result.matches), "init") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return init_run(result.matches, ctx); }
+        if parse_ok { return init_run(result.matches, ctx); }
         print("usage: sfn init");
         return 2;
     }
@@ -277,7 +315,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // dispatch above (the `sfn/cli` `EXIT_*` constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "login") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return login_run(result.matches, ctx); }
+        if parse_ok { return login_run(result.matches, ctx); }
         print("usage: sfn login [token]");
         return 2;
     }
@@ -292,7 +330,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // `sfn/cli` `EXIT_*` constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "add") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return add_run(result.matches, ctx); }
+        if parse_ok { return add_run(result.matches, ctx); }
         print("usage: sfn add [--dev] [--update] <capsule>");
         return 2;
     }
@@ -308,7 +346,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // to 0 here).
     if strings_equal(subcommand(result.matches), "publish") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return publish_run(result.matches, ctx); }
+        if parse_ok { return publish_run(result.matches, ctx); }
         print("usage: sfn publish [path]");
         return 2;
     }
@@ -326,7 +364,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "lock") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return lock_run(result.matches, ctx); }
+        if parse_ok { return lock_run(result.matches, ctx); }
         print("usage: sfn lock [--work-dir DIR]");
         return 2;
     }
@@ -342,7 +380,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // `EXIT_*` constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "package") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return package_run(result.matches, ctx); }
+        if parse_ok { return package_run(result.matches, ctx); }
         print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]");
         return 2;
     }
@@ -360,7 +398,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // above (the `sfn/cli` `EXIT_*` constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "emit") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return emit_run(result.matches, ctx); }
+        if parse_ok { return emit_run(result.matches, ctx); }
         print("usage: sfn emit [--timing] [-o OUTPUT] [--module-name SLUG] [--import-context DIR] [--attempts N] [--no-retry] [--validate] [--no-validate] [--no-resolve-gate] <llvm|sailfin|native> <file.sfn>");
         return 2;
     }
@@ -377,7 +415,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "fmt") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return fmt_run(result.matches, ctx); }
+        if parse_ok { return fmt_run(result.matches, ctx); }
         print("usage: sfn fmt [--check] [--write] <path...>");
         return 2;
     }
@@ -396,7 +434,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // lower to 0 here).
     if strings_equal(subcommand(result.matches), "test") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return test_run(result.matches, ctx); }
+        if parse_ok { return test_run(result.matches, ctx); }
         print("usage: sfn test [--json] [-k NAME] [--tag TAG] [--update-snapshots] [--no-test-cache] [--jobs N] <suite...>");
         return 2;
     }
@@ -413,7 +451,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // constants lower to 0 here).
     if strings_equal(subcommand(result.matches), "check") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return check_run(result.matches, ctx); }
+        if parse_ok { return check_run(result.matches, ctx); }
         print("usage: sfn check [--quiet] [--json] [--allow-bare-assert] [path...]");
         return 2;
     }
@@ -436,9 +474,9 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     if config_path.length > 0 {
         if strings_equal(config_path[0], "config") {
             if ctx.trace_argv { _v2_trace_argv(argv); }
-            if result.ok { return config_run(result.matches, ctx); }
-            if result.error.message.length > 0 {
-                print(result.error.message);
+            if parse_ok { return config_run(result.matches, ctx); }
+            if parse_error.message.length > 0 {
+                print(parse_error.message);
             } else {
                 print("usage: sfn config <get|set|unset|list> [key] [value]");
             }
@@ -461,23 +499,23 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     if cache_path.length > 0 {
         if strings_equal(cache_path[0], "cache") {
             if ctx.trace_argv { _v2_trace_argv(argv); }
-            if result.ok { return cache_run(result.matches, ctx); }
-            if result.error.message.length > 0 {
-                print(result.error.message);
+            if parse_ok { return cache_run(result.matches, ctx); }
+            if parse_error.message.length > 0 {
+                print(parse_error.message);
             } else { print("usage: sfn cache <info|prune|clean>"); }
             return 2;
         }
     }
 
     let mut handled_version: boolean = false;
-    if result.ok {
+    if parse_ok {
         // `sfn version` — the registered subcommand matched.
         if strings_equal(subcommand(result.matches), "version") {
             handled_version = true;
         }
     } else {
         // `sfn --version` / `sfn -V` — the built-in version flag.
-        if strings_equal(result.error.kind, "version_requested") {
+        if strings_equal(parse_error.kind, "version_requested") {
             handled_version = true;
         }
     }
@@ -487,7 +525,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
         // `SAILFIN_TRACE_ARGV` toggle would go silent on `version`.
         if ctx.trace_argv { _v2_trace_argv(argv); }
         // Dispatch to the `version` command's `run`. On the `--version` /
-        // `-V` flag path `result.ok` is false, but `result.matches` still
+        // `-V` flag path `parse_ok` is false, but `result.matches` still
         // reflects the accumulated parse state; `version.run` ignores it,
         // so passing it on both paths keeps the dispatch uniform.
         return version_run(result.matches, ctx);
@@ -502,7 +540,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // usage error (exit 2) — the parser owns argument validation.
     if strings_equal(subcommand(result.matches), "build") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return build_run(result.matches, ctx); }
+        if parse_ok { return build_run(result.matches, ctx); }
         print("usage: sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)");
         return 2;
     }
@@ -516,7 +554,7 @@ fn sailfin_cli_main_v2(argv: string[]) -> int ![io, clock] {
     // re-enters here as `["run", foo.sfn]` from the legacy fallthrough.
     if strings_equal(subcommand(result.matches), "run") {
         if ctx.trace_argv { _v2_trace_argv(argv); }
-        if result.ok { return run_run(result.matches, ctx); }
+        if parse_ok { return run_run(result.matches, ctx); }
         print("usage: sfn run [--no-cache] [--clean] [--cache-trace] <file.sfn>");
         return 2;
     }

--- a/compiler/tests/integration/cli_version_command_test.sfn
+++ b/compiler/tests/integration/cli_version_command_test.sfn
@@ -14,11 +14,14 @@
 // (the built-in `parse()` version flag) are exercised, mirroring the v2
 // dispatch in `cli/main.sfn`: on success the matched subcommand is
 // "version"; on the flag path `parse()` reports `version_requested` and
-// `result.matches` still carries the accumulated state that `run`
+// `parse_matches(result)` still carries the accumulated state that `run`
 // uniformly accepts. `run` returns `EXIT_OK` (0) on every version path.
 import {
     command,
     parse,
+    parse_error,
+    parse_is_ok,
+    parse_matches,
     subcommand,
     with_subcommand
 } from "sfn/cli";
@@ -47,10 +50,11 @@ test "version command: command_def is a bare 'version' subcommand" {
 test "version command: 'sfn version' routes to the version subcommand" ![io] {
     let root = with_subcommand(command("sfn", "Sailfin compiler"), command_def());
     let result = parse(root, ["sfn", "version"]);
-    assert result.ok;
-    assert strings_equal(subcommand(result.matches), "version");
+    assert parse_is_ok(result);
+    let matches = parse_matches(result);
+    assert strings_equal(subcommand(matches), "version");
 
-    let code = run(result.matches, _empty_ctx());
+    let code = run(matches, _empty_ctx());
     assert code == 0;
 }
 
@@ -59,11 +63,11 @@ test "version command: 'sfn --version' flag still dispatches run to EXIT_OK" ![i
     let result = parse(root, ["sfn", "--version"]);
     // The built-in version flag surfaces through the error channel, not
     // a matched subcommand — exactly the path v2 keys on.
-    assert ! result.ok;
-    assert strings_equal(result.error.kind, "version_requested");
+    assert ! parse_is_ok(result);
+    assert strings_equal(parse_error(result).kind, "version_requested");
 
     // `run` ignores `matches`; passing the accumulated matches keeps the
     // dispatch uniform across the subcommand and flag paths.
-    let code = run(result.matches, _empty_ctx());
+    let code = run(parse_matches(result), _empty_ctx());
     assert code == 0;
 }


### PR DESCRIPTION
### Motivation
- Replace the old ad-hoc `ok` sentinel/exit-code plumbing in the CLI parser with typed error propagation using `Result<T, E>` and the `?` operator to align with the runtime `Result`/`?` convention. 
- Preserve existing user-visible parse error output and exit codes by carrying partial `Matches` on parse failures so consumers can reproduce legacy usage handling. 
- Update compiler-side consumers of the parser so the capsule API and its in-repo callers remain consistent in one bundled change.

### Description
- Change `parse()` / `parse_with_env()` to return `Result<ParseResult, ParseError>` and adjust `_validate_level()` and `_err_result()` to return `Result` variants, with `?` used at descent sites. 
- Add a `matches: Matches` field to `ParseError` so errors carry partial parse state for legacy usage/exit handling. 
- Update the exiting wrapper `run()` to inspect `Result` and print/exit exactly as before, and update `compiler/src/cli/main.sfn` to unpack the typed parse result (`parse_ok` / `parse_error`) and preserve all usage messages and exit codes. 
- Introduce helper constructors `_empty_matches()` and `_empty_parse_error()` to initialize temporaries during the `Result`->consumer transitions, and apply `sfn` formatting to touched files. 

### Testing
- Ran `build/native/sailfin fmt --write capsules/sfn/cli/src/types.sfn capsules/sfn/cli/src/parser.sfn compiler/src/cli/main.sfn` and then `build/native/sailfin fmt --check` on the same files, and the formatter checks passed. 
- Ran `make compile` and the repository compiled successfully with the updated capsule + compiler consumers. 
- Exercised the runtime parse-failure path with `build/native/sailfin build --nonexistent-flag foo.sfn` which exited `2` and printed the unchanged usage/error text as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e8d3c56888324923a3190a4c55edf)