### PR TITLE
perf(ci): raise macOS shard test jobs 2 → 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,10 +868,15 @@ jobs:
           seed_version: ${{ steps.seed.outputs.seed_version }}
           # Each leg runs only its shard; package only on the primary leg.
           shard: ${{ matrix.shard }}
-          # Per-file parallelism within the shard leg. Conservative 2 on the
-          # 3-vCPU/7GB macos-arm64 runner: Darwin has no RLIMIT_AS backstop
-          # (SFEP-0022), so keep headroom and confirm before raising.
-          shard_test_jobs: "2"
+          # Per-file parallelism within the shard leg, raised 2 -> 3 to
+          # match the 3-vCPU macos-arm64 runner: the macOS unit/e2e legs
+          # are the PR-CI critical path (24-32 min) and the prior
+          # conservative 2 left a core idle. Darwin has no RLIMIT_AS
+          # backstop, but the per-child emit fan-out is RAM-aware
+          # (SFEP-0022 governor) and the heavy-child working set is
+          # frontend-bound, not RSS-bound (#2010). Drop back to 2 if a
+          # shard leg OOMs on the 7GB runner.
+          shard_test_jobs: "3"
           package: ${{ matrix.primary && 'true' || 'false' }}
 
       # #1235 measurement (read-only): surface this shard leg's test-phase


### PR DESCRIPTION
The macOS unit/e2e shard legs are the PR-CI critical path (24-32 min
per leg; flat across recent runs) while Linux legs finish in 4-12 min.
The macOS legs ran the test pool at --jobs 2 on a 3-vCPU runner — the
original comment said "confirm before raising"; this is that
confirmation run. The per-child emit fan-out is RAM-aware on Darwin
(SFEP-0022 governor), so the extra child stays within the 7GB runner's
headroom. Revert to 2 if a shard leg OOMs.

Expected: ~15-25% off the macOS shard wall times that pin the PR CI
total. The structural fix for the remaining heavy-child cost
(resolver + interface typecheck per child) is tracked in #2010/#1997.
