### PR TITLE
fix(ci): give make check's cold full-suite pool a wider per-test cap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,24 @@ TEST_JOBS_FLAG = --jobs $(TEST_JOBS)
 # above already captures it, so no origin-check branch is needed here).
 CHECK_TEST_JOBS ?= $(TEST_JOBS)
 
+# Per-test wall-clock cap for the `make check` cold full-suite run.
+# `make check` runs the whole suite in ONE parallel pool with
+# `--no-test-cache` (Makefile check-impl), so the sole e2e test that does
+# full `sfn build -p compiler` self-host builds (work_dir_parity_test.sfn:
+# two cold builds, serially, in one child) is CPU-contended by the pool and
+# its two cold builds together exceed the runner's 300s default per-test cap
+# — exit 124. A single cold `-p compiler` build measures ~206s uncontended,
+# so the two serial builds (~412s) already clear 300s before the pool's CPU
+# contention stretches them further on the 4-vCPU runner. macOS dodges it by
+# shipping no `timeout` binary (no cap at all), so the timeout only surfaces
+# on the nightly Linux `make check` leg. The cap is a backstop, not a budget:
+# a child exits the instant its builds finish, so a wider cap costs nothing
+# on the passing path — it only stops a false-positive kill of a
+# slow-but-progressing child. Genuine compile hangs are still bounded by the
+# per-phase cap in compiler/src/main.sfn, and the whole job by the workflow's
+# `timeout-minutes: 180`. Override with `CHECK_TEST_TIMEOUT=<secs>`.
+CHECK_TEST_TIMEOUT ?= 1800
+
 # Strict self-host gate (#1830). When SELFHOST_STRICT=1, `make check`
 # passes `--strict` to `sfn selfhost` so a stage2/stage3 fixed-point
 # mismatch is fatal (exit non-zero, no promotion) instead of the default
@@ -570,8 +588,8 @@ check-impl:
 	@# Set CHECK_FULL_PASS1=1 to restore the old two-full-suite behaviour
 	@# (escape hatch for bisect / pre-release double-check).
 ifeq ($(CHECK_FULL_PASS1),1)
-	@echo "[check] CHECK_FULL_PASS1=1: running full suite on first-pass binary (jobs=$(CHECK_TEST_JOBS))..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@echo "[check] CHECK_FULL_PASS1=1: running full suite on first-pass binary (jobs=$(CHECK_TEST_JOBS), test-timeout=$(CHECK_TEST_TIMEOUT)s)..."
+	@SAILFIN_TEST_TIMEOUT=$(CHECK_TEST_TIMEOUT) $(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 else
 	@echo "[check] pass1 smoke gate: hello-world + sfn/test capsule tests (jobs=$(CHECK_TEST_JOBS))..."
 	@t60=""; \
@@ -611,8 +629,8 @@ endif
 		--promote-to $(NATIVE_BIN) \
 		--smoke-timeout 10 \
 		$(SELFHOST_STRICT_FLAG)
-	@echo "[check] running full test suite with seedcheck binary (cold backstop, jobs=$(CHECK_TEST_JOBS))..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@echo "[check] running full test suite with seedcheck binary (cold backstop, jobs=$(CHECK_TEST_JOBS), test-timeout=$(CHECK_TEST_TIMEOUT)s)..."
+	@SAILFIN_TEST_TIMEOUT=$(CHECK_TEST_TIMEOUT) $(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 
 # Fast PR-feedback gate: run `sfn check` against the compiler tree and
 # the runtime prelude. No codegen, no clang, just parse + typecheck +

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,12 @@ CHECK_TEST_JOBS ?= $(TEST_JOBS)
 # `timeout-minutes: 180`. Override with `CHECK_TEST_TIMEOUT=<secs>`.
 CHECK_TEST_TIMEOUT ?= 1800
 
+# Env prefix applied to the `make check` full-suite `make test` invocations.
+# Kept as a single variable (not `export`) so both call sites can't diverge
+# while the wider cap stays scoped to `make check` — plain `make test` and
+# per-PR CI keep the runner's 300s default.
+CHECK_TEST_TIMEOUT_ENV = SAILFIN_TEST_TIMEOUT=$(CHECK_TEST_TIMEOUT)
+
 # Strict self-host gate (#1830). When SELFHOST_STRICT=1, `make check`
 # passes `--strict` to `sfn selfhost` so a stage2/stage3 fixed-point
 # mismatch is fatal (exit non-zero, no promotion) instead of the default
@@ -589,7 +595,7 @@ check-impl:
 	@# (escape hatch for bisect / pre-release double-check).
 ifeq ($(CHECK_FULL_PASS1),1)
 	@echo "[check] CHECK_FULL_PASS1=1: running full suite on first-pass binary (jobs=$(CHECK_TEST_JOBS), test-timeout=$(CHECK_TEST_TIMEOUT)s)..."
-	@SAILFIN_TEST_TIMEOUT=$(CHECK_TEST_TIMEOUT) $(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@$(CHECK_TEST_TIMEOUT_ENV) $(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 else
 	@echo "[check] pass1 smoke gate: hello-world + sfn/test capsule tests (jobs=$(CHECK_TEST_JOBS))..."
 	@t60=""; \
@@ -630,7 +636,7 @@ endif
 		--smoke-timeout 10 \
 		$(SELFHOST_STRICT_FLAG)
 	@echo "[check] running full test suite with seedcheck binary (cold backstop, jobs=$(CHECK_TEST_JOBS), test-timeout=$(CHECK_TEST_TIMEOUT)s)..."
-	@SAILFIN_TEST_TIMEOUT=$(CHECK_TEST_TIMEOUT) $(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@$(CHECK_TEST_TIMEOUT_ENV) $(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 
 # Fast PR-feedback gate: run `sfn check` against the compiler tree and
 # the runtime prelude. No codegen, no clang, just parse + typecheck +


### PR DESCRIPTION
## Summary

The **nightly self-host check** (Linux leg) has failed every run since 2026-07-05 ([run 86](https://github.com/SailfinIO/sailfin/actions/runs/29011345700)). The single persistent failure is `compiler/tests/e2e/work_dir_parity_test.sfn` timing out — the test-runner exits **124** (`timeout`-killed child).

`work_dir_parity_test.sfn` is the *only* e2e test that runs full `sfn build -p compiler` self-host builds — **two of them, serially, in one test child** (the #379 byte-identity invariant needs two `--work-dir` roots). `make check` runs the whole suite in **one `--no-test-cache` parallel pool** (`check-impl` → seedcheck full-suite run), so those two cold builds are CPU-contended and together exceed the runner's **300s default per-test wall-clock cap**.

Measured here: a single cold `-p compiler` build takes **~206s uncontended**, so the two serial builds (~412s) already clear 300s *before* pool contention stretches them further on the 4-vCPU runner. Two legs dodge the failure and mask it:
- **Per-PR CI** runs e2e serially (`--jobs 1`) — no pool contention.
- **macOS** ships no `timeout` binary, so there is no cap at all (run 86's macOS leg passed, proving the test terminates — this is a wall-clock budget problem, not a hang).

This is not a compiler bug: the compiler self-hosts and the test passes given adequate time.

## Changes

- **driver / Makefile:** add `CHECK_TEST_TIMEOUT` (default `1800`) and apply it via `SAILFIN_TEST_TIMEOUT` to the two `make check` full-suite `make test` invocations (`check-impl`: the seedcheck cold-backstop run and the `CHECK_FULL_PASS1=1` first-pass run). The cap is a **backstop, not a budget** — a child exits the instant its builds finish, so a wider cap costs nothing on the passing path; it only prevents a false-positive kill of a slow-but-progressing child. Genuine compile hangs remain bounded by the per-phase cap in `compiler/src/main.sfn`, and the whole job by the workflow's `timeout-minutes: 180`. Regular `make test` and per-PR CI keep the tight 300s default.

## Validation

- [x] Makefile-only change — no `.sfn` touched (no `fmt`/`sfn check`/self-host gate applies)
- [x] `make compile` — compiler self-hosts cleanly (sanity, unaffected by this change)
- [x] `make -n check-impl` confirms the recipe expands to `SAILFIN_TEST_TIMEOUT=1800 make test …`
- [x] Runner honors `SAILFIN_TEST_TIMEOUT` end-to-end: a pool run (`--jobs 2`) with `SAILFIN_TEST_TIMEOUT=1` kills its children → **exit 124** (reproduces the nightly's failure code); the single-file in-process path is unaffected (no wrapper)
- [x] `work_dir_parity_test.sfn` passes with adequate headroom (`SAILFIN_TEST_TIMEOUT=1800` → both sub-tests pass, exit 0)
- [x] N/A — docs/config-only change

## Notes for reviewers

- The two-serial-cold-build shape is inherent to the #379 AC (byte-identity across two `--work-dir` roots), and the idempotent shared-scratch design couples the two builds into whichever child runs first, so splitting the file doesn't cleanly bound each child to one build. Raising the backstop for the cold-parallel `make check` path is the proportionate fix.
- `1800s` is deliberately generous (safe over worst-case contention) and overridable with `CHECK_TEST_TIMEOUT=<secs>`; since the cap has zero cost on success, margin is free.
- Related but distinct: SFN-87 tracks the *macOS* intermittent OOM/SIGABRT (exit 134) in concurrent build-and-run e2e tests — a different failure mode/platform, not addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTZ67vnmfPvzLD6R9uFxLA)_