### PR TITLE
docs(sfep-0045): link implementing issue SFN-152 in tracking front-matter

### DIFF
--- a/docs/proposals/0045-shared-frontend-test-runner.md
+++ b/docs/proposals/0045-shared-frontend-test-runner.md
@@ -4,9 +4,9 @@ title: Shared-frontend test runner — parent compiles, children only execute
 status: Accepted
 type: tooling
 created: 2026-07-08
-updated: 2026-07-08
+updated: 2026-07-09
 author: "agent:compiler-architect; human review"
-tracking: "#2010, #1997"
+tracking: "SFN-152, #2010, #1997"
 supersedes:
 superseded-by:
 graduates-to:


### PR DESCRIPTION
## Summary

Grooming artifact for **SFEP-0045 — Shared-frontend test runner: parent compiles, children only execute** (Accepted). The epic was decomposed into its single implementing Linear issue (**SFN-152**, Ready/High, under *Test-Infra Phase 4 — Parallel Test Execution*), and this PR records that issue in the SFEP's `tracking:` front-matter. Docs-only; no compiler source touched.

Related to SFN-152

<!-- link-only on purpose: SFN-152 is the not-yet-done implementation issue; this grooming PR must not auto-close it. -->

## Changes

- docs: `docs/proposals/0045-shared-frontend-test-runner.md` — add `SFN-152` to `tracking:`, bump `updated:` to 2026-07-09.

## Validation

- [x] N/A — docs/config-only change (no `.sfn` touched)

## Notes for reviewers

Companion to the grooming pass, not implementation:
- **SFN-152** carries SFEP-0045 Phases A + B bundled in one PR (parent compiles per resolver group + exec-only `__run-test-bin` child), plus the four e2e isolation/cache regressions. Seed dependency: **None** (pure `[io]` driver orchestration).
- Phase C (fan compile across a bounded pool) is left in SFEP-0045 §3.2 only — deferred, gated on the structured-concurrency runtime + per-thread arenas.
- The narrower resolver-dedup precursor (former **SFN-24** / #1997) was canceled as superseded; its scope is folded into SFN-152.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZLYWNuGoGGE29pWguqgLT)_