### PR TITLE
perf(test): pre-warm dep-closure module cache before the runner fans out

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -838,7 +838,21 @@ fn cache_store_artifact(root: string, key: CacheKey, kind: string, src_path: str
     let entry_dir = _cache_entry_dir(root, key);
     _ensure_dir_recursive_cmd(entry_dir);
     let dst = cache_artifact_path(root, key, kind);
-    return _cache_atomic_copy(src_path, dst);
+    let stored = _cache_atomic_copy(src_path, dst);
+    if stored {
+        // SFN-148: debug-gated emit ledger. A `.ll` store means a cache
+        // miss→emit just happened; recording the key digest lets a
+        // regression assert each dep module is emitted at most once per
+        // invocation (a duplicate digest == a stampede). Inert unless
+        // SAILFIN_EMIT_LEDGER is set, so real builds pay nothing.
+        if strings_equal(kind, "ll") {
+            let ledger = _get_env_cmd("SAILFIN_EMIT_LEDGER");
+            if ledger.length > 0 {
+                fs.appendFile(ledger, key.digest + "\n");
+            }
+        }
+    }
+    return stored;
 }
 
 // ----------------------------------------------------------------

--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -703,6 +703,10 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
         let mut sf_tb_misses: int = 0;
         let mut overall_rc: int = 0;
         if jobs > 1 {
+            // SFN-148: warm the dep-closure module cache once before the
+            // pool fans out, so the cold-start wave cache-hits instead of
+            // each child re-emitting the shared closure.
+            _prewarm_test_dep_closures(test_files, binary_dir);
             // #1236: bounded worker pool. A sliding window keeps at
             // most `jobs` children live: the launch loop tops the
             // window up via `process.spawn_with_env`, then the parent
@@ -1878,6 +1882,63 @@ fn _test_resolver_consumer_for_group(file_path: string) -> ResolverConsumer ![io
         walk_project_src: false,
         include_host_as_dep: true
     };
+}
+
+// SFN-148: pre-warm the shared module `.ll` cache once per invocation.
+// The parallel worker pool otherwise cold-starts a cache stampede —
+// every child in the first wave re-emits the same dep closure before any
+// cache write lands. Resolving + compiling the union closure here (per
+// resolver group) makes every child cache-hit. Best-effort: a warm
+// failure logs and returns; children then compile per file as before.
+fn _prewarm_test_dep_closures(test_files: string[], binary_dir: string) -> void ![io] {
+    // Partition into resolver groups exactly as the leaf path does
+    // (group key = capsule/project the file resolves under), so a
+    // multi-project invocation warms each project's closure separately.
+    let mut group_keys: string[] = [];
+    let mut group_files: string[][] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= test_files.length { break; }
+        let key = _test_group_key(test_files[i]);
+        // find-or-create the group bucket
+        let mut gi: int = 0;
+        let mut found: int = -1;
+        loop {
+            if gi >= group_keys.length { break; }
+            if strings_equal(group_keys[gi], key) {
+                found = gi;
+                break;
+            }
+            gi += 1;
+        }
+        if found < 0 {
+            group_keys.push(key);
+            let empty: string[] = [];
+            group_files.push(empty);
+            found = group_keys.length - 1;
+        }
+        group_files[found].push(test_files[i]);
+        i += 1;
+    }
+    let mut g: int = 0;
+    loop {
+        if g >= group_files.length { break; }
+        let files = group_files[g];
+        if files.length > 0 {
+            let consumer = _test_resolver_consumer_for_group(files[0]);
+            // Trailing args MUST be exactly ("", "", binary_dir) —
+            // byte-identical to the child call site (currently
+            // test.sfn line ~1028). The module cache key folds
+            // `effective_exe`, which is derived from these args; any
+            // deviation derives a different key and children miss the
+            // warm entries.
+            let res = prepare_project_capsules_for_test(files, consumer, "", "", binary_dir);
+            if res.staging_failed {
+                print.err("[test] warning: dep-closure pre-warm failed for a group (children will compile per file)");
+            }
+        }
+        g += 1;
+    }
 }
 
 fn _find_test_group(groups: TestGroup[], key: string) -> int {

--- a/compiler/tests/e2e/dep_closure_prewarm_test.sfn
+++ b/compiler/tests/e2e/dep_closure_prewarm_test.sfn
@@ -1,0 +1,127 @@
+// Regression test for SFN-148: parent pre-warm of the dep-closure module
+// `.ll` cache before `sfn test <files> --jobs N` fans out its worker pool.
+//
+// On a cold module `.ll` cache, the first wave of concurrent children all
+// LLVM-emit the SAME dep closure before any cache write lands (a
+// stampede) — `_prewarm_test_dep_closures` (compiler/src/cli/commands/
+// test.sfn) closes that by compiling each resolver group's dep closure
+// once in the parent, so every child cache-hits instead.
+//
+// The signal is the `SAILFIN_EMIT_LEDGER`-gated append in
+// `cache_store_artifact` (compiler/src/build_cache.sfn): a `.ll` store
+// fires only on a cache miss→emit, so a digest appearing twice in the
+// ledger is exactly a stampede. Two compiler unit tests that both pull
+// in the heavy parser/typecheck/effect_checker closure and resolve
+// under the same group are run together with `--jobs 4` on a fresh
+// cache; the ledger must contain no duplicate digest.
+//
+// See `.claude/rules/no-bash-e2e.md` for the `*_test.sfn` e2e pattern
+// this follows (mirrors `guillermo_test.sfn` / `sailfin_main_entry_test.sfn`).
+import { split } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+// Two compiler unit tests that each pull in a large dep closure and
+// resolve under the same group (both plain files under
+// `compiler/tests/unit/`, no capsule.toml between them and the repo
+// root). Each must independently exceed the positional-isolation
+// threshold (`_cr_positional_isolation_threshold` = 16 modules,
+// capsule_resolver.sfn): below it a single-file child derives
+// `effective_exe = ""` and a different module cache key than the parent's
+// warm, so it would silently miss the warm and its stampede would not
+// surface as a duplicate. Measured solo closures: atomic_fence ~131,
+// check_tool ~50 — both comfortably clear 16.
+fn _fixture_a() -> string { return "compiler/tests/unit/atomic_fence_test.sfn"; }
+
+fn _fixture_b() -> string { return "compiler/tests/unit/check_tool_test.sfn"; }
+
+// Child environment for the spawned `sfn test` run. Built explicitly
+// (not from `process.environ()`) per `.claude/rules/no-bash-e2e.md`: the
+// nested run spawns its own children that compile+link via clang, so
+// PATH/HOME/TMPDIR must be threaded through — but inheriting the outer
+// environment wholesale would (a) leak the outer runner's managed
+// `SAILFIN_TEST_*` keys into the nested run and (b) risk a pre-existing
+// `SAILFIN_BUILD_CACHE_DIR` shadowing our fresh cold cache via a
+// duplicate env key, making the regression vacuously pass. An empty env
+// array is the EMPTY environment (never "inherit"), so thread each key.
+fn _child_env(cache_dir: string, ledger: string, scratch_dir: string) -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    e.push("SAILFIN_BUILD_CACHE_DIR=" + cache_dir);
+    e.push("SAILFIN_EMIT_LEDGER=" + ledger);
+    e.push("SAILFIN_TEST_SCRATCH=" + scratch_dir);
+    return e;
+}
+
+// Non-empty digest lines from the ledger (missing file → empty list).
+fn _ledger_lines(ledger: string) -> string[] ![io] {
+    let mut lines: string[] = [];
+    if !fs.exists(ledger) { return lines; }
+    let text = fs.readFile(ledger);
+    let raw_lines = split(text, "\n");
+    let mut i: int = 0;
+    loop {
+        if i >= raw_lines.length { break; }
+        if raw_lines[i].length > 0 { lines.push(raw_lines[i]); }
+        i += 1;
+    }
+    return lines;
+}
+
+// Returns 1 if `lines` contains a duplicate digest, 0 otherwise.
+fn _has_duplicate(lines: string[]) -> int {
+    let mut a: int = 0;
+    loop {
+        if a >= lines.length { break; }
+        let mut b: int = a + 1;
+        loop {
+            if b >= lines.length { break; }
+            if lines[a] == lines[b] { return 1; }
+            b += 1;
+        }
+        a += 1;
+    }
+    return 0;
+}
+
+test "dep-closure pre-warm: no dep module is emitted more than once under --jobs" ![io] {
+    // Outcome codes: -1 environmental skip (nested build couldn't run);
+    // 0 pass; 1 duplicate digest (stampede, or a prewarm whose key missed
+    // the children); 2 emits suppressed (exit 0 but empty ledger).
+    let outcome = with_tmp_dir(fn (dir: string) -> int {
+        let cache_dir = dir + "/cache";
+        let ledger = dir + "/emit.ledger";
+        let scratch_dir = dir + "/scratch";
+        let env_vec = _child_env(cache_dir, ledger, scratch_dir);
+        let exit = process.run_capture([_sfn_bin(), "test", _fixture_a(), _fixture_b(), "--jobs", "4", "--no-test-cache"], env_vec);
+        let _out = process.capture_take_stdout();
+        let _err = process.capture_take_stderr();
+        // Non-zero exit ⇒ the nested build/run could not complete (e.g. no
+        // clang/linker on PATH). The ledger can't be trusted; skip.
+        if exit != 0 { return -1; }
+        // Healthy run on a COLD cache: every dep module is a miss→emit→
+        // store, so the ledger MUST be non-empty. An empty ledger on a
+        // clean exit means a change suppressed emits (including the
+        // prewarm's own) — a real regression, never a vacuous pass.
+        let lines = _ledger_lines(ledger);
+        if lines.length == 0 { return 2; }
+        return _has_duplicate(lines);
+    });
+    if outcome == -1 {
+        // Environmental skip: the nested toolchain could not build.
+        assert true;
+    } else {
+        // 0 pass; 1 stampede/duplicate; 2 emits suppressed (vacuous).
+        assert outcome == 0;
+    }
+}

--- a/compiler/tests/e2e/dep_closure_prewarm_test.sfn
+++ b/compiler/tests/e2e/dep_closure_prewarm_test.sfn
@@ -94,11 +94,28 @@ fn _has_duplicate(lines: string[]) -> int {
     return 0;
 }
 
+// True when a `clang` toolchain is on PATH — the nested `sfn test` build
+// needs it (compile + link). Probing lets the test skip ONLY when the
+// host toolchain is absent, so a genuine nested-run failure (clang
+// present but `sfn test` regressed) is surfaced rather than masked.
+fn _clang_available() -> boolean ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let exit = process.run_capture(["clang", "--version"], e);
+    let _o = process.capture_take_stdout();
+    let _er = process.capture_take_stderr();
+    return exit == 0;
+}
+
 test "dep-closure pre-warm: no dep module is emitted more than once under --jobs" ![io] {
-    // Outcome codes: -1 environmental skip (nested build couldn't run);
-    // 0 pass; 1 duplicate digest (stampede, or a prewarm whose key missed
-    // the children); 2 emits suppressed (exit 0 but empty ledger).
+    // Outcome codes: -1 skip (host toolchain absent); 0 pass; 1 duplicate
+    // digest (stampede, or a prewarm whose key missed the children); 2
+    // emits suppressed (exit 0 but empty ledger); 3 nested run failed with
+    // the toolchain present (a genuine `sfn test` regression to surface).
     let outcome = with_tmp_dir(fn (dir: string) -> int {
+        // Skip only when the toolchain the nested build needs is missing.
+        if !_clang_available() { return -1; }
         let cache_dir = dir + "/cache";
         let ledger = dir + "/emit.ledger";
         let scratch_dir = dir + "/scratch";
@@ -106,9 +123,9 @@ test "dep-closure pre-warm: no dep module is emitted more than once under --jobs
         let exit = process.run_capture([_sfn_bin(), "test", _fixture_a(), _fixture_b(), "--jobs", "4", "--no-test-cache"], env_vec);
         let _out = process.capture_take_stdout();
         let _err = process.capture_take_stderr();
-        // Non-zero exit ⇒ the nested build/run could not complete (e.g. no
-        // clang/linker on PATH). The ledger can't be trusted; skip.
-        if exit != 0 { return -1; }
+        // Toolchain is present, so a non-zero exit is a real failure of the
+        // nested `sfn test` (not an environmental skip) — surface it.
+        if exit != 0 { return 3; }
         // Healthy run on a COLD cache: every dep module is a miss→emit→
         // store, so the ledger MUST be non-empty. An empty ledger on a
         // clean exit means a change suppressed emits (including the
@@ -118,10 +135,10 @@ test "dep-closure pre-warm: no dep module is emitted more than once under --jobs
         return _has_duplicate(lines);
     });
     if outcome == -1 {
-        // Environmental skip: the nested toolchain could not build.
+        // Skip: the nested toolchain (clang) is not installed.
         assert true;
     } else {
-        // 0 pass; 1 stampede/duplicate; 2 emits suppressed (vacuous).
+        // 0 pass; 1 stampede/duplicate; 2 emits suppressed; 3 nested run failed.
         assert outcome == 0;
     }
 }

--- a/docs/proposals/design-notes/sfn-148-dep-closure-prewarm.md
+++ b/docs/proposals/design-notes/sfn-148-dep-closure-prewarm.md
@@ -15,7 +15,7 @@ compiler dep closure (parser/typecheck/effect_checker/…). On a **cold** shared
 module `.ll` cache the first concurrent wave all LLVM-emit the same closure
 before any cache write lands — an 8× CPU / 5.8× wall stampede at jobs 8.
 
-## Decision: (a) parent pre-warm — rejected (b) single-flight lock
+## Decision: chose (a) parent pre-warm; rejected (b) single-flight lock
 
 Before fanning out children, the parent resolves the **union** dep closure across
 all test files (per resolver group) and compiles each unique module once into the
@@ -52,7 +52,7 @@ subprocess-per-module isolation + parallel-fan for free (large closure ⇒ non-e
 
 The warm call is thus byte-identical to the child's line 1028 except `entry_paths`
 is the whole group's file list. That multi-file-group shape of
-`prepare_project_capsules_for_test` is already the exercised in-process path
+`prepare_project_capsules_for_test` is already exercised in the in-process path
 (line 1028), and it only resolves + compiles module `.ll`s (no link, no run), so it
 sidesteps the resolver-union execution conflict (`test.sfn` ~560) that the
 subprocess fan-out exists to avoid.

--- a/docs/proposals/design-notes/sfn-148-dep-closure-prewarm.md
+++ b/docs/proposals/design-notes/sfn-148-dep-closure-prewarm.md
@@ -1,0 +1,92 @@
+# Design note — SFN-148: parent pre-warm of the dep-closure module `.ll` cache
+
+Successor to **SFEP-0044** (`0044-test-runner-invocation-cache.md`, Implemented)
+— realizes dep-closure *compile* sharing, which SFEP-0044 tracked as `#2010` and
+kept distinct from its work item C (resolver-pass sharing = SFN-141, gated on
+proposal 0006). This is a design-note, not a new SFEP: no language/ABI/parser
+change, no seed dependency, modest driver-only surface.
+
+## Problem
+
+`sfn test <files> --jobs N` (`compiler/src/cli/commands/test.sfn`, `fn run`
+multi-file branch, ~583) spawns a bounded pool of N children, each of which
+runs `prepare_project_capsules_for_test([its_file], …)` and compiles the shared
+compiler dep closure (parser/typecheck/effect_checker/…). On a **cold** shared
+module `.ll` cache the first concurrent wave all LLVM-emit the same closure
+before any cache write lands — an 8× CPU / 5.8× wall stampede at jobs 8.
+
+## Decision: (a) parent pre-warm — rejected (b) single-flight lock
+
+Before fanning out children, the parent resolves the **union** dep closure across
+all test files (per resolver group) and compiles each unique module once into the
+shared content-addressed `.ll` cache, mirroring the shipped runtime-identity-stamp
+warming (`test.sfn` ~644–670, SFEP-0044 work item A). Children then all cache-hit
+and skip the emit.
+
+**Why not (b) single-flight lock.** No cross-process exclusive-create / `flock`
+primitive exists in the runtime today: `_ensure_dir_cmd` is `mkdir -p` (idempotent,
+not exclusive) and cache stores are temp+rename (`build_cache.sfn`
+`cache_store_artifact`, `build/fs.sfn` `_atomic_rename_into_place`). (b) would
+require a **new runtime primitive** (`O_CREAT|O_EXCL` / `flock`) plus stale-lock
+crash recovery, and it would touch the general `cache_store_artifact` path used by
+every build (large blast radius). (a) reuses `_cr_resolve_and_dedupe` +
+`compile_capsule_modules` verbatim, needs no new primitive, and mirrors shipped
+precedent — smaller and self-hosting-safe.
+
+## The cache-key parity constraint (load-bearing)
+
+Children call `prepare_project_capsules_for_test(entry, consumer, "", "", binary_dir)`
+(`test.sfn` ~1028): `sailfin_exe=""`, `work_dir=""`, real `binary_dir`. The module
+`.ll` cache key mixes `cache_compiler_identity(version, effective_exe)`
+(`capsule_resolver.sfn` ~1742), where `effective_exe =
+_cr_effective_isolation_exe(sailfin_exe, binary_dir, source_count)`. For the heavy
+closure (source_count ≫ 16 threshold) that resolves to `binary_dir + "/sailfin"`.
+
+Therefore the parent warm **must pass the identical trailing arguments**
+(`sailfin_exe=""`, `work_dir=""`, same `binary_dir`) so `_cr_effective_isolation_exe`
+derives the same `effective_exe`, yielding identical keys — otherwise (e.g. passing
+`self_exe` directly) a `.dirty` dev stamp would key the warm entries differently
+and children would miss them. Passing `""`+`binary_dir` also gives the parent
+subprocess-per-module isolation + parallel-fan for free (large closure ⇒ non-empty
+`effective_exe` ⇒ `go_parallel`), so the parent warm neither OOMs nor serializes.
+
+The warm call is thus byte-identical to the child's line 1028 except `entry_paths`
+is the whole group's file list. That multi-file-group shape of
+`prepare_project_capsules_for_test` is already the exercised in-process path
+(line 1028), and it only resolves + compiles module `.ll`s (no link, no run), so it
+sidesteps the resolver-union execution conflict (`test.sfn` ~560) that the
+subprocess fan-out exists to avoid.
+
+## Gating (no regression to warm / serial / single-file)
+
+- Multi-file branch only (already guaranteed at ~583).
+- `jobs > 1` only: serial already warms via child[0]; pre-warm there just adds a
+  redundant union resolve with no benefit.
+- Best-effort / non-fatal: on `staging_failed` (or `has_collision`) log a warning
+  and continue — children fall back to today's behavior; correctness never depends
+  on the warm succeeding.
+- Warm-when-already-warm cost is one union resolve (O(closure), `#1247`
+  scan-memoized) + all-hit lookups (no emit) — bounded, comparable to the JSON
+  pre-parse the parent already does at ~680.
+
+## Emit-ledger observability (for the regression test)
+
+Gate an append-only emit ledger behind `SAILFIN_EMIT_LEDGER=<path>` at the single
+store choke point `cache_store_artifact` (`build_cache.sfn` ~838), on the success
+path only: when the env is set and `kind == "ll"`, append `<digest>\n` via
+`fs.appendFile` (implemented as `fopen(..., "ab")` = `O_APPEND`, so the short
+~65-byte line is a single atomic `write()` — non-interleaving across the concurrent
+parent + child appenders; no per-store subprocess, no new runtime primitive; when
+the env is unset the only added cost is one in-process `getenv`). A store fires only
+on a cache **miss → emit**, so a duplicate digest in the ledger is exactly a
+stampede. Order-independent set-uniqueness makes the assertion non-flaky under the
+pool. The regression additionally asserts the ledger is non-empty on a clean exit,
+so a change that suppresses all emits cannot pass vacuously.
+
+## Effects / self-hosting
+
+All changes are `![io]` build/test-driver code (`test.sfn`, `build_cache.sfn`);
+no new effects, keywords, or pipeline-pass changes. `make compile` self-hosts from
+the old seed in one pass (the driver *is* the compiler; no cross-consumer seed
+gate — one PR). No change to test-bin cache semantics or `--no-test-cache` (module
+`.ll` cache is orthogonal), so `make check` stays cold-by-policy for test-bins.


### PR DESCRIPTION
## Summary

- At `sfn test <files> --jobs N` the parent forks a worker pool; on a **cold** module `.ll` cache the first concurrent wave of children all LLVM-emit the *same* imported compiler-module dep closure (parser/typecheck/…) before any cache write lands — a cold-start **stampede** that emits the shared closure ~N times instead of once.
- The shared content-addressed caches already exist and are genuinely shared on-disk; the invocation just never lets them warm before fan-out. Fix: the parent compiles each resolver group's union dep closure **once** before launching the pool (`_prewarm_test_dep_closures`), so every child cache-hits. Best-effort/non-fatal; gated to the multi-file `jobs > 1` path. Mirrors the shipped runtime-identity-stamp warming (SFEP-0044 work item A) — no new machinery, **no seed cut** (the driver *is* the compiler; one self-host pass).

Fixes SFN-148

## Investigation (Linux x86_64)

The caches are not the problem — a warm sequential build is already 9.5× faster than cold (2.9s vs 27.8s CPU/file). The waste is the concurrent cold start. `--no-test-cache` disables only the *test-bin* cache, not the module `.ll` cache.

| Cold parallel, 12 heavy-closure unit files @ jobs 8, `--no-test-cache` | User CPU | Wall |
|---|---|---|
| Baseline (before) | 1088s | 5:10 |
| **Fixed (pre-warm)** | **392s** | **3:14** |
| Warm floor (reference) | 136s | 0:53 |

Cold-parallel CPU drops **2.8×** (−64%); the cold/warm CPU ratio falls from 8.0× to 2.9×. The residual is the parent's one-time cold union emit + per-child verification/link — the territory of the sibling issues (SFN-141 resolver sharing, SFN-149 `.ll→.o` object cache, SFN-150 import re-parse), explicitly out of scope here.

## Load-bearing detail

The pre-warm's cache key must match the children's, or the warm silently no-ops. It calls `prepare_project_capsules_for_test` with the byte-identical `("", "", binary_dir)` trailing args the leaf child uses, so the folded `effective_exe` (and thus the module key) agrees. The regression catches a parity break directly: a mis-keyed child re-emits → duplicate digest → test fails.

## Acceptance Criteria

- [x] Cold `sfn test <unit-subset> --jobs 8 --no-test-cache` total user CPU drops materially — cold-parallel no longer ~8× warm (now 2.9×); each unique dep module emitted ≤ once per invocation.
- [x] Unit tier per-file cold cost drops proportionally (12-file subset: wall −37%, CPU −64%).
- [x] `make compile` self-hosts.
- [x] `make test` green — unit 201/201, integration 42/42, e2e 204/204, capsules 38/38.
- [x] Regression test covering the single-emit / no-stampede behavior (`compiler/tests/e2e/dep_closure_prewarm_test.sfn`).
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Map reconciliation

Advisory `## Files Affected` from the issue: `test.sfn`, `capsule_resolver.sfn`, `build_cache.sfn`, `build/fs.sfn`. Actual: `test.sfn` (parent pre-warm) and `build_cache.sfn` (emit ledger) only. `capsule_resolver.sfn` needed no change — the pre-warm *reuses* `prepare_project_capsules_for_test` verbatim. `build/fs.sfn` needed no change — `fs.appendFile` already exists and is `O_APPEND`-atomic for the short digest line. In-scope reconciliation, no semantic drift.

## Verification

```bash
# Headline (cold parallel, heavy-closure unit subset)
export SAILFIN_BUILD_CACHE_DIR=$(mktemp -d)
FILES=$(grep -l 'from "\.\./\.\./src/\(parser\|typecheck\|effect_checker\)' compiler/tests/unit/*_test.sfn | head -12)
/usr/bin/time -v build/native/sailfin test $FILES --jobs 8 --no-test-cache   # 1088s -> 392s CPU

build/native/sailfin test compiler/tests/e2e/dep_closure_prewarm_test.sfn    # PASS
make compile   # self-hosts
make test      # 485/485 green
```

## Files Changed

- `compiler/src/cli/commands/test.sfn` — `_prewarm_test_dep_closures` helper + one gated call at the top of the `jobs > 1` block.
- `compiler/src/build_cache.sfn` — `SAILFIN_EMIT_LEDGER`-gated `.ll`-store ledger in `cache_store_artifact` (inert unless the env is set).
- `compiler/tests/e2e/dep_closure_prewarm_test.sfn` — new regression (asserts no duplicate emit per invocation; non-empty ledger on clean exit so it can't pass vacuously).
- `docs/proposals/design-notes/sfn-148-dep-closure-prewarm.md` — design record.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbrwZKbQvGAi41T5cGey4w)_