### PR TITLE
perf(test): content-addressed dep .ll→.o object cache for test links

### DIFF
--- a/compiler/src/backend.sfn
+++ b/compiler/src/backend.sfn
@@ -147,7 +147,9 @@ fn _probe_macos_sdk_root() -> string ![io] {
 }
 
 // Build the clang link argv for the `sfn test` layout:
-// `clang -O0 -Wno-override-module <sdk_flags…> -o OUT <test.ll> <dep.ll…> <runtime.o…> <libs…>`.
+// `clang -O0 -Wno-override-module <sdk_flags…> -o OUT <test.ll> [dep.ll fallback…] <runtime.o…> <dep.o…> <libs…>`.
+// On a cache hit (#2013) resolver-produced dep modules link as pre-assembled `.o` objects
+// appended after the runtime objects; on cache failure they degrade to `.ll` IR inputs.
 fn _llvm_text_link_test_argv(plan: LinkPlan, sdk_flags: string[]) -> string[] {
     let mut args: string[] = ["clang", plan.opt_flag, "-Wno-override-module"];
     let mut si: int = 0;

--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -48,16 +48,20 @@ import {
 import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } from "../../assert_failure";
 import { Program, Statement } from "../../ast";
 import { LinkPlan, LlvmTextBackend } from "../../backend";
+import { llvm_assemble } from "../../build/clang_argv";
 import {
+    _atomic_rename_into_place,
     _dirname_cmd,
     _ends_with_cmd,
     _ensure_dir_cmd,
+    _mktemp_sibling_cmd,
     _path_join_cmd,
     _sanitize_filename_cmd,
     _shell_read_cmd,
     _strip_trailing_slashes_cmd,
     _write_text_cmd
 } from "../../build/fs";
+import { sha256_hex_of_string } from "../../build/hash";
 import {
     assemble_runtime_capsule_link_inputs,
     runtime_stamp_identity,
@@ -70,6 +74,7 @@ import {
     cache_store_artifact,
     canonicalize_flags,
     runtime_link_inputs_identity,
+    sha256_of_file,
     test_bin_cache_key,
     test_bin_cache_root
 } from "../../build_cache";
@@ -1434,6 +1439,37 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
     return overall_rc;
 }
 
+// Content-addressed dep-object cache for the test link (#2013). A test
+// child's dependency `.ll` files are byte-identical across the pool's
+// children (same compiler, same sources), yet each child's clang link
+// re-codegens all of them — ~8.3 s per heavy-closure child (#2010).
+// Assemble each dep module to a `.o` once, keyed by the `.ll` content
+// hash plus a 12-hex prefix of the assembling clang's version string
+// (mirrors the toolchain-identity fold in `runtime_objs.sfn`, #1197/#632,
+// so a clang upgrade on the persistent leaf path (`build/sailfin/dep-obj`)
+// invalidates cached objects rather than relinking stale code), and hand
+// clang the object instead. The cache dir lives in the parent's
+// invocation-scoped warm objdir, so the existing scratch cleanup removes
+// it. Racing children produce byte-identical objects;
+// `_atomic_rename_into_place` makes last-writer-wins safe. Returns "" on
+// any hash/assemble failure so the caller falls back to the raw `.ll` IR
+// input (behaviour byte-identical to the pre-cache path).
+fn _dep_object_for_ll(ll_path: string, dep_obj_dir: string, clang_id: string) -> string ![io] {
+    let hash = sha256_of_file(ll_path);
+    if hash.length == 0 { return ""; }
+    let obj_path = dep_obj_dir + "/" + hash + "-O0-" + clang_id + ".o";
+    if fs.exists(obj_path) { return obj_path; }
+    let tmp = _mktemp_sibling_cmd(obj_path);
+    if tmp.length == 0 { return ""; }
+    let no_includes: string[] = [];
+    if llvm_assemble(ll_path, tmp, "-O0", no_includes) != 0 {
+        process.run(["rm", "-f", tmp]);
+        return "";
+    }
+    if !_atomic_rename_into_place(tmp, obj_path) { return ""; }
+    return obj_path;
+}
+
 // Resolver-driven test linker. Takes a list of dependency `.ll` paths
 // produced by `prepare_project_capsules_for_test` and adds them to
 // the link line alongside the runtime sources + globals + prelude.
@@ -1466,16 +1502,14 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     // triple`, which clang's link overrides — matching the suppression on
     // every other clang invocation in cli_main.sfn so the test path is not
     // the lone source of `[-Woverride-module]` noise.
-    // Test link layout (`-o` before inputs; test source `.ll` then dep
-    // `.ll` as IR inputs). The driver assembles the semantic pieces and
-    // `LlvmTextBackend.link` reproduces the exact clang argv.
-    let mut ir_inputs: string[] = [ll_path];
-    let mut di: int = 0;
-    loop {
-        if di >= dep_ll_paths.length { break; }
-        ir_inputs.push(dep_ll_paths[di]);
-        di += 1;
-    }
+    //
+    // Link order (head → tail):
+    //   1. Test source `.ll` (strong, IR input)
+    //   2. Resolver-produced dep modules: cached `.o` objects (assembled
+    //      once per invocation via `_dep_object_for_ll`, #2013), falling
+    //      back to `.ll` IR inputs on cache failure
+    //   3. Runtime sources + globals + prelude (strong, objects)
+    //
     // Issue #940: resolve the implicit runtime capsule
     // (`<runtime_root>/capsule.toml`) and assemble its objects
     // on the SAME path as `sfn build` / `sfn run` — c-sources +
@@ -1496,6 +1530,27 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     let mut rt_cache_dir = cache_dir;
     let shared_objdir = _get_env_cmd("SAILFIN_TEST_RUNTIME_OBJDIR");
     if shared_objdir.length > 0 { rt_cache_dir = shared_objdir; }
+    let dep_obj_dir = rt_cache_dir + "/dep-obj";
+    _ensure_dir_cmd(dep_obj_dir);
+    // #2013: fold the assembling clang's identity into the dep-object
+    // name so the persistent leaf-path cache (`build/sailfin/dep-obj`)
+    // cannot relink a stale object after a toolchain upgrade — the same
+    // stale-object class the runtime objects' identity fold closes
+    // (#1197). First `clang --version` line is stable per install and
+    // one popen per link is noise next to the assembly it deduplicates.
+    let clang_line = _shell_read_cmd("clang --version 2>/dev/null | head -n 1");
+    let clang_id = substring(sha256_hex_of_string(clang_line), 0, 12);
+    let mut ir_inputs: string[] = [ll_path];
+    let mut dep_objects: string[] = [];
+    let mut di: int = 0;
+    loop {
+        if di >= dep_ll_paths.length { break; }
+        let dep_obj = _dep_object_for_ll(dep_ll_paths[di], dep_obj_dir, clang_id);
+        if dep_obj.length > 0 { dep_objects.push(dep_obj); } else {
+            ir_inputs.push(dep_ll_paths[di]);
+        }
+        di += 1;
+    }
     let runtime_caps = runtime_capsule_from_root(runtime_root);
     if runtime_caps.length == 0 {
         print.err("sfn test: runtime bundle/manifest missing — expected "
@@ -1542,8 +1597,21 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     // exactly (test_mode).
     let backend = LlvmTextBackend { };
     let no_link_flags: string[] = [];
+    let mut link_objects: string[] = [];
+    let mut oi: int = 0;
+    loop {
+        if oi >= rt.object_paths.length { break; }
+        link_objects.push(rt.object_paths[oi]);
+        oi += 1;
+    }
+    let mut doi: int = 0;
+    loop {
+        if doi >= dep_objects.length { break; }
+        link_objects.push(dep_objects[doi]);
+        doi += 1;
+    }
     let plan = LinkPlan {
-        objects: rt.object_paths,
+        objects: link_objects,
         ir_inputs: ir_inputs,
         out_path: out_path,
         opt_flag: "-O0",

--- a/compiler/tests/e2e/dep_object_cache_test.sfn
+++ b/compiler/tests/e2e/dep_object_cache_test.sfn
@@ -1,0 +1,86 @@
+// compiler/tests/e2e/dep_object_cache_test.sfn
+//
+// End-to-end regression coverage for the dep-object cache (#2013).
+//
+// Verifies two contracts:
+//   A. When a nested `sfn test` run uses a shared SAILFIN_TEST_RUNTIME_OBJDIR,
+//      the dep-object cache populates `dep-obj/<sha256>-O0-<clang_id>.o`
+//      entries in that dir.
+//   B. When `dep-obj` is unwritable (chmod 555), the nested `sfn test` run
+//      still exits 0 — every dep degrades to a raw `.ll` IR input, and the
+//      suite passes (fallback contract, #2013).
+//
+// Follows the `guillermo_test.sfn` shape: `_sfn_bin()` honours `SAILFIN_BIN`,
+// `_child_env()` threads PATH/HOME/TMPDIR/SAILFIN_TEST_SCRATCH per the
+// build-and-run isolation rule (`.claude/rules/no-bash-e2e.md`).
+import { find, split, contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _child_env(scratch: string, objdir: string) -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    if objdir.length > 0 {
+        e.push("SAILFIN_TEST_RUNTIME_OBJDIR=" + objdir);
+    }
+    return e;
+}
+
+fn _scratch_base() -> string ![io] {
+    let mut base = env.get("SAILFIN_TEST_SCRATCH");
+    if base.length == 0 { base = "/tmp"; }
+    fs.createDirectory(base, true);
+    return base;
+}
+
+test "test link: dep objects cached content-addressed in the shared objdir" ![io] {
+    let base = _scratch_base();
+    let d = fs.mkdtemp(base + "/sfn-dep-obj-cache-a-");
+    let env_args = _child_env(d, d);
+    // `--no-test-cache` bypasses the test-binary artifact cache so the
+    // cold compile+link path always runs and populates `dep-obj/`; without
+    // it a warm test-bin cache hit skips `_clang_link_test_cmd_with_deps`
+    // entirely and the dep-obj dir is never created.
+    let exit = process.run_capture([_sfn_bin(), "test", "--no-test-cache", "compiler/tests/unit/string_utils_test.sfn"], env_args);
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    assert exit == 0;
+    // Verify dep-obj dir was created and contains at least one cached object
+    // with the expected naming pattern: <64-hex>-O0-<12-hex>.o
+    let ls_exit = process.run_capture(["sh", "-c", "ls '" + d
+        + "/dep-obj' 2>/dev/null"], []);
+    let ls_out = process.capture_take_stdout();
+    let _ls_err = process.capture_take_stderr();
+    assert ls_exit == 0;
+    // Confirm at least one entry carries the `-O0-` infix (content + clang-id key, #2013)
+    assert find(ls_out, "-O0-", 0) >= 0;
+}
+
+test "test link: unwritable dep-obj dir falls back to raw IR inputs" ![io] {
+    let base = _scratch_base();
+    let d2 = fs.mkdtemp(base + "/sfn-dep-obj-cache-b-");
+    // Pre-create dep-obj and make it unwritable so every cache write fails.
+    let dep_obj_dir = d2 + "/dep-obj";
+    fs.createDirectory(dep_obj_dir, true);
+    let chmod_rc = process.run(["chmod", "555", dep_obj_dir]);
+    assert chmod_rc == 0;
+    let env_args = _child_env(d2, d2);
+    let exit = process.run_capture([_sfn_bin(), "test", "--no-test-cache", "compiler/tests/unit/string_utils_test.sfn"], env_args);
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    // Restore before any early-return so tmp cleanup works.
+    let _chmod_back = process.run(["chmod", "755", dep_obj_dir]);
+    // The suite must pass even when the dep-obj cache is unavailable —
+    // every dep falls back to a raw `.ll` IR input (#2013 fallback contract).
+    assert exit == 0;
+}


### PR DESCRIPTION
## Summary

Every pooled test child's clang link re-codegened the same resolver-produced dependency `.ll` files from scratch — ~8.3 s per heavy-closure child even with every other cache warm (#2010 root-cause anatomy). This PR assembles each dep module to a `.o` once per invocation, content-addressed, and hands clang objects instead of raw IR.

Closes #2013 (sub-item (a) of #2010).

## Numbers

| Metric | Before | After | Δ |
|---|---|---|---|
| Unit tier wall (201 files, `--jobs 8 --no-test-cache`, macOS arm64) | 19:35.61 | 18:34.83 | **−5.2%** |
| Unit tier CPU (user) | 2990.66 s | 2832.83 s | −5.3% |
| Dep-IR codegen share of a warm heavy-child link (130-dep closure, identical argv shape, IR vs objects) | 6.7 s | 0.2 s | **−97%** |
| Suite | 201/201 | 201/201 | no regression |

The tier-wide number is bounded by design: clang codegen was ~8 s of the ~66 s heavy-child anatomy. The dominant shares (resolver ~32 s + interface typecheck ~26 s per child) are process-model work — that's #2010 (b), to be merged with #1997 and designed under SFEP.

## Design

- New module-private `_dep_object_for_ll` in `cli/commands/test.sfn`: key = `sha256(.ll)` + `-O0` + 12-hex hash of `clang --version` (the #1197/#632 toolchain-identity discipline — without it the persistent leaf-path `build/sailfin/dep-obj` would relink a stale object across a clang upgrade).
- Cache dir `<rt_cache_dir>/dep-obj/` — the parent's invocation-scoped warm objdir (`SAILFIN_TEST_RUNTIME_OBJDIR`), shared by all pool children, removed by existing scratch cleanup.
- Race safety: `_mktemp_sibling_cmd` + `_atomic_rename_into_place` (mv -f, same-fs atomic rename — the #1011/#1034 invariant). Racing children produce byte-identical objects; last-writer-wins.
- Fallback is total: any hash/assemble/rename failure degrades that dep to a raw `.ll` IR input, byte-identical to the pre-cache link. No third branch — a dep can never be dropped.
- Link argv (`_llvm_text_link_test_argv`): dep objects append after runtime objects; all inputs are explicit files (not archives), so ordering cannot change symbol resolution.

## Review

Opus code-review adjudicated fallback totality, race safety, ordering, and self-host safety as sound; its two blocking findings (clang-identity fold; e2e coverage) are incorporated.

## Verification

- `make compile` green (self-host invariant)
- `sfn fmt --check` clean on all touched files
- New e2e `dep_object_cache_test.sfn`: cache-hit naming contract (`<64-hex>-O0-<12-hex>.o` present in shared objdir) + unwritable-dir fallback contract (suite passes with cache unavailable)
- `SAILFIN_TRACE_LINK=1` confirms dep objects in the link argv
- Heavy single-file smoke (`routine_nursery_test.sfn`) passes