### PR TITLE
refactor(llvm): reconcile prelude-mirror registry rows against the prelude define; fatal on drift

### DIFF
--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -144,7 +144,7 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
 
     // Runtime helper declarations
     if debug_lowering { print.err("emit-llvm: phase=render_helpers"); }
-    let helper_declarations = render_runtime_helper_declarations(runtime_helpers, local_functions, imported_functions);
+    let helper_declarations = render_runtime_helper_declarations(runtime_helpers, local_functions, imported_functions, type_context);
     if helper_declarations != null {
         if helper_declarations.length > 0 {
             lines = extend_string_lines(lines, helper_declarations);

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -102,7 +102,99 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
 // =============================================================================
 // Runtime Helper Declarations
 // =============================================================================
-fn render_runtime_helper_declarations(used_targets: string[], local_functions: NativeFunction[], imported_functions: NativeFunction[]) -> string[] {
+// #1779 (SFEP-0035 §3.1): locate an imported prelude function by its sanitized
+// LLVM symbol so a `target == symbol` mirror registry row can be reconciled
+// against that function's real lowered signature before the declare loop defers
+// to the imported declare.
+fn _find_imported_fn_by_symbol(imported_functions: NativeFunction[], symbol: string) -> NativeFunction? {
+    let mut index: int = 0;
+    loop {
+        if index >= imported_functions.length { break; }
+        if sanitize_symbol(imported_functions[index].name) == symbol {
+            return imported_functions[index];
+        }
+        index += 1;
+    }
+    return null;
+}
+
+// #1779 (SFEP-0035 §3.1): the enumerated prelude-mirror targets — registry rows
+// whose `return_type`/`parameter_types` hand-transcribe a `runtime/prelude.sfn`
+// function (§2.1). Reconciliation is gated on this explicit set rather than the
+// structural `target == symbol && native_signature == null` predicate: the
+// libc-fallback rows `nanosleep` / `clock_gettime` also satisfy that structural
+// shape but are NOT prelude mirrors — their registry signature is the deliberate
+// opaque-pointee `i8*` form that differs by design from the `%Timespec*` import
+// they defer to, so reconciling them would false-positive. The follow-up that
+// derives these rows from the prelude and deletes the hand-typed set is #1780
+// (SFEP-0035 §3.2); when it lands, this list and the guard retire together.
+fn _is_prelude_mirror_target(target: string) -> boolean {
+    if target == "char_code" { return true; }
+    if target == "char_at" { return true; }
+    if target == "char_from_code" { return true; }
+    if target == "find_char" { return true; }
+    if target == "string_starts_with" { return true; }
+    if target == "record_eq_flag_message" { return true; }
+    return false;
+}
+
+// #1779 (SFEP-0035 §3.1): element-wise LLVM shape-string comparison for the
+// mirror-row reconciliation.
+fn _llvm_shape_lists_equal(registry: string[], prelude: string[]) -> boolean {
+    if registry.length != prelude.length { return false; }
+    let mut index: int = 0;
+    loop {
+        if index >= registry.length { break; }
+        if registry[index] != prelude[index] { return false; }
+        index += 1;
+    }
+    return true;
+}
+
+// #1779 (SFEP-0035 §3.1): reconcile one prelude-mirror registry row against the
+// prelude function's actual lowered signature. The imported function's
+// parameter/return types are lowered with the same `map_return_type` /
+// `collect_parameter_types` the imported-declare pass
+// (`render_imported_function_declarations`) applies, so the compared shapes are
+// exactly the ones that would be emitted. On drift the fatal names the target
+// and both shapes and `throw`s: the synthesized `@main` wrapper renders the
+// message to stderr and exits non-zero, so the *next* `make compile` fails at
+// the moment drift is introduced instead of silently mis-declaring the helper
+// on a fallback path (where the registry row, not the prelude declare, fires).
+fn _reconcile_mirror_row_or_fatal(descriptor: RuntimeHelperDescriptor, imported_functions: NativeFunction[], effective_symbol: string, context: TypeContext) -> void {
+    let imported = _find_imported_fn_by_symbol(imported_functions, effective_symbol);
+    if imported != null {
+        let prelude_return = map_return_type(context, imported.return_type);
+        let prelude_params = collect_parameter_types(context, imported.parameters, imported.name);
+        let mut _drift: boolean = false;
+        // Compare against `descriptor.return_type` (the caller-visible return),
+        // not `effective_helper_declare_return_type(descriptor)`: the six mirror
+        // rows all carry `c_abi_return_type == null`, so the two collapse to the
+        // same value. A mirror row that ever opts into the #638 post-call
+        // coercion (`c_abi_return_type` set) would need the effective return here.
+        if prelude_return != descriptor.return_type { _drift = true; }
+        if !_llvm_shape_lists_equal(descriptor.parameter_types, prelude_params) {
+            _drift = true;
+        }
+        if _drift {
+            let registry_shape = descriptor.return_type + "("
+                + join_with_separator(descriptor.parameter_types, ", ")
+                + ")";
+            let prelude_shape = prelude_return + "(" + join_with_separator(prelude_params, ", ")
+                + ")";
+            throw "runtime-helper mirror row '" + descriptor.target
+                + "' signature drift: registry declares "
+                + registry_shape
+                + " but prelude '"
+                + effective_symbol
+                + "' lowers to "
+                + prelude_shape
+                + "; update compiler/src/llvm/runtime_helpers.sfn or the prelude in lock-step";
+        }
+    }
+}
+
+fn render_runtime_helper_declarations(used_targets: string[], local_functions: NativeFunction[], imported_functions: NativeFunction[], context: TypeContext) -> string[] {
     if used_targets.length == 0 { return []; }
     // Build list of local function symbols to avoid declaring helpers that are defined locally
     let mut local_symbols: string[] = [];
@@ -306,6 +398,28 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             let mut _shadowed_by_import: boolean = false;
             if descriptor.target == descriptor.symbol {
                 if string_array_contains(imported_symbols, effective_symbol) {
+                    // #1779 (SFEP-0035 §3.1): before deferring to the prelude's
+                    // imported declare, reconcile the registry mirror row's
+                    // hand-typed shape against the prelude function's actual
+                    // lowered signature, so any future drift becomes a loud
+                    // build-time fatal on a normal build (where the prelude IS
+                    // imported) instead of a silent ABI mismatch on the fallback
+                    // paths (where the registry row, not the import, fires).
+                    //
+                    // Restricted to the enumerated prelude-mirror targets, NOT
+                    // every `target == symbol && native_signature == null` row:
+                    // the libc-fallback rows `nanosleep` / `clock_gettime` also
+                    // match that structural shape but are NOT prelude mirrors —
+                    // their registry signature is the deliberate opaque-pointee
+                    // form (`i8*`) that intentionally differs from the staged
+                    // `posix.sfn` `%Timespec*` import it defers to, so
+                    // reconciling them would be a false-positive drift. Those
+                    // rows keep the plain #633 suppression below; only the six
+                    // rows that genuinely mirror a `runtime/prelude.sfn`
+                    // definition are reconciled.
+                    if _is_prelude_mirror_target(descriptor.target) {
+                        _reconcile_mirror_row_or_fatal(descriptor, imported_functions, effective_symbol, context);
+                    }
                     _shadowed_by_import = true;
                 }
             }

--- a/compiler/tests/integration/prelude_mirror_reconcile_test.sfn
+++ b/compiler/tests/integration/prelude_mirror_reconcile_test.sfn
@@ -1,0 +1,114 @@
+// compiler/tests/integration/prelude_mirror_reconcile_test.sfn
+//
+// T1 for #1779 (SFEP-0035 §3.1): the prelude-mirror reconciliation guard's
+// positive path. `render_runtime_helper_declarations` reconciles each
+// `target == symbol && native_signature == null` registry mirror row against
+// the imported prelude function's real lowered signature before deferring to
+// the imported declare (#633 suppression); a drift throws a fatal.
+//
+// This pins the SFEP §2.1 table for the rows whose registry shape matches the
+// prelude define today: feeding each with its true prelude source-level
+// signature must reconcile cleanly (no throw) and suppress the registry row
+// (the import wins, so the helper symbol is NOT re-declared here). If a future
+// change drifts one of these registry rows away from its prelude definition,
+// the guard fires and this test goes red.
+//
+// `char_from_code` is intentionally excluded: its registry row declares `i8*`
+// while the prelude `char_from_code(code: int) -> string` lowers to
+// `{i8*, i64}`. That row is a pre-existing latent drift that never surfaces at
+// build time because `char_from_code` is emitted from the registry directly and
+// is never imported/shadowed — so the guard never reconciles it. Structurally
+// deriving (and thereby fixing) the hand-typed rows is the sequenced follow-up
+// #1780 (SFEP-0035 §3.2); this guard only makes drift loud when a mirror symbol
+// IS imported.
+import { find } from "sfn/strings";
+
+import { render_runtime_helper_declarations } from "../../src/llvm/rendering";
+import { TypeContext } from "../../src/llvm/types";
+import { NativeFunction, NativeParameter } from "../../src/native_ir";
+
+fn _empty_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
+}
+
+fn _param(type_annotation: string) -> NativeParameter {
+    return NativeParameter {
+        name: "p",
+        type_annotation: type_annotation,
+        mutable: false,
+        default_value: null,
+        span: null
+    };
+}
+
+fn _fn(name: string, return_type: string, parameters: NativeParameter[]) -> NativeFunction {
+    return NativeFunction {
+        name: name,
+        is_async: false,
+        parameters: parameters,
+        return_type: return_type,
+        effects: [],
+        decorators: [],
+        is_extern: true,
+        instructions: []
+    };
+}
+
+// True if any emitted line declares `@<symbol>(`.
+fn _declares(lines: string[], symbol: string) -> boolean {
+    let needle = "@" + symbol + "(";
+    let mut i: int = 0;
+    loop {
+        if i >= lines.length { break; }
+        if find(lines[i], "declare ", 0) == 0 {
+            if find(lines[i], needle, 0) >= 0 { return true; }
+        }
+        i += 1;
+    }
+    return false;
+}
+
+// Drive the emitter with a single mirror `target` and one imported prelude
+// function carrying `return_type`/`params` (source-level spellings). Returns
+// whether the registry row was suppressed (import wins → symbol NOT declared).
+// A signature drift would throw before returning, failing the test.
+fn _reconciles_and_suppresses(target: string, return_type: string, params: NativeParameter[]) -> boolean {
+    let no_locals: NativeFunction[] = [];
+    let imports: NativeFunction[] = [_fn(target, return_type, params)];
+    let lines = render_runtime_helper_declarations([target], no_locals, imports, _empty_context());
+    return !_declares(lines, target);
+}
+
+test "prelude-mirror reconcile (#1779): char_code reconciles clean and is suppressed" {
+    // prelude: char_code(character: string) -> int  ⇒  i64 ⟵ [{i8*, i64}]
+    assert _reconciles_and_suppresses("char_code", "int", [_param("string")]);
+}
+
+test "prelude-mirror reconcile (#1779): char_at reconciles clean and is suppressed" {
+    // prelude: char_at(value: string, index: int) -> string
+    //          ⇒  {i8*, i64} ⟵ [{i8*, i64}, i64]
+    assert _reconciles_and_suppresses("char_at", "string", [_param("string"), _param("int")]);
+}
+
+test "prelude-mirror reconcile (#1779): find_char reconciles clean and is suppressed" {
+    // prelude: find_char(text: string, character: string, start: int) -> int
+    //          ⇒  i64 ⟵ [{i8*, i64}, {i8*, i64}, i64]
+    assert _reconciles_and_suppresses("find_char", "int", [_param("string"), _param("string"), _param("int")]);
+}
+
+test "prelude-mirror reconcile (#1779): string_starts_with reconciles clean and is suppressed" {
+    // prelude: string_starts_with(value: string, prefix: string) -> boolean
+    //          ⇒  i1 ⟵ [{i8*, i64}, {i8*, i64}]
+    assert _reconciles_and_suppresses("string_starts_with", "boolean", [_param("string"), _param("string")]);
+}
+
+test "prelude-mirror reconcile (#1779): record_eq_flag_message reconciles clean and is suppressed" {
+    // prelude: record_eq_flag_message(boolean, string, boolean, string) -> boolean
+    //          ⇒  i1 ⟵ [i1, {i8*, i64}, i1, {i8*, i64}]
+    assert _reconciles_and_suppresses("record_eq_flag_message", "boolean", [_param("boolean"), _param("string"), _param("boolean"), _param("string")]);
+}

--- a/compiler/tests/integration/prelude_mirror_reconcile_test.sfn
+++ b/compiler/tests/integration/prelude_mirror_reconcile_test.sfn
@@ -2,9 +2,13 @@
 //
 // T1 for #1779 (SFEP-0035 §3.1): the prelude-mirror reconciliation guard's
 // positive path. `render_runtime_helper_declarations` reconciles each
-// `target == symbol && native_signature == null` registry mirror row against
+// *enumerated* prelude-mirror registry row (`_is_prelude_mirror_target`) against
 // the imported prelude function's real lowered signature before deferring to
-// the imported declare (#633 suppression); a drift throws a fatal.
+// the imported declare (#633 suppression); a drift throws a fatal. The gate is
+// an explicit six-target set, NOT every `target == symbol && native_signature
+// == null` row — libc-fallback rows (`nanosleep` / `clock_gettime`) share that
+// structural shape but are exempt (see the `nanosleep` case in the T2 unit
+// test).
 //
 // This pins the SFEP §2.1 table for the rows whose registry shape matches the
 // prelude define today: feeding each with its true prelude source-level

--- a/compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
+++ b/compiler/tests/unit/prelude_helper_declare_dedup_test.sfn
@@ -99,7 +99,7 @@ test "declare-dedup (#1736): extract_declared_symbol_names reads symbols from de
 // ── Pass 1 emits the typed declare for the target != symbol rows ──
 test "declare-dedup (#1736): helper pass emits the typed print/concat declares" {
     let no_locals: NativeFunction[] = [];
-    let helper_lines = render_runtime_helper_declarations(["print", "concat"], no_locals, _colliding_imports());
+    let helper_lines = render_runtime_helper_declarations(["print", "concat"], no_locals, _colliding_imports(), _empty_context());
     assert _declare_count(helper_lines, "sfn_print") == 1;
     assert _declare_count(helper_lines, "sfn_array_concat") == 1;
 }
@@ -108,7 +108,7 @@ test "declare-dedup (#1736): helper pass emits the typed print/concat declares" 
 test "declare-dedup (#1736): imported pass defers to the typed helper declare" {
     let no_locals: NativeFunction[] = [];
     let imports = _colliding_imports();
-    let helper_lines = render_runtime_helper_declarations(["print", "concat"], no_locals, imports);
+    let helper_lines = render_runtime_helper_declarations(["print", "concat"], no_locals, imports, _empty_context());
     let already = extract_declared_symbol_names(helper_lines);
 
     // With the helper-declared set threaded in, pass 2 emits NO second declare.

--- a/compiler/tests/unit/prelude_mirror_drift_fatal_test.sfn
+++ b/compiler/tests/unit/prelude_mirror_drift_fatal_test.sfn
@@ -1,0 +1,132 @@
+// compiler/tests/unit/prelude_mirror_drift_fatal_test.sfn
+//
+// T2 for #1779 (SFEP-0035 §3.1): the prelude-mirror reconciliation guard
+// actually FATALS on drift — the failure mode the whole guard exists to catch.
+//
+// `render_runtime_helper_declarations` reconciles each
+// `target == symbol && native_signature == null` mirror registry row against
+// the imported prelude function's real lowered signature before deferring to
+// it (#633 suppression). When the two disagree it throws a `signature drift`
+// fatal naming the target and both shapes; the synthesized `@main` wrapper
+// renders that to stderr and exits non-zero, so `make compile` fails at the
+// moment drift is introduced instead of silently mis-declaring the helper on a
+// fallback path.
+//
+// Here the real registry `char_code` row (i64 ⟵ [{i8*, i64}]) is fed an
+// imported `char_code` whose return deliberately disagrees (string ⇒
+// {i8*, i64}), so the guard must fire.
+import { expect_to_throw, expect_to_throw_with } from "sfn/test";
+
+import { render_runtime_helper_declarations } from "../../src/llvm/rendering";
+import { TypeContext } from "../../src/llvm/types";
+import { NativeFunction, NativeParameter } from "../../src/native_ir";
+
+fn _empty_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
+}
+
+fn _param(type_annotation: string) -> NativeParameter {
+    return NativeParameter {
+        name: "p",
+        type_annotation: type_annotation,
+        mutable: false,
+        default_value: null,
+        span: null
+    };
+}
+
+fn _fn(name: string, return_type: string, parameters: NativeParameter[]) -> NativeFunction {
+    return NativeFunction {
+        name: name,
+        is_async: false,
+        parameters: parameters,
+        return_type: return_type,
+        effects: [],
+        decorators: [],
+        is_extern: true,
+        instructions: []
+    };
+}
+
+// An imported `char_code` whose RETURN drifts from the registry row: the
+// registry declares `i64`, but a `string` return lowers to `{i8*, i64}`. The
+// single `string` parameter still matches the registry (`{i8*, i64}`), so the
+// mismatch is isolated to the return.
+fn _drifted_char_code() -> NativeFunction[] {
+    return [_fn("char_code", "string", [_param("string")])];
+}
+
+// An imported `char_code` whose signature MATCHES the registry row
+// (int ⇒ i64, string ⇒ {i8*, i64}) — the positive control.
+fn _matching_char_code() -> NativeFunction[] {
+    return [_fn("char_code", "int", [_param("string")])];
+}
+
+// An imported `nanosleep` whose lowered signature disagrees with the registry
+// row (registry: i32 ⟵ [i8*, i8*]). `nanosleep` satisfies the structural
+// `target == symbol && native_signature == null` mirror shape but is a
+// libc-fallback row, NOT a prelude mirror — its registry `i8*` is the
+// deliberate opaque-pointee form that differs by design from the staged
+// `posix.sfn` `%Timespec*` import. It must therefore be EXEMPT from
+// reconciliation (only #633-suppressed), never fatal on this divergence.
+fn _drifted_nanosleep() -> NativeFunction[] {
+    return [_fn("nanosleep", "int", [_param("string"), _param("string")])];
+}
+
+fn _no_fns() -> NativeFunction[] { return []; }
+
+test "prelude-mirror drift (#1779): a drifted mirror row fatals" ![pure] {
+    assert expect_to_throw(fn () -> int {
+        let _ = render_runtime_helper_declarations(["char_code"], _no_fns(), _drifted_char_code(), _empty_context());
+        return 0;
+    }).ok;
+}
+
+test "prelude-mirror drift (#1779): the fatal names the target and both shapes" ![pure] {
+    // The message must name the drifting target...
+    assert expect_to_throw_with(fn () -> int {
+        let _ = render_runtime_helper_declarations(["char_code"], _no_fns(), _drifted_char_code(), _empty_context());
+        return 0;
+    }, "char_code").ok;
+    // ...the registry shape (return i64)...
+    assert expect_to_throw_with(fn () -> int {
+        let _ = render_runtime_helper_declarations(["char_code"], _no_fns(), _drifted_char_code(), _empty_context());
+        return 0;
+    }, "i64(").ok;
+    // ...and the prelude shape (return {i8*, i64}).
+    assert expect_to_throw_with(fn () -> int {
+        let _ = render_runtime_helper_declarations(["char_code"], _no_fns(), _drifted_char_code(), _empty_context());
+        return 0;
+    }, "{i8*, i64}(").ok;
+}
+
+test "prelude-mirror drift (#1779): a matching mirror row does not fatal" ![pure] {
+    // Negative control: an in-sync import reconciles cleanly (no throw). The
+    // matcher fails iff the thunk throws, so `!ok` proves the guard does not
+    // over-fire on a matching signature.
+    let r = expect_to_throw(fn () -> int {
+        let _ = render_runtime_helper_declarations(["char_code"], _no_fns(), _matching_char_code(), _empty_context());
+        return 0;
+    });
+    assert ! r.ok;
+}
+
+test "prelude-mirror drift (#1779): a non-mirror libc-fallback row is exempt from reconciliation" ![pure] {
+    // Scope boundary: `nanosleep` matches the structural mirror shape
+    // (`target == symbol`, `native_signature == null`) but is NOT a prelude
+    // mirror, so its intentional registry/import divergence must NOT fatal. If
+    // the reconciliation gate ever widened from the enumerated prelude-mirror
+    // set back to the raw structural predicate, this drifting import would throw
+    // and break every build that stages `posix.sfn` — so `!ok` locks the
+    // exemption at unit speed.
+    let r = expect_to_throw(fn () -> int {
+        let _ = render_runtime_helper_declarations(["nanosleep"], _no_fns(), _drifted_nanosleep(), _empty_context());
+        return 0;
+    });
+    assert ! r.ok;
+}

--- a/compiler/tests/unit/prelude_mirror_drift_fatal_test.sfn
+++ b/compiler/tests/unit/prelude_mirror_drift_fatal_test.sfn
@@ -3,14 +3,17 @@
 // T2 for #1779 (SFEP-0035 §3.1): the prelude-mirror reconciliation guard
 // actually FATALS on drift — the failure mode the whole guard exists to catch.
 //
-// `render_runtime_helper_declarations` reconciles each
-// `target == symbol && native_signature == null` mirror registry row against
-// the imported prelude function's real lowered signature before deferring to
-// it (#633 suppression). When the two disagree it throws a `signature drift`
-// fatal naming the target and both shapes; the synthesized `@main` wrapper
-// renders that to stderr and exits non-zero, so `make compile` fails at the
-// moment drift is introduced instead of silently mis-declaring the helper on a
-// fallback path.
+// `render_runtime_helper_declarations` reconciles each *enumerated*
+// prelude-mirror registry row (`_is_prelude_mirror_target`) against the imported
+// prelude function's real lowered signature before deferring to it (#633
+// suppression). When the two disagree it throws a `signature drift` fatal naming
+// the target and both shapes; the synthesized `@main` wrapper renders that to
+// stderr and exits non-zero, so `make compile` fails at the moment drift is
+// introduced instead of silently mis-declaring the helper on a fallback path.
+// The gate is an explicit six-target set, NOT every `target == symbol &&
+// native_signature == null` row: the libc-fallback rows (`nanosleep` /
+// `clock_gettime`) share that structural shape but are exempt (pinned by the
+// `nanosleep` case below).
 //
 // Here the real registry `char_code` row (i64 ⟵ [{i8*, i64}]) is fed an
 // imported `char_code` whose return deliberately disagrees (string ⇒

--- a/compiler/tests/unit/runtime_helper_metadata_only_test.sfn
+++ b/compiler/tests/unit/runtime_helper_metadata_only_test.sfn
@@ -26,6 +26,7 @@
 import { find } from "sfn/strings";
 
 import { render_runtime_helper_declarations } from "../../src/llvm/rendering";
+import { TypeContext } from "../../src/llvm/types";
 import { NativeFunction } from "../../src/native_ir";
 
 // The effect-metadata-only targets that remain after the #1876 client
@@ -33,6 +34,17 @@ import { NativeFunction } from "../../src/native_ir";
 // `websocket.connect`/`.send`/`.close` ops are no longer metadata-only).
 fn _metadata_only_targets() -> string[] {
     return ["serve", "websocket.serve"];
+}
+
+// Empty type context: the metadata-only rows carry no prelude-mirror
+// reconciliation (#1779), so no struct/enum tables are consulted.
+fn _empty_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
 }
 
 // True if any emitted line contains `needle` as a substring.
@@ -54,7 +66,7 @@ test "metadata-only rows (#1631): sentinel targets emit no declare for the unbri
     // assertions at unit speed instead of as a link failure.
     let no_locals: NativeFunction[] = [];
     let no_imports: NativeFunction[] = [];
-    let lines = render_runtime_helper_declarations(_metadata_only_targets(), no_locals, no_imports);
+    let lines = render_runtime_helper_declarations(_metadata_only_targets(), no_locals, no_imports, _empty_context());
 
     assert ! _any_line_contains(lines, "sfn_serve_unbridged");
     assert ! _any_line_contains(lines, "sfn_websocket_unbridged");
@@ -70,7 +82,7 @@ test "metadata-only rows (#1631): the real serve_start row still declares (skip 
     // metadata-only target, not a `sfn_serve` prefix.
     let no_locals: NativeFunction[] = [];
     let no_imports: NativeFunction[] = [];
-    let lines = render_runtime_helper_declarations(["serve_start"], no_locals, no_imports);
+    let lines = render_runtime_helper_declarations(["serve_start"], no_locals, no_imports, _empty_context());
 
     assert _any_line_contains(lines, "@sfn_serve(");
     assert ! _any_line_contains(lines, "sfn_serve_unbridged");

--- a/docs/conventions/runtime-helpers.md
+++ b/docs/conventions/runtime-helpers.md
@@ -83,8 +83,19 @@ actual lowered signature before deferring to the prelude declare, and **throws a
 `signature drift` fatal on mismatch** — so drift fails `make compile` at the
 moment it is introduced rather than silently mis-declaring the helper on a
 fallback path. When you edit a mirror row (or its prelude function), change both
-in lock-step. Design record: SFEP-0035 §3.1; the follow-up that derives these
-rows from the prelude (removing the hand-typed duplication) is SFEP-0035 §3.2
+in lock-step.
+
+Reconciliation is gated on an **explicit enumeration** of the prelude-mirror
+targets (`_is_prelude_mirror_target` in `rendering.sfn`: `char_code`, `char_at`,
+`char_from_code`, `find_char`, `string_starts_with`, `record_eq_flag_message`),
+**not** the raw `target == symbol && native_signature == null` predicate: the
+libc-fallback rows `nanosleep` / `clock_gettime` also match that structural
+shape but are not prelude mirrors — their registry signature is the deliberate
+opaque-pointee (`i8*`) form that differs by design from the `%Timespec*` import
+they defer to, so reconciling them would false-positive. Those rows keep the
+plain #633 import suppression without reconciliation. Design record:
+SFEP-0035 §3.1; the follow-up that derives these rows from the prelude (removing
+the hand-typed duplication, and this enumeration with it) is SFEP-0035 §3.2
 (#1780).
 
 ## Returning the `{i8*, i64}` aggregate from a Sailfin body (`SfnString`)

--- a/docs/conventions/runtime-helpers.md
+++ b/docs/conventions/runtime-helpers.md
@@ -72,6 +72,21 @@ preamble's `render_runtime_helper_declarations` then emits a single
 `declare` per used target's effective symbol — no aliases, no
 per-target fallbacks.
 
+## Prelude-mirror reconciliation invariant (#1779)
+
+A **prelude-mirror row** (`target == symbol` and `native_signature == null`,
+whose `return_type`/`parameter_types` transcribe a `runtime/prelude.sfn`
+function by hand) must stay ABI-identical to that prelude definition. On any
+build where the mirror symbol is imported, `render_runtime_helper_declarations`
+(`rendering.sfn`) reconciles the registry row against the imported function's
+actual lowered signature before deferring to the prelude declare, and **throws a
+`signature drift` fatal on mismatch** — so drift fails `make compile` at the
+moment it is introduced rather than silently mis-declaring the helper on a
+fallback path. When you edit a mirror row (or its prelude function), change both
+in lock-step. Design record: SFEP-0035 §3.1; the follow-up that derives these
+rows from the prelude (removing the hand-typed duplication) is SFEP-0035 §3.2
+(#1780).
+
 ## Returning the `{i8*, i64}` aggregate from a Sailfin body (`SfnString`)
 
 A handful of helpers carry the `{i8*, i64}` SfnString aggregate return ABI


### PR DESCRIPTION
## Summary

Extends the #633 import-shadow check in `render_runtime_helper_declarations` (`compiler/src/llvm/rendering.sfn`) so each enumerated prelude-mirror registry row is **reconciled** against the prelude function's actual lowered signature before deferring to the imported declare, and **throws a fatal on mismatch**. This converts the latent silent-miscompile class from the prelude-mirror signature coupling into a loud, build-time failure on every normal build (incl. `make compile`), where the prelude is imported — instead of a silent ABI mismatch that only bites on the fallback paths.

The reconciliation reuses the same `map_return_type` / `collect_parameter_types` lowering the imported-declare pass applies, so the compared shapes are exactly the ones that would be emitted (no divergent re-implementation that could false-positive/negative). Touches only the LLVM rendering pass + tests + a docs line; no ABI/symbol change, no seed cut.

Fixes SFN-89

Design: SFEP-0035 §3.1 (`docs/proposals/0035-prelude-mirror-signature-derivation.md`). Structural de-duplication of the hand-typed rows is the sequenced follow-up #1780.

## Changes

- **llvm rendering** (`rendering.sfn`): new `_reconcile_mirror_row_or_fatal` + `_find_imported_fn_by_symbol` + `_llvm_shape_lists_equal` + `_is_prelude_mirror_target` helpers; the `_shadowed_by_import` branch now reconciles a mirror row's `return_type`/`parameter_types` against the imported prelude function's lowered signature and `throw`s a `signature drift` fatal (naming the target + both shapes) on mismatch. `render_runtime_helper_declarations` gains a `context: TypeContext` parameter for the type-mapping.
- **llvm lowering** (`lowering/lowering_phase_render.sfn`): the sole production caller passes `type_context`.
- **tests**: T1 (`integration/prelude_mirror_reconcile_test.sfn`) — the 5 in-sync rows (`char_code`, `char_at`, `find_char`, `string_starts_with`, `record_eq_flag_message`) reconcile clean and are suppressed; T2 (`unit/prelude_mirror_drift_fatal_test.sfn`) — injected drift fatals naming the target + both shapes, plus negative controls for a matching row and the exempt libc row. Two existing unit tests updated for the new `context` param.
- **docs** (`conventions/runtime-helpers.md`): the mirror-row reconciliation invariant.

**Scope note — why the gate is an explicit set, not the structural predicate:** the SFEP framed the mirror class as `target == symbol && native_signature == null`, but the libc-fallback rows `nanosleep` / `clock_gettime` also match that shape while carrying a *deliberate* opaque-pointee (`i8*`) signature that differs by design from the staged `posix.sfn` `%Timespec*` import they defer to. The initial structural gate false-positived on `nanosleep` during `make compile`; the guard is now gated on the six enumerated prelude-mirror targets. A regression test pins that the libc rows stay exempt.

## Map reconciliation

Advisory `## Files Affected` matched the tree, with one addition surfaced at implementation: `compiler/src/llvm/lowering/lowering_phase_render.sfn` (the sole caller) needed the `context` argument threaded through — an in-scope mechanical consequence of the signature change, same semantic unit.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts (byte-neutral on the in-sync tree)
- [x] Regression coverage added under `compiler/tests/` (T1 + T2)
- [x] Full unit suite: **202/202 passed**; integration suite: **43/43 passed**

## Notes for reviewers

- **`char_from_code` is a real pre-existing drift, deliberately left for #1780.** Its registry row declares `i8*` but the prelude `char_from_code(code: int) -> string` lowers to `{i8*, i64}` (verified against the emitted `define {i8*, i64} @char_from_code(i64)`). It stays green because `char_from_code` is never imported — it always emits from the registry, is never shadowed, so the guard never reconciles it. Fixing it (deriving/removing the hand-typed rows) is the sequenced follow-up #1780; this PR only makes drift **loud** when a mirror symbol is imported. If `char_from_code` ever becomes imported, the guard will (correctly) fatal.
- The reconciliation compares against `descriptor.return_type` (not `effective_helper_declare_return_type`), which is correct only because the six mirror rows carry `c_abi_return_type == null` — noted in an inline comment.
- Reviewed by the `code-reviewer` agent (approved; no correctness/self-host/effect blockers); its suggested follow-ups (the `return_type` assumption comment and a test pinning non-mirror rows are exempt) are both incorporated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNXA3X8iM8hxMmv43ycQVB)_