### PR TITLE
Add pull request template with Linear magic-word linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+<!--
+Sailfin PR template. Fill in each section; delete this comment and any
+inapplicable rows. Keep the Linear line — the org webhook links and closes
+the issue from it. See docs/conventions/linear-workflow.md.
+-->
+
+## Summary
+
+<!-- What changed and why, in a few sentences. Which compiler pass(es) or
+runtime module(s) this touches. Link the SFEP if one governs this work. -->
+
+Fixes SFN-<N>
+
+<!--
+Linear magic words (org GitHub integration):
+  - Auto-close on merge: Fixes / Closes / Resolves / Implements / Completes SFN-<N>
+  - Link only, no close: Ref / Refs / Part of / Related to / Contributes to SFN-<N>
+  - Several at once:      Fixes SFN-12, SFN-34 and SFN-56
+  - Suppress linking:     add `skip SFN-<N>` or `ignore SFN-<N>`
+Prefer `Fixes SFN-<N>` for the leaf this PR completes — never `Closes #N`
+(GitHub-issue numbers don't drive our Linear workflow state).
+-->
+
+## Changes
+
+<!-- Bullet the concrete edits, grouped by pipeline stage where it helps:
+     lexer / parser / ast / typecheck / effect_checker / emit_native / llvm
+     lowering / runtime / driver / tests / docs. -->
+
+-
+
+## Validation
+
+<!-- Check what you actually ran. Compiler-source changes MUST clear the
+self-host gate; a green `sfn check` is not a build guarantee (#1389). -->
+
+- [ ] `sfn fmt --check` clean on every touched `.sfn` file
+- [ ] `sfn check` (fast static analysis) passes
+- [ ] `make compile` — compiler self-hosts (required for any `compiler/src/*.sfn` change; `make clean-build` first for structural changes)
+- [ ] `make check` — full suite + seedcheck (for shipped features / releases / structural changes)
+- [ ] Regression coverage added or updated under `compiler/tests/`
+- [ ] N/A — docs/config-only change (no `.sfn` touched)
+
+## Stage1 readiness
+
+<!-- Only for a language/runtime feature. Delete this section otherwise.
+"Parsed but not enforced" is NOT shipped — see CLAUDE.md. -->
+
+- [ ] Parses, type-checks, and effect-checks
+- [ ] Emits valid `.sfn-asm` and lowers to LLVM IR
+- [ ] Effect enforcement wired end-to-end (not annotation-only)
+- [ ] `docs/status.md` and the relevant spec §N chapter updated
+
+## Notes for reviewers
+
+<!-- Risk areas, deferred follow-ups (file a Linear issue and cite it —
+no bare TODO), or anything the diff doesn't make obvious. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,15 +9,15 @@ the issue from it. See docs/conventions/linear-workflow.md.
 <!-- What changed and why, in a few sentences. Which compiler pass(es) or
 runtime module(s) this touches. Link the SFEP if one governs this work. -->
 
-Fixes SFN-<N>
+Fixes SFN-NNN
 
 <!--
 Linear magic words (org GitHub integration):
-  - Auto-close on merge: Fixes / Closes / Resolves / Implements / Completes SFN-<N>
-  - Link only, no close: Ref / Refs / Part of / Related to / Contributes to SFN-<N>
+  - Auto-close on merge: Fixes / Closes / Resolves / Implements / Completes SFN-NNN
+  - Link only, no close: Ref / Refs / Part of / Related to / Contributes to SFN-NNN
   - Several at once:      Fixes SFN-12, SFN-34 and SFN-56
-  - Suppress linking:     add `skip SFN-<N>` or `ignore SFN-<N>`
-Prefer `Fixes SFN-<N>` for the leaf this PR completes — never `Closes #N`
+  - Suppress linking:     add `skip SFN-NNN` or `ignore SFN-NNN`
+Prefer `Fixes SFN-NNN` for the leaf this PR completes — never `Closes #N`
 (GitHub-issue numbers don't drive our Linear workflow state).
 -->
 


### PR DESCRIPTION
## Summary

Adds a repo PR template at `.github/pull_request_template.md`, part of the GitHub → Linear migration. The org's Linear GitHub integration links and closes issues from magic words in the PR body, so the template makes `Fixes SFN-<N>` the default and documents the full keyword set inline. Docs/config-only change — no `.sfn` files touched, so the self-host gate does not apply.

<!-- No governing Linear issue for this tooling change; linking left to the author. -->

## Changes

- **New** `.github/pull_request_template.md`:
  - **Linear linking** front-and-center — `Fixes SFN-<N>` with an inline cheat sheet of the auto-close words (`Fixes`/`Closes`/`Resolves`/`Implements`/`Completes`), the link-only words (`Ref`/`Part of`/`Related to`/`Contributes to`), multi-issue syntax, and `skip`/`ignore` suppression. Steers away from `Closes #N`, which doesn't drive Linear workflow state (per `docs/conventions/issue-naming.md` § Cross-surface flow).
  - **Validation** checklist encoding the repo's ladder — `sfn fmt --check`, `sfn check`, `make compile` (self-host gate, required for any `compiler/src/*.sfn` change), `make check`, plus a docs/config-only escape hatch.
  - **Stage1 readiness** section mirroring the `CLAUDE.md` checklist, with the "parsed but not enforced is not shipped" guard.
  - Reviewer-notes section that nudges toward filing a Linear issue over a bare `TODO`.

## Validation

- [x] N/A — docs/config-only change (no `.sfn` touched)

## Notes for reviewers

Keyword lists verified against Linear's GitHub integration docs. The template is a layout to fill in — sections (e.g. Stage1 readiness) are meant to be deleted when inapplicable. Easy to trim if it reads as too heavy for small PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_011SWhN8kQmCJZmp6eXu2pMN)_