### PR TITLE
chore(claude): allowlist Linear MCP server at server level in Auto mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -78,6 +78,7 @@
       "mcp__Claude_Code_Remote",
       "mcp__sailfin",
       "mcp__github",
+      "mcp__Linear",
       "mcp__Linear__save_issue",
       "mcp__Linear__save_project",
       "mcp__Linear__save_comment",
@@ -107,7 +108,12 @@
       "Bash(git commit*--no-verify*)",
       "Bash(git commit*--no-gpg-sign*)",
       "Bash(gh release delete*)",
-      "Bash(gh repo delete*)"
+      "Bash(gh repo delete*)",
+      "mcp__Linear__delete_comment",
+      "mcp__Linear__delete_attachment",
+      "mcp__Linear__delete_customer",
+      "mcp__Linear__delete_customer_need",
+      "mcp__Linear__delete_status_update"
     ]
   },
   "autoMode": {


### PR DESCRIPTION
## What

Add a **server-level** `mcp__Linear` grant to `permissions.allow` in `.claude/settings.json`, and deny the Linear `delete_*` tools so destructive operations still prompt.

## Why

Running in cloud Auto mode, the Linear MCP planning tools (`save_issue`, `save_comment`, etc.) triggered a permission prompt on every call — even though they were already listed individually in `permissions.allow`.

The other MCP servers — `mcp__github`, `mcp__sailfin`, `mcp__Claude_Code_Remote` — are granted at **server level** (`mcp__<server>`, no `__tool` suffix) and never prompted. Linear was the only server granted **per-tool** (`mcp__Linear__save_issue`, …). The cloud Auto-mode runtime honored the server-level grants but prompted on the per-tool Linear entries, so every Linear call fell through to a prompt while github/sailfin sailed past.

This aligns Linear with the working server-level pattern.

## Changes

- `permissions.allow`: add `mcp__Linear` (server-level). Existing per-tool Linear entries left in place as a harmless fallback.
- `permissions.deny`: add `mcp__Linear__delete_comment`, `delete_attachment`, `delete_customer`, `delete_customer_need`, `delete_status_update`. Deny beats allow, so destructive Linear ops continue to require approval — matching the intent already documented in the `autoMode` block ("This does NOT extend to destructive Linear tools").

## Scope / risk

Config-only change to `.claude/settings.json` (validated as parseable JSON). No compiler/runtime source touched, so no self-host or `sfn fmt` gate applies. Permission changes may only take effect in a fresh session rather than hot-reloading mid-session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfcdhQn1agP16Kjra8dpkJ)_