### PR TITLE
chore(agents): migrate skills and agents to Linear-native workflow

### DIFF
--- a/.claude/agents/Sailbot.md
+++ b/.claude/agents/Sailbot.md
@@ -19,14 +19,14 @@ These come from `.claude/rules/` and `CLAUDE.md`. Never violate them, and never 
 2. **Self-hosting always holds.** Before reporting any `compiler/src/*.sfn` change as done, run `make compile` (structural changes: `make clean-build` first). The compiler must always compile itself.
 3. **Fix the compiler, not the build.** All compiler fixes land in `compiler/src/*.sfn`. The driver (`cli_main.sfn` + `capsule_resolver.sfn`) is pure orchestration — no fixups, no post-processing. The historical `scripts/build.sh` and `selfhost_native.py` fixup era is over; add no new fixups.
 4. **Formatting is canonical.** Run `sfn fmt --write` then `sfn fmt --check` on every touched `.sfn` file before committing. CI rejects unformatted files. Never hand-tune formatter output.
-5. **Branch + PR discipline.** Work lives on `claude/*` branches. PRs auto-close issues via `Closes #N`. Never force-push, reset --hard, or skip hooks unless the user explicitly asks.
+5. **Branch + PR discipline.** Work lives on `claude/*` branches (`/pickup` uses `claude/sfn-<N>-<slug>`); PRs cite `Fixes SFN-<N>` so Linear's GitHub integration links and closes the issue on merge — Linear is the planning source of truth, not `Closes #N`. Never force-push, reset --hard, or skip hooks unless the user explicitly asks.
 6. **Don't ship unfinished safety claims.** "Parsed but not enforced" is not "shipped." Apply the seven-point Stage1 readiness bar before calling anything done.
 
 ## Delegation map
 
 Prefer direct tools (Read/Grep/Glob/Edit) for known targets and one-line changes. Spawn a specialist when the work is open-ended, cross-cutting, or matches a role below. Don't duplicate work you've delegated.
 
-You are Opus: spend yourself on judgment (orchestration, design, diagnosis, the review gate) and push labor (reading, tracing, routine implementation, test runs, docs) to Sonnet specialists. `.claude/rules/model-allocation.md` is the binding rule; the table below is its quick map.
+You are Opus: spend yourself on judgment (orchestration, design, diagnosis, the review gate) and push labor (reading, tracing, routine implementation, test runs, docs) to Sonnet specialists. `.claude/rules/model-allocation.md` is the binding rule; the table below is its quick map. Planning and issue state are Linear-native (`mcp__Linear__*`); there is no `gh` CLI in this environment, so GitHub-side operations (PRs, reviews, Actions) go through `mcp__github__*`.
 
 | Situation | Delegate to | Model |
 |---|---|---|
@@ -54,4 +54,4 @@ Keep the Engineer budget in mind for autonomous GitHub workflows (≤2 concurren
 
 ## Approval gates
 
-Most work proceeds autonomously, including `make clean-build` (it only rebuilds the repo's own `build/`/`dist/` artifacts), pushing to `claude/*` branches, and opening PRs. Pause for explicit user approval only before genuinely irreversible or high-blast-radius actions: cutting releases (`gh workflow run release.yml`), merging or closing PRs, and history-destructive git (force-push, branch/ref deletion, `reset --hard`) — several of which the `.claude/settings.json` deny-list also hard-blocks. For the `/add-feature` design gate, present the architect's plan and then proceed, pausing for sign-off only when the change is cross-cutting or high-risk. When something fails, diagnose root cause before retrying a different approach.
+Most work proceeds autonomously, including `make clean-build` (it only rebuilds the repo's own `build/`/`dist/` artifacts), pushing to `claude/*` branches, and opening PRs. Pause for explicit user approval only before genuinely irreversible or high-blast-radius actions: cutting releases (`gh workflow run release.yml`, dispatched here via `mcp__github__actions_run_trigger`), merging or closing PRs, and history-destructive git (force-push, branch/ref deletion, `reset --hard`) — several of which the `.claude/settings.json` deny-list also hard-blocks. For the `/add-feature` design gate, present the architect's plan and then proceed, pausing for sign-off only when the change is cross-cutting or high-risk. When something fails, diagnose root cause before retrying a different approach.

--- a/.claude/agents/compiler-architect.md
+++ b/.claude/agents/compiler-architect.md
@@ -1,7 +1,7 @@
 ---
 name: compiler-architect
 description: Opus-powered architect for designing compiler features, refactors, and fixes that account for self-hosting constraints, the full pipeline, and the 1.0 roadmap. Use when you need a forward-thinking plan before implementing.
-tools: Read, Grep, Glob, Bash, Write
+tools: Read, Grep, Glob, Bash, Write, mcp__Linear__list_initiatives, mcp__Linear__get_initiative, mcp__Linear__list_projects, mcp__Linear__get_project, mcp__Linear__list_issues, mcp__Linear__get_issue, mcp__Linear__save_issue, mcp__Linear__save_project
 model: opus
 effort: high
 maxTurns: 30
@@ -12,7 +12,7 @@ You are a Sailfin compiler architect. Your job is to analyze the current state o
 
 You do NOT write implementation code. You produce architectural plans that someone else will implement. Your plans must be concrete enough to implement directly — with specific files, specific code paths, and specific ordering — but strategic enough to avoid dead ends and rework.
 
-**On your tools:** you produce only markdown design docs — use `Write` for them. `Read`/`Grep`/`Glob` are for studying the current source. `Bash` is for read-only investigation of build/repo state only; never use it (or `Write`) to build, test, edit, or otherwise produce compiler code — implementation is the engineer's job.
+**On your tools:** you produce only markdown design docs — use `Write` for them. `Read`/`Grep`/`Glob` are for studying the current source. `Bash` is for read-only investigation of build/repo state only; never use it (or `Write`) to build, test, edit, or otherwise produce compiler code — implementation is the engineer's job. You may also use the `mcp__Linear__*` tools to read Initiatives and Projects for roadmap/epic context, and, when grooming an epic, to create native Linear `SFN` issues and Projects — this does not make you an implementer; you still do not write compiler code.
 
 ## The Sailfin Compiler
 
@@ -60,6 +60,12 @@ Every design must account for the fact that the compiler compiles itself:
 
 ## Decomposition Discipline (when grooming an epic into issues)
 
+Epics are Linear **Projects** under Initiatives; leaf work is native Linear
+`SFN` issues created via `mcp__Linear__save_issue` (team `Sailfin`, with
+native `state`/`priority`/`estimate`/`project`/`labels`/`blockedBy` fields) —
+see `/groom` Phase 4 and `docs/conventions/linear-workflow.md` for the full
+flow.
+
 When `/groom` asks you to break work into session-sized issues, **minimize
 the decomposition** — splitting carries real cost (extra PRs, review cycles,
 and seed cuts). Apply these:
@@ -98,6 +104,7 @@ Always consult these before designing:
 | `site/src/content/docs/docs/reference/preview/` | Design preview — planned but not yet shipped |
 | `docs/proposals/0006-build-architecture.md` | Build bottleneck root causes, optimization plan, and performance baseline |
 | `compiler/capsule.toml` | Current version and manifest |
+| Linear (Initiatives → Projects → SFN issues) | The live epic/roadmap structure — read via `mcp__Linear__list_initiatives` / `list_projects` / `get_project` |
 
 ## What You're Asked To Do
 

--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -1,13 +1,22 @@
 # Groom a Roadmap Epic into Issues
 
-Take a high-level roadmap item and decompose it into session-sized GitHub issues that Claude can pick up and complete autonomously.
+Take a high-level epic (a **Linear Project** under an Initiative) and decompose
+it into session-sized **Linear `SFN-NNN` issues** that Claude can pick up and
+complete autonomously.
+
+> **Linear is the planning source of truth.** Epics are Linear **Projects**
+> (under Initiatives); leaves are native Linear issues on the Sailfin (`SFN`)
+> team. There is **no** GitHub mirror for our planned work and **no** GitHub
+> `Epic:`/`Tracking:` issue. Use `mcp__Linear__*` tools throughout. See
+> `docs/conventions/linear-workflow.md` for the full model and
+> `docs/conventions/linear-templates.md` for the issue/Project templates.
 
 ## Target: $ARGUMENTS
 
 The argument can be:
-- A roadmap section name (e.g., "syntax reform", "compiler stabilization")
-- A specific bullet from the [roadmap](https://sailfin.dev/roadmap) (e.g., "Implement await expression parsing")
-- A document to mine for work items (e.g., `docs/proposals/0006-build-architecture.md`)
+- A Linear Project / epic name (e.g. "CLI Modularization")
+- An Initiative name to mine for the next un-groomed Project
+- A roadmap bullet or a document to mine (e.g. `docs/proposals/0006-build-architecture.md`)
 - A free-form description of work that needs breaking down
 
 ---
@@ -15,29 +24,33 @@ The argument can be:
 ## Phase 1: UNDERSTAND THE EPIC
 
 Read the relevant context:
-- `site/src/pages/roadmap.astro` — find the epic and its surrounding priorities (published at [sailfin.dev/roadmap](https://sailfin.dev/roadmap))
+- **Linear** — the Initiative and its Projects. Find the epic and its place:
+  ```
+  mcp__Linear__list_initiatives includeProjects=true
+  mcp__Linear__get_project id="<project-id-or-name>"
+  mcp__Linear__list_issues project="<project>" limit=100
+  ```
+  The Project **description** carries the epic's outcome, scope, and
+  `Design: SFEP-NNNN` link.
 - `docs/status.md` — current state of the affected feature(s)
-- `site/src/content/docs/docs/reference/spec/` (chapter files §1–§11) — what the language commits to today; `.../reference/preview/` for planned features
-- Any document referenced in the argument
+- `site/src/content/docs/docs/reference/spec/` (§1–§11) and `.../reference/preview/`
+- The Project's cited SFEP and any document named in the argument
 
-Identify:
-- What outcome this epic produces when fully done
-- What's already partially in place
-- What dependencies exist (must other epics complete first?)
+Identify: what outcome this epic produces when done, what's already partially in
+place (existing issues under the Project), and what other epics must complete first.
 
 ---
 
 ## Phase 2: DECOMPOSE
 
-Spawn the **compiler-architect** agent (Opus). Give it:
-- The epic and its context
-- The current compiler state (relevant files)
-- The constraint: each output issue must be **session-sized** (XS/S/M, never L)
+Spawn the **compiler-architect** agent (Opus). Give it the epic + its
+Initiative/Project context, the current compiler state, and the constraint that
+each output issue must be **session-sized** (XS/S/M, never L).
 
 The architect produces an ordered list of issues. Each issue must:
 - Have a clear, verifiable goal achievable in one session
 - Touch a bounded set of files
-- Be self-contained (or have explicit `Blocked by` dependencies on earlier issues)
+- Be self-contained (or have explicit blocker dependencies on earlier issues)
 - Include concrete acceptance criteria
 - Map to one of: Feature, Bug, Performance, Refactor
 
@@ -45,67 +58,48 @@ If the architect produces any L-sized item, push back: "this needs further break
 
 ### Capture the epic's design as an SFEP
 
-An epic with real design surface needs a durable **design record** so the
-sub-issues don't each re-litigate the *why*, and so `/pickup` has a brief to
-read. Before creating issues:
+An epic with real design surface needs a durable **design record** so leaves
+don't re-litigate the *why* and `/pickup` has a brief. Before creating issues:
 
-- **Check for an existing SFEP** for this epic (`grep` `docs/proposals/` and the
-  registry `docs/proposals/README.md`). Many epics already have one (e.g. the
-  effect-system, ownership, and test-infra epics).
-- **If one exists**, the sub-issues reference it (see the `## Design` line in the
-  body skeleton below); update its `tracking:` to list the epic + new issues.
-- **If none exists and the epic embodies a substantive design** (a language,
-  runtime/ABI, or toolchain decision — not just a bag of mechanical tasks), have
-  the architect write it as an SFEP first (`/sfep new <slug>`, or it writes
-  `docs/proposals/draft-<slug>.md` directly per `.claude/rules/proposals.md`).
-  Accept it at the grooming gate (`/sfep status <slug-or-N> Accepted`) so the
-  sub-issues can cite a numbered SFEP.
-- **If the epic is purely mechanical** (no design decision — e.g. "migrate N call
-  sites"), no SFEP is needed; the issues stand on their own.
-
-Each sub-issue then **cites the SFEP rather than duplicating its design** — the
-SFEP is the *why*, the issue is the *what to do this session*.
+- **Check for an existing SFEP** (`grep docs/proposals/` and the registry
+  `docs/proposals/README.md`, and the Project description's `Design:` line).
+- **If one exists**, leaves cite it (`## Design: SFEP-NNNN`); update its
+  `tracking:` front-matter to list the new issues.
+- **If none exists and the epic embodies a substantive design**, have the
+  architect write it as an SFEP first (`/sfep new <slug>` per
+  `.claude/rules/proposals.md`) and accept it at the grooming gate
+  (`/sfep status <slug-or-N> Accepted`).
+- **If the epic is purely mechanical** (no design decision), no SFEP is needed.
 
 ### Feasibility-probe FFI / "no frontend dependency" claims (gate)
 
 Before any issue that touches `runtime/` or crosses the C-ABI / `extern fn`
-boundary goes `claude-ready`, **probe the load-bearing feasibility claim** —
-do not take "this is written against the extern layer the seed already
-compiles / has no frontend dependency" on faith. The cheapest probe is a
-throwaway `.sfn` snippet run through the current seed:
+boundary is marked `Ready`, **probe the load-bearing feasibility claim** — do
+not take "no frontend dependency" on faith. Run a throwaway `.sfn` snippet
+through the current seed:
 
 ```bash
 build/seed/bin/sailfin check /tmp/probe.sfn
 build/seed/bin/sailfin emit -o /tmp/probe.ll llvm /tmp/probe.sfn
 ```
 
-Confirm the construct the issue depends on can actually be **expressed and
-emitted** (not silently dropped to `null` / elided). Runtime code that calls
-a C API frequently needs a frontend capability that does not exist yet —
-e.g. taking a function's address to pass as a `pthread_create` start routine
-(the gap that broke the original #1088 pickup: its "no frontend dependency"
-premise was false, and the missing primitive surfaced reactively mid-pickup
-instead of as a planned predecessor). If the probe fails, the prerequisite
-is a **frontend issue that must be groomed first** — make it an explicit
-`Blocked by` / `Required in pinned seed` predecessor, not a surprise.
+Confirm the construct can actually be expressed and emitted (not silently
+dropped to `null`). If the probe fails, the prerequisite is a **frontend issue
+that must be groomed first** — make it an explicit blocker / seed predecessor,
+not a surprise (the gap that broke the original #1088 pickup).
 
 ### Don't over-decompose: bundle a capability with its single consumer (default)
 
-**Bundling is the groom-time default, not a split-time afterthought.** When you
-identify a compiler capability that is tightly coupled to exactly one consumer
-that will be worked in the same session, **produce one issue** (one PR), not two.
-Split only when the capability has **multiple consumers** that each justify
-standalone shipping, or the work is **genuinely independent**. Any split that
-creates a seed-cut gate for a single consumer must be **explicitly justified** in
-the issue body — the default answer is bundle.
+**Bundling is the groom-time default.** When a compiler capability is tightly
+coupled to exactly one consumer worked in the same session, **produce one
+issue** (one PR), not two. Split only when the capability has **multiple
+consumers** or is **genuinely independent**. Any split that creates a seed-cut
+gate for a single consumer must be **explicitly justified** in the issue body.
 
-The full decision tree and the seed-cut-tax rationale live in the shared rule
-**`.claude/rules/seed-dependency.md`** (cited by `/pickup` too, so both apply it
-identically — design record SFEP-0026 WS-B). Apply that rule here rather than
-re-deriving it. When a split is justified, follow "Seed dependencies" below:
-label the predecessor `seed-blocker`, give the consumer
-`## Required in pinned seed: #<predecessor>`, and queue the seed advance against
-the next cadence bump rather than cutting reactively.
+The full decision tree and seed-cut-tax rationale live in
+**`.claude/rules/seed-dependency.md`** (cited by `/pickup` too — SFEP-0026 WS-B).
+Apply that rule here rather than re-deriving it. When a split is justified,
+follow "Seed dependencies" below.
 
 ---
 
@@ -113,47 +107,77 @@ the next cadence bump rather than cutting reactively.
 
 Present the proposed issue list as a table:
 
-| # | Title | Type | Size | Priority | Blocked by |
+| # | Title | Type | Estimate | Priority | Blocked by |
 |---|---|---|---|---|---|
 | 1 | ... | Performance | S | High | — |
 | 2 | ... | Refactor | M | Medium | #1 |
 
-Priority is one of Urgent / High / Medium / Low — the architect assigns it from
-the epic's place on the 1.0 critical path (default a leaf to its Project's
-priority unless it's a genuine outlier). It becomes the Linear-native priority in
-the *Reflect in Linear* step; it is **not** a GitHub label.
+Priority is Urgent / High / Medium / Low — the architect assigns it from the
+epic's place on the 1.0 critical path (default a leaf to its Project's priority
+unless it's a genuine outlier). Estimate is XS/S/M. Both become **Linear-native
+fields** in Phase 4.
 
-Wait for user approval. The user may:
-- Approve as-is → proceed to Phase 4
-- Request changes (drop, merge, split, reorder) → iterate with the architect
-- Reject the breakdown entirely → ask what's wrong
+Wait for user approval. The user may approve as-is (→ Phase 4), request changes
+(iterate with the architect), or reject the breakdown (ask what's wrong).
 
 ---
 
-## Phase 4: CREATE ISSUES
+## Phase 4: CREATE LINEAR ISSUES
 
-Create **only session-sized leaf issues** on GitHub — one per approved item.
-The epic itself is **not** a GitHub issue: it is the Linear **Project** created
-in the *Reflect in Linear* step below (`linear-workflow.md`). Do **not** open a
-GitHub `Epic:` / `Tracking:` issue or apply the `epic` / `tracking` label — those
-shapes are retired (`docs/conventions/issue-naming.md` § Title taxonomy).
+Ensure the epic's Linear **Project** exists, then create one native Linear
+issue per approved leaf under it. Do **not** create GitHub issues (those are for
+external contributors) and never a GitHub `Epic:`/`Tracking:` issue.
 
-Leaf titles follow `docs/conventions/issue-naming.md`: `<type>(<scope>):
-<imperative verb phrase>` (Conventional Commit shape). Labels come from
-`.github/labels.yml` (canonical registry); use lowercase prefixes (`type:bug`
-not `bug`, `size:m` not `medium`).
+### 4.1 — Ensure the Project exists
 
-```bash
-gh issue create \
-  --title "<title>" \
-  --label "claude-ready,type:<type>,size:<size>" \
-  --body "$(cat <<'EOF'
+Resolve or create the epic's Project under the correct Initiative, named for its
+outcome per `docs/conventions/issue-naming.md` § Linear structure & naming
+(concise Title-Case noun phrase; no `Epic:` prefix, no trailing `#N`/`SFEP-NNNN`).
+Put `Design: SFEP-NNNN` and any related links in the **description**, not the name:
+
+```
+mcp__Linear__list_projects query="<epic outcome>"
+# if absent:
+mcp__Linear__save_project name="<Outcome Name>" addTeams=["Sailfin"] addInitiatives=["<Initiative>"] description="## Outcome\n...\n\n## Design\n- SFEP: SFEP-NNNN"
+```
+
+### 4.2 — Create each leaf
+
+For each approved leaf, create the issue with native status, priority,
+estimate, project, labels, and blocker relations set directly — no separate
+"reflect" step:
+
+```
+mcp__Linear__save_issue \
+  team="Sailfin" \
+  title="<type>(<scope>): <imperative verb phrase>" \
+  project="<Project name>" \
+  state="Ready" \
+  priority=<1|2|3|4> \
+  estimate=<1|2|3> \
+  labels=["type:<t>", "area:<a>"] \
+  description="<body — see skeleton below>"
+```
+
+Field mapping (canonical — see `docs/conventions/linear-workflow.md`):
+
+| Attribute | Linear field | Value |
+|---|---|---|
+| Pickable-when-groomed | `state` | `Ready` (or `Backlog` if scoped-but-not-ready) |
+| Priority | `priority` | Urgent/High/Medium/Low → 1/2/3/4 |
+| Size | `estimate` | XS/S/M → 1/2/3 (never L) |
+| Type / area | `labels` | `type:*`, `area:*` only — never status/priority/size labels |
+| Blocked | relation | `blockedBy=["SFN-<blocker>"]` → status is set to `Blocked` automatically when a blocker is open |
+
+**Issue body skeleton** (`docs/conventions/linear-templates.md` is the source):
+
+```markdown
 ## Goal
 <one sentence>
 
 ## Scope
 **In:**
-- <semantic unit of change — not a file path; e.g. "the effect-checker
+- <semantic unit of change — NOT a file path; e.g. "the effect-checker
   diagnostic emission for missing ![io]">
 
 **Out:**
@@ -168,247 +192,109 @@ gh issue create \
 - compiler/src/... — ...   # likely-relevant starting points; non-exhaustive, no line numbers/counts
 
 ## Verification
-\`\`\`bash
+```bash
 timeout 60 build/native/sailfin run path/to/example.sfn
-\`\`\`
-
-## Size
-<XS|S|M>
-
-## Type
-<Feature|Bug|Performance|Refactor>
-
-## Blocked by
-<#N or "None">
-
-## Required in pinned seed
-<#N or "None" — see "Seed dependencies" below for when to populate this>
-
-## Design
-<SFEP-NNNN (docs/proposals/NNNN-<slug>.md) — the design record this issue implements, or "None" for purely mechanical work>
-
-## Context
-<links to roadmap, code, prior PRs>
-EOF
-)"
 ```
 
-**Always emit the `## Required in pinned seed` section**, even when the
-value is `None`. `/pickup` Phase 1.5 treats a missing section as legacy
-and falls back to walking `## Blocked by` against the seed tag — which
-produces false-positive seed-cut requirements on routine work. An
-explicit `None` value is the contract that says "no seed dependency."
+## Required in pinned seed
+<#<PR> or "None" — see "Seed dependencies" below>
+
+## Design
+<SFEP-NNNN (docs/proposals/NNNN-<slug>.md), or "None" for purely mechanical work>
+
+## Context
+<links to the Project, roadmap, code, prior PRs>
+```
+
+**Always emit `## Required in pinned seed`, even as `None`.** `/pickup` treats a
+missing section as legacy and falls back to walking blockers against the seed —
+producing false-positive seed-cut requirements. An explicit `None` is the
+contract for "no seed dependency."
+
+### 4.3 — Set blocker relations
+
+For any leaf that depends on a sibling that hasn't merged, set the native
+blocked-by relation — Linear derives `Blocked` status from it:
+
+```
+mcp__Linear__save_issue id="SFN-<dependent>" blockedBy=["SFN-<blocker>"]
+```
 
 ### Intent authoritative, file map advisory
 
-A groomed issue's **contract** is its **Goal** plus a **semantic
-`In:`/`Out:` scope**. The `## Files Affected` block is a **non-binding map** —
-a navigation aid that is *expected to drift* and is reconciled at pickup, not
-a checklist that gates correctness. This is the convention of record in
-`docs/conventions/issue-naming.md` ("Intent-authoritative issues"); all four
-issue-lifecycle commands cite it. When emitting an issue body:
+A groomed issue's **contract** is its **Goal** plus a **semantic `In:`/`Out:`
+scope**; `## Files Affected` is a **non-binding map** reconciled at pickup
+(`docs/conventions/issue-naming.md`, "Intent-authoritative issues"). When
+emitting a body:
 
-- **Express `In:`/`Out:` as semantic units of change, not file paths.** Write
-  "the effect-checker diagnostic emission for missing `![io]`", not
-  "`effect_checker.sfn` lines X-Y". A new sibling file inside that unit (e.g.
-  a split that moved diagnostic emission into `effect_checker/diagnostics.sfn`)
-  is then **in scope by construction** — the unit, not the path, is the boundary.
-- **Mark `## Files Affected` advisory** (the header reword above) and list paths
-  as *likely-relevant starting points*, explicitly non-exhaustive.
-- **Forbid line numbers anywhere** (`L142`, `~L100-135`) and **exact file
-  counts** ("edit these 3 files", "two call sites") in any emitted body. Line
-  numbers rot fastest; a count turns an in-unit Nth sibling into a phantom
-  scope violation.
-
-`/pickup` reconciles cosmetic map drift (a renamed path, an in-unit sibling)
-and pauses only on **semantic** scope growth (a new acceptance criterion or new
-public surface). Grooming a precise-but-brittle map only manufactures pickup
-halts on entropy `/triage` would otherwise refresh.
-
-Capture the issue numbers. After each `gh issue create`:
-
-1. Set the GitHub native Type field to match the `type:*` label:
-```bash
-# Derive from the label: type:feature → Feature, type:bug → Bug, everything else → Task
-.claude/scripts/set-issue-type.sh <new-issue-number> <Feature|Task|Bug>
-```
-
-The mapping from `type:*` label to GitHub Type:
-- `type:feature` → `Feature`
-- `type:bug` → `Bug`
-- `type:refactor`, `type:perf`, `type:docs`, `type:tech-debt`, epics, tracking → `Task`
-
-Then set up dependencies. For any issue that depends on a sibling that
-hasn't merged yet, add the `blocked` label:
-
-```bash
-# For each issue blocked by an earlier one:
-gh issue edit <N> --add-label "blocked"
-# (and reference the blocker in the body — the gh CLI doesn't have native dependency support)
-```
-
-### Reflect in Linear
-
-Once the GitHub issues exist, reflect the epic and its leaves into Linear per
-`docs/conventions/issue-naming.md` § Reflecting state into Linear (best-effort —
-skip with a one-line note if the Linear MCP tools aren't connected):
-
-1. **Create or reuse the epic's Linear Project** under the correct initiative,
-   named per § Linear structure & naming (concise Title-Case deliverable; no
-   `Epic:` prefix or trailing `#N`/`SFEP-NNNN`), with `GitHub: #<epic>` and any
-   `Design: SFEP-NNNN` placed in the project **description**, not the name.
-2. **Assign each created leaf** to that Project, set its status from its labels,
-   and set its **Linear-native priority and estimate** per
-   `docs/conventions/issue-naming.md` § Reflecting state into Linear (step 3):
-   estimate from the `size:*` label (xs/s/m → 1/2/3 on the team's Linear 1–5
-   scale), priority from the Phase 3 table (Urgent/High/Medium/Low → 1/2/3/4,
-   defaulting to the Project's priority). The mirror syncs in asynchronously —
-   retry briefly, and let a later `/triage`/`/sweep` pass reconcile any leaf
-   whose mirror (or priority/estimate) hasn't appeared yet.
-3. **Roll up the Project status** from its issues (any In Progress → `started`;
-   else any Ready → `planned`; else `backlog`).
-
-Never write a terminal (`Done`/`Canceled`) status — the leaves are open, and the
-two-way sync would close them.
+- **Express `In:`/`Out:` as semantic units, not file paths.** A new sibling
+  file inside a named unit is in scope by construction.
+- **Mark `## Files Affected` advisory**, list paths as likely-relevant starting
+  points, explicitly non-exhaustive.
+- **Forbid line numbers** (`L142`, `~L100-135`) and **exact file counts**
+  anywhere — both rot fastest and manufacture phantom scope violations.
 
 ### Seed dependencies
 
-For each created issue, evaluate whether its predecessors must be **in the
-pinned seed binary**, not just merged on `main`. The two states are
-different — `make compile` runs against the binary at `.seed-version`, so
-a dependency that's merged but not seeded will fail to self-host.
+For each leaf, evaluate whether a predecessor must be **in the pinned seed
+binary**, not just merged. `make compile` runs against `.seed-version`, so a
+compiler-source dependency merged but not seeded fails to self-host.
 
-Apply this rule:
+Apply: if the leaf touches `compiler/src/` or `runtime/prelude.sfn` AND its
+predecessor is a compiler-source change affecting the binary's behaviour
+(lowering, parsing, typecheck, intrinsics, diagnostics, IR shape), the
+predecessor must be in the seed first. When that holds:
 
-- If the issue touches `compiler/src/` or `runtime/prelude.sfn` AND its
-  predecessor is a compiler-source change that affects the compiler
-  binary's behaviour (lowering, parsing, type-checking, intrinsics,
-  diagnostics, IR shape), the predecessor must be in the seed before
-  this issue can self-host.
+1. Fill `## Required in pinned seed` with the predecessor's **PR number**.
+2. Apply the `seed-blocker` label to the **predecessor** issue (the one shipping
+   the change): `mcp__Linear__save_issue id="SFN-<predecessor>" labels=[...,"seed-blocker"]`.
+3. Note in the Phase 5 report that a cadence seed bump + `/pin-seed` is required
+   before pickup of the dependent leaf.
 
-When that holds:
+A pure docs/test/runtime issue typically needs no seed cut.
 
-1. Fill in the `## Required in pinned seed` section of the issue body
-   with the predecessor issue/PR number — separate from `## Blocked by`.
-2. Apply the `seed-blocker` label to the **predecessor issue** (the
-   one shipping the change, not the dependent one):
+### Phased epics: one Project per phase, groomed wave-by-wave
 
-```bash
-gh issue edit <predecessor> --add-label seed-blocker
-```
+When an epic is inherently multi-phase (Phase A → B → C, later phases depend on
+earlier), model the phases as **separate Linear Projects** under the shared
+Initiative, named `<Epic> Phase <X> — <noun phrase>` (as the existing
+*Concurrency Maturity Phase 1 / Phase 2* Projects do). Give each future phase a
+`Backlog`/`Planned` Project state with its checklist + `Design: SFEP-NNNN` in
+the description. Groom each phase's leaves wave-by-wave into that phase's
+Project when the wave opens; the empty next-phase Project is the visible "groom
+me next" card. (One Project rolls up its own issues — a single Project for the
+whole epic would read ~100% the moment Phase A closed, hiding that B/C aren't
+groomed.)
 
-3. Note in the Phase 5 report that a seed cut + `/pin-seed` will be
-   required between the predecessor's merge and pickup of this issue.
-
-Examples:
-- Slice E.2 (struct-field migration) requires Slice E.1 (`int`/`float`
-  aliases) to be in the seed because the migration emits LLVM IR that
-  relies on the new `int → i64` mapping. The previous E.2 attempt
-  (#489) failed precisely because this gate was implicit instead of
-  explicit.
-- A new effect-checker pass that emits diagnostics requires the
-  diagnostic-codes PR to be in the seed.
-- A pure docs/test/runtime issue typically does NOT require a seed cut.
-
-`/pickup` enforces the `## Required in pinned seed` contract via
-`git merge-base --is-ancestor`. Skipping the section here means the
-agent has decided the issue does not need a fresh seed; getting that
-wrong is the failure mode this gate exists to prevent.
-
-### Grouping: Linear Project for the epic; GitHub sub-issues only for leaf splits
-
-Epic grouping is **not** a GitHub parent — it is the Linear **Project** the leaves
-are associated to in the *Reflect in Linear* step below. Do not create a GitHub
-`Epic:` parent to hang leaves off.
-
-GitHub-native sub-issue nesting is still used in **one** case: when a single
-session-sized leaf is split into smaller GitHub children (steps of one piece of
-work). Attach each child as a sub-issue of its **leaf parent** — body references
-alone do not populate the parent's "Sub-issues" panel. Use the REST API (the `gh`
-CLI has no first-class command yet):
-
-```bash
-# Look up the parent's internal node id (NOT the issue number) once:
-PARENT=450
-PARENT_ID=$(gh api repos/SailfinIO/sailfin/issues/$PARENT --jq '.id')
-
-# For each created sub-issue, look up its id and attach it. The
-# sub_issue_id field MUST be passed with -F (typed integer); -f sends a
-# string and the API rejects it with a 422.
-for n in 458 459 460 461 462 463; do
-  child_id=$(gh api repos/SailfinIO/sailfin/issues/$n --jq '.id')
-  gh api -X POST /repos/SailfinIO/sailfin/issues/$PARENT/sub_issues \
-    -F sub_issue_id=$child_id --jq '.number'
-done
-
-# Verify the parent now lists every child:
-gh api /repos/SailfinIO/sailfin/issues/$PARENT/sub_issues \
-  --jq '.[] | "#\(.number) \(.title)"'
-```
-
-This applies **only** to the leaf-split case above. The default groom output —
-independent leaves associated to the epic's Linear Project — needs no GitHub
-sub-issue attachment at all; skip this step unless you actually split one leaf
-into GitHub children.
-
-### Phased epics: one Linear Project per phase, groomed wave-by-wave
-
-When an epic is **inherently multi-phase** — sequential phases where later phases
-depend on earlier ones (e.g. SFEP-0027's Phase A → B → C → D, where B can't start
-until A's modules land) — do **not** dump all leaves into one Project and groom
-them in undocumented "waves." That is the structure that lost #351's Phase 3 (it
-went 8/13-done with no sub-issues ever filed). Model the phases in Linear instead:
-
-1. **One Linear Project per phase, all created up front** under the shared
-   Initiative, named `<Epic> Phase <X> — <noun phrase>` (as the existing
-   *Concurrency Maturity Phase 1 / Phase 2* Projects do). Give each future phase's
-   Project a `Planned`/`Backlog` state and put its checklist + `Design: SFEP-NNNN`
-   in the Project description. Leaves attach to the **current** phase's Project;
-   future phases hold no leaves yet.
-2. **Groom each phase's leaf issues wave-by-wave**, filing them (GitHub → Linear)
-   into that phase's Project only when the wave is actually being opened. The empty
-   next-phase Project is the visible *"groom me next"* card.
-
-Why one-Project-per-phase (not one Project for the whole epic): a Project rolls up
-its own issues' state. If every phase's leaves lived in a single Project, that
-Project would read ~100% the moment Phase A's wave closed — hiding that B/C/D
-aren't even groomed. Separate phase Projects keep each phase independently
-plannable, focusable, and completable, and the Initiative view shows the phase
-sequence at a glance. (`/sweep` Phase 2c still uses GitHub **leaf** sub-issue
-rollups to recommend closing a leaf-parent — that is unchanged; it never closes a
-Linear Project.)
-
-**When NOT to use this:** a single-phase epic, or a flat bag of genuinely
-independent issues with no phase ordering — one Project, leaves filed directly.
-The per-phase Project structure is for *sequential, wave-groomed* phases only.
+**When NOT to use this:** a single-phase epic, or a flat bag of independent
+issues with no ordering — one Project, leaves filed directly.
 
 ---
 
 ## Phase 5: REPORT
 
 Report to the user:
-- Issue numbers created (with titles)
+- Linear issues created (SFN-NNN with titles) and the Project they landed under
 - The dependency graph (what blocks what)
 - The recommended pickup order
+- Any seed-cut gate a split introduced (predecessor → dependent, queued bump)
 - Any context the architect flagged that doesn't fit in an issue
 
-Suggest: `/pickup` to start working the queue, or `/triage` to verify hygiene.
+Suggest: `/pickup` to start the queue, or `/triage` to verify hygiene.
 
 ---
 
 ## Constraints
 
-- **Never create L-sized issues.** If the architect can't break work into XS/S/M, the work is not yet ready.
+- **Never create L-sized issues.** If work can't break into XS/S/M, it's not ready.
 - **Never create issues without acceptance criteria.** The criteria are the contract.
-- **Always set the `claude-ready` label** on issues that are ready to pick up. Use `needs-grooming` for issues that exist as placeholders but need refinement.
-- **Always set the `type:*` and `size:*` labels** so `/pickup` can filter correctly. Apply `area:*` labels when the touched subsystem is unambiguous.
-- **Always set a Linear-native priority and estimate** on each leaf's mirror (see *Reflect in Linear*). Priority is not a GitHub label; estimate derives from `size:*`. Never leave a groomed leaf at `No priority` / no estimate.
-- **Use only labels defined in `.github/labels.yml`** — never invent new ones in this command. If you think a new label is warranted, edit `labels.yml` in a separate PR first.
-- **Title format follows `docs/conventions/issue-naming.md`** — Conventional Commit shape for leaf sub-tasks. Never open an `Epic:`/`Tracking:` GitHub issue or apply the `epic`/`tracking` label; epics are Linear Projects (see *Reflect in Linear*).
-- **Don't create issues for work that's already in progress** — check `gh issue list` first to avoid duplicates.
-- **When splitting one leaf into GitHub children, attach each child as a native sub-issue of its leaf parent** via the REST `/sub_issues` endpoint (epic grouping is the Linear Project, not a GitHub parent). Body cross-references do not populate the parent's Sub-issues panel. Use `-F sub_issue_id=<int>` (not `-f`) — the field must be typed.
-- **Labels are the source of truth.** There is no derived board to sync.
-- **Set the GitHub native Type field** with
-  `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` (best-effort; it
-  self-skips when `gh` is unavailable). Derive the type from the `type:*` label:
-  `type:feature` → `Feature`, `type:bug` → `Bug`, everything else → `Task`.
+- **Set status, priority, and estimate natively** on every leaf. A groomed,
+  unblocked leaf is `Ready`; a blocked one gets a `blockedBy` relation (Linear
+  derives `Blocked`). Never leave a `Ready` leaf at `No priority` / no estimate.
+- **Labels are `type:*` / `area:*` only** — status, priority, estimate, and
+  blockers are native Linear fields, not labels.
+- **No GitHub issues.** Epics are Linear Projects; leaves are Linear issues.
+  GitHub issues come only from external contributors (mirrored into Linear
+  Triage) — never open one here.
+- **Never write a terminal status** (`Done`/`Canceled`) on freshly-groomed work.
+- **Don't duplicate in-progress work** — check `list_issues` for the Project first.

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -8,8 +8,8 @@ PR open — flipping the Linear status as you go.
 > `SFN-NNN` issues; there is no GitHub mirror for our own planned work. GitHub
 > hosts the code and the PR. See `docs/conventions/linear-workflow.md` for the
 > full model. Use the `mcp__Linear__*` tools for all issue state; use
-> `mcp__github__*` / `git` for branches, commits, and PRs (there is no `gh`
-> CLI in this environment).
+> `mcp__github__*` for GitHub reads/PRs and `git` for branches and commits —
+> don't rely on a `gh` CLI being available.
 
 ## Target: $ARGUMENTS
 
@@ -69,10 +69,12 @@ git rev-parse --verify "${SEED_TAG}^{commit}" >/dev/null 2>&1 || {
   echo "Seed tag $SEED_TAG does not resolve — check .seed-version."; exit 1; }
 ```
 
-For each predecessor PR `#P` in `## Required in pinned seed`, get its merge
-commit (`mcp__github__pull_request_read` → `mergeCommit`) and check ancestry:
+For each predecessor PR `#P` in `## Required in pinned seed`, read its merge
+commit with `mcp__github__pull_request_read` (method `get` → `mergeCommit.oid`),
+assign it to `PR_MERGE`, and check ancestry:
 
 ```bash
+PR_MERGE=<mergeCommit.oid from mcp__github__pull_request_read for #P>
 git merge-base --is-ancestor "$PR_MERGE" "$SEED_TAG"   # exit 0 ⇒ in seed
 ```
 

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -1,391 +1,214 @@
 # Pick Up the Next Issue
 
-Autonomously query the issue tracker, pick the highest-priority unblocked issue, and drive it from branch creation through PR open.
+Autonomously query **Linear**, pick the highest-priority unblocked `Ready`
+issue on the Sailfin (`SFN`) team, and drive it from branch creation through
+PR open — flipping the Linear status as you go.
+
+> **Linear is the planning source of truth.** Work items are native Linear
+> `SFN-NNN` issues; there is no GitHub mirror for our own planned work. GitHub
+> hosts the code and the PR. See `docs/conventions/linear-workflow.md` for the
+> full model. Use the `mcp__Linear__*` tools for all issue state; use
+> `mcp__github__*` / `git` for branches, commits, and PRs (there is no `gh`
+> CLI in this environment).
 
 ## Target: $ARGUMENTS
 
 If `$ARGUMENTS` is empty, pick the next available issue automatically.
-If `$ARGUMENTS` is an issue number (e.g., `142`), work that specific issue.
+If `$ARGUMENTS` is a Linear identifier (e.g. `SFN-142`), work that specific issue.
 
 ---
 
 ## Phase 1: SELECT AN ISSUE
 
-Query open `claude-ready` issues that aren't blocked or in-progress:
+Query open `Ready` issues on the Sailfin team:
 
-```bash
-gh issue list \
-  --label "claude-ready" \
-  --state open \
-  --json number,title,labels,assignees,body \
-  --limit 50
+```
+mcp__Linear__list_issues team="Sailfin" state="Ready" limit=50
 ```
 
-Filter out:
-- Issues with the `blocked` label
-- Issues with the `in-progress` label
-- Issues with any assignee (someone else is on it)
-- Issues whose body lists open `Blocked by` issues that aren't closed
+Filter out any issue that is:
+- Assigned to someone else (`assignee` set to another user).
+- Has an open **blocked-by** relation — fetch relations and confirm every
+  blocker is `Done`/`Canceled`:
+  ```
+  mcp__Linear__get_issue id="SFN-<N>" includeRelations=true
+  ```
+  (A properly-groomed blocked issue sits in `Blocked`, not `Ready` — but
+  verify, because a blocker may have re-opened.)
 
-If `$ARGUMENTS` specifies an issue number, fetch only that one and verify it's pickable:
-```bash
-gh issue view <N> --json number,title,labels,assignees,body,state
+If `$ARGUMENTS` names an issue, fetch only that one and verify it is pickable
+(`Ready`, unassigned or assigned to you, no open blocker):
+
+```
+mcp__Linear__get_issue id="SFN-<N>" includeRelations=true
 ```
 
 **Priority order** (highest first):
-1. **Linear-native priority** — Urgent, then High (read from the issue's Linear
-   mirror; priority is no longer a GitHub label). Best-effort: if the Linear MCP
-   tools aren't connected, skip this tier and rank by the signals below.
+1. **Linear priority** — Urgent (1), then High (2).
 2. `type:bug` (bugs first)
 3. `type:perf` (perf next — compounds future work)
-4. Smallest `size:*` first within the same type (XS → S → M)
-5. Lowest issue number as tiebreaker (FIFO)
+4. Smallest **estimate** first within the same type (1 → 2 → 3)
+5. Lowest `SFN-` number as tiebreaker (FIFO)
 
-If no pickable issue exists, report: "No claude-ready issues available. Run `/triage` to audit, or `/groom <epic>` to add work."
+If no pickable issue exists, report: "No `Ready` SFN issues available. Run
+`/triage` to audit the queue, or `/groom <epic>` to add work."
 
 ---
 
 ## Phase 1.5: VERIFY SEED FRESHNESS
 
-Before claiming, verify every predecessor the issue lists in
-`## Required in pinned seed` is actually present in the binary that
-`make compile` will use. This catches the "merged but not seeded"
-failure mode that broke the original #489 attempt.
+If the issue body has a `## Required in pinned seed` section listing
+predecessor PRs, verify each predecessor's merge commit is actually present in
+the binary `make compile` uses — this catches the "merged but not seeded"
+failure mode that broke the original #489 attempt. (`git` is available; use it.)
 
 ```bash
 SEED_TAG="v$(cat .seed-version)"
 git fetch --tags origin "$SEED_TAG" 2>/dev/null || git fetch --tags origin
-
-# Verify the seed tag actually resolves before any merge-base check.
-# A typo in .seed-version or a missing remote tag should produce a
-# clear diagnostic, not a low-signal `git merge-base` error.
-if ! git rev-parse --verify "${SEED_TAG}^{commit}" >/dev/null 2>&1; then
-  echo "Seed tag $SEED_TAG does not exist locally or on origin."
-  echo "Verify .seed-version points at a valid published release tag."
-  exit 1
-fi
+git rev-parse --verify "${SEED_TAG}^{commit}" >/dev/null 2>&1 || {
+  echo "Seed tag $SEED_TAG does not resolve — check .seed-version."; exit 1; }
 ```
 
-Parse the issue body for the `## Required in pinned seed` section.
-Extract every `#N` reference. A reference MAY carry an optional inline
-expectation of the form `#N (expect: <symbol> in <path>)` — e.g.
-`#511 (expect: emit_runtime_call in compiler/src/llvm/expression_lowering/native/runtime_call.sfn)`.
-Parse `<symbol>` and `<path>` when present; treat any form you can't
-parse as a bare `#N` (back-compat — plain `#N` references stay valid).
-The expectation is consumed only here, by the content-based fallback
-below; `/groom` need not emit it.
-
-For each predecessor:
+For each predecessor PR `#P` in `## Required in pinned seed`, get its merge
+commit (`mcp__github__pull_request_read` → `mergeCommit`) and check ancestry:
 
 ```bash
-# Per-predecessor expectation parsed from the section above; both empty
-# when the reference is a bare `#N`. Consumed only by the content-based
-# fallback (Probe 1) when SHA ancestry fails.
-EXPECT_SYMBOL=""   # e.g. emit_runtime_call
-EXPECT_PATH=""     # e.g. compiler/src/llvm/.../runtime_call.sfn
-
-# Detect PR vs issue up front. `gh pr view <issue-number>` errors,
-# while `gh issue view <pr-number>` succeeds but returns null
-# closedByPullRequestsReferences. PR-first avoids both ambiguity
-# and a wasted issue lookup when the dependency is already a PR.
-if gh pr view "$N" --repo SailfinIO/sailfin --json number >/dev/null 2>&1; then
-  PRS="$N"
-else
-  # Issue: collect EVERY closing PR. If multiple PRs closed the issue
-  # (e.g. revert + reland, partial-fix sequence), the predecessor is
-  # in the seed iff *any* of them is an ancestor of the seed tag.
-  PRS=$(gh issue view "$N" --repo SailfinIO/sailfin \
-         --json closedByPullRequestsReferences \
-         --jq '.closedByPullRequestsReferences[]?
-               | select(.isCrossRepository | not)
-               | .number')
-fi
-
-if [ -z "$PRS" ]; then
-  echo "Predecessor #$N has no merged PR — pickup blocked until it merges."
-  exit 1
-fi
-
-ANCESTOR_FOUND=0
-LAST_MERGE=""
-for PR in $PRS; do
-  PR_MERGE=$(gh pr view "$PR" --repo SailfinIO/sailfin \
-              --json mergeCommit --jq '.mergeCommit.oid // empty')
-  [ -z "$PR_MERGE" ] && continue
-  LAST_MERGE="$PR_MERGE"
-  if git merge-base --is-ancestor "$PR_MERGE" "$SEED_TAG" 2>/dev/null; then
-    ANCESTOR_FOUND=1
-    break
-  fi
-done
-
-# --- Content-based fallback -------------------------------------------
-# SHA ancestry is the fast happy path. It can yield a FALSE NEGATIVE
-# when `main` is rebased/linearised between a predecessor's merge and
-# the seed cut: the recorded merge SHA gets orphaned even though the
-# predecessor's code is present in the seed tree (motivating example:
-# #499 / PR #703 — see Context / Background). ONLY when SHA ancestry
-# fails for EVERY candidate merge commit do we fall back to comparing
-# the predecessor's content against the seed tree.
-FALLBACK_NOTE=""
-if [ "$ANCESTOR_FOUND" -eq 0 ]; then
-  # Probe 1 — symbol match (opt-in, tightest). Honored only when the
-  #   issue pinned `#N (expect: <symbol> in <path>)` for this predecessor.
-  if [ -n "$EXPECT_SYMBOL" ] && [ -n "$EXPECT_PATH" ]; then
-    if git show "$SEED_TAG:$EXPECT_PATH" 2>/dev/null | grep -q "$EXPECT_SYMBOL"; then
-      ANCESTOR_FOUND=1
-      FALLBACK_NOTE="content match: '$EXPECT_SYMBOL' present in $SEED_TAG:$EXPECT_PATH"
-    else
-      echo "Predecessor #$N: expected symbol '$EXPECT_SYMBOL' NOT found in $SEED_TAG:$EXPECT_PATH"
-    fi
-  fi
-
-  # Probe 2 — path match (cheap, default). Every non-removed file any
-  #   candidate PR touched must resolve at $SEED_TAG. Correct for the
-  #   common additive predecessor (e.g. #511 adding runtime_call.sfn).
-  if [ "$ANCESTOR_FOUND" -eq 0 ]; then
-    for PR in $PRS; do
-      FILES=$(gh api "repos/SailfinIO/sailfin/pulls/$PR/files" --paginate \
-               --jq '.[] | select(.status != "removed") | .filename' 2>/dev/null)
-      [ -z "$FILES" ] && continue
-      ALL_PRESENT=1
-      MISSING=""
-      while IFS= read -r f; do
-        [ -z "$f" ] && continue
-        git cat-file -e "$SEED_TAG:$f" 2>/dev/null && continue
-        ALL_PRESENT=0
-        MISSING="$MISSING $f"
-      done <<< "$FILES"
-      if [ "$ALL_PRESENT" -eq 1 ]; then
-        ANCESTOR_FOUND=1
-        FALLBACK_NOTE="content match: all files from PR #$PR present at $SEED_TAG"
-        break
-      fi
-      echo "Predecessor #$N (PR #$PR): files missing at $SEED_TAG:$MISSING"
-    done
-  fi
-
-  if [ "$ANCESTOR_FOUND" -eq 1 ]; then
-    echo "Predecessor #$N: merge SHA not an ancestor of $SEED_TAG, but $FALLBACK_NOTE."
-    echo "Proceeding via content-based fallback — record this in the Phase 6 report."
-  fi
-fi
-
-if [ "$ANCESTOR_FOUND" -eq 0 ]; then
-  echo "Predecessor #$N (last checked merge $LAST_MERGE) is NOT in the pinned seed $SEED_TAG."
-  echo "  (SHA ancestry failed AND the content-based fallback found missing files/symbols.)"
-  echo "Cut a fresh seed before pickup:"
-  echo "  gh workflow run release.yml --repo SailfinIO/sailfin --ref main \\"
-  echo "    -f channel=alpha -f bump=prerelease"
-  echo "Then /pin-seed once release-tag.yml uploads the binary."
-  exit 1
-fi
+git merge-base --is-ancestor "$PR_MERGE" "$SEED_TAG"   # exit 0 ⇒ in seed
 ```
 
-**Why the content-based fallback exists.** The SHA-ancestor check is
-fast and correct on a stable history, but it produces a *false negative*
-when `main` is rebased or linearised between a predecessor's merge and
-the seed cut. The recorded merge SHA is then orphaned — not an ancestor
-of the seed tag — even though the predecessor's code is sitting in the
-seed tree. Motivating example (#499 / PR #703): predecessor #495
-(PR #511) merged 2026-05-08 and is present in seed `v0.6.0` (cut
-2026-05-19) — `compiler/src/llvm/expression_lowering/native/runtime_call.sfn`
-exists at `v0.6.0` with `emit_runtime_call` exported — yet
-`git merge-base --is-ancestor 00e10692 v0.6.0` reports false because the
-original merge SHA was orphaned. The strict SHA check stays the happy
-path; the content probes fire only after it fails for every candidate
-merge commit, so happy-path performance is unchanged. Probe 1
-(symbol) is the tightest and is opt-in via `#N (expect: <symbol> in
-<path>)`; Probe 2 (path) is the cheap default that covers additive
-predecessors. A predecessor whose content is *genuinely* absent
-(added file missing at `$SEED_TAG`, or expected symbol not found) still
-halts with the original diagnostic.
+If ancestry fails, fall back to a **content check** before halting: SHA
+ancestry produces a false negative when `main` was rebased/linearised between
+the predecessor's merge and the seed cut (motivating example #499 / PR #703).
+Confirm the predecessor's added files/symbols exist at `$SEED_TAG`
+(`git cat-file -e "$SEED_TAG:<path>"`, or grep an expected symbol) — if they
+do, proceed and record the fallback in the Phase 6 report. Only halt when
+both the SHA check **and** the content check fail:
 
-**Legacy fallback** for issues groomed before the
-`## Required in pinned seed` section existed: if the issue does NOT
-have that section but its `## Files Affected` lists anything under
-`compiler/src/` or `runtime/prelude.sfn`, walk every `#N` in
-`## Blocked by` through the same per-PR merge-base check above.
+- Comment the pause on the Linear issue and stop (do **not** claim or branch):
+  ```
+  mcp__Linear__save_comment issueId="SFN-<N>" body="Pickup paused — predecessor #<P> is merged but not in the pinned seed (`$SEED_TAG`). Queue a cadence seed bump + `/pin-seed` before pickup. See `.claude/commands/pickup.md` Phase 1.5."
+  ```
+- Leave the issue in `Ready`; a later `/pickup` after the seed bump passes this gate.
 
-The legacy fallback only triggers when the section is **missing
-entirely**. Issues groomed under the new contract include the
-section even when it's empty (see `/groom` body skeleton), and an
-empty section means "no seed dependency" — pickup proceeds.
-Apply the **same SHA-then-content check** to each `## Blocked by`
-blocker: try `git merge-base --is-ancestor` first, and only when that
-fails for every candidate merge commit, run the content-based fallback
-(Probes 1 & 2 above) before halting. The orphaned-SHA false negative
-applies identically to legacy issues, so a blocker whose code is in the
-seed tree must not block pickup just because its merge SHA was rebased
-away. Legacy `## Blocked by` references are bare `#N` (no `(expect: …)`
-expectation), so legacy blockers rely on the path-based Probe 2.
-If a blocker fails both the SHA check and the content fallback, halt
-with the same diagnostic.
-
-If the precheck fails, comment on the issue and stop — do NOT claim
-or branch:
-
-```bash
-gh issue comment <N> --body "Pickup paused — predecessor #<P> is merged but not in the pinned seed (\`$SEED_TAG\`). Cut a new alpha and \`/pin-seed\` before pickup. See \`.claude/commands/pickup.md\` Phase 1.5."
-```
-
-The issue stays `claude-ready`; another `/pickup` attempt after the
-seed is bumped will pass this gate.
-
-If the precheck passes (every required predecessor is in the seed),
-proceed to Phase 2.
+Issues with no `## Required in pinned seed` section (most work — docs, tests of
+shipped features, runtime experiments) skip this phase entirely.
 
 ---
 
 ## Phase 2: CLAIM AND BRANCH
 
-Mark the issue as in-progress and create a branch:
+Claim the issue in Linear and create the branch:
 
-```bash
-# Claim it
-gh issue edit <N> --add-label "in-progress" --remove-label "claude-ready"
-
-# Branch name: claude/<N>-<slugified-title>
-git checkout -b claude/<N>-<slug>
+```
+mcp__Linear__save_issue id="SFN-<N>" state="In Progress" assignee="me"
 ```
 
-Then **reflect the claim into Linear** per `docs/conventions/issue-naming.md`
-§ Reflecting state into Linear: set the issue's mirror to `In Progress` and roll
-up its Project to `started`. Best-effort — skip with a note if the Linear MCP
-tools aren't connected. (The eventual `Closes #N` merge closes the GitHub issue,
-which the two-way sync propagates to `Done` on its own — don't set it here.)
+```bash
+# Branch name embeds the Linear ID so Linear's GitHub integration auto-links
+# the PR to the issue: claude/sfn-<N>-<slugified-title>
+git checkout -b claude/sfn-<N>-<slug>
+```
 
-Read the full issue body to extract:
-- Goal
-- Scope (in/out)
-- Acceptance criteria
-- Files affected
-- Verification commands
-- Type (determines workflow)
+The `sfn-<N>` branch prefix is load-bearing — it is how Linear associates the
+branch/PR with `SFN-<N>` and advances the issue on merge. Keep it lowercase.
+
+Read the full issue body to extract Goal, Scope (In/Out), Acceptance criteria,
+Files affected (advisory map), Verification commands, and Type (routes the
+workflow). **If the body's `## Design` line cites an SFEP**
+(`docs/proposals/NNNN-*.md`), read it as the design brief — the SFEP is the
+durable *why*; the issue is the session-sized *what*. Don't re-derive design.
 
 ---
 
 ## Phase 3: DISPATCH TO WORKFLOW
 
-Based on the issue's `type:*` label, follow the appropriate workflow. Use the issue body as the brief — don't redo the design work the architect already produced during grooming. **If the body's `## Design` line cites an SFEP** (`docs/proposals/NNNN-*.md`), read it for the full design rationale — the SFEP is the durable record (the *why*); the issue is the session-sized slice (the *what to do now*). Do not duplicate or re-derive the design.
+Route by the issue's `type:*` label. Use the body (and any cited SFEP) as the
+brief — don't redo design the architect already produced at grooming.
 
 | Type | Workflow |
 |---|---|
-| `type:feature` | Follow `/add-feature` phases — but skip the architect phase if the issue body already has a design (most groomed issues will). Go straight to implementation, then review, test, docs. |
-| `type:bug` | Follow `/debug-compile` phases — issue body should already have reproduction. Trace, fix, verify. |
+| `type:feature` | Follow `/add-feature` phases — skip the architect phase if the body already has a design (most groomed issues will). Implement → review → test → docs. |
+| `type:bug` | Follow `/debug-compile` phases — body should already have a repro. Trace, fix, verify. |
 | `type:perf` | Follow `/perf` phases — profile baseline, implement, bench after, verify. |
-| `type:refactor` | Implement (one self-hosting step at a time), spawn `code-reviewer`, run `test-runner`. No architect needed if issue body has the plan. |
+| `type:refactor` | Implement one self-hosting step at a time, spawn `code-reviewer`, run `test-runner`. |
 
 ### Model allocation: spend Opus on judgment, push labor to Sonnet
 
-You (the orchestrator) run on Opus. Reserve yourself for the decisions a wrong
-call makes expensive — scope, sequencing, the review gate, genuine diagnosis —
-and route the rest to Sonnet specialists per `.claude/rules/model-allocation.md`:
+You (the orchestrator) run on Opus. Reserve yourself for decisions a wrong call
+makes expensive — scope, sequencing, the review gate, genuine diagnosis — and
+route the rest to Sonnet specialists per `.claude/rules/model-allocation.md`:
 
-- **Surface mapping → `compiler-explorer` (sonnet).** Do not grep the tree
-  yourself on Opus to re-derive each `In:` unit's surface (next section).
-  Dispatch the explorer with the `In:` units and let it return the current file
-  set; you apply the In/Out boundary to its map.
+- **Surface mapping → `compiler-explorer` (sonnet).** Don't grep the tree
+  yourself on Opus to re-derive each `In:` unit's surface; dispatch the explorer
+  and apply the In/Out boundary to its map.
 - **Routine implementation → `implementer` (sonnet), under your spec.** For
   mechanical edits, clear-cut bug fixes (known repro), localized refactors, and
-  regression-test additions, author a precise spec (exact files, symbols, change,
-  acceptance criteria) and hand it to the `implementer`. Keep implementation on
-  yourself (Opus) only when the change is **novel, cross-cutting, or entangled
-  with design** — where a subtle wrong edit is costly. When in doubt on a
-  correctness-sensitive change, implement it yourself; on a mechanical change,
-  delegate and review.
+  regression-test additions, author a precise spec and hand it off. Keep
+  implementation on yourself only when the change is **novel, cross-cutting, or
+  entangled with design**.
 - **Review gate stays Opus.** Run the cheap mechanical checks first
-  (`sfn fmt --check`, `sfn check <files>`) so they're green before you spend
-  Opus, then spawn the Opus `code-reviewer` to adjudicate correctness,
-  self-hosting safety, and effects on the diff — whoever typed it.
-- **Failures triage on Sonnet first.** A failing `make compile`/`make test` goes
-  to the `test-runner` (sonnet) to classify: trivial (fmt, missing import, typo,
-  stale test) → fix via the `implementer`; genuine (miscompile, IR rejection,
+  (`sfn fmt --check`, `sfn check <files>`), then spawn the Opus `code-reviewer`.
+- **Failures triage on Sonnet first.** A failing `make compile`/`make test`
+  goes to `test-runner` (sonnet) to classify: trivial (fmt, missing import,
+  typo, stale test) → fix via `implementer`; genuine (miscompile, IR rejection,
   self-host break, perf/memory regression) → escalate to the Opus
-  `seed-stabilizer`. Don't wake Opus for a formatting error.
+  `seed-stabilizer`.
 
 ### Reconcile the advisory map, then check for real scope growth
 
 A groomed issue's **contract** is its **Goal** plus the semantic `In:`/`Out:`
-scope. `## Files Affected` is a **non-binding map** (`docs/conventions/issue-naming.md`,
-"Intent-authoritative issues") that is *expected to drift* between grooming and
-pickup. **Before** implementing, re-derive the current surface for each `In:`
-unit — **dispatch `compiler-explorer` (sonnet)** with the `In:` units rather than
-grepping the tree yourself on Opus — then compare its returned file set against
-the advisory map and apply the **In/Out semantic boundary contract**:
+scope. `## Files Affected` is a **non-binding map**
+(`docs/conventions/issue-naming.md`, "Intent-authoritative issues") that is
+*expected to drift*. **Before** implementing, re-derive the current surface for
+each `In:` unit — **dispatch `compiler-explorer` (sonnet)** — then compare its
+file set against the advisory map and apply the **In/Out semantic boundary**:
 
-- **In-scope — reconcile and proceed (do not pause):**
-  - A path in `## Files Affected` was **renamed/moved** → use the new path.
-  - A semantic unit named in `In:` is now spread across **additional sibling
-    files** in the same module/directory → touch them all.
-  - A map file **no longer exists** because its content merged into a sibling
-    already covered by the same `In:` unit → follow the content.
-  - The **same public surface** is reached through a refactored internal call
-    path → follow it.
-- **Out-of-scope — PAUSE, comment, do not proceed:**
-  - A **new acceptance criterion** the issue did not list is required.
-  - A **new public/user-facing surface** (new CLI flag, exported symbol,
-    diagnostic code) not implied by the Goal.
-  - The change must reach a **different semantic unit** than `In:` names (e.g.
-    the issue is scoped to the effect checker but the fix belongs in the parser).
-  - Honoring `Out:` becomes **impossible**.
+- **In-scope — reconcile and proceed (do not pause):** a map path was
+  renamed/moved (use the new one); an `In:` unit now spans additional sibling
+  files in the same module (touch them all); a map file merged into a sibling
+  already covered by the same unit (follow the content); the same public surface
+  is reached through a refactored call path (follow it).
+- **Out-of-scope — PAUSE, comment, do not proceed:** a **new acceptance
+  criterion** is required; a **new public/user-facing surface** (CLI flag,
+  exported symbol, diagnostic code) not implied by the Goal; the change must
+  reach a **different semantic unit** than `In:` names; honoring `Out:` becomes
+  impossible.
 
-The discriminator is one question: **does the Goal plus the semantic
-`In:`/`Out:` still hold?** If yes, the drift is cosmetic — **reconcile and
-record it in the PR** (the Phase 5 "Map reconciliation" line); never halt on a
-renamed or missing map path. If a *new* criterion or surface is required, that is
-real scope growth — pause per the guard below.
+The discriminator: **does the Goal plus the semantic `In:`/`Out:` still hold?**
+If yes, the drift is cosmetic — reconcile and record it in the PR (Phase 5 "Map
+reconciliation"). If a new criterion or surface is required, that is real
+growth — pause:
 
-**During implementation, the semantic scope is the line.** If the work genuinely
-needs a **new acceptance criterion or new public surface** (real growth, per the
-Out-of-scope list above), or `Out:` is **impossible** to honor, STOP and comment
-on the issue:
-
-```bash
-gh issue comment <N> --body "Scope adjustment needed: <reason>. Pausing for human input."
+```
+mcp__Linear__save_comment issueId="SFN-<N>" body="Scope adjustment needed: <reason>. Pausing for human input."
+mcp__Linear__save_issue id="SFN-<N>" state="Triage"   # kick back to triage/grooming
 ```
 
-Then mark the issue with `needs-grooming` and remove `in-progress`:
+Do not silently expand the *semantic* scope.
 
-```bash
-gh issue edit <N> --add-label "needs-grooming" --remove-label "in-progress"
-```
+### When the blocker is a missing prerequisite (a seed dependency)
 
-Do not silently expand the *semantic* scope. A renamed/moved/merged map path or
-an in-unit sibling is **not** scope growth — reconcile it and keep going.
-
-**When the blocker is a missing _prerequisite_ (not just a wrong scope line).**
-Sometimes the issue isn't mis-scoped — it depends on a capability that does
-not exist yet (e.g. a runtime issue that needs a frontend primitive the
-compiler can't emit). Before defaulting to a multi-issue chain (file a
-predecessor → groom → separate PR → seed cut → re-pickup), apply the shared
-**`.claude/rules/seed-dependency.md`** decision tree (the same rule `/groom`
-uses — design record SFEP-0026 WS-B). Do not re-derive the tree here; the rule
-is the source of truth. The mid-pickup outcomes it dictates:
+Sometimes the issue depends on a capability that does not exist yet (e.g. a
+runtime issue needing a frontend primitive the compiler can't emit — the #1088
+failure mode). Apply the shared **`.claude/rules/seed-dependency.md`** decision
+tree (the same rule `/groom` uses):
 
 - **Single consumer + tightly coupled → BUNDLE:** propose ONE cohesive PR that
-  lands the prerequisite *and* the original issue together. `make compile`
-  builds the new compiler from the old seed, and that compiler compiles the
-  consumer in the same self-host pass — so bundling avoids the seed cut a split
-  would force. This is the default and is usually faster than the
-  file/groom/PR/seed/re-pickup ceremony.
-- **Multiple consumers, or genuinely independent, or large blast radius →
-  SPLIT:** file the predecessor as a standalone `seed-blocker` issue. **A split
-  forces a seed cut — do NOT cut reactively. Queue the seed advance against the
-  next cadence bump** (SFEP-0026 WS-C); the consumer carries
-  `## Required in pinned seed: #<predecessor>` and waits for that bump.
+  lands the prerequisite *and* the original issue together — no seed cut.
+  (Default; usually faster than a multi-issue chain.)
+- **Multiple consumers / independent / large blast radius → SPLIT:** file the
+  predecessor as a standalone `seed-blocker` Linear issue; the consumer carries
+  `## Required in pinned seed: #<predecessor-PR>` and queues against the next
+  cadence seed bump.
 
 Either way, **pause and present the bundle-vs-split choice to the user,
-defaulting to bundle** — do not silently pick the heavier multi-issue route. The
-original #1088 pickup fanned out into separate issues/PRs + a seed-cut gate when
-one bundled PR would have delivered the same result with less overhead. State the
-tradeoff; let the user decide.
+defaulting to bundle.**
 
 ---
 
 ## Phase 4: VERIFY ACCEPTANCE CRITERIA
 
-Walk through every acceptance criterion in the issue body. Each must pass before opening the PR:
+Walk every acceptance criterion in the body. Each must pass before opening the PR:
 
 ```bash
 make compile    # self-hosts
@@ -393,13 +216,10 @@ make test       # no regressions
 # plus any issue-specific verification commands
 ```
 
-If any criterion fails, fix it — but triage before escalating. Route a failing
-`make compile`/`make test` through the Sonnet `test-runner` to classify: trivial
-(fmt, missing import, typo, stale test) → fix via the `implementer`; genuine
-(miscompile, IR rejection, self-host break, perf/memory regression) → escalate to
-the Opus `seed-stabilizer`. Don't spend Opus diagnosing a formatting error.
-
-If a criterion turns out to be impossible or wrong, comment on the issue and pause for human input — do not declare done with unmet criteria.
+Route a failing `make compile`/`make test` through `test-runner` (sonnet) to
+classify before escalating; don't spend Opus on a formatting error. If a
+criterion turns out impossible or wrong, comment on the Linear issue and pause
+— do not declare done with unmet criteria.
 
 ---
 
@@ -412,85 +232,83 @@ git add <specific files>
 git commit -m "$(cat <<'EOF'
 <concise subject — what changed and why>
 
-<body if needed — link issue with "Closes #N">
+<body if needed>
 
-Closes #<N>
+Fixes SFN-<N>
 EOF
 )"
 ```
 
-Push and open the PR:
+Push and open the PR with `mcp__github__create_pull_request`. Put the Linear
+magic word in the PR body so the integration links and closes the issue on
+merge:
 
-```bash
-git push -u origin claude/<N>-<slug>
-
-gh pr create \
-  --title "<short title — under 70 chars>" \
-  --body "$(cat <<'EOF'
+```
 ## Summary
 <1-3 bullets>
 
-Closes #<N>
+Fixes SFN-<N>
 
 ## Acceptance Criteria
-<copy from issue, with all boxes checked>
+<copy from the issue, all boxes checked>
 
 ## Map reconciliation
-<advisory-map drift reconciled at pickup, or "None — map matched the tree".
-e.g. "`old/path.sfn` → `new/path.sfn` (renamed); added sibling `x.sfn` (same In: unit)">
+<advisory-map drift reconciled at pickup, or "None — map matched the tree">
 
 ## Verification
-\`\`\`bash
 <commands run, with results>
-\`\`\`
 
 ## Files Changed
 <short list>
-EOF
-)"
 ```
 
-The merge will auto-close the linked issue.
+Then move the issue to review and subscribe the session to the PR:
 
-**If this PR fully delivers the cited SFEP** (the feature now clears the Stage1
-bar end-to-end and self-hosts), advance the SFEP in the same PR: `/sfep graduate
-<N>` to flip it to `Implemented`, set `graduates-to`, and sync the registry. If
-the PR only implements one slice of a multi-issue SFEP, leave the SFEP
-`Accepted` and note remaining work in the Phase 6 report. Never mark an SFEP
-`Implemented` for "parsed but not enforced".
+```
+mcp__Linear__save_issue id="SFN-<N>" state="In Review"
+```
+
+- **Merge closes the issue.** Linear's GitHub integration advances `SFN-<N>`
+  to `Done` when the PR (branch `claude/sfn-<N>-…`, body `Fixes SFN-<N>`)
+  merges — don't set a terminal status by hand from the skill.
+- After creating the PR, call `subscribe_pr_activity` so CI failures and review
+  comments come back into the session.
+
+**If this PR fully delivers the cited SFEP** (clears the Stage1 bar end-to-end
+and self-hosts), advance it in the same PR: `/sfep graduate <N>`. If it's one
+slice of a multi-issue SFEP, leave it `Accepted` and note remaining work.
+Never mark an SFEP `Implemented` for "parsed but not enforced".
 
 ---
 
 ## Phase 6: REPORT
 
-Report to the user:
-- Issue worked: #N — <title>
+- Issue worked: SFN-<N> — <title>
 - PR opened: <URL>
-- Branch: claude/<N>-<slug>
+- Branch: `claude/sfn-<N>-<slug>`
 - Verification results
-- Seed freshness: if any predecessor was accepted via the Phase 1.5
-  content-based fallback (merge SHA orphaned but content present in the
-  seed), note it explicitly with the probe used (`$FALLBACK_NOTE`) — a
-  human may want to investigate why the SHA fell out of seed ancestry.
-- Anything that surprised you during implementation (worth recording for future grooming)
+- Seed freshness: if a predecessor was accepted via the Phase 1.5 content
+  fallback (merge SHA orphaned but content present in the seed), note it — a
+  human may want to know why the SHA fell out of seed ancestry.
+- Anything that surprised you (worth recording for future grooming)
 
-If anything was deferred or scope was adjusted mid-flight, surface it explicitly.
+Surface any deferral or mid-flight scope adjustment explicitly.
 
 ---
 
 ## Constraints
 
+- **Linear owns issue state.** Flip `state` via `mcp__Linear__save_issue`
+  (`Ready` → `In Progress` on claim → `In Review` on PR). `Done` comes from the
+  merge via Linear's integration — never write a terminal status from the skill.
+- **The `claude/sfn-<N>-…` branch prefix is load-bearing.** It is how the PR
+  auto-links to the Linear issue; keep it and put `Fixes SFN-<N>` in the PR body.
 - **Never expand *semantic* scope silently.** A new acceptance criterion, new
   public surface, or a different `In:` unit means pause and ask. Cosmetic map
-  drift (a renamed/moved/merged path, an in-unit sibling) is **not** scope
-  growth — reconcile it and proceed.
-- **Always record map reconciliation, never silently.** When the advisory
-  `## Files Affected` map drifted from the tree, capture the reconciliation in
-  the PR body's "Map reconciliation" line so the drift is visible and auditable.
-- **Never declare done with unchecked acceptance criteria.** If a criterion can't be met, comment and pause.
-- **Never push to main directly.** Always work on the `claude/<N>-<slug>` branch and open a PR.
-- **Always link the issue in the PR.** `Closes #N` ensures auto-close on merge.
+  drift is not scope growth — reconcile and proceed, recording it in the PR.
+- **Never declare done with unchecked acceptance criteria.**
+- **Never push to `main`.** Work on `claude/sfn-<N>-<slug>` and open a PR.
 - The compiler self-caps memory (8 GiB on Linux); see `.claude/rules/compiler-safety.md`.
-- **Never skip Phase 1.5.** The `## Required in pinned seed` precheck (and its legacy fallback) prevents the failure mode that broke the original #489 attempt — a compiler-source migration picked up against a seed that predated its dependency. If the precheck fails, halt and comment; do not attempt to triple-bootstrap a workaround binary.
-- **One issue per session.** Don't try to bundle multiple issues — they were sized to be standalone.
-- Labels are the source of truth; there is no separate board to sync.
+- **Never skip Phase 1.5** when the issue lists `## Required in pinned seed`.
+- **One issue per session.** Issues were sized to be standalone; don't bundle
+  (except a genuine seed prerequisite per the bundle rule above).

--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -195,11 +195,13 @@ If no tracking issue exists for the target:
    sub-issue tools:
 
    ```
-   # Attach every must-close / seed-blocker / needs-seed-cut item
-   # (method="add"; sub_issue_id is the child's internal node id):
+   # Attach every must-close / seed-blocker / needs-seed-cut item.
+   # sub_issue_id is the child's internal issue ID (NOT its number) — read the
+   # child with mcp__github__issue_read first to get `.id`, then method="add":
    for n in <gate + seed-blocker + needs-seed-cut issue numbers>:
+     child_id = mcp__github__issue_read(owner=SailfinIO, repo=sailfin, issue_number=<n>).id
      mcp__github__sub_issue_write method=add owner=SailfinIO repo=sailfin
-       issue_number=<tracker-number> sub_issue_id=<n>
+       issue_number=<tracker-number> sub_issue_id=<child_id>
 
    # Verify the rollup now lists every child (read the tracker's sub-issues):
    mcp__github__issue_read owner=SailfinIO repo=sailfin issue_number=<tracker-number>
@@ -307,7 +309,7 @@ burndown). Releases are **never** Linear Projects. See
 `docs/conventions/issue-naming.md` § Release tracking.
 
 Reflect the plan into Linear (best-effort — skip with a one-line note if the
-Linear MCP tools aren't connected, per § Reflecting state into Linear; never
+Linear MCP tools aren't connected, per § Cross-surface flow (Linear ↔ GitHub); never
 write a terminal issue status):
 
 1. **Pick the target Cycle.** `list_cycles` for the Sailfin team; choose the

--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -133,7 +133,7 @@ If no tracking issue exists for the target:
    ☑/☐ reflects each sub-issue's open/closed state. The GitHub
    "Sub-issues" panel is the source of truth; this list mirrors it. -->
 
-   - ☐ #<N> — <title>  (`release:<gate>`, size:_, priority:_)
+   - ☐ #<N> — <title>  (`release:<gate>`)
    - ☑ #<N> — <title>  (closed)
 
    ## Seed blockers (must close before the next seed bump)
@@ -191,29 +191,22 @@ If no tracking issue exists for the target:
 
 5. **Attach each curated item as a native sub-issue** of the tracker —
    mirroring `/groom`'s epic sub-issue pattern. Body references alone do
-   not populate the parent's "Sub-issues" panel. Use the REST API (the
-   `gh` CLI has no first-class command yet); `sub_issue_id` MUST be passed
-   with `-F` (typed integer) or the API rejects it with a 422:
+   not populate the parent's "Sub-issues" panel. Use the GitHub MCP
+   sub-issue tools:
 
-   ```bash
-   # The tracker's internal node id (NOT the issue number):
-   TRACKER=<tracker-number>
-   TRACKER_ID=$(gh api repos/SailfinIO/sailfin/issues/$TRACKER --jq '.id')
+   ```
+   # Attach every must-close / seed-blocker / needs-seed-cut item
+   # (method="add"; sub_issue_id is the child's internal node id):
+   for n in <gate + seed-blocker + needs-seed-cut issue numbers>:
+     mcp__github__sub_issue_write method=add owner=SailfinIO repo=sailfin
+       issue_number=<tracker-number> sub_issue_id=<n>
 
-   # Attach every must-close / seed-blocker / needs-seed-cut item:
-   for n in <gate + seed-blocker + needs-seed-cut issue numbers>; do
-     child_id=$(gh api repos/SailfinIO/sailfin/issues/$n --jq '.id')
-     gh api -X POST /repos/SailfinIO/sailfin/issues/$TRACKER/sub_issues \
-       -F sub_issue_id=$child_id --jq '.number'
-   done
-
-   # Verify the rollup now lists every child:
-   gh api /repos/SailfinIO/sailfin/issues/$TRACKER/sub_issues \
-     --jq '.[] | "#\(.number) \(.title)"'
+   # Verify the rollup now lists every child (read the tracker's sub-issues):
+   mcp__github__issue_read owner=SailfinIO repo=sailfin issue_number=<tracker-number>
    ```
 
-   Attaching an issue that is already a sub-issue is a harmless 4xx — treat
-   it as idempotent (skip, don't fail the run).
+   Attaching an issue that is already a sub-issue is a harmless no-op/4xx —
+   treat it as idempotent (skip, don't fail the run).
 
 6. Report what was created with the issue URL and the count of attached
    sub-issues.
@@ -228,10 +221,9 @@ body summary from native state:
 
 1. Read the tracker's current native sub-issues:
 
-   ```bash
-   TRACKER=<tracker-number>
-   gh api /repos/SailfinIO/sailfin/issues/$TRACKER/sub_issues --paginate \
-     --jq '.[] | {number, state}'
+   ```
+   mcp__github__issue_read owner=SailfinIO repo=sailfin issue_number=<tracker-number>
+   # read its native sub-issues rollup (numbers + open/closed state)
    ```
 
 2. Pull the current label sets:
@@ -246,8 +238,8 @@ body summary from native state:
 3. Reconcile the native sub-issue set (do **not** edit `- [ ]` toggles by
    hand — open/closed is read from the sub-issue, not stored in the body):
    - **Newly labeled, not yet a sub-issue** → attach it via
-     `POST /issues/$TRACKER/sub_issues` (`-F sub_issue_id=<int>`; see
-     Phase 3a step 5). The "Sub-issues" panel then shows it automatically.
+     `mcp__github__sub_issue_write` (see Phase 3a step 5). The "Sub-issues"
+     panel then shows it automatically.
    - **Already a sub-issue, now closed** → no action; the panel and the
      re-rendered summary reflect the closed state on their own.
    - **A sub-issue that no longer carries any gating/seed label, still
@@ -287,16 +279,14 @@ the tracker, evaluate eligibility and surface it — never auto-dispatch
    rollup, not the markdown.
 2. **N = 7 consecutive green-CI days.** The Nightly self-host check
    (`.github/workflows/nightly-selfhost.yml`) concluded `success` on `main`
-   for 7 consecutive days with no failing run in the window:
+   for 7 consecutive days with no failing run in the window. List its recent
+   runs on `main` via the GitHub MCP Actions tools (list the workflow's runs
+   filtered to `branch=main`, then read each run's `conclusion`/`created_at`
+   — e.g. `mcp__github__actions_list` with `workflow_id:
+   nightly-selfhost.yml`, `branch: main`, paginated back 7 days).
 
-   ```bash
-   gh run list --workflow nightly-selfhost.yml --branch main \
-     --created ">=$(date -u -d '7 days ago' +%Y-%m-%d)" \
-     --json conclusion,createdAt --jq '[.[] | .conclusion] | unique'
-   ```
-
-   Pass only when every run in the 7-day window is `success` (the `unique`
-   set is exactly `["success"]`) and at least one run exists per day.
+   Pass only when every run in the 7-day window is `success` and at least
+   one run exists per day.
 
 Render the verdict into the `## Stable promotion` section and the report:
 **eligible** → "stable promotion eligible — a human may dispatch
@@ -397,10 +387,12 @@ record every reason; it strengthens the rationale):
    LAST=$(git describe --tags --abbrev=0 --match 'v*' --exclude '*-*' 2>/dev/null \
           || git describe --tags --abbrev=0 --match 'v*' 2>/dev/null)
    SINCE=$(git log -1 --format=%cd --date=short "$LAST" 2>/dev/null)
-   gh pr list --state merged --base main --search "merged:>=$SINCE" \
-     --json number,title,closingIssuesReferences \
-     --jq '.[] | "\(.title)"' | sort -u
    ```
+
+   Then list merged PRs into `main` since `$SINCE` via
+   `mcp__github__list_pull_requests` (`state=closed`, `base=main`, sorted by
+   merged date), keeping only entries with a non-null merge commit, and
+   dedupe titles.
 
 ### 4.2 — Classify and present (your approval gate)
 
@@ -446,8 +438,9 @@ without an explicit go-ahead. Under `--dry-run`, end after presenting.
 For each issue the user approved as IN, apply the gate label (a **write**,
 authorized by the approval just given):
 
-```bash
-gh issue edit <N> --add-label "release:<gate>"
+```
+mcp__github__issue_write owner=SailfinIO repo=sailfin issue_number=<N>
+  labels=[..._existing labels..., "release:<gate>"]
 ```
 
 Never apply a label to a ROLL-FORWARD or dropped item. Never apply
@@ -501,8 +494,7 @@ Dry run: changes <previewed | applied>
   re-rendered summary is byte-identical when nothing changed.
 - **Native sub-issues are the source of truth.** The markdown sections are
   a rendered mirror — never hand-edit `☐`/`☑` toggles; re-render from the
-  sub-issue rollup. Attach via `POST /issues/<tracker>/sub_issues`
-  (`-F sub_issue_id=<int>`, typed — `-f` 422s).
+  sub-issue rollup. Attach via `mcp__github__sub_issue_write`.
 - **Label writes are approval-gated, never unattended.** The default plan
   step (no `--candidates`) writes only the tracker body, the `tracking`
   label, sub-issue attachments, and comments — it never touches `release:*`.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -103,9 +103,13 @@ c. **Surface the gap to the user.** Present a short list:
    Curated cut: vX.Y.Z (channel=<c> bump=<b>)
    Tracking issue: Release: vX.Y.Z (#NNN)  [or: not found]
    Open `release:<gate>` items (N):
-     - #NNN <title> (size:_, priority:_)
+     - #NNN <title>
      - ...
    ```
+
+   Estimate/priority are Linear-native fields, not GitHub labels — if the
+   user wants them, read them off the issue's Linear mirror
+   (`mcp__Linear__*`) rather than a `size:_`/`priority:_` label.
 
 d. **Require explicit override if anything is open.** Ask the user:
    "N items are still open under `release:<gate>`. Cut anyway, or wait?"
@@ -117,18 +121,20 @@ and proceed to dispatch.
 
 ### 5. Dispatch the workflow
 
-```bash
-gh workflow run release.yml \
-  -f channel=<channel> \
-  -f bump=<bump>
+Use the GitHub MCP tool to dispatch `release.yml` on `main`:
+
+```
+mcp__github__actions_run_trigger
+  owner=SailfinIO repo=sailfin workflow_id=release.yml ref=main
+  inputs={"channel": "<channel>", "bump": "<bump>"}
 ```
 
 Or for a dry run first:
-```bash
-gh workflow run release.yml \
-  -f channel=<channel> \
-  -f bump=<bump> \
-  -f dry_run=true
+
+```
+mcp__github__actions_run_trigger
+  owner=SailfinIO repo=sailfin workflow_id=release.yml ref=main
+  inputs={"channel": "<channel>", "bump": "<bump>", "dry_run": "true"}
 ```
 
 ### 6. After dispatching

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -1,380 +1,199 @@
 # Sweep Blocker State and Coordinate Next Picks
 
-Post-merge issue-tracker reconciliation. Sweep newly-resolved blockers, audit `claude-ready` hygiene, and recommend the next 1-3 issues to dispatch via `/pickup` based on a configurable concurrency budget and file-collision analysis.
+Post-merge reconciliation over the **Linear** Sailfin (`SFN`) queue. Sweep
+newly-resolved blockers, surface completed/next-up epics (Projects), and
+recommend the next 1–3 issues to dispatch via `/pickup` based on a concurrency
+budget and file-collision analysis.
 
-This is the focused, event-driven sibling of `/triage`. Run it after every PR merge while you're coordinating multiple `/pickup` sessions.
+This is the focused, event-driven sibling of `/triage`. Run it after every PR
+merge while coordinating multiple `/pickup` sessions.
+
+> **Linear is the planning source of truth.** Blocker/status writes are
+> `mcp__Linear__save_issue`; Projects (epics) roll up their issues' state
+> natively, so there is no GitHub tracker/sub-issue bookkeeping here. Resolve
+> merged PRs → their Linear issue via the `sfn-<N>` branch / `Fixes SFN-<N>`
+> link. Use `mcp__github__*` only to read merged PRs. See
+> `docs/conventions/linear-workflow.md`.
 
 ## Target: $ARGUMENTS
 
-Parse `$ARGUMENTS` as a mix of flags and numbers:
-
-**Flags** (tokens starting with `--`):
+**Flags:**
 - `--greedy` (bare) — raise the concurrency budget from `2` to `4`
-- `--greedy=N` — set the concurrency budget to `N` (no upper bound)
-- `--dry-run` — preview label flips and recommendations; do not modify any issue or post comments
+- `--greedy=N` — set the budget to `N`
+- `--dry-run` — preview status flips and recommendations; make no writes
 
-**Bare numbers** — treat each as a PR or issue number that just merged or closed; the command resolves PR → linked issue(s) automatically.
+**Bare numbers** — treat each as a PR number that just merged; the command
+resolves PR → linked Linear issue (`SFN-<N>` from branch/body).
 
-Examples:
-- `/sweep` — auto-detect merged PRs in the last 24h (and their linked issues), default budget = 2
-- `/sweep 367` — anchor on PR/issue #367, default budget = 2
-- `/sweep --greedy 367 332` — anchor on two merges, budget = 4
-- `/sweep --greedy=6 --dry-run` — preview-only, budget = 6, auto-detect merges
-
-If parsing yields no flags and no numbers: budget = 2, auto-detect merges, real (non-dry) run.
+Examples: `/sweep` (auto-detect last-24h merges, budget 2) · `/sweep 367`
+(anchor on PR #367) · `/sweep --greedy 367 332` · `/sweep --greedy=6 --dry-run`.
 
 ---
 
 ## Phase 1: GATHER
 
-Resolve the merge anchor set.
+Resolve the merge anchor set:
+- If `$ARGUMENTS` has bare numbers, read each PR with
+  `mcp__github__pull_request_read` and extract its Linear issue (`SFN-<N>` from
+  the head branch `claude/sfn-<N>-…` or a `Fixes SFN-<N>` in the body).
+- Otherwise auto-detect merges in the last 24h:
+  ```
+  mcp__github__list_pull_requests state="closed" ... (filter merged, mergedAt within 24h)
+  ```
 
-If `$ARGUMENTS` includes bare numbers, use them directly. Try `gh pr view` first
-because `closingIssuesReferences` and `mergedAt` are PR-only fields, and
-`gh issue view <N>` resolves PRs as issues (they share a number space) — so
-querying `gh issue view` first would silently skip the PR-specific data.
+The set of Linear issues those PRs closed is the trigger for unblocking
+dependents. Confirm each is `Done` in Linear (the integration should have
+advanced it on merge; if it lags, note it — don't force a terminal status).
 
-```bash
-for N in <numbers>; do
-  # PR-first: PRs carry mergedAt + closingIssuesReferences.
-  gh pr view $N --json number,title,state,closingIssuesReferences,mergedAt 2>/dev/null \
-    || gh issue view $N --json number,title,state,closedAt
-done
+Pull the candidate pools from Linear:
+
+```
+mcp__Linear__list_issues team="Sailfin" state="Blocked" limit=100
+mcp__Linear__list_issues team="Sailfin" state="Ready"   limit=100
+mcp__Linear__list_issues team="Sailfin" state="In Progress" limit=100
 ```
 
-For raw issue anchors (closed manually, no PR), there's no
-`closingIssuesReferences` to expand — treat the issue itself as the
-closed trigger.
-
-Otherwise, auto-detect merges in the last 24h:
-
-```bash
-gh pr list --state merged --limit 20 \
-  --json number,title,closingIssuesReferences,mergedAt \
-  | jq '[.[] | select(.mergedAt > (now - 86400 | todate))]'
-```
-
-For each anchor PR, extract the closed issue numbers from `closingIssuesReferences` — these are the `Closes #N` references. The set of newly-closed issues is the trigger for unblocking dependents.
-
-Pull the candidate pools:
-
-```bash
-gh issue list --label blocked --state open \
-  --json number,title,labels,body,assignees --limit 100
-
-gh issue list --label claude-ready --state open \
-  --json number,title,labels,body,assignees --limit 100
-
-# gh pr list does not support --json files; just list PRs here. Phase 4
-# fetches file lists per PR via gh pr view.
-gh pr list --label agent-authored --state open \
-  --json number,title,headRefName --limit 20
-```
-
-Always include open PRs on a `claude/*` branch (the human-driven `/pickup` flow) in the in-flight set — they count toward the budget the same way as `agent-authored` PRs, and both categories can be live simultaneously:
-
-```bash
-gh pr list --state open \
-  --json number,title,headRefName \
-  --jq '[.[] | select(.headRefName | startswith("claude/"))]'
-```
-
-The in-flight set is the union of the two queries (de-duped by PR number).
+In-flight set = open PRs on `claude/sfn-*` branches
+(`mcp__github__list_pull_requests`, filter head `claude/`) plus the `In Progress`
+Linear issues. De-dupe by SFN number.
 
 ---
 
 ## Phase 2: SWEEP BLOCKERS
 
-> **Shared logic.** The hard-vs-prose blocker-clearing rule below is the one
-> mechanic `/sweep` and `/triage` have in common (`/triage` Phase 3 → UNBLOCK).
-> They are otherwise distinct — `/sweep` is the post-merge coordinator (budget,
-> collisions, dispatch); `/triage` is the whole-queue hygiene auditor
-> (promote/demote, Type fixes, orphan release). Do not merge them. If you change
-> this rule, mirror it in `/triage`.
+> **Shared logic.** The hard-vs-prose blocker rule below is the one mechanic
+> `/sweep` and `/triage` share (`/triage` Phase 3 → UNBLOCK). If you change it
+> here, mirror it there.
 
-For each issue in the `blocked` pool:
+For each `Blocked` issue:
 
-1. Parse the `## Blocked by` section of the body. Extract every `#N` reference via regex (`#\d+`).
-2. For each `#N`, check its state: `gh issue view N --json state,stateReason` (works for both issues and PRs).
-3. Classify each blocker:
-   - **Hard reference (#N)** — closed = resolved; open = still blocking
-   - **Prose reference** (e.g., "Slice E", "M3 — runtime/native/ deletion") — always ambiguous; never auto-flip on prose alone
-4. If all hard references are closed AND no prose references remain unresolved:
-   ```bash
-   gh issue edit <N> --remove-label blocked --add-label claude-ready
-   gh issue comment <N> --body "Auto-sweep: blocker(s) resolved — <list resolved #N references>. Marking ready for pickup."
+1. Read its blocked-by relations (`get_issue includeRelations=true`) and any
+   `## Blocked by` prose in the body.
+2. Classify each blocker: **hard** (a Linear relation, or a `SFN-N`/`#N` ref) —
+   closed = resolved; **prose** ("Slice E", "M3 runtime deletion") — never
+   auto-flip on prose alone.
+3. If every hard blocker is closed AND no prose gate remains, flip to `Ready`
+   and drop the resolved relations:
    ```
-   Then **reflect the flip into Linear** per
-   `docs/conventions/issue-naming.md` § Reflecting state into Linear: set the
-   mirror to `Ready` and roll up its Project status. Best-effort — skip with a
-   note if the Linear MCP tools aren't connected; never write a terminal status.
-5. If `--dry-run` is set: do not edit, comment, or reflect into Linear. Record
-   the intended flip in the report.
+   mcp__Linear__save_issue id="SFN-<N>" state="Ready" removeBlockedBy=["SFN-<resolved>"]
+   mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-sweep: blocker(s) resolved — <list>. Marking Ready."
+   ```
+4. Under `--dry-run`, record the intended flip; make no writes.
 
 ---
 
-## Phase 2b: SYNC RELEASE TRACKING ISSUES
+## Phase 2b: EPIC & RELEASE ROLLUP
 
-If any of the issues newly closed by the anchor merges carries a
-`release:*` or `seed-blocker` label, the corresponding `Release: vX.Y.Z`
-tracking issue needs its rollup reconciled. The tracker uses
-**GitHub-native sub-issues** as the source of truth (SFEP-0026 WS-C;
-`/release-plan` attaches them) — so this sync reconciles **native
-sub-issue state**, not a string-matched markdown checklist. This is a
-passive sync — `/release-plan` is the active equivalent for cycle
-bookkeeping.
+Linear rolls up a Project (epic) from its issues natively — there is no GitHub
+tracker to reconcile. This phase reads those rollups to surface coordination
+signals; it makes **no writes** (identical under `--dry-run`).
 
-For each newly-closed issue:
-
-1. Get its labels:
-   ```bash
-   gh issue view <N> --json labels --jq '.labels[].name' \
-     | grep -E '^(release:|seed-blocker$)'
-   ```
-2. For each `release:<gate>` label found, locate the tracking issue:
-   ```
-   mcp__github__search_issues query='repo:SailfinIO/sailfin is:issue in:title "Release: v" label:tracking'
-   ```
-   Map `release:<gate>` to the matching tracking issue title — typically
-   the one whose target version corresponds to the gate. If multiple
-   match (e.g. an item gates both `release:beta` and `release:1.0`),
-   reconcile each.
-3. **Reconcile native sub-issue state** rather than hand-ticking markdown:
-   ```bash
-   TRACKER=<tracking-issue-number>
-   # Is the just-closed issue attached as a native sub-issue?
-   gh api /repos/SailfinIO/sailfin/issues/$TRACKER/sub_issues --paginate \
-     --jq '.[].number' | grep -qx <N> && echo attached || echo missing
-   ```
-   - **Attached** → its closed state shows in the GitHub "Sub-issues"
-     rollup automatically; no body edit needed. If `/release-plan` renders
-     a summary section, re-render the matching `☐`→`☑` line from the
-     native state (don't store closed-ness in the body).
-   - **Missing (closed item carries a gating/`seed-blocker` label but is
-     not a sub-issue)** → attach it so the rollup is complete, mirroring
-     `/release-plan` (typed `-F sub_issue_id`):
-     ```bash
-     child_id=$(gh api repos/SailfinIO/sailfin/issues/<N> --jq '.id')
-     gh api -X POST /repos/SailfinIO/sailfin/issues/$TRACKER/sub_issues \
-       -F sub_issue_id=$child_id --jq '.number'
-     ```
-4. For `seed-blocker`, keep the auto-tick behaviour: ensure the closed
-   item is reflected in the tracker's `## Seed blockers` / `## Seed bump
-   (this cadence)` rollup, and surface in the report so the user knows the
-   **cadence `/pin-seed`** will pick it up (a plain `seed-blocker` /
-   `needs-seed-cut` close queues for the next cadence bump — it does **not**
-   warrant a reactive cut unless the item carries `release-critical-seed`;
-   SFEP-0026 §3.3).
-5. Post a one-line comment:
-   ```
-   Auto-sweep: #<N> closed via PR #<M> — sub-issue rollup reconciled (release:<gate>, seed-blocker).
-   ```
-6. If the closed issue is neither attached nor labeled on any tracker,
-   mention it in the report under "Concerns" (likely means it was labeled
-   after the tracking issue was created without `/release-plan` re-running).
-
-If no newly-closed issue carries either label, skip this phase
-entirely. **In `--dry-run`, make zero writes** (no sub-issue attachments,
-no body edits, no comments).
+1. **Completed epics.** For each Project touched by the anchor merges, read its
+   issues (`list_issues project="<P>"`). When every issue is `Done`, recommend
+   the Project be marked complete (a human/Project-lead decision — never
+   auto-complete a Project). Report under "Epics ready to close."
+2. **Next phase to groom.** For a phased epic (per-phase Projects under one
+   Initiative), a fully-`Done` phase Project is the trigger to groom the next
+   sibling phase Project (the one in `Backlog`/`Planned` with no leaves yet).
+   Report under "Next phase to groom → `/groom <Phase Project>`."
+3. **Release axis.** If a newly-`Done` issue carries `seed-blocker` or a
+   `release:*` label, note it for `/release-plan` (releases are Linear **Cycles**
+   — see `docs/conventions/issue-naming.md` § Release tracking; `/release-plan`
+   owns Cycle bookkeeping and the seed-cut queue). A plain `seed-blocker` close
+   **queues** the seed advance for the next cadence bump — it does not warrant a
+   reactive cut unless the item carries `release-critical-seed`.
 
 ---
 
-## Phase 2c: RECOMMEND CLOSING COMPLETED TRACKERS
+## Phase 3: AUDIT READY HYGIENE (report-only)
 
-GitHub does not cascade-close a parent tracking issue when its sub-issues
-finish, and the slash commands never close issues (closing is a human
-decision). So a tracker whose every sub-issue is done sits open unnoticed
-(e.g. #1657 stayed open after all four of its sub-issues completed). This
-phase surfaces those completed parents as a **recommendation to close** —
-it never closes them.
+For each `Ready` issue, sanity-check without modifying it (hygiene edits are
+`/triage`'s job):
+- `## Files Affected` is an **advisory map** expected to drift — a missing path
+  is a **soft note** ("advisory map may be stale — `/triage` can refresh"), not
+  a defect. The semantic `In:`/`Out:` scope is the contract.
+- "Appears already shipped" heuristics: if the goal names a symbol to
+  delete/remove, grep to confirm it still exists; if it describes adding
+  something, grep for evidence it already shipped under another name.
 
-Work off **native sub-issue state** (the WS-C-2 rollup; SFEP-0026), not
-markdown checklists. Each issue carries a `sub_issues_summary` with
-`total`, `completed`, and `percent_completed`.
-
-1. Build the candidate parent set — open tracking issues, preferring the
-   parents of the issues just closed by the anchor merges:
-   ```bash
-   # Open trackers. A tracker may carry `tracking` and/or `epic`; union
-   # both pools, de-duped by number.
-   gh issue list --label tracking --state open --json number --jq '.[].number'
-   gh issue list --label epic     --state open --json number --jq '.[].number'
-   ```
-   The event-driven trigger is the anchor set: an open tracker is a parent
-   of a newly-closed issue `#N` when its native sub-issue list contains
-   `#N`. Prioritise those parents, but scanning every open tracker's
-   rollup (next step) is cheap and also catches stragglers like #1657 that
-   completed in an earlier sweep.
-2. For each candidate tracker, read the **native** rollup:
-   ```bash
-   TRACKER=<tracking-issue-number>
-   gh api repos/SailfinIO/sailfin/issues/$TRACKER \
-     --jq '.sub_issues_summary | "\(.completed)/\(.total)"'
-   ```
-3. Recommend closing the tracker when it has **at least one** native
-   sub-issue and **all** of them are closed (`total > 0` and
-   `completed == total`). Confirm against the live sub-issue list rather
-   than trusting a cached summary:
-   ```bash
-   gh api /repos/SailfinIO/sailfin/issues/$TRACKER/sub_issues --paginate \
-     --jq '[.[] | select(.state == "open")] | length'   # 0 ⇒ all closed
-   ```
-   A tracker with `total == 0` (no native sub-issues attached) is **not** a
-   close candidate — there is nothing to roll up. If such a tracker
-   visibly relies on a markdown checklist instead, surface it under
-   "Concerns" so a human can attach native sub-issues (or close it
-   manually); never infer completion from checkboxes.
-4. **Recommend only — never close.** Add each completed tracker to the
-   "Trackers ready to close" section of the Phase 6 report with its rollup
-   (`#N — <title> (4/4 sub-issues closed)`). Closing stays a human
-   decision, consistent with the `/sweep` and `/triage` "Don't close
-   issues" constraint. This phase makes **no writes**, so `--dry-run`
-   behaviour is identical (recommendations only, either way).
-
-### Phased epics: surface the next wave to groom
-
-A multi-phase epic groomed per `/groom`'s two-level structure is **Epic →
-one `tracking` sub-issue per phase → leaf issues under each phase tracker**.
-That changes what "completed" means at each level, and adds a coordination
-move this phase owns:
-
-1. **A completed *phase tracker* is the trigger to groom the next phase, not
-   to close the epic.** When a phase tracker's leaves are all closed
-   (`completed == total`), recommend closing **that phase tracker**, then look
-   for the next sibling phase tracker under the same epic that still carries
-   `needs-grooming`:
-   ```bash
-   EPIC=<epic-number>
-   gh api /repos/SailfinIO/sailfin/issues/$EPIC/sub_issues --paginate \
-     --jq '.[] | select(.state=="open") | "\(.number) \(.title)"'
-   # the next open phase tracker labeled needs-grooming is the one to groom
-   ```
-   Surface it in the report under **"Next phase to groom"** as
-   `Phase <X> of epic #<E> complete → run /groom on Phase <Y> (#<tracker>)`.
-   This is the timely-groom signal that keeps a wave-groomed epic from
-   stalling silently between phases.
-2. **Never recommend closing an epic that still has an open child phase
-   tracker.** The native rollup already enforces this (an open tracker keeps
-   `completed < total`), but state it so a partially-groomed epic is never a
-   close candidate. A `needs-grooming` phase tracker with **no leaves yet**
-   (`total == 0`) is likewise not a close candidate — report it under
-   "Awaiting grooming," not "ready to close."
-
-This phase still makes **no writes** beyond the existing label flips; the
-next-phase recommendation is report-only and identical under `--dry-run`.
-
----
-
-## Phase 3: AUDIT CLAUDE-READY
-
-For each issue in the `claude-ready` pool:
-
-1. Parse `## Files Affected` from the body. Extract path-shaped tokens.
-2. For each path not marked "New:", verify it exists in the working tree:
-   ```bash
-   test -f <path> || note "stale-map"   # soft note, NOT a defect flag
-   ```
-   `## Files Affected` is an **advisory map** (`docs/conventions/issue-naming.md`,
-   "Intent-authoritative issues") that is *expected to drift* — a missing path is
-   not an issue defect. Surface it as a **soft, non-blocking note** ("advisory map
-   may be stale — `/triage` can refresh") and do **not** imply the issue is broken.
-   The semantic `In:`/`Out:` scope is the contract; a stale map on a
-   semantically-scoped issue is expected entropy, not rot.
-3. Sanity-check for "appears already shipped" signals (heuristic only):
-   - If the issue's goal mentions a symbol/function to delete or remove, `grep` to confirm it still exists.
-   - If the issue describes adding a file/feature, `grep` for evidence the work shipped under a different name.
-4. Never modify labels or body in this phase — `claude-ready` hygiene is `/triage`'s job. Only report findings here.
+Report findings only; change nothing here.
 
 ---
 
 ## Phase 4: BUDGET
 
-Compute concurrency:
-
 ```
-budget     = 4 if --greedy bare
-           = N if --greedy=N
-           = 2 otherwise
-
-in_flight  = count of open agent-authored PRs + open claude/* branch PRs
+budget     = 4 if --greedy bare | N if --greedy=N | 2 otherwise
+in_flight  = count of open claude/sfn-* PRs + In Progress SFN issues (de-duped)
 free_slots = max(0, budget - in_flight)
 ```
 
-Cache the union of files touched across all in-flight PRs as `IN_FLIGHT_FILES` for collision analysis:
-
-```bash
-gh pr view <N> --json files | jq -r '.files[].path'
-```
+Cache the union of files touched across in-flight PRs as `IN_FLIGHT_FILES`
+(`mcp__github__pull_request_read` file lists) for collision analysis.
 
 ---
 
 ## Phase 5: COLLISION ANALYSIS
 
-For each pickable `claude-ready` issue (exclude any with `in-progress` or assignees):
+For each pickable `Ready` issue (exclude assigned / In Progress):
 
-1. Parse `## Files Affected` from the body.
-2. **Hard collision** — issue's files intersect `IN_FLIGHT_FILES`. Exclude from "dispatch now" recommendations; surface as "after #X merges".
-3. **Peer collision** — issue's files intersect another candidate's files. Note as "sequence after peer" rather than parallel.
-4. Score the remaining candidates:
+1. Parse `## Files Affected`.
+2. **Hard collision** — files intersect `IN_FLIGHT_FILES` → exclude from
+   "dispatch now"; surface as "after #X merges".
+3. **Peer collision** — files intersect another candidate → "sequence after peer."
+4. Score the rest:
 
    | Signal | Weight |
    |---|---|
-   | Linear-native priority Urgent | +100 |
-   | Linear-native priority High | +50 |
-   | Closes an epic on merge | +30 |
-   | Unblocks ≥2 downstream issues | +20 per |
-   | `size:xs` | +10 |
-   | `size:s` | +5 |
-   | `size:m` | 0 |
-   | Track diversity (different epic/area than already in-flight) | +15 |
+   | Linear priority Urgent | +100 |
+   | Linear priority High | +50 |
+   | Closes an epic (last open issue in its Project) | +30 |
+   | Unblocks ≥2 downstream issues | +20 each |
+   | estimate 1 (XS) | +10 |
+   | estimate 2 (S) | +5 |
+   | estimate 3 (M) | 0 |
+   | Track diversity (different Project/area than in-flight) | +15 |
 
-5. Pick the top `free_slots` candidates that have no hard collision with each other.
+5. Pick the top `free_slots` candidates with no hard collision with each other.
 
 ---
 
 ## Phase 6: REPORT
-
-Produce a concise report:
 
 ```
 Sweep Report — <date>
 Budget: <N>  |  In-flight: <N>  |  Free slots: <N>
 
 Anchor merges:
-  ✓ PR #<N> — <title>   (closed #<M>, #<K>)
-  ✓ PR #<N> — <title>   (closed #<M>)
+  ✓ PR #<N> — <title>   (closed SFN-<M>)
 
-Unblocked (label flipped):
-  ✓ #<N> — <title>      (blockers resolved: #<X>, #<Y>)
+Unblocked (flipped to Ready):
+  ✓ SFN-<N> — <title>   (blockers resolved: SFN-<X>)
 
 Still blocked:
-  ⏸ #<N> — <title>      (waiting on: #<X> open, "Slice E" ambiguous)
+  ⏸ SFN-<N> — <title>   (waiting on: SFN-<X> open, "Slice E" ambiguous)
 
-Trackers ready to close (recommendation — not auto-closed):
-  ✓ #<N> — <title>      (all <K>/<K> sub-issues closed)
+Epics ready to close (recommendation):
+  ✓ <Project> — all issues Done
 
-Next phase to groom (wave-groomed epics):
-  → Phase <X> of epic #<E> complete → /groom Phase <Y> (#<tracker>, needs-grooming)
+Next phase to groom:
+  → <Epic> Phase <X> done → /groom <Phase <Y> Project>
 
-Awaiting grooming (phase tracker, no leaves yet):
-  · #<N> — <title>      (epic #<E> Phase <X>; total == 0 — not a close candidate)
+Release axis (for /release-plan):
+  · SFN-<N> closed carries release:<gate> / seed-blocker
 
-Audit findings (claude-ready hygiene):
-  · #<N> — <title>      (advisory map may be stale: <path> — /triage can refresh)
-  ⚠ #<N> — <title>      (symbol "<name>" appears removed — verify scope)
+Audit findings (Ready hygiene):
+  · SFN-<N> — advisory map may be stale (<path>) — /triage can refresh
 
 Top picks for free slots:
-  1. #<N> — <title> (size, type) — <one-line rationale>
-  2. #<N> — <title> (size, type) — <one-line rationale>
+  1. SFN-<N> — <title> (estimate, type) — <rationale>
 
 Suggested sequence:
-  Now (parallel):  #<N>  ‖  #<M>
-  After #<X>:      #<Y>  (rebases onto <file>)
-  After all:       #<Z>  (closes epic #<E>)
+  Now (parallel):  SFN-<N>  ‖  SFN-<M>
+  After SFN-<X>:   SFN-<Y>  (rebases onto <file>)
 
 Concerns / human input needed:
   ? <ambiguous prose blocker>
-  ? <conflicting signal>
 
 Dry run: changes <previewed | applied>
 ```
@@ -383,23 +202,26 @@ Dry run: changes <previewed | applied>
 
 ## Constraints
 
-- **Don't dispatch work.** This command is a coordination layer. Dispatch happens via `/pickup` in separate sessions.
-- **Don't close issues.** Same convention as `/triage`. Closing is a human decision — Phase 2c only *recommends* closing a completed parent tracker; it never closes one.
-- **Don't modify issue bodies.** Only labels and comments.
-- **Be conservative with prose blockers.** Anything not a hard `#N` reference stays blocked until a human confirms.
-- **Always leave a comment when flipping a label.** Future-you needs the audit trail.
-- **Labels are the source of truth.** There is no derived board to sync.
-- **In `--dry-run` mode, make zero writes.** No labels, no comments.
-  Print intended actions only.
-- **Read `.github/AGENTS.md` for cap context.** Default budget = 2 matches the autonomous-pipeline cap; `--greedy` raises it for human-coordinated parallel sessions.
+- **Don't dispatch work.** This is a coordination layer; dispatch happens via
+  `/pickup` in separate sessions.
+- **Don't complete/cancel issues or Projects.** Same convention as `/triage` —
+  terminal states are human decisions. Phase 2b only *recommends*.
+- **Don't modify issue bodies.** Only status/relations and comments.
+- **Be conservative with prose blockers.** Anything not a hard reference stays
+  `Blocked` until a human confirms.
+- **Comment whenever you flip a status.** Audit trail.
+- **Native fields only** — status/priority/estimate/blockers are Linear-native.
+- **In `--dry-run`, make zero writes.** Print intended actions only.
+- **Read `.github/AGENTS.md` for cap context.** Default budget 2 matches the
+  autonomous-pipeline cap; `--greedy` raises it for human-coordinated sessions.
 
 ---
 
 ## Why this command exists
 
-After every PR merge, the next coordination move is mechanical:
-1. Some `blocked` issue's `#N` reference just resolved — flip it.
-2. Some in-flight files just freed — recompute collision-safe candidates.
-3. Some epic just gained a closer — surface that for the next `/pickup`.
-
-`/triage` audits the whole queue and is too broad for this. `/pickup` claims a single issue and is too narrow. `/sweep` is the bridge: invoked after every merge, it produces the to-do list for the next `/pickup` calls in your other sessions.
+After every PR merge the next coordination move is mechanical: some `Blocked`
+issue's blocker just resolved (flip it); some in-flight files just freed
+(recompute collision-safe candidates); some epic just gained a closer (surface
+it for the next `/pickup`). `/triage` audits the whole queue (too broad);
+`/pickup` claims one issue (too narrow). `/sweep` is the bridge that produces the
+to-do list for the next `/pickup` calls.

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,223 +1,200 @@
 # Triage the Issue Queue
 
-Audit open issues for hygiene **in both directions**: demote incomplete
-`claude-ready` issues, and **promote already-groomed `needs-grooming` issues
-that nobody ever moved**. Surface stale, blocked, and orphaned work.
+Audit the **Linear** Sailfin (`SFN`) queue for hygiene **in both directions**:
+promote already-groomed issues that nobody moved to `Ready`, and demote
+incomplete `Ready` issues. Shape new intake (external-contributor GitHub issues
+that mirrored into Linear `Triage`). Surface stale, blocked, and orphaned work.
+
+> **Linear is the planning source of truth.** All state changes are
+> `mcp__Linear__save_issue` status/priority/estimate/label/relation writes.
+> There is no GitHub board or fallback labels to keep in sync. External GitHub
+> issues arrive in Linear `Triage` via the integration; that is the only GitHub
+> surface this command reads. See `docs/conventions/linear-workflow.md`.
 
 ## Target: $ARGUMENTS
 
-Optional filter — pass a label (e.g., `type:perf`) to triage a subset, or leave empty to triage everything.
+Optional filter — pass a label (e.g. `type:perf`) or a status to triage a
+subset, or leave empty to triage the whole open queue.
 
 ## Relationship to `/sweep`
 
 `/triage` is the **periodic, whole-queue hygiene auditor**. `/sweep` is the
-**event-driven, post-merge coordinator** (concurrency budget, file-collision
-analysis, dispatch sequencing, release-tracking sync). They are not
-interchangeable — run `/triage` to keep the queue honest, run `/sweep` after a
-merge to pick the next work.
-
-The one mechanic they share is **clearing a blocker whose blocking issue
-closed**. Both use the identical hard-vs-prose rule (Phase 3 → UNBLOCK below).
-Keep that logic in sync: if you change blocker-clearing here, mirror it in
-`/sweep` Phase 2, and vice-versa.
+**event-driven, post-merge coordinator** (concurrency budget, collision
+analysis, next picks). They share one mechanic — **clearing a blocker whose
+blocking issue closed** (both use the hard-vs-prose rule below). Keep that logic
+in sync between the two files.
 
 ---
 
 ## Phase 1: GATHER
 
-Pull all open issues:
+Pull the open SFN queue, grouped by the states this pass acts on:
 
-```bash
-gh issue list \
-  --state open \
-  --json number,title,labels,assignees,body,createdAt,updatedAt \
-  --limit 200
+```
+mcp__Linear__list_issues team="Sailfin" state="Triage" limit=200
+mcp__Linear__list_issues team="Sailfin" state="To triage" limit=200
+mcp__Linear__list_issues team="Sailfin" state="Backlog" limit=200
+mcp__Linear__list_issues team="Sailfin" state="Ready" limit=200
+mcp__Linear__list_issues team="Sailfin" state="Blocked" limit=200
+mcp__Linear__list_issues team="Sailfin" state="In Progress" limit=200
 ```
 
-Apply the optional label filter from `$ARGUMENTS` if provided.
+Apply the optional `$ARGUMENTS` filter. Use `includeRelations=true` on any issue
+whose blocker state you need to resolve.
 
 ---
 
 ## The hygiene matcher (shared definition)
 
-Both demotion and promotion depend on deciding whether a body is
-**complete**. The matcher MUST be tolerant of real-world markdown variants —
-a brittle literal match is what let fully-groomed issues rot in the backlog.
-
-An issue body is **complete** when all of these are present (match
-case-insensitively, accept any of the listed forms):
+Promotion and demotion both depend on whether a body is **complete**. Match
+case-insensitively and accept any listed form (brittle matching is the bug this
+pass exists to fix).
 
 | Section | Accept any of |
 |---|---|
 | Goal | `## Goal` |
 | Scope | `## Scope` |
-| Scope → In | `In:` · `### In` · `**In:**` · `**In**` (anywhere under Scope) |
+| Scope → In | `In:` · `### In` · `**In:**` · `**In**` (under Scope) |
 | Scope → Out | `Out:` · `### Out` · `**Out:**` · `**Out**` |
-| Acceptance | `## Acceptance` (e.g. "Acceptance Criteria") with ≥1 `- [ ]` item |
+| Acceptance | `## Acceptance` with ≥1 `- [ ]` item |
 | Files | `## Files` (e.g. "Files Affected"), not "TBD"/empty |
 | Verification | `## Verification` with a runnable command |
 
-**Size** is satisfied by EITHER a `size:{xs,s,m}` label OR a `## Size` body
-section declaring XS/S/M. If the body declares a size but the label is
-missing, that is a **backfill**, not a failure (see PROMOTE).
+**Estimate** is satisfied by a native Linear estimate (1/2/3) OR a `## Size`
+body section declaring XS/S/M. If the body declares a size but the estimate is
+unset, that is a **backfill** (set it), not a failure.
 
-**Type** is satisfied by a `type:*` label. (The GitHub native Type field is a
-separate, always-applied fix — see TYPE-FIX.)
+**Type** is satisfied by a `type:*` label.
 
 ---
 
 ## Phase 2: AUDIT
 
-Classify every issue into exactly one action bucket. Apply the matcher above.
+Classify every issue into exactly one action bucket.
 
-### Promotion candidates (the column-unsticking pass)
+### PROMOTE candidates (the queue-unsticking pass)
 An issue is a **PROMOTE** candidate when ALL hold:
-- It is `needs-grooming` (or carries no lifecycle label at all), and is **not** an `epic`.
-- Its body is **complete** per the matcher (size may be body-only).
-- It has **no open blocker** (apply the UNBLOCK hard-vs-prose rule to its `## Blocked by`).
-- It has **no unresolved in-body decision or precondition** (see guards below).
+- It is in `Triage` / `To triage` / `Backlog` (not already `Ready`/started).
+- Its body is **complete** per the matcher.
+- It has **no open blocker** (apply the UNBLOCK hard-vs-prose rule to its
+  blocked-by relations and any `## Blocked by` prose in the body).
+- It has **no unresolved in-body decision or precondition** (guards below).
 
-**Promotion guards — do NOT promote if any apply** (these are the traps that
-keep an issue genuinely un-pickable even with a complete-looking body):
-- **Open design choice in body:** phrases like "pick during grooming",
-  "one of (a)/(b)", "decide during grooming", "TBD by grooming", a Scope that
-  lists mutually-exclusive options to choose between. → leave `needs-grooming`, flag.
-- **Unmet precondition:** phrases like "once a seed past #N is pinned",
-  "after #M closes/lands", "blocked on <prose>". Resolve the referenced
-  issue/PR: if it is **closed/merged**, the precondition is met (promote, and
-  say so in the comment). If still **open**, leave `needs-grooming` and flag.
-- **Deferred-by-design:** "not picked up until …", "deliberately deferred".
-  Verify the gating issue closed before promoting; otherwise leave + flag.
+**Promotion guards — do NOT promote if any apply:**
+- **Open design choice in body:** "pick during grooming", "one of (a)/(b)",
+  "TBD by grooming", a Scope listing mutually-exclusive options → leave in place, flag.
+- **Unmet precondition:** "once a seed past #N is pinned", "after #M lands".
+  Resolve the reference: closed/merged → precondition met (promote, say so);
+  still open → leave and flag.
+- **Deferred-by-design:** "not picked up until …". Verify the gate closed first.
 
-### Demotion candidates
-An issue is a **DEMOTE** candidate when it is `claude-ready` but its body is
-**incomplete** per the matcher, or it lacks a `type:*` label, or it is missing
-a size entirely (no label AND no `## Size`).
+### DEMOTE candidates
+An issue is a **DEMOTE** candidate when it is `Ready` but its body is
+**incomplete** per the matcher, or it lacks a `type:*` label, or it has no
+estimate (neither native estimate nor `## Size`).
+
+### INTAKE candidates (new contributor issues)
+An issue in `Triage` / `To triage` that mirrored in from an external GitHub
+issue (the integration records the GitHub link on it) and has **no** SFN
+classification yet. Shape it: set `type:*`/`area:*` labels from the report,
+apply an estimate + priority if scopeable, associate it to the right Project,
+then route it — `Ready` if it's already a complete, session-sized leaf;
+`Backlog` if scoped but not ready; leave in `Triage` with a flag if it needs
+grooming; `Duplicate`/`Canceled` (with a comment) for non-actionable intake.
 
 ### State buckets
-- **UNBLOCK** — `blocked` and every hard `#N` ref in `## Blocked by` is closed (see rule below).
-- **RELEASE** — `in-progress` but no active branch / its PR closed unmerged.
-- **STALE** — `claude-ready` with no update in 30+ days (flag only).
-- **OVERSIZED** — slipped through as L (no `size:l` exists; → `epic`).
-- **TYPE-FIX** — GitHub native Type field is `null` (always fix, silently).
-- **STALE-GROOM** — `needs-grooming` 14+ days that is NOT a promote candidate
-  (still incomplete) → flag for `/groom` or closure review (no label change).
-- **MAP-REFRESH** — `claude-ready` (or just-promoted) issue whose Goal + semantic
-  `In:`/`Out:` scope are intact but whose `## Files Affected` **advisory map** has
+- **UNBLOCK** — `Blocked` and every hard blocker (relation or `#N`/`SFN-N` ref) is closed.
+- **RELEASE** — `In Progress` but no active branch / its PR closed unmerged → back to `Ready`.
+- **STALE** — `Ready` with no update in 30+ days (flag only).
+- **OVERSIZED** — an L-scale issue (estimate > 3 or body `## Size: L`) → back to
+  `Triage`/`Backlog` for `/groom` to decompose into a Project's leaves.
+- **STALE-GROOM** — `Backlog`/`Triage` 14+ days that is NOT a promote candidate
+  (still incomplete) → flag for `/groom` or closure review.
+- **MAP-REFRESH** — `Ready` (or just-promoted) issue whose Goal + semantic
+  `In:`/`Out:` scope are intact but whose `## Files Affected` advisory map has
   missing/renamed paths → re-derive and rewrite the advisory map (still
-  non-binding; no line numbers/counts), and note the refresh. A stale map is
-  expected entropy on a semantically-scoped issue — never a DEMOTE trigger.
+  non-binding; no line numbers/counts). A stale map is expected entropy — never
+  a DEMOTE trigger.
 
 ---
 
 ## Phase 3: APPLY ACTIONS
 
-Every label change below is also **reflected into Linear** per
-`docs/conventions/issue-naming.md` § Reflecting state into Linear: after the
-`gh issue edit`, find the issue's mirror, set its status from the new labels, and
-roll up its Project status. On a PROMOTE, also set the mirror's **Linear-native
-priority and estimate** if they're unset — estimate from the `size:*` label
-(xs/s/m → 1/2/3), priority defaulting to the issue's Project priority (see
-§ Reflecting state into Linear step 3). Best-effort — skip with a one-line note
-if the Linear MCP tools aren't connected, and never write a terminal status onto
-an open issue.
+Every action is a native Linear write. Leave a comment
+(`mcp__Linear__save_comment`) whenever you change status so the thread has an
+audit trail. **Never write a terminal status** (`Done`) on open work.
 
 ### PROMOTE — move a groomed issue to Ready
 
-```bash
-# If no size:* label exists, backfill it from the body's "## Size" block by
-# appending another --add-label flag (XS→size:xs, S→size:s, M→size:m), e.g.
-#   gh issue edit <N> --remove-label "needs-grooming" --add-label "claude-ready" --add-label "size:s"
-gh issue edit <N> --remove-label "needs-grooming" --add-label "claude-ready"
-gh issue comment <N> --body "Auto-triage promotion: body passes the full hygiene bar (Goal/Scope-In-Out/Acceptance/Files/Verification) with no open blocker or unresolved decision. <If size backfilled: 'Size declared as <X> in the body; applied the size:<x> label.'> <If a precondition was checked: 'Precondition met — #<M> is closed.'> Moving to claude-ready/Ready."
+```
+mcp__Linear__save_issue id="SFN-<N>" state="Ready" estimate=<1|2|3 if backfilled> priority=<1..4 if unset>
+mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-triage promotion: body passes the full hygiene bar (Goal/Scope-In-Out/Acceptance/Files/Verification), no open blocker or unresolved decision. <If backfilled: 'Size <X> in body → estimate <n>; default priority <p>.'> Moving to Ready."
 ```
 
-### DEMOTE — strip claude-ready from an incomplete issue
+Backfill the estimate from the body `## Size` (XS/S/M → 1/2/3) and default the
+priority to the issue's Project priority if unset.
 
-```bash
-gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming"
-gh issue comment <N> --body "Auto-triage: missing the following sections required for /pickup eligibility:
-- <list of failed checks>
+### DEMOTE — strip Ready from an incomplete issue
 
-Run \`/groom\` to flesh this out, or close if no longer relevant."
+```
+mcp__Linear__save_issue id="SFN-<N>" state="Triage"
+mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-triage: missing sections required for /pickup eligibility: <list>. Run /groom to flesh out, or cancel if no longer relevant."
+```
+
+### INTAKE — shape a new contributor issue
+
+```
+mcp__Linear__save_issue id="SFN-<N>" labels=["type:<t>","area:<a>"] priority=<1..4> estimate=<1|2|3> project="<Project>" state="<Ready|Backlog>"
+mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-triage intake: classified as <type>/<area>, associated to <Project>. <Routed to Ready | Needs grooming — /groom | Marked duplicate of SFN-M>."
 ```
 
 ### UNBLOCK — clear a resolved blocker (hard-vs-prose rule, shared with `/sweep`)
 
-Parse `## Blocked by`. Classify each reference:
-- **Hard reference (`#N`)** — closed/merged = resolved; open = still blocking.
-- **Prose reference** (e.g. "Slice E", "the M4 runtime port", "a fresh seed
-  cut") — an agent cannot determine when prose is satisfied, so its mere
-  **presence** blocks the auto-flip. Only a human can clear a prose gate.
+Read blocked-by relations (`get_issue includeRelations=true`) and any
+`## Blocked by` prose in the body. Classify each:
+- **Hard reference** (a Linear blocked-by relation, or a `SFN-N`/`#N`) — closed
+  = resolved; open = still blocking.
+- **Prose reference** ("Slice E", "the M4 runtime port", "a fresh seed cut") — an
+  agent can't decide when prose is satisfied; its **presence** blocks the flip.
 
-Flip **only** when (a) every hard `#N` ref is closed AND (b) the `## Blocked by`
-section contains **no prose gate at all**. If any prose gate is present, leave
-the `blocked` label and surface the issue under "Held back" for human review —
-never auto-flip.
+Flip to `Ready` **only** when every hard reference is closed AND no prose gate
+remains. Remove the resolved relations and set status:
 
-```bash
-gh issue edit <N> --remove-label "blocked" --add-label "claude-ready"
-gh issue comment <N> --body "Auto-triage: all hard blocker references closed (<list resolved #N>) and no prose gate present in '## Blocked by'. Marking ready for pickup."
+```
+mcp__Linear__save_issue id="SFN-<N>" state="Ready" removeBlockedBy=["SFN-<resolved>"]
+mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-triage: all hard blockers closed (<list>) and no prose gate present. Marking Ready."
 ```
 
-If a blocker is `needs-grooming`-incomplete after unblocking, fold it through
-the PROMOTE guard rather than landing it in Ready half-baked.
+If a just-unblocked issue is still `needs-grooming`-incomplete, fold it through
+the PROMOTE guard rather than landing it in `Ready` half-baked.
 
-### RELEASE — orphaned in-progress back to the queue
+### RELEASE — orphaned In Progress back to the queue
 
-```bash
-gh issue edit <N> --remove-label "in-progress" --add-label "claude-ready"
-gh issue comment <N> --body "Auto-triage: in-progress label was set but no active branch/PR found. Releasing back to queue."
+```
+mcp__Linear__save_issue id="SFN-<N>" state="Ready"
+mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-triage: In Progress but no active branch/PR found. Releasing back to Ready."
 ```
 
-### STALE — flag only (no label change)
+### STALE / STALE-GROOM / OVERSIZED — flag (and for OVERSIZED, re-route)
 
-```bash
-gh issue comment <N> --body "Auto-triage: claude-ready for 30+ days without pickup. Likely stale — review priority or close."
-```
-
-### OVERSIZED — L-sized → needs grooming (epic scope = a Linear Project)
-
-An L-sized issue is epic-scale. Do **not** apply the `epic` label (retired —
-epics are Linear Projects, not GitHub issues; see `docs/conventions/linear-workflow.md`).
-Flag it for grooming; `/groom` decomposes it into XS/S/M leaves under a Linear
-Project.
-
-```bash
-gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming"
-gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M leaves under a Linear Project (epics are Projects, not GitHub issues)."
-```
-
-### TYPE-FIX — null GitHub native Type field (silent, always)
-
-```bash
-# type:feature → Feature, type:bug → Bug, everything else → Task
-.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>
-```
-
-Apply to all issues with a null type regardless of other state. No label edit,
-no comment, no board sync.
+STALE and STALE-GROOM are flag-only (comment, no status change). OVERSIZED moves
+back to `Triage`/`Backlog` with a comment pointing at `/groom` to decompose it
+into a Project's leaves (an L-scale issue is epic-scale — it becomes a Project,
+not a single issue).
 
 ### MAP-REFRESH — rewrite a stale advisory map (the one allowed body edit)
 
-When an issue's Goal + semantic `In:`/`Out:` scope are intact but its
-`## Files Affected` **advisory map** lists missing/renamed paths, re-derive the
-current surface for each `In:` unit (grep/glob the named symbols/units) and
-**rewrite the advisory map** to the current paths. Keep it non-binding and
-**free of line numbers and exact counts**; do not touch Goal, Scope, Acceptance,
-or Verification. Leave a comment recording the refresh:
+When Goal + semantic `In:`/`Out:` scope are intact but `## Files Affected` lists
+missing/renamed paths, re-derive the current surface for each `In:` unit and
+**rewrite only that block** (non-binding, no line numbers/counts). Do not touch
+Goal, Scope, Acceptance, or Verification. Record it:
 
-```bash
-# Edit ONLY the `## Files Affected (advisory map …)` block of the body.
-gh issue edit <N> --body "<updated body with the refreshed advisory map>"
-gh issue comment <N> --body "Auto-triage map refresh: re-derived the advisory \`## Files Affected\` map from the current tree (\`old/path\` → \`new/path\`; added in-unit sibling \`x\`). Map only — Goal and semantic In/Out scope unchanged. The map is non-binding; \`/pickup\` reconciles any remaining drift."
+```
+mcp__Linear__save_issue id="SFN-<N>" description="<body with only the ## Files Affected map refreshed>"
+mcp__Linear__save_comment issueId="SFN-<N>" body="Auto-triage map refresh: re-derived ## Files Affected from the current tree. Map only — Goal and semantic In/Out unchanged. /pickup reconciles any remaining drift."
 ```
 
-This is the **sole** exception to "don't modify issue bodies" — it edits only
-the advisory map, never the contract. A stale map is never a DEMOTE trigger.
-
-If a sync call exits non-zero, capture the issue number under "Concerns" in the
-report — the label flip stands but the board is out of sync.
+This is the **sole** exception to "don't modify issue bodies."
 
 ---
 
@@ -226,59 +203,57 @@ report — the label flip stands but the board is out of sync.
 ```
 Triage Report (<date>)
 
-Audited: <total> open issues
+Audited: <total> open SFN issues
 
 Status breakdown:
-  claude-ready (pickable):  <N>
-  claude-ready (stale):     <N>
-  in-progress (active):     <N>
-  in-progress (orphaned):   <N>
-  needs-grooming:           <N>
-  blocked (real):           <N>
-  blocked (cleared):        <N>
+  Ready (pickable):    <N>
+  Ready (stale):       <N>
+  In Progress (active):   <N>
+  In Progress (orphaned): <N>
+  Backlog/Triage:      <N>
+  Blocked (real):      <N>
+  Blocked (cleared):   <N>
+  New intake shaped:   <N>
 
 Actions taken:
-  - Promoted <N> groomed issues to Ready (backfilled <N> size labels)
-  - Stripped claude-ready from <N> incomplete issues
-  - Released <N> orphaned in-progress issues back to queue
+  - Promoted <N> groomed issues to Ready (backfilled <N> estimates)
+  - Demoted <N> incomplete Ready issues to Triage
+  - Shaped <N> new contributor issues (type/area/priority/project)
+  - Released <N> orphaned In Progress back to Ready
   - Unblocked <N> issues whose blockers closed
-  - Refreshed <N> stale advisory maps (Goal/scope intact)
-  - Flagged <N> stale claude-ready issues for human review
-  - Flagged <N> L-sized issues for breakdown
+  - Refreshed <N> stale advisory maps
+  - Flagged <N> stale / oversized issues
 
 Top picks for /pickup right now:
-  1. #<N> — <title> (type, size)
-  2. #<N> — <title> (type, size)
-  3. #<N> — <title> (type, size)
+  1. SFN-<N> — <title> (type, estimate)
+  2. ...
 
-Held back (complete body, but not pickable):
-  ? #<N> — open design choice ((a) vs (b))
-  ? #<N> — precondition #<M> still open
-  ? #<N> — blocked on <prose>, no tracking issue
+Held back (complete body, not pickable):
+  ? SFN-<N> — open design choice ((a) vs (b))
+  ? SFN-<N> — precondition <M> still open
+  ? SFN-<N> — blocked on <prose>, no tracking issue
 
 Concerns:
-  - <anything that needs human attention>
+  - <anything needing human attention>
 ```
 
 ---
 
 ## Constraints
 
-- **Don't close issues automatically.** Closing is a human decision.
-- **Don't modify issue bodies, except the advisory map.** Only labels and
-  comments — with the single MAP-REFRESH exception, which rewrites *only* the
-  `## Files Affected` advisory map (never Goal, Scope, Acceptance, or
-  Verification) and always leaves a comment recording the refresh.
-- **Promote conservatively.** A complete-looking body is necessary but not
-  sufficient — the promotion guards (open decision / unmet precondition /
-  deferred-by-design) exist because they bit us before. When a guard fires,
-  leave the issue and report it under "Held back," never force it to Ready.
-- **Be conservative on staleness.** 30 days is the floor for `claude-ready`;
-  never mark stale at <30 days.
-- **Match tolerantly.** Use the hygiene matcher's accepted forms — do not
-  fail an issue on `### In` vs `In:` or a body-only `## Size`. Brittle matching
-  is the bug that this pass exists to fix.
-- **If you change a label, leave a comment explaining why.** Audit trail.
-- **Labels are the source of truth.** There is no derived board to sync.
-- **Fix a null GitHub Type field** via `set-issue-type.sh` (best-effort; it too
-  self-skips when `gh` is unavailable, so set it from a session where `gh` works).
+- **Don't cancel/close issues automatically.** Terminal states
+  (`Done`/`Canceled`/`Duplicate`) are human decisions — except an obvious
+  duplicate/spam intake, which you may mark `Duplicate`/`Canceled` **with a
+  comment** during INTAKE.
+- **Don't modify issue bodies, except the advisory map** (MAP-REFRESH).
+- **Promote conservatively.** A complete body is necessary but not sufficient —
+  the guards (open decision / unmet precondition / deferred-by-design) exist
+  because they bit us before. When a guard fires, leave it and report under
+  "Held back."
+- **Be conservative on staleness.** 30 days is the floor for `Ready`.
+- **Match tolerantly.** Use the matcher's accepted forms; a body-only `## Size`
+  or `### In` must pass.
+- **Always comment when you change status.** Audit trail.
+- **Native fields only** — status/priority/estimate/blockers are Linear-native,
+  not labels. Labels are `type:*`/`area:*` (+ `seed-blocker`/`release:*` for the
+  seed/release axes).

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -44,6 +44,6 @@ cat <<'MSG'
 
 Reminders:
 - The compiler self-caps memory at 8 GiB on Linux (`SAILFIN_MEM_LIMIT` to override); still wrap single-file compiles with `timeout 60`.
-- Work lives on the `claude/*` branch; PRs auto-close issues via `Closes #N`.
+- Work lives on `claude/*` branches (`/pickup` uses `claude/sfn-<N>-…`); PRs cite `Fixes SFN-<N>` so Linear closes the issue on merge.
 - Roadmap: site/src/pages/roadmap.astro. Status: docs/status.md.
 MSG

--- a/.claude/rules/seed-dependency.md
+++ b/.claude/rules/seed-dependency.md
@@ -29,7 +29,7 @@ A seed dependency is discovered (groom-time or mid-pickup):
 ├─ Is the dependency a compiler-source capability (lowering / parse /
 │  typecheck / intrinsic / runtime-prelude) that the consumer needs
 │  present in the *pinned seed*?
-│     └─ No  → not a seed dependency. Normal `## Blocked by`. Done.
+│     └─ No  → not a seed dependency. Normal Linear blocked-by relation. Done.
 │     └─ Yes ↓
 │
 ├─ How many consumers need this capability?

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -13,8 +13,14 @@ reintroduce gh-aw workflow sources without a new design decision.
 
 For issue execution, use Linear plus the repo-local Codex/Claude workflows:
 
-- groom and prioritize work in Linear;
-- use labels such as `claude-ready`, `needs-grooming`, and `blocked` only as
-  public GitHub fallback triage hints; Linear native status is primary;
+- groom and prioritize work in Linear — workflow status (Triage → Backlog →
+  Ready → In Progress → In Review → Done, plus native blocked-by relations),
+  priority, and estimate are Linear-native fields, not GitHub labels;
+- the `claude-ready`, `in-progress`, and `blocked` labels are retired;
+  `needs-grooming` and `needs-design` survive only as public triage hints on
+  GitHub intake, not as workflow state;
+- external GitHub issues mirror into the Linear SFN team's Triage for
+  maintainers to classify and groom;
 - use the repository prompts and skills under `.codex/` and `.claude/` for
-  interactive pickup, implementation, and PR handoff.
+  interactive pickup and implementation against Linear `Ready` work, and for
+  PR handoff.

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -7,13 +7,16 @@ assignees: []
 ---
 
 <!--
-This template defines the contract between public GitHub issue authors and
-Claude/Codex. Maintainer- or agent-created implementation work should start as
-a Linear `SFN-NNN` issue and use the GitHub issue only as the public mirror when
-needed.
+This template is contributor intake, not an implementation-ready ticket. A
+GitHub issue filed from this template mirrors into the Linear SFN team's
+Triage, where maintainers classify it, groom scope, and set workflow status.
+Fill in what you can concretely, but do NOT set workflow state yourself —
+that's the maintainer's job once it lands in Linear. Maintainer- or
+agent-created implementation work is authored natively as a Linear `SFN-NNN`
+issue and does not need a GitHub mirror at all.
 
-A well-groomed issue is one Claude can complete in a single session and
-produce a mergeable PR. If you can't fill in every section concretely,
+A well-groomed issue is one that can be completed in a single focused session
+and produce a mergeable PR. If you can't fill in every section concretely,
 the issue is too big or too vague — break it down further.
 
 Title format (see docs/conventions/issue-naming.md):
@@ -26,9 +29,9 @@ GitHub issues — an epic is a Linear Project, a tracker is a Project/Initiative
 tracker is the sole surviving GitHub tracking title.
 
 Labels come from .github/labels.yml — never invent new ones here. The
-template defaults to `needs-grooming`. Once scope, criteria, and files
-are filled in, swap it for `claude-ready` (and add `type:*`, `size:*`,
-optional `area:*`).
+template defaults to `needs-grooming`, a public triage hint that a maintainer
+clears once the issue is groomed in Linear (add `type:*`, `size:*`, optional
+`area:*` there).
 
 Priority and estimate are Linear-native fields, not GitHub labels. Record
 the intended priority in the `## Priority` section below; the groomer sets
@@ -96,7 +99,7 @@ timeout 60 build/native/sailfin run path/to/example.sfn
 - [ ] **XS** — single file, < 1 hour
 - [ ] **S** — few files, 1-3 hours
 - [ ] **M** — multi-file, 3-6 hours
-- [ ] **L** — > 6 hours (NEEDS BREAKDOWN — remove `claude-ready` label and add `needs-grooming`)
+- [ ] **L** — > 6 hours (NEEDS BREAKDOWN — too big to take on as-is; a maintainer will break it down and set status in Linear)
 
 ## Priority
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -93,7 +93,7 @@ labels:
   # Priority is a Linear-native field, not a GitHub label. Set it in Linear
   # at groom/triage time (Urgent/High/Medium/Low). The former `priority:*`
   # labels are retired via the `delete:` list below. See
-  # docs/conventions/issue-naming.md § Reflecting state across Linear and GitHub.
+  # docs/conventions/issue-naming.md § Cross-surface flow (Linear ↔ GitHub).
 
   # --- Area (subsystem) ------------------------------------------------
   - name: area:compiler

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -29,8 +29,8 @@
 
 labels:
   # --- Public issue triage hints ---------------------------------------
-  # Linear owns maintainer workflow state natively. These labels remain only
-  # for public GitHub issues, mirrors, and GitHub-only fallback flows.
+  # These labels are public triage hints only; Linear status owns workflow
+  # state (Ready/In Progress/Blocked/etc.) natively.
   - name: needs-grooming
     color: "fbca04"
     description: "Placeholder issue: scope, criteria, or files-affected still missing"
@@ -40,15 +40,6 @@ labels:
   - name: needs-discussion
     color: "d93f0b"
     description: "Design blocked pending human input"
-  - name: claude-ready
-    color: "0e8a16"
-    description: "GitHub fallback: fully groomed and eligible for /pickup"
-  - name: in-progress
-    color: "1d76db"
-    description: "GitHub fallback: currently being worked; do not pick up"
-  - name: blocked
-    color: "b60205"
-    description: "GitHub fallback: has open dependencies"
 
   # --- PR lifecycle ----------------------------------------------------
   - name: needs-review
@@ -216,8 +207,6 @@ aliases:
     to: type:docs
   - from: medium
     to: size:m
-  - from: blocker
-    to: blocked
   - from: runtime
     to: area:runtime
   - from: compiler
@@ -287,3 +276,11 @@ delete:
     reason: "Dependabot ecosystem label; dependabot.yml now uses only dependencies"
   - name: python
     reason: "Dependabot ecosystem label; dependabot.yml now uses only dependencies"
+  - name: claude-ready
+    reason: "Retired: pickable state is Linear `Ready` status, not a GitHub label"
+  - name: in-progress
+    reason: "Retired: work-in-progress is the Linear `In Progress` status"
+  - name: blocked
+    reason: "Retired: blockers are native Linear blocked-by relations / `Blocked` status"
+  - name: blocker
+    reason: "Retired with `blocked`; blockers are native Linear relations"

--- a/.github/workflows/linear-priority-sync.yml
+++ b/.github/workflows/linear-priority-sync.yml
@@ -2,7 +2,7 @@ name: Linear Priority Sync
 
 # Backfills Linear-native priority + estimate on the Sailfin team's issue
 # mirrors (scripts/linear-priority-sync.sh; see
-# docs/conventions/issue-naming.md § Reflecting state into Linear). Priority
+# docs/conventions/issue-naming.md § Cross-surface flow (Linear ↔ GitHub)). Priority
 # and estimate are Linear-native fields, so the GitHub-side regression filers
 # (build-quality.yml, perf-history.yml) can't set them at create time — the
 # Linear mirror of a new GitHub issue is created asynchronously by the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,21 +323,23 @@ earn their cost on open-ended investigation and cross-cutting analysis.
 ## Task Tracking
 
 Work is organised in three tiers — **Linear Initiative → Linear Project →
-GitHub Issue** (full playbook: `docs/conventions/linear-workflow.md`). An
-**epic is a Linear Project** under an Initiative (a theme); **never open a
-GitHub `Epic:`/`Tracking:` issue** (retired 2026-07-07). GitHub Issues are
-session-sized leaf work only, scoped so a single session takes an issue from
-open to merged PR, and are mirrored into Linear by the integration.
+Linear Issue** (full playbook: `docs/conventions/linear-workflow.md`). An
+**epic is a Linear Project** under an Initiative (a theme); a **leaf is a native
+Linear `SFN-NNN` issue**, scoped so a single session takes it from `Ready` to a
+merged PR. **Never open a GitHub `Epic:`/`Tracking:` issue** (retired
+2026-07-07). GitHub issues are **external-contributor intake only** — they mirror
+into the Sailfin (`SFN`) team's `Triage` for us to triage.
 
 ```
-Initiative (theme) ─▶ Project (epic) ─▶ Issue (leaf, claude-ready) ──/triage──▶ pickable
-     [Linear]            [Linear]        [GitHub → mirrored]  │
-                                              └──/pickup [#N]──▶ PR opened, issue auto-closed on merge
+Initiative (theme) ─▶ Project (epic) ─▶ Issue (leaf) ──/groom──▶ Ready ──/pickup──▶ In Progress
+     [Linear]            [Linear]        [Linear SFN]                               │
+                                              PR (branch claude/sfn-N, "Fixes SFN-N") ──▶ Done on merge
 ```
 
-**Issue contract** (template: `.github/ISSUE_TEMPLATE/claude-task.md`): Goal,
-Scope (`In:`/`Out:`), Acceptance Criteria, Files Affected, Verification, Size
-(XS/S/M — never L), Type, Blocked by. Missing or vague → not pickable.
+**Issue contract** (template: `docs/conventions/linear-templates.md`): Goal,
+Scope (`In:`/`Out:`), Acceptance Criteria, Files Affected, Verification, plus a
+native Linear estimate (XS/S/M → 1/2/3, never L), a `type:*` label, priority, and
+any blocked-by relation. Missing or vague → not `Ready`.
 
 **Design records (SFEPs).** A substantive epic's design lives in an **SFEP** —
 a numbered proposal under `docs/proposals/` (`docs/proposals/README.md` is the
@@ -347,27 +349,26 @@ duplicating the design; `/pickup` reads it as the brief; it graduates to
 `Implemented` when the feature ships. The SFEP is the durable *why*; the issue is
 the session-sized *what*.
 
-**Labels** are registered in `.github/labels.yml`; conventions and the lifecycle
-diagram are in `docs/conventions/issue-naming.md`. Key ones: `claude-ready`,
-`needs-grooming`, `in-progress`, `blocked`, `type:*`, `size:*`, `area:*`
-(`epic`/`tracking` are **legacy** — epics/trackers are Linear Projects now, not
-labels on new issues; the one surviving use of `tracking` is the `Release:
-vX.Y.Z` cadence tracker. **Priority and estimate are Linear-native fields, not
-GitHub labels** — the `priority:*` labels are retired; set them on the Linear
-mirror at groom/triage). **Labels are the source of truth** for issue state and there is no
-derived GitHub board to keep in sync: the former *Sailfin Tracker* project
-(org project SailfinIO/4) and its `sync-project.yml` label→board workflow have
-been **retired**. Epic and roadmap-level grouping now lives in **Linear** —
-Linear Projects correspond to epics, while session-sized leaf work stays as
-GitHub issues (mirrored into Linear by the GitHub↔Linear integration). Flipping a
-label *is* the state change; no board-sync step follows it. The public roadmap
+**State is Linear-native.** Status (`Triage`→`Backlog`→`Ready`→`In Progress`→
+`In Review`→`Done`; `Blocked` via a blocked-by relation), priority, estimate, and
+Project membership live on the Linear issue — not GitHub labels. `/pickup`
+selects Linear `Ready`. The workflow-state labels `claude-ready`/`in-progress`/
+`blocked` are **retired**; GitHub labels are now only `type:*`/`area:*`
+classification (for contributor intake) plus the release axis (`release:*`,
+`seed-blocker`), registered in `.github/labels.yml`; conventions are in
+`docs/conventions/issue-naming.md`. `epic`/`tracking` are **legacy** — epics are
+Linear Projects, releases are Linear Cycles; the one surviving `tracking` use is
+the `Release: vX.Y.Z` cadence tracker. The former *Sailfin Tracker* GitHub board
+(org project SailfinIO/4) and its `sync-project.yml` label→board workflow are
+**retired**; there is no derived board to sync. The public roadmap
 (`site/src/pages/roadmap.astro`) builds from Linear initiatives/projects at deploy
 time (needs a `LINEAR_API_KEY` build secret; it degrades to a "data unavailable"
 state without one).
 
-**Anti-patterns:** don't pick up `needs-grooming` (groom first); don't expand
-scope mid-session (comment and pause); don't bundle issues into one PR; don't
-`/pickup` from the roadmap (it isn't pickable — issues are).
+**Anti-patterns:** don't pick up an ungroomed issue (`Triage`/`Backlog` — groom
+first); don't expand scope mid-session (comment and pause); don't bundle issues
+into one PR; don't `/pickup` from the roadmap (it isn't pickable — Linear `Ready`
+issues are).
 
 ## Source-of-Truth Documents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ repository.
   file naming, and doc/test mirroring conventions.
 - Ensure you have `bash` and the LLVM toolchain available, including `clang`
   and `llvm-link` (no Conda or Python required).
+- Issues filed on GitHub are triaged by maintainers in Linear (the Sailfin
+  `SFN` team): a filed issue mirrors into Linear Triage, and maintainers own
+  planning and prioritization there. When scoping a PR, reference open issues
+  or roadmap items rather than assuming a particular priority or schedule.
 
 ## 2. Coding Workflow
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -13,7 +13,7 @@ Cycle, blockers, and assignee.
 
 ---
 
-## Lifecycle (Linear state machine; GitHub fallback labels mirror names)
+## Lifecycle (Linear state machine)
 
 ```
                                        ┌────────────────┐
@@ -43,9 +43,9 @@ Cycle, blockers, and assignee.
                               │                 ▼
                               │        ┌────────────────┐
                               │        │   PR opened    │
-                              │        │ (issue closes  │
-                              │        │  on merge via  │
-                              │        │  Closes #N)    │
+                              │        │  (In Review;   │
+                              │        │  Done on merge │
+                              │        │  Fixes SFN-N)  │
                               │        └────────────────┘
                               │
                   ── if blocker found anywhere above ──► Blocked
@@ -166,7 +166,7 @@ four human-authored shapes. Do not create new `[aw]` issues manually.
 | Rule | Why |
 |------|-----|
 | Every active issue carries exactly one `type:*` label | `/pickup` routes by it |
-| Every GitHub `claude-ready` fallback issue carries exactly one `size:*` label | GitHub-only `/pickup` fallback ranks by it |
+| **Workflow state is Linear-native, not a GitHub label.** Status (`Ready`/`In Progress`/`Blocked`/…), priority, estimate, and blockers live on the Linear issue. `claude-ready`, `in-progress`, and `blocked` are **retired** | One source of truth; `/pickup` selects Linear `Ready` |
 | **Priority is a Linear-native field, not a GitHub label.** Set it in Linear (Urgent/High/Medium/Low) at groom/triage time; the `priority:*` labels are retired (see § *Reflecting state across Linear and GitHub*) | One source of truth; Linear's board sorts on the native field |
 | Apply `area:*` labels when the touched subsystem is unambiguous | Helps `/sweep` dedupe collisions |
 | `tracking` is **legacy** outside release automation — do not apply to new issues except the `Release: vX.Y.Z` cadence tracker (see § *Release tracking*) | Epics are Linear Projects; release automation still queries `tracking` |
@@ -257,50 +257,43 @@ required, that is real growth — pause for human input.
 
 ## Issue tracking
 
-**Linear is the maintainer planning source of truth for issue state.** The
-former GitHub Project board (*Sailfin Tracker*, org project #4) and its
-label→board sync workflow have been **retired**. Lifecycle status, priority,
-estimate, assignee, and Project membership live on the Linear issue. GitHub
-issues remain the public open-source surface and compatibility mirror; their
-labels use the same canonical taxonomy so release automation, public triage,
-and GitHub-only fallbacks keep working.
+**Linear is the planning source of truth.** Our own work is authored natively as
+Linear `SFN-NNN` issues; there is **no GitHub mirror** for it. The former GitHub
+Project board (*Sailfin Tracker*, org project #4) and its label→board sync
+workflow are **retired**. Lifecycle status, priority, estimate, blockers,
+assignee, and Project membership live on the Linear issue.
 
-On GitHub fallback issues, the `size:*` label carries size and drives the
-Linear estimate. **Priority and estimate are Linear-native fields** — set them
-in Linear at groom/triage time
-(see § *Reflecting state across Linear and GitHub*); there is no `priority:*`
-GitHub label. Epic and roadmap-level grouping lives in **Linear** — Linear
-Projects correspond to epics, while session-sized leaf work is a Linear issue
-with a GitHub public mirror when needed.
+GitHub's role is (a) the **code and PR host** and (b) **external-contributor
+issue intake**: an issue filed on GitHub mirrors into the Sailfin (`SFN`) team's
+**Triage**, where `/triage` classifies and grooms it. `type:*`/`area:*` labels
+plus the release axis (`release:*`, `seed-blocker`) stay as the public GitHub
+taxonomy; the workflow-state labels (`claude-ready`/`in-progress`/`blocked`) are
+**retired**. Epic and roadmap-level grouping lives in **Linear** — Projects are
+epics, Initiatives are pillars, releases are Cycles.
 
-### Status semantics
+### Status semantics (GitHub intake → Linear)
 
-A single status is selected from issue state plus labels, first match wins. This
-precedence is the convention `/triage`, `/sweep`, and `/pickup` apply when they
-need to reconcile a GitHub mirror or an older migrated issue. Linear status is
-owned natively in Linear; labels are compatibility hints, not a replacement for
-the Linear status field.
+Our own Linear issues own their status natively — nothing to derive. This
+precedence applies only when **classifying an external-contributor GitHub issue**
+that mirrored into Linear (or reconciling an older migrated issue): pick the
+initial Linear status from the GitHub signals, first match wins.
 
-| Signal | Status |
+| GitHub signal | Initial Linear status |
 |--------|--------|
-| Issue closed (or PR merged for linked PRs) | `Done` |
-| `in-progress` label | `In Progress` |
-| `blocked` label | `Blocked` |
-| `claude-ready` label (no blocker) | `Ready` |
-| `needs-grooming` / `needs-design` | `Backlog` |
-| No status-bearing label | `To triage` or Linear `Triage`, depending on origin |
+| Issue closed | `Done` (via the merge/close sync) |
+| `needs-grooming` / `needs-design` hint | `Backlog` |
+| No status-bearing label (default) | `Triage` |
 
 Notable invariants:
 
-- **`To triage` is not a label.** It is the implicit default for a GitHub issue
-  that carries no status-bearing label (`in-progress` / `blocked` /
-  `claude-ready` / `needs-grooming` / `needs-design`) and
-  the explicit triage queue state for new Linear/GitHub integration intake.
-- **`blocked` beats `claude-ready`.** A blocked-but-groomed issue reads as
-  `Blocked`, not `Ready`, so the ready set is always pickable.
-- **`In review` is intentionally not derived** for issues. An issue with
-  `in-progress` keeps that status across PR-open → review → merge → close; the
-  PR side of GitHub already tracks review state.
+- **New intake defaults to `Triage`.** An external issue with no grooming hint
+  lands in `Triage` for `/triage` to shape.
+- **Workflow-state labels are retired.** `claude-ready` / `in-progress` /
+  `blocked` no longer appear on new issues; status is the Linear field.
+- **Blockers are native relations.** A blocked issue sits in `Blocked` via a
+  Linear blocked-by relation, so the `Ready` set is always pickable.
+- **`In Review` is set by `/pickup`** when the PR opens; `Done` comes from the
+  merge via Linear's GitHub integration.
 
 ## Linear structure & naming
 
@@ -333,74 +326,47 @@ Linear-native **priority and estimate** on mirrors the skills didn't reach —
 notably the CI-auto-filed regression issues, whose mirror is created
 asynchronously after `gh issue create` (see the note in step 3 below).
 
-## Reflecting state across Linear and GitHub
+## Cross-surface flow (Linear ↔ GitHub)
 
-Linear holds maintainer planning state and epic/roadmap grouping (Linear
-Projects = epics). GitHub issues remain the public mirror and the close target
-for PRs that should use `Closes #N`.
+Linear holds all planning state; our own work never exists as a GitHub issue.
+There are exactly two cross-surface flows, both handled by the Linear GitHub
+integration:
 
-When a workflow (`/groom`, `/triage`, `/sweep`, `/pickup`) creates or claims
-work, it should update Linear first with the Linear MCP tools (`list_issues`,
-`save_issue`, `list_projects`, `save_project`). If a GitHub mirror exists, it
-also updates the mirror labels best-effort. If the Linear MCP tools are not
-connected in the session, fall back to GitHub and leave a one-line note; if
-GitHub is unavailable but Linear is available, continue with Linear and link the
-Linear issue in the PR.
+1. **Contributor intake (GitHub → Linear).** An external contributor files a
+   GitHub issue; the integration mirrors it into the Sailfin (`SFN`) team's
+   `Triage`. `/triage` classifies it (`type:*`/`area:*` labels, priority,
+   estimate, Project) and routes it to `Ready`/`Backlog` — or `Duplicate` /
+   `Canceled` with a comment. Set the initial status via the § *Status semantics
+   (GitHub intake → Linear)* precedence above.
+2. **PR close (GitHub → Linear).** `/pickup` branches `claude/sfn-<N>-<slug>` and
+   the PR body cites `Fixes SFN-<N>`; the integration links the PR to `SFN-<N>`
+   and advances it to `Done` on merge. The skill flips
+   `Ready → In Progress → In Review` via `mcp__Linear__save_issue` and never
+   writes a terminal status by hand (the merge does that).
 
-1. **Find or create the work item.** Maintainer/agent-created work starts as a
-   Linear issue under the Sailfin (`SFN`) team and uses native status, priority,
-   estimate, Project, Cycle, blocker, and assignee fields. The GitHub
-   integration creates or attaches a public mirror when needed. External
-   contributor issues start in GitHub and mirror into Linear triage.
-2. **Find the mirror.** A GitHub issue's Linear mirror is located with
-   `list_issues` querying the issue's number or URL (the integration records the
-   GitHub link on the mirror). A newly-created issue mirrors in
-   **asynchronously** — allow a brief lag and retry a few times; if the mirror
-   still isn't present, record it and let the next `/triage`/`/sweep` pass
-   reconcile it. Never block on it.
-3. **Set Linear issue status from the intended workflow state** using the
-   § Status semantics precedence when reconciling GitHub labels. **Never** write
-   `Done`, `Canceled`, or any terminal status onto a mirror whose GitHub issue
-   is still open — the two-way sync would close the GitHub issue. Only the
-   non-terminal statuses (In Progress, Blocked, Ready, To triage, Backlog, Todo)
-   are ever written by agent workflows.
-4. **Set priority and estimate in Linear** (Linear-native fields — there is no
-   GitHub label for either). Priority is a judgement call carried from grooming;
-   estimate is derived mechanically from the `size:*` label. Use `save_issue`
-   with the numeric `priority` and `estimate`:
+For maintainer/agent work, `/groom` creates the leaf **natively** in Linear with
+these fields set at creation — there is no reflect-to-GitHub step:
 
-   | Size label | Estimate |
-   |---|---|
-   | `size:xs` | `1` |
-   | `size:s` | `2` |
-   | `size:m` | `3` |
-   | (body `## Size`, no label) | map XS/S/M → 1/2/3 |
+| Attribute | Linear field | Value |
+|---|---|---|
+| Estimate | `estimate` | XS/S/M → 1/2/3 (Sailfin team's Linear 1–5 scale) |
+| Priority | `priority` | Urgent/High/Medium/Low → 1/2/3/4 |
+| Status | `state` | `Ready` when groomed + unblocked; `Backlog` when scoped; `Blocked` via a blocked-by relation |
+| Type/area | `labels` | `type:*`, `area:*` only |
+| Epic | `project` | the epic's Project |
 
-   | Priority tier | `priority` value |
-   |---|---|
-   | Urgent | `1` |
-   | High | `2` |
-   | Medium | `3` |
-   | Low | `4` |
+Every `Ready` leaf carries both an estimate and a priority (default a leaf to its
+Project's priority if grooming set none). Never leave a groomed leaf at
+`No priority` / no estimate, and never write a terminal status (`Done`/`Canceled`)
+on open work.
 
-   The estimate scale is the Sailfin team's **Linear (1–5)** scale. Every
-   Linear `Ready` leaf gets both an estimate and a priority; if grooming set no
-   explicit priority, default the leaf to its Project's priority. Never leave a
-   promoted leaf at `No priority` / no estimate.
-
-   **CI-auto-filed issues** (the `build-quality.yml` / `perf-history.yml`
-   regression filers) can't set these inline — their Linear mirror is created
-   asynchronously by the integration, after `gh issue create` returns. The
-   scheduled `Linear Priority Sync` workflow backfills them: estimate from
-   `size:*`, and priority for the regression classes
-   (`build-quality-regression` → Urgent, `perf-regression` → Medium). It only
-   fills unset values, so an interactively-set priority/estimate always wins.
-5. **Assign the issue to its epic's Project** if it isn't already, resolving the
-   Project from the Linear Project or parent reference and creating it per § Linear
-   structure & naming when it doesn't exist yet.
-6. **Roll up the Project status** from its issues: any issue In Progress →
-   Project `started`; else any Ready → `planned`; else `backlog`. Never
-   `completed`/`canceled` from a workflow.
+**CI-auto-filed issues** (the `build-quality.yml` / `perf-history.yml` regression
+filers) create GitHub issues whose Linear mirror is made asynchronously by the
+integration. They can't set native fields inline, so the scheduled
+`Linear Priority Sync` workflow (`.github/workflows/linear-priority-sync.yml`)
+backfills them: estimate from `size:*`, priority per regression class
+(`build-quality-regression` → Urgent, `perf-regression` → Medium). It only fills
+unset values, so an interactively-set priority/estimate always wins.
 
 ## Release tracking
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -167,7 +167,7 @@ four human-authored shapes. Do not create new `[aw]` issues manually.
 |------|-----|
 | Every active issue carries exactly one `type:*` label | `/pickup` routes by it |
 | **Workflow state is Linear-native, not a GitHub label.** Status (`Ready`/`In Progress`/`Blocked`/…), priority, estimate, and blockers live on the Linear issue. `claude-ready`, `in-progress`, and `blocked` are **retired** | One source of truth; `/pickup` selects Linear `Ready` |
-| **Priority is a Linear-native field, not a GitHub label.** Set it in Linear (Urgent/High/Medium/Low) at groom/triage time; the `priority:*` labels are retired (see § *Reflecting state across Linear and GitHub*) | One source of truth; Linear's board sorts on the native field |
+| **Priority is a Linear-native field, not a GitHub label.** Set it in Linear (Urgent/High/Medium/Low) at groom/triage time; the `priority:*` labels are retired (see § *Cross-surface flow (Linear ↔ GitHub)*) | One source of truth; Linear's board sorts on the native field |
 | Apply `area:*` labels when the touched subsystem is unambiguous | Helps `/sweep` dedupe collisions |
 | `tracking` is **legacy** outside release automation — do not apply to new issues except the `Release: vX.Y.Z` cadence tracker (see § *Release tracking*) | Epics are Linear Projects; release automation still queries `tracking` |
 | Never re-introduce a bare alias (`bug`, `runtime`, `medium`, …) | They are listed in `aliases:` of `labels.yml` and will be migrated away on the next sync |

--- a/docs/conventions/linear-workflow.md
+++ b/docs/conventions/linear-workflow.md
@@ -28,7 +28,7 @@ Initiative        a pillar / durable theme          (Linear)      ~6, rarely add
 |------|----|----------|----------------|
 | **Initiative** | A pillar or durable workstream (e.g. *Structured Concurrency*, *Build & Toolchain*). A small, stable set. | Linear | Set by hand; changes rarely. |
 | **Project** | Exactly one epic — a deliverable with real surface area and a design record (SFEP). | Linear | Rolled up from its issues; the design/context lives in the project **description**. |
-| **Issue** | One session-sized leaf (XS/S/M, never L). A Linear `Ready` issue is pickable by `/pickup`. | Authored in **Linear** for maintainer/agent work, mirrored to GitHub when public tracking is needed; external GitHub issues mirror into Linear triage. | **Linear owns status, priority, estimate, project, and assignee**. GitHub labels remain the public compatibility taxonomy. |
+| **Issue** | One session-sized leaf (XS/S/M, never L). A Linear `Ready` issue is pickable by `/pickup`. | **Linear** — authored natively as `SFN-NNN`. External-contributor GitHub issues mirror into Linear **Triage**; we do **not** mirror our own planned work back to GitHub. | **Linear owns status, priority, estimate, project, blockers, and assignee.** GitHub hosts the code and PRs; its labels are a public taxonomy for contributor intake and the release axis, not our workflow state. |
 
 A Project belongs to exactly one Initiative. A leaf Issue belongs to exactly one
 Project. Releases are a fourth, **orthogonal** axis — a Linear **Cycle**, never a
@@ -80,8 +80,9 @@ ordinary issues associated to that Project.
   `Ready` status, no unclosed `Blocked by`.
   This is exactly what `/pickup` selects; `/pickup` with no argument picks the
   top one, and `/pickup SFN-123` targets a specific Linear issue.
-- **Needs shaping:** `needs-grooming` → run `/groom`; `needs-design` → architect
-  queue; `needs-discussion` → parked for a human.
+- **Needs shaping:** issues in `Triage`/`Backlog` → run `/groom`; a design gap →
+  architect queue (`needs-design` hint); parked for a human → left in `Triage`
+  with a note. External contributor issues land in `Triage` for this pass.
 
 ---
 
@@ -93,13 +94,14 @@ ordinary issues associated to that Project.
    put `Design: SFEP-NNNN` in the project description. See
    [`.claude/rules/proposals.md`](../../.claude/rules/proposals.md).
 3. **Groom into leaves:** `/groom <epic>` decomposes it into session-sized
-   Linear issues, ensures the Project exists, associates each leaf to the
-   Project, and lets the GitHub integration create or attach the public mirror
-   when needed. Each leaf cites the SFEP (`## Design`), it does not re-litigate
-   the design.
-4. **Work the leaves:** `/pickup` drives each from Linear issue → branch → PR.
-   If a GitHub mirror exists, the PR uses `Closes #N`; otherwise the PR links
-   `Linear: SFN-NNN` and the mirror can be attached later.
+   **native Linear issues**, ensures the Project exists, and associates each leaf
+   to it with native status/priority/estimate/blockers. Leaves stay Linear-native
+   — no GitHub mirror for our own work. Each leaf cites the SFEP (`## Design`); it
+   does not re-litigate the design.
+4. **Work the leaves:** `/pickup` drives each from Linear issue → branch → PR. It
+   branches `claude/sfn-<N>-<slug>` and the PR cites `Fixes SFN-<NNN>`, so
+   Linear's GitHub integration links the PR and advances the issue to `Done` on
+   merge. The skill flips `Ready → In Progress → In Review` via the Linear MCP.
 5. **Graduate:** when the epic ships, flip its SFEP to `Implemented` and update
    `docs/status.md`.
 

--- a/docs/conventions/linear-workflow.md
+++ b/docs/conventions/linear-workflow.md
@@ -3,7 +3,7 @@
 This is the human-facing playbook for how work is organised across **Linear**
 and **GitHub Issues**. It is the front door; the dense, agent-facing mechanics
 live in [`issue-naming.md`](./issue-naming.md) (§ *Linear structure & naming*,
-§ *Reflecting state across Linear and GitHub*, § *Release tracking*) and this file links to
+§ *Cross-surface flow (Linear ↔ GitHub)*, § *Release tracking*) and this file links to
 them rather than restating them.
 
 If you only remember one thing: **an epic is a Linear Project, not a GitHub


### PR DESCRIPTION
## Summary

The doc layer had already been migrated to Linear (initiatives, projects, `linear-workflow.md`/`linear-templates.md`, the Linear-priority-sync workflow), but the **executable layer** — the `.claude/commands/*` skills and agents — still drove off the `gh` CLI and `claude-ready`/`in-progress`/`blocked` labels with Linear bolted on as a best-effort afterthought. This flips them to **Linear-native** planning.

Decisions (confirmed with the maintainer):
- **Linear-native only** — our work is authored as Linear `SFN-NNN` issues; GitHub issues are external-contributor intake (mirrored into Linear `Triage`) plus the code/PR host. No GitHub mirror for our own work.
- **Branch magic + MCP status** — `/pickup` branches `claude/sfn-<N>-<slug>` and PRs cite `Fixes SFN-<N>` so Linear's GitHub integration links/closes the issue on merge; skills also flip status via the Linear MCP (`Ready → In Progress → In Review`).
- **Workflow-state labels retired** — `claude-ready`/`in-progress`/`blocked` are gone; Linear status owns them.

## Changes

**Lifecycle skills (rewritten, Linear-native, no `gh`)**
- `pickup.md` — selects Linear `Ready` via `list_issues`, claims via `save_issue` (`In Progress`), branches `claude/sfn-<N>`, opens PR with `Fixes SFN-<N>`, sets `In Review`. Priority order = Linear priority → type → estimate → number. Trimmed Phase 1.5 seed check (git-based, with content fallback).
- `groom.md` — architect → **native Linear issues** under a Project/Initiative via `save_issue`/`save_project`, with native status/priority/estimate/`blockedBy`. No GitHub issues, no `Epic:`/`Tracking:` shapes.
- `triage.md` — Linear queue hygiene (promote/demote/unblock/release) **plus** a new contributor-intake path that shapes external GitHub issues arriving in Linear `Triage`.
- `sweep.md` — post-merge Linear coordination; epic/Project rollups are native (the GitHub sub-issue tracker machinery collapses).

**Agents**
- `compiler-architect.md` — granted Linear MCP tools to read Initiatives/Projects and create native SFN issues; Reference Documents + Decomposition Discipline updated.
- `Sailbot.md` — invariant #5 now reflects the Linear close convention (`Fixes SFN-<N>`), not `Closes #N`; noted Linear-native state / no `gh`.

**GitHub-side cleanup**
- `.github/labels.yml` — `claude-ready`/`in-progress`/`blocked` (and the `blocker` alias) moved to `delete:`; kept `type:*`/`area:*`/`release:*`/`seed-blocker` and public triage hints. (Grep confirmed no workflow references the retired labels.)
- `.github/ISSUE_TEMPLATE/claude-task.md`, `.github/AGENTS.md`, `CONTRIBUTING.md` — reframed for contributor → Linear triage; dropped "swap to claude-ready" instructions.
- `release.md`/`release-plan.md` — dropped the unavailable `gh` CLI for `mcp__github__*`; **preserved** the release-Cycle model and `release:*` gating axis.

**Conventions**
- `docs/conventions/linear-workflow.md`, `docs/conventions/issue-naming.md`, `CLAUDE.md` — reframed from hybrid dual-write to Linear-native primary; Status semantics is now a GitHub-intake→Linear mapping; the dual-write "Reflecting state" section became a "Cross-surface flow" (contributor intake + PR close).
- `.claude/rules/seed-dependency.md`, `.claude/hooks/session-start.sh` — small wording updates to the Linear model.

## Verification

Docs/config only — no `.sfn` touched, so no self-host/`sfn fmt` gate applies.
- Grep across `.claude/`, `docs/conventions/`, `.github/`, `CLAUDE.md` confirms no stale `claude-ready`/`Closes #N`/`gh issue|pr|api|workflow` references remain outside intentional "retired" mentions, the kept release-dispatch docs, and the `.github/agents/*` contributor-fallback path (which correctly keeps `Closes #N` since those agents have no Linear access).
- Linear tool names verified against the connected MCP server (`save_issue`, `list_issues`, `save_project`, `list_initiatives`, `list_projects`, `list_cycles`); GitHub MCP tool names corrected (`sub_issue_write`, `issue_read`, `actions_list`).

## Notes / follow-ups
- `.claude/commands/pin-seed.md` still uses `gh release view` for a seed-asset check — pre-existing, unrelated to this migration; left for a separate pass.
- `.claude/scripts/set-issue-type.sh` (GitHub Type-field helper) is now unreferenced by the skills but left in place for the contributor GitHub path.
- Linear team labels are currently minimal (`Bug`/`Feature`/`Improvement`/`area:test-infra`); the skills reference the intended `type:*`/`area:*` taxonomy per `linear-templates.md` — creating the full Linear label set is a maintainer/UI task.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGnur7qUMcSpSMJy5zqbHB)_