### PR TITLE
perf(lowering): parse each imported .sfn-asm text once, not five times

### DIFF
--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -31,7 +31,6 @@ import {
 import {
     parse_native_artifact,
     parse_native_artifact_from_lines,
-    parse_native_bindings_from_text,
     parse_native_function_count_from_text,
     parse_native_functions_from_text
 } from "../../native_ir_api";

--- a/compiler/src/llvm/lowering/lowering_phase_imports.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_imports.sfn
@@ -16,12 +16,8 @@ import {
     NativeStruct
 } from "../../native_ir";
 import {
-    parse_native_bindings_from_text,
-    parse_native_enums_for_import,
-    parse_native_functions_for_import,
-    parse_native_imports_for_import,
-    parse_native_interfaces_for_import,
-    parse_native_structs_for_import
+    parse_native_artifact_for_import_with_bindings,
+    parse_native_imports_for_import
 } from "../../native_ir_api";
 import { apply_layout_manifest_to_module } from "../imports";
 import { collect_exported_symbol_names, find_function_by_name_or_import } from "../rendering_helpers";
@@ -47,42 +43,6 @@ struct ImportedModuleSymbols {
     functions: NativeFunction[];
     struct_methods: NativeFunction[];
     bindings: NativeBinding[];
-}
-
-// Collect the module-level `let` constants an imported text EXPORTS (#1368).
-// Only exported bindings are surfaced: a producer's non-exported globals are
-// an implementation detail the importer must not materialise. The importer
-// value-inlines each exported constant into its own module
-// (`lower_imported_bindings_to_globals`), so the producer's value is read
-// directly with no cross-object link dependency.
-fn parse_single_import_exported_bindings(native_text: string) -> NativeBinding[] {
-    let mut exported: NativeBinding[] = [];
-    let all_bindings = parse_native_bindings_from_text(native_text);
-    if all_bindings.length == 0 { return exported; }
-    let exported_names = collect_exported_symbol_names(parse_native_imports_for_import(native_text));
-    if exported_names.length == 0 { return exported; }
-    let mut index: int = 0;
-    loop {
-        if index >= all_bindings.length { break; }
-        let binding = all_bindings[index];
-        index += 1;
-        if binding == null { continue; }
-        if binding.name == null { continue; }
-        if string_array_contains(exported_names, binding.name) {
-            exported.push(binding);
-        }
-    }
-    return exported;
-}
-
-// Parse imported interfaces from a single import text.
-fn parse_single_import_interfaces(native_text: string) -> NativeInterface[] {
-    return parse_native_interfaces_for_import(native_text);
-}
-
-// Parse imported functions from a single import text.
-fn parse_single_import_functions(native_text: string) -> NativeFunction[] {
-    return parse_native_functions_for_import(native_text);
 }
 
 // Extract struct methods from applied structs.
@@ -142,11 +102,20 @@ fn build_import_alias_signatures(imports: NativeImport[], candidate_functions: N
 }
 
 // Gather the per-import contribution (structs/enums/interfaces/functions/
-// struct-methods) for the whole import list.  Pure code-move from
-// lowering_core.sfn's Phase 2 loop; semantics are byte-for-byte preserved,
-// including the intentional drop of apply_layout_manifest_to_module's
-// diagnostics field (the same-module call in lowering_core still captures
-// them for local manifest application).
+// struct-methods/bindings) for the whole import list.  Parses each imported
+// `.sfn-asm` text exactly ONCE per loop iteration using
+// parse_native_artifact_for_import_with_bindings (the native_ir_api
+// wrapper for (false, true)): `include_instructions=false`
+// skips function bodies (only headers/params/meta needed for import context)
+// and `include_top_level_bindings=true` collects exported `.let`/`.extern-var`
+// constants (#1368).  The five per-kind parse calls this replaces all called
+// parse_native_artifact_impl internally with (false, false) or (true, true);
+// the flag difference for bindings is immaterial because binding lines are
+// top-level (current==null), so the include_instructions fast-forward never
+// activates for them (#2016, 5-parses→1).  Semantics are byte-for-byte
+// preserved, including the intentional drop of apply_layout_manifest_to_module's
+// diagnostics field and the parse_native_imports_for_import fast-path scan for
+// export-name filtering.
 fn gather_imported_module_symbols(safe_imported_native_texts: string[], safe_imported_manifests: LayoutManifest[]) -> ImportedModuleSymbols {
     let mut imported_structs: NativeStruct[] = [];
     let mut imported_enums: NativeEnum[] = [];
@@ -173,28 +142,39 @@ fn gather_imported_module_symbols(safe_imported_native_texts: string[], safe_imp
             text_index += 1;
             continue;
         }
-        // Single-pass: parse structs+enums once, apply manifest once
-        let imported_structs_safe = parse_native_structs_for_import(native_text);
-        let imported_enums_safe = parse_native_enums_for_import(native_text);
-        let applied_import = apply_layout_manifest_to_module(imported_structs_safe, imported_enums_safe, manifest_for_module);
+        let parsed = parse_native_artifact_for_import_with_bindings(native_text);
+        let mut parsed_structs = parsed.structs;
+        if parsed_structs == null { parsed_structs = []; }
+        let mut parsed_enums = parsed.enums;
+        if parsed_enums == null { parsed_enums = []; }
+        let applied_import = apply_layout_manifest_to_module(parsed_structs, parsed_enums, manifest_for_module);
         let mut applied_structs = applied_import.structs;
         if applied_structs == null { applied_structs = []; }
         let mut applied_enums = applied_import.enums;
         if applied_enums == null { applied_enums = []; }
-        let applied_interfaces = parse_single_import_interfaces(native_text);
-        let applied_functions = parse_single_import_functions(native_text);
+        let mut parsed_interfaces = parsed.interfaces;
+        if parsed_interfaces == null { parsed_interfaces = []; }
+        let mut parsed_functions = parsed.functions;
+        if parsed_functions == null { parsed_functions = []; }
+        let mut all_bindings = parsed.bindings;
+        if all_bindings == null { all_bindings = []; }
         imported_structs = extend_native_structs(imported_structs, applied_structs);
         imported_enums = extend_native_enums(imported_enums, applied_enums);
-        imported_interfaces = extend_native_interfaces(imported_interfaces, applied_interfaces);
-        imported_functions = extend_native_functions(imported_functions, applied_functions);
+        imported_interfaces = extend_native_interfaces(imported_interfaces, parsed_interfaces);
+        imported_functions = extend_native_functions(imported_functions, parsed_functions);
         let imported_methods = extract_import_struct_methods(applied_structs);
         imported_struct_methods = extend_native_functions(imported_struct_methods, imported_methods);
-        let exported_bindings = parse_single_import_exported_bindings(native_text);
+        let exported_names = collect_exported_symbol_names(parse_native_imports_for_import(native_text));
         let mut bi: int = 0;
         loop {
-            if bi >= exported_bindings.length { break; }
-            imported_bindings.push(exported_bindings[bi]);
+            if bi >= all_bindings.length { break; }
+            let binding = all_bindings[bi];
             bi += 1;
+            if binding == null { continue; }
+            if binding.name == null { continue; }
+            if string_array_contains(exported_names, binding.name) {
+                imported_bindings.push(binding);
+            }
         }
         text_index += 1;
     }

--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -170,6 +170,16 @@ fn parse_native_artifact_for_import_context(text: string) -> ParseNativeResult {
     return parse_native_artifact_impl(text, false, false);
 }
 
+// Single-parse import gather (#2016): one full parse yielding structs,
+// enums, interfaces, functions AND top-level bindings for an imported
+// text. `include_instructions=false` (function bodies are never read on
+// the import path) + `include_top_level_bindings=true` (exported-binding
+// filtering needs them). Replaces five per-kind parses per imported text
+// in `gather_imported_module_symbols`.
+fn parse_native_artifact_for_import_with_bindings(text: string) -> ParseNativeResult {
+    return parse_native_artifact_impl(text, false, true);
+}
+
 export {
     select_text_artifact,
     select_layout_manifest_artifact,
@@ -184,6 +194,7 @@ export {
     parse_native_enums_for_import,
     parse_native_functions_for_import,
     parse_native_artifact_for_import_context,
+    parse_native_artifact_for_import_with_bindings,
     parse_layout_manifest
 };
 


### PR DESCRIPTION
## Summary

`gather_imported_module_symbols` rebuilt imported-symbol tables from raw `.sfn-asm` text with **five independent full parses per imported text** — ~650 full parses per compile on a 130-module closure, measured at 21.0 s of a 25.3 s lowering phase. Instrumentation shows the prior #2010 anatomy misattributed this cost to typecheck: typecheck proper is ~1 ms. This path runs in **every compile with imports** — test children, `sfn build`, and the self-host build all collect the win.

Closes #2016.

## Numbers

| Metric | Before | After | Δ |
|---|---|---|---|
| Unit tier wall (201 files, `--jobs 8 --no-test-cache`, macOS arm64) | 18:34.83 | **12:54.40** | **−30.5%** |
| Unit tier CPU (user) | 2832.83 s | 1586.19 s | **−44.0%** |
| Warm heavy child (130-dep closure) | 64.9 s | 44.8 s | −31% |
| Instrumented lowering phase (same child) | 25.3 s | ~9 s | −64% |
| Suite | 201/201 | 201/201 | no regression |

Cumulative from today's start (pre-#2013 baseline 19:35.61): **−34% unit-tier wall**.

## Design

One `parse_native_artifact_for_import_with_bindings` call (new thin `native_ir_api` wrapper for `parse_native_artifact_impl(text, false, true)`) replaces the five per-kind parses; all five symbol kinds destructure from the single `ParseNativeResult`.

**Parity proven at the parser level** (Opus review, parser-line citations):
- `include_top_level_bindings` never reaches struct/enum/interface/function collection — those four kinds are byte-identical to the old `(false,false)` parses.
- The `include_instructions` fast-forward only activates inside function bodies (`current != null`); both binding sources (`.extern-var`, top-level `Let`) are provably top-level-only (`emit_native.sfn:402`), so bindings are byte-identical to the old `(true,true)` parse. The fast-forward re-processes the `.endfn` terminator, preserving parser state transitions.
- Exported-bindings filter keeps the cheap `parse_native_imports_for_import` fast-path scan with identical order and null guards; manifest application order unchanged; the empty-text manifest-only branch and leftover-manifest tail untouched.

Layering preserved: the parse routes through `native_ir_api` (the established single API surface), not a direct `native_ir_parser` import. The newly-dead `parse_native_bindings_from_text` import in `lowering_core.sfn` is removed (the function stays live via `lowering_phase_sanitize.sfn:364`).

## Residual (tracked, not in scope)

- `collect_available_import_module_names` mangle re-scan (~4.1 s/compile, same disease) — follow-up candidate.
- Per-child resolver re-walk (~32 s) — #2010(b), shared-frontend runner SFEP in draft.

## Verification

- `make compile` green (this function feeds symbol resolution for the self-host build itself)
- Full unit tier 201/201; `hello-world` smoke; heavy-closure smoke (`routine_nursery_test.sfn`)
- `sfn fmt --check` clean on all touched files