### PR TITLE
chore(agents): allow-list Linear MCP tools for auto-mode pickup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,8 +87,6 @@
       "mcp__Linear__get_project",
       "mcp__Linear__list_initiatives",
       "mcp__Linear__get_initiative",
-      "mcp__Linear__list_issue_statuses",
-      "mcp__Linear__list_issue_labels",
       "mcp__Linear__list_cycles"
     ],
     "deny": [
@@ -118,7 +116,7 @@
       "Project build, test, and formatting commands are safe: make compile, make rebuild, make check, make test (and its make test-* variants), make bench, make fetch-seed, make clean, make clean-build, sfn, and build/native/sailfin invocations. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts, never files outside the repo, so treat them as routine, not destructive. This does not extend to make install, which writes to PREFIX/bin outside the repo.",
       "Scheduling and session-management tools from the Claude_Code_Remote MCP server (send_later, create_trigger, and the other trigger tools) are safe.",
       "All tools from the sailfin MCP server (mcp__sailfin__*: sailfin_check, sailfin_diagnostics, sailfin_fmt_check, sailfin_fmt_write, sailfin_build, sailfin_test, sailfin_emit_native, sailfin_emit_llvm, sailfin_version) are safe. They are the project's own in-repo developer tooling — each is a pure passthrough to a single `sailfin` subcommand, path-restricted to the workspace root, and exists specifically for agents to use during development. Never prompt for them.",
-      "Linear planning tools are safe: the read tools (mcp__Linear__list_issues, get_issue, list_projects, get_project, list_initiatives, get_initiative, list_issue_statuses, list_issue_labels, list_cycles) and the planning writes the /pickup, /groom, /triage, and /sweep skills depend on (mcp__Linear__save_issue, save_project, save_comment). Linear is the project's planning source of truth (team SFN), so creating/updating issues, projects, and comments is routine agent work — never prompt for these. This does NOT extend to destructive Linear tools (mcp__Linear__delete_*), which are not allow-listed and must still prompt."
+      "Linear planning tools are safe: the read tools (mcp__Linear__list_issues, mcp__Linear__get_issue, mcp__Linear__list_projects, mcp__Linear__get_project, mcp__Linear__list_initiatives, mcp__Linear__get_initiative, mcp__Linear__list_cycles) and the planning writes the /pickup, /groom, /triage, /sweep, and /release-plan skills depend on (mcp__Linear__save_issue, mcp__Linear__save_project, mcp__Linear__save_comment). Linear is the project's planning source of truth (team SFN), so creating/updating issues, projects, and comments is routine agent work — never prompt for these. This does NOT extend to destructive Linear tools (mcp__Linear__delete_*), which are not allow-listed and must still prompt."
     ]
   },
   "env": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,7 +77,19 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "mcp__Claude_Code_Remote",
       "mcp__sailfin",
-      "mcp__github"
+      "mcp__github",
+      "mcp__Linear__save_issue",
+      "mcp__Linear__save_project",
+      "mcp__Linear__save_comment",
+      "mcp__Linear__list_issues",
+      "mcp__Linear__get_issue",
+      "mcp__Linear__list_projects",
+      "mcp__Linear__get_project",
+      "mcp__Linear__list_initiatives",
+      "mcp__Linear__get_initiative",
+      "mcp__Linear__list_issue_statuses",
+      "mcp__Linear__list_issue_labels",
+      "mcp__Linear__list_cycles"
     ],
     "deny": [
       "Bash(rm -rf /*)",
@@ -105,7 +117,8 @@
       "$defaults",
       "Project build, test, and formatting commands are safe: make compile, make rebuild, make check, make test (and its make test-* variants), make bench, make fetch-seed, make clean, make clean-build, sfn, and build/native/sailfin invocations. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts, never files outside the repo, so treat them as routine, not destructive. This does not extend to make install, which writes to PREFIX/bin outside the repo.",
       "Scheduling and session-management tools from the Claude_Code_Remote MCP server (send_later, create_trigger, and the other trigger tools) are safe.",
-      "All tools from the sailfin MCP server (mcp__sailfin__*: sailfin_check, sailfin_diagnostics, sailfin_fmt_check, sailfin_fmt_write, sailfin_build, sailfin_test, sailfin_emit_native, sailfin_emit_llvm, sailfin_version) are safe. They are the project's own in-repo developer tooling — each is a pure passthrough to a single `sailfin` subcommand, path-restricted to the workspace root, and exists specifically for agents to use during development. Never prompt for them."
+      "All tools from the sailfin MCP server (mcp__sailfin__*: sailfin_check, sailfin_diagnostics, sailfin_fmt_check, sailfin_fmt_write, sailfin_build, sailfin_test, sailfin_emit_native, sailfin_emit_llvm, sailfin_version) are safe. They are the project's own in-repo developer tooling — each is a pure passthrough to a single `sailfin` subcommand, path-restricted to the workspace root, and exists specifically for agents to use during development. Never prompt for them.",
+      "Linear planning tools are safe: the read tools (mcp__Linear__list_issues, get_issue, list_projects, get_project, list_initiatives, get_initiative, list_issue_statuses, list_issue_labels, list_cycles) and the planning writes the /pickup, /groom, /triage, and /sweep skills depend on (mcp__Linear__save_issue, save_project, save_comment). Linear is the project's planning source of truth (team SFN), so creating/updating issues, projects, and comments is routine agent work — never prompt for these. This does NOT extend to destructive Linear tools (mcp__Linear__delete_*), which are not allow-listed and must still prompt."
     ]
   },
   "env": {


### PR DESCRIPTION
## Summary

Follow-up to the Linear-native migration (#2019). A first auto-mode cloud `/pickup` session hit approval prompts when the skill went to create/update a Linear issue — because no `mcp__Linear__*` rule was allow-listed in `.claude/settings.json`. (GitHub tools were already covered by the server-level `mcp__github` entry, so PR/comment ops didn't prompt; Linear had no entry at all.)

## Changes (`.claude/settings.json` only)

- **`permissions.allow`** — added the specific Linear tools the `/pickup`, `/groom`, `/triage`, `/sweep` skills use:
  - Planning writes: `save_issue`, `save_project`, `save_comment`
  - Reads: `list_issues`, `get_issue`, `list_projects`, `get_project`, `list_initiatives`, `get_initiative`, `list_issue_statuses`, `list_issue_labels`, `list_cycles`
- **`autoMode.allow`** — added a note documenting these as routine (mirroring the existing `sailfin` / `Claude_Code_Remote` server notes), so the auto-mode classifier treats them as safe.

## Least-privilege

Deliberately **not** a blanket `mcp__Linear` server allow: the destructive `mcp__Linear__delete_*` tools (delete_comment / delete_issue-relations / delete_customer / etc.) are left off the allow-list, so they still prompt. The `autoMode.allow` note states this explicitly.

## Verification

- `python3 -m json.tool` / `json.load` confirms `.claude/settings.json` is valid JSON with all 12 Linear entries present.
- Config-only change; no `.sfn` touched, no self-host/`sfn fmt` gate.

Branch restarted from `main` since #2019 already merged (its head branch was auto-deleted on merge); this is a new PR, not a reopen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGnur7qUMcSpSMJy5zqbHB)_