### PR TITLE
SFEP-0045: Demote to Draft, post-mortem the failed Accepted design

### DIFF
--- a/docs/proposals/0045-shared-frontend-test-runner.md
+++ b/docs/proposals/0045-shared-frontend-test-runner.md
@@ -1,7 +1,7 @@
 ---
 sfep: 0045
 title: Shared-frontend test runner — parent compiles, children only execute
-status: Accepted
+status: Draft
 type: tooling
 created: 2026-07-08
 updated: 2026-07-09
@@ -18,21 +18,131 @@ graduates-to:
 
 `sfn test <dir>` forks one `sfn test <file>` child per test file, and every
 child re-does the full compiler frontend+lowering pipeline — capsule resolution
-(~32 s) and import-context lowering (~9 s after #2016; was ~25 s) — from
-scratch, work that is **identical across every child of one invocation**. On a
-heavy-closure test that is ~41 s of duplicated per-child labor against 0.5 s of
-actual test execution. This SFEP makes the **parent** run the frontend
-(resolve + typecheck + emit + lower + link) **once per resolver group** in its
-own already-warm in-process state — the exact shape the single-process serial
-path already uses today (`test.sfn:1017-1420`) — and demotes children to
-`exec(test_binary)` under a timeout. Fault isolation (a crashing/hanging test
-must not take down the runner) and per-child scratch isolation are preserved
-because *execution* stays in a subprocess; only *frontend recomputation* is
-eliminated. This is the resolver-sharing work SFEP-0044 §3-C explicitly deferred
-(issue #1997) and the structural fix for #2010 sub-item (b). Target: heavy child
-≈ light child (marginal ~1.5–2.5 s per file, per the Phase 0 probe math), macOS
-unit shards ~15–22 min (post-#2016) → ~8–10 min, full local suite within a few ×
-of the ~90 s compiler self-build.
+(~32 s) and import-context lowering (~9 s after #2016) — from scratch, work that
+is **identical across every child of one invocation**. This SFEP set out to make
+the **parent** run the frontend (resolve + typecheck + emit + lower + link)
+**once per resolver group** in its own already-warm in-process state, and demote
+children to `exec(test_binary)` under a timeout, preserving execution fault
+isolation while eliminating frontend recomputation.
+
+The originally-Accepted design (below, §6-legacy) rested on a premise that a
+real implementation **falsified**: it assumed grouping tests by
+`(project_root, workspace_root)` avoids the resolver-union descriptor conflict
+that per-file forking was built to sidestep. It does not — for the compiler's
+own suite, which is the primary consumer (every `make check` / seedcheck run goes
+through this runner), *all* of `compiler/tests/{unit,integration,e2e}` share one
+project root and therefore collapse into a single ~400-file resolver group whose
+unioned import descriptors conflict pervasively. The full parent-compiles
+orchestration was built, self-hosts, and passes on small/medium suites, but
+**fails `make test`** (0 passed, 435 `compile failed`, ~2 h runaway). This
+revision demotes the SFEP to `Draft`, records the post-mortem honestly, retracts
+the false claim in the motivation and design, and reframes §3 as a set of
+candidate directions with an explicit prerequisite (fixing the within-project
+descriptor conflict) plus a decomposition into groomable issues. The one
+salvageable, independently-landable piece — the exec-only child — is called out
+as such.
+
+## 1a. Post-mortem — why the Accepted design failed
+
+The Accepted design was implemented end-to-end (parent compiles per resolver
+group, children only execute), self-hosts via `make compile`, and **passes** on
+standalone multi-file dirs, single-capsule dirs, and `sailfin test capsules`
+(38/38). It **fails the real gate** — `make test`, i.e.
+`sailfin test compiler/tests/unit compiler/tests/integration compiler/tests/e2e
+capsules --jobs N` — with **0 passed, 435 `compile failed`, and a ~2-hour
+runaway**. Four findings, in priority order, and all treated here as ground
+truth from that run:
+
+### Finding 1 — the central claim is false: grouping does NOT avoid the resolver-union conflict
+
+§2 of the Accepted text asserted "the union conflict is avoided by *grouping*,
+not by *forking*," citing the single-process serial path
+(`test.sfn:1017-1420`) as having "already solved it." That serial group-union
+machinery was **dead code**: the #848 multi-file fork branch (`test.sfn:583`,
+`if test_files.length > 1`) returns before the serial path is ever reached, so
+the group loop had **never** run with more than one file per group. The premise
+was therefore never validated by any real multi-file run.
+
+When the fork bypass is removed and the serial group loop is actually
+activated on the compiler suite:
+
+- All of `compiler/tests/{unit,integration,e2e}` share project root
+  `compiler/`, so they land in **one resolver group of ~400 files**.
+- `prepare_project_capsules_for_test(group.entry_paths, …)`
+  (`capsule_resolver.sfn:3476`) **unions** the import descriptors of all ~400
+  entry paths and picks **one descriptor per symbol**. Files that expected a
+  different descriptor for the same symbol lose.
+
+Grouping only separates *different* project roots. The conflicting files live
+under the *same* root, so grouping is structurally incapable of helping — this
+is exactly the conflict #848's per-file forking was built to avoid
+(`test.sfn:557-576`). The conflicts are **pervasive, not a handful**:
+
+- `number_to_string`: the `![pure]` int-signature import (#633) vs. the
+  `double` runtime helper. Union picks one; victims fail with
+  `llvm lowering [fatal]: ABI primitive mismatch: callee expects i64 (int) but
+  caller produced double` and/or `undefined reference to number_to_string`.
+- `runtime_object_cache_key` / `runtime_object_cache_key_with_identity`:
+  `llvm lowering [fatal]: cannot resolve return type … callee signature is not
+  known to the compiler`.
+
+Because the compiler's own suite is the *primary* consumer of this runner
+(`make check` and seedcheck both run through it), a design that mishandles this
+suite is a design that does not ship.
+
+### Finding 2 — a reactive per-file resolver fallback does not rescue it
+
+The tried mitigation: compile each file against the shared per-group context
+(fast path); on compile/link failure, re-resolve *that one file alone*
+(`prepare_project_capsules_for_test([file], …)`) and retry in-process. It
+failed on both axes:
+
+- **Correctness** — the solo re-resolve re-stages into the already-populated
+  group staging dir and yields an *incomplete* context, so the retry still
+  fails with `callee signature not known`.
+- **Cost** — each solo re-resolve is a full ~32 s whole-compiler resolution.
+  With hundreds of conflict victims (a *large fraction* of files use a
+  conflicting symbol), that is the ~2-hour runaway. A fallback that fires on a
+  large fraction of the suite is not a fallback; it is the common case, and it
+  does not scale by construction.
+
+### Finding 3 — in-process serial compile is slow and has an unaddressed memory hazard
+
+- **Slow.** A single heavy compiler-unit file (imports the ~130-module
+  compiler) took **~12 s** to lower in-process (measured `phase=functions
+  ms=8121`, `phase=finalize ms=12595`) with **no group memo landed**. ×~400
+  files serially ≈ 40 min of compiles alone — the opposite of the perf goal.
+  The Accepted §3.2 ~1.5–2.5 s/file projection assumed a group-scoped
+  `ImportedModuleSymbols` memo that was never implemented.
+- **Memory hazard.** `SAILFIN_USE_ARENA` is **off by default**
+  (`test.sfn:1078-1079`: the per-file `arena_mark`/`arena_rewind` is "No-op
+  when the arena is disabled"). So the Accepted §3.1/§3.2 memory reclamation is
+  a **no-op under `make test`**. Compiling hundreds of heavy files in one
+  never-rewound process revives the pre-#848 OOM/segfault that the fork model
+  avoided via per-file process teardown (the OOM documented at the original
+  `test.sfn:1019-1025`). The Accepted text treated arena-rewind as load-bearing
+  without noting it is opt-in and unvalidated as a default.
+
+### Finding 4 — what is sound and salvageable
+
+- The **exec-only child** (Accepted Phase B): a hidden `__run-test-bin`
+  dispatch where the parent compiles+links the binary and the child just execs
+  it under `timeout` with per-child scratch. This works, preserves fault
+  isolation, and is independent of the broken resolver-sharing half.
+- **Parent-compile for conflict-free groups.** Where a group has no descriptor
+  conflict (standalone multi-file dirs, single-capsule dirs, `capsules`), the
+  parent-compiles path is correct and passes today.
+
+The broken half is Phase A's "one shared resolve per project/workspace group"
+applied to a group whose descriptors conflict.
+
+### Incidental note (not part of this design)
+
+The implementation attempt surfaced a latent **giant-function codegen
+miscompile**: a `bounds_check` abort in `cli/commands/test.sfn::run` that
+shifted/vanished when a gated `print.err` was added and when the run phase was
+extracted into a helper. It is layout-sensitive and worth a **separate compiler
+issue**; it is orthogonal to the runner design and is not addressed here.
 
 ## 2. Motivation
 
@@ -40,432 +150,434 @@ of the ~90 s compiler self-build.
 
 Per-child anatomy for a heavy-closure test
 (`compiler/tests/unit/routine_nursery_test.sfn`, ~130 compiler-module deps),
-**all caches warm**. The original #2010 anatomy attributed ~25.6 s to
-"typechecking against 130 interfaces"; phase timers (instrumented
-`main.sfn:482` + `lowering_core.sfn`) showed that attribution was wrong —
-**typecheck proper is ~1 ms**; the cost was LLVM lowering's per-compile
-re-parsing of the imported `.sfn-asm` texts. Corrected, post-#2016 anatomy:
+**all caches warm**. Phase timers (instrumented `main.sfn:482` +
+`lowering_core.sfn`) show **typecheck proper is ~1 ms**; the cost is LLVM
+lowering's per-compile re-parsing of the imported `.sfn-asm` texts.
 
 | Phase | Cost | Constant across children of one invocation? |
 |---|---|---|
-| resolver pass (`prepare_project_capsules_for_test`, `capsule_resolver.sfn:3476`) | **31.9 s** | Yes — same project/workspace roots, same dep closure |
+| resolver pass (`prepare_project_capsules_for_test`, `capsule_resolver.sfn:3476`) | **31.9 s** | Per *resolver group* — same project/workspace roots, same dep closure |
 | parse test src + typecheck + effect/ownership + emit `.sfn-asm` | **~110 ms** | Genuinely per-file, already cheap |
-| LLVM lowering (`gather_imported_module_symbols` + mangle re-scan over the 130 imported texts) | **~9 s** (was 25.3 s; #2016 / PR #2018 collapsed 5 parses per text to 1; ~4 s of the residue is `collect_available_import_module_names` re-scanning the same texts) | Yes — pure function of the group's `native_texts` + manifests, byte-identical across every file in the group |
-| clang link | ~1 s (was 8.3 s; #2013 dep `.ll`→`.o` cache, PR #2014) | — |
-| test execution | **0.5 s** | No — this is the only genuinely per-file work |
+| LLVM lowering (`gather_imported_module_symbols` + mangle re-scan over the 130 imported texts) | **~9 s** (post-#2016; ~4 s of the residue is `collect_available_import_module_names` re-scanning) | Per resolver group — pure function of the group's `native_texts` + manifests |
+| clang link | ~1 s (post-#2013 dep `.ll`→`.o` cache) | — |
+| test execution | **0.5 s** | No — the only genuinely per-file work |
 
-So ~41 s of every heavy child (resolver ~32 s + lowering ~9 s) is work re-done
-from scratch, byte-for-byte identical across children in the same resolver
-group. Light tests pay ~4.5 s total. CI macOS unit shards sat at **24–32 min**
-pre-#2016 (~15–22 min after) and are the PR-CI critical path; nightly
-`make check`'s cold seedcheck suite pays the same tail.
+So ~41 s of every heavy child (resolver ~32 s + lowering ~9 s) is re-done from
+scratch. The duplication is real and worth eliminating — the question this SFEP
+must now answer honestly is **how**, given that the naive "share one resolve
+across the whole project group" collapses on the descriptor conflict.
 
 ### Why the duplication exists at all
 
-The multi-file runner (issue #848, `test.sfn:583`) forks a `sfn test <file>`
+The multi-file runner (#848, `test.sfn:583`) forks a `sfn test <file>`
 subprocess per file for three reasons, all real:
 
-1. **Fault isolation** — a test that `assert false`s calls `abort()` and brings
-   its whole process down; a hanging test must be killable by a per-child
-   `timeout`. One crashing test must not abort the runner or its siblings.
+1. **Fault isolation** — a test that `assert false`s calls `abort()`; a hanging
+   test must be killable by a per-child `timeout`. One crashing test must not
+   abort the runner or its siblings.
 2. **Per-child scratch isolation** — each child gets its own
-   `SAILFIN_TEST_SCRATCH` (#1333) so parallel compiles don't collide on the fixed
-   `build/sailfin/program.ll`.
-3. **Resolver-union conflict avoidance** — the *original* single-process path
-   (pre-#848) grouped every test under one resolver pass whose `native_texts` was
-   the **union** of every test's imports, and tests with conflicting descriptors
-   for the same symbol (the `number_to_string` `![pure]`-int vs. `double`-runtime
-   case, `test.sfn:562-576`) cannot coexist. It also OOM'd/segfaulted on the real
-   suite because the whole ~120-module closure accumulated in one never-freed
-   bump arena (`test.sfn:1019-1025`).
+   `SAILFIN_TEST_SCRATCH` (#1333) so parallel compiles don't collide on the
+   fixed `build/sailfin/program.ll`.
+3. **Resolver-union conflict avoidance** — the single-process path unions every
+   test's imports into one resolver pass; tests with conflicting descriptors for
+   the same symbol (`number_to_string` `![pure]`-int vs. `double`-runtime,
+   `test.sfn:562-576`) cannot coexist in that union, and the whole closure
+   accumulating in one never-freed arena OOM'd/segfaulted on the real suite.
 
-**The key observation this SFEP rests on:** the single-process serial path that
-*still exists today* (`test.sfn:1017-1420`, taken when `test_files.length <= 1`
-or in the per-child leaf) already solved (3): it partitions tests into **resolver
-groups** by `(discover_project_root, discover_workspace_root)` + consumer, runs
-`prepare_project_capsules_for_test` **once per group**, and reuses
-`interfaces` / `native_texts` / `dep_ll_paths` / `function_effects` /
-`capabilities_required` across every test in the group, rewinding the arena
-(`sailfin_intrinsic_runtime_arena_mark`/`_rewind`) between files so the closure
-does **not** accumulate. The union conflict is avoided by *grouping*, not by
-*forking*. The OOM is avoided by *arena rewind*, not by *forking*. The only thing
-the fork still buys that grouping+rewind does not is **fault isolation of
-execution** (reason 1) and **per-child scratch** (reason 2) — and both of those
-apply to *running the binary*, not to *compiling it*.
+**Retraction of the Accepted premise.** The Accepted text claimed reason (3) was
+"already solved" by the serial group path and that grouping avoids the union
+conflict. **This is false** (Finding 1): the serial group path was dead code and
+was never exercised with >1 file per group; grouping only separates *different*
+project roots, while the conflicting files share one root. Reason (3) is a live,
+pervasive obstacle for the compiler's own suite — the very suite `make
+check`/seedcheck depend on — and any shared-resolve design must confront it
+head-on rather than assume it away. Reasons (1) and (2) remain correct and apply
+to *running* the binary, not to *compiling* it — which is why the exec-only
+child (Finding 4) is salvageable regardless of how the compile side is resolved.
 
-Today the multi-file path throws away the parent's warm resolver state and makes
-each child rebuild it. This SFEP keeps the warm frontend in the parent and forks
-only for the 0.5 s exec.
+## 3. Design — candidate directions
 
-## 3. Design
+The goal is unchanged: stop every child re-doing the ~41 s frontend. The
+Accepted single approach ("parent compiles once per project/workspace group") is
+**withdrawn** for the compiler suite because a project-root group's descriptors
+conflict. Below are the candidate directions, evaluated honestly. None is
+re-committed to as *the* answer; the intended shipping order is
+prerequisite → exec-only child → one of the sharing strategies, and the
+decomposition in §3.6 makes the dependency ordering explicit.
 
-### 3.1 Recommended approach: **parent compiles, child only executes** (Alternative 2)
+The load-bearing constraint on **every** direction: it must be validated on the
+**combined** compiler suite (`unit`+`integration`+`e2e`+`capsules` in one
+`make test`/`make check` invocation), because that is the invocation that
+exposed the flaw. Passing on small dirs proves nothing.
 
-The parent process, which already partitions tests into resolver groups and warms
-runtime objects into `sub_root`, additionally **compiles and links every test
-binary in-process**, reusing its resident resolver/typecheck state across the
-group exactly as the serial path does today. Each test's linked binary is written
-into the shared objdir. Children are reduced to a thin
-`timeout <secs> <test_binary>` exec with per-child scratch — no compiler,
-no resolver, no typecheck. The bounded worker pool (`--jobs N`) moves from
-"compile+run per child" to "**parent compiles** (serially, arena-rewound), **pool
-runs** the resulting binaries".
+### 3.1 Direction (i) — fix the underlying within-project descriptor conflict (prerequisite)
 
-This is chosen over the serialized-snapshot (Alt 1) and daemon/IPC (Alt 3)
-approaches in §6. The decisive facts making it low-risk:
+**Root cause.** A single project must not be able to resolve one symbol name
+(`number_to_string`, `runtime_object_cache_key`, …) to two *incompatible ABIs*
+depending on which entry file drives resolution. This is the #633-class
+ambiguity: the `![pure]` int-signature import and the `double` runtime helper
+are two different callees sharing a name, and the resolver's union picks one.
 
-**Core compiler passes hold zero cross-compilation mutable state.** Grepping every
-`compiler/src/**.sfn` for module-level `let mut`:
+**Why this is the prerequisite, not just an option.** *Any* shared-resolve
+approach — one group, sub-partitioned groups, or shared staged artifacts — is
+only sound if a project cannot present two conflicting descriptors for the same
+symbol in the first place. If the ambiguity is removed at the source (distinct
+mangled names, or a single canonical descriptor the whole project agrees on),
+then a project-root group's union has no conflict to lose, and the entire
+Accepted approach becomes viable as originally imagined. If it is *not* removed,
+every sharing strategy must carry conflict-detection machinery forever.
 
-- `typecheck.sfn`, `typecheck_types.sfn`, `emit_native.sfn`,
-  `effect_checker.sfn`, `ast.sfn`: **0** module-level `let mut`. No global type
-  interner, no monomorphization cache, no symbol table accumulator that would
-  corrupt across files.
-- `backend.sfn`: `_macos_sdk_probe_done` / `_macos_sdk_root` — an idempotent
-  memoized SDK probe, **invocation-constant**, correct to reuse.
-- `llvm/lowering_debug_state.sfn`: errno/clock/nprocessors/stat-offset locators —
-  all idempotent memoized host probes, invocation-constant.
-- `ice.sfn`: `_ice_stage`/`_ice_source`/`_ice_binary_dir` — set-per-compile ICE
-  context, overwritten each file, never read across files.
-- `test_runner_state.sfn`: `_active`/`_trace`/`_filter_name`/`_filter_tag` — set
-  once at runner entry, identical for every file in the invocation.
+**Shape (to be designed in its own issue, likely its own SFEP or a #633
+follow-up).** Options span: (a) make the two `number_to_string`-class callees
+resolve to distinct mangled symbols so both can coexist in one link
+(`number_to_string$int` vs. `number_to_string$double`); (b) canonicalize the
+project to a single descriptor per symbol so the union is a no-op; (c) diagnose
+the conflict at resolve time (`E0xxx`) instead of miscompiling. This direction
+is **not** free — it touches the resolver and mangling — but it is the only one
+that eliminates the class rather than routing around it, and it is a
+**prerequisite** for shipping any parent-compile sharing on the compiler suite.
 
-There is **no per-compilation mutable accumulator** that makes in-process reuse
-across files unsound. The serial path already proves this daily: it compiles
-~75 self-host-suite tests back-to-back in one process. This SFEP extends that
-proven path to the multi-file case rather than inventing new machinery.
+### 3.2 Direction (ii) — conflict-free sub-partitioning of a group
 
-### 3.2 Mechanism
+Rather than fix the conflict at the source, detect descriptor conflicts within a
+project-root group and split it into the **minimal set of conflict-free
+sub-groups**, running one shared resolve per sub-group. *Assessment:* this keeps
+the sharing benefit for the (majority) conflict-free files while isolating the
+conflicting ones. Costs, both real: (a) the resolver must expose per-file
+descriptor sets so the partitioner can detect conflicts *before* resolving —
+new resolver support, non-trivial; (b) the sub-group count is **pathological in
+the worst case** — a symbol with two descriptors used by interleaved files can
+force many small sub-groups, each paying a full ~32 s resolve, degenerating
+toward the per-file cost this SFEP is trying to escape. Sub-partitioning is
+therefore a *mitigation* that only pays off if conflicts are rare; on today's
+suite they are pervasive (Finding 1), so this direction is weak **unless
+paired with (i)** to shrink the conflict set first.
 
-**Phase 0 — marginal-compile probe (RUN 2026-07-08; gate results recorded).**
-An env-gated fork bypass forced the serial group loop for two heavy same-group
-files in one process. Result: 1 file = 64.9 s; 2 files = 95.3 s — **marginal
-cost of the second file ≈ 30 s**, falsifying the original "seconds once
-interfaces are resident" assumption. Phase-timer attribution of the marginal
-30 s: typecheck ~1 ms; the cost was `gather_imported_module_symbols`
-re-parsing each of the 130 imported `.sfn-asm` texts five times (~21 s) plus
-the `collect_available_import_module_names` mangle re-scan (~4 s) — per-file
-recomputation of a value that is a pure function of the group's
-`native_texts`. Two consequences, both already acted on:
+### 3.3 Direction (iii) — keep forking, share the resolver's staged artifacts
 
-1. The 21 s share was an algorithmic defect fixed independently of this SFEP
-   (#2016 / PR #2018, 5 parses → 1), cutting the marginal in-process compile
-   to ~9–10 s and every fork-path child by the same amount.
-2. The residual ~9–10 s marginal (lowering's remaining single parse + the
-   ~4 s mangle re-scan + ~1 s link) still exceeds the target, so **Phase A
-   explicitly includes group-scoped memoization**: compute
-   `ImportedModuleSymbols` (and the mangle pass's available-module-names
-   list) **once per resolver group** and reuse it for every file in the
-   group — both are pure functions of the group's `native_texts` +
-   manifests, so this is a cache of an invocation-constant value, not new
-   semantics. Projected marginal per-file cost after Phase A:
-   **~1.5–2.5 s** (one cheap per-file lowering pass + clang link + exec).
+Keep per-file forked compilation (so each child's resolver sees only its own
+imports — no union, no conflict, fault isolation intact for the compile too),
+but eliminate the *recomputation* by sharing the resolver's already-staged
+artifacts and a cached lowering import-context across children. This is closer
+to SFEP-0044's parent-warms/children-consume shape, extended from backend
+artifacts to the frontend:
 
-With the corrected numbers, serial parent-compile at ~2 s/file beats the fork
-path (~43 s/child post-#2016 ÷ jobs) for any realistic `--jobs`, so the
-serial-parent design holds without Phase C.
+- The parent stages the dependency `.sfn-asm`/`.ll` closure once (already true —
+  `resolution.asm_paths` / `resolution.ll_paths` are on disk).
+- Children skip **re-staging** and **re-parsing** by consuming a
+  parent-produced, group-keyed cache of `ImportedModuleSymbols` (the pure
+  function of `native_texts` + manifests that lowering recomputes today).
+- Each child still runs *its own* resolve-scoped typecheck+emit+lower+link
+  against *its own* import set, so there is **no union and no descriptor
+  conflict**, and no in-process compile-all memory hazard (per-file teardown
+  survives).
 
-**Phase A — hoist the compile loop into the multi-file parent.** Today the
-multi-file branch (`test.sfn:583`) forks children; the serial compile+link loop
-lives below it (`test.sfn:1017-1420`) and is only reached when `test_files.length
-<= 1`. Refactor so the multi-file parent:
+*Assessment:* this is the most conservative direction — it preserves every
+correctness and isolation property of the current fork path and only removes the
+duplicated *work*, not the process boundary. The open questions are whether the
+shared import-context can be serialized/consumed cheaply (this is close to Alt 1
+below and inherits some of its format-drift risk) and how much of the ~41 s it
+actually removes (the resolver *staging* walk itself may resist sharing). It does
+**not** require Direction (i) as a prerequisite, because it never unions
+conflicting descriptors — making it the safest first sharing step if (i) proves
+expensive.
 
-1. Runs the existing resolver-group partition + per-group
-   `prepare_project_capsules_for_test` + `load_imported_interfaces_from_paths`
-   (already present at `test.sfn:1017-1067`).
-2. Warms runtime objects into `sub_root` once (already present, `test.sfn:657`)
-   and writes the SFEP-0044 stamp (already present, `test.sfn:666`).
-3. **Computes the group's lowering import context once** (Phase 0 finding):
-   `gather_imported_module_symbols` over the group's `native_texts` +
-   manifests, and the mangle pass's `collect_available_import_module_names`
-   list, are pure functions of group-constant inputs — memoize both per
-   resolver group and thread the memo into the per-file lowering call
-   instead of recomputing per file (~9–10 s → amortized once per group).
-   The memo must be keyed per group so it never leaks across the #848
-   union-conflict groups.
-4. **Compiles + links each test binary in-process**, reusing the group's warm
-   interfaces/native_texts/dep_ll_paths, with `arena_mark`/`arena_rewind` around
-   each file (the existing per-test rewind, `test.sfn:1419`). The linked binary
-   is written to a stable per-file path in `sub_root` (e.g.
-   `sub_root/bin/<sanitized_test_path>`), and the test-bin content cache
-   (`test_bin_cache_key`) is consulted/populated exactly as the serial path does
-   now (`test.sfn:1194-1222`) — a cache hit skips lower+link entirely.
-5. Records, per file, the binary path and the pre-parsed `TestEntry[]` (for
-   `--json` attribution and the aggregate `start` total, already computed at
-   `test.sfn:679-694`).
+### 3.4 Direction (iv) — make in-process compile-all safe before using it
 
-**Phase B — the exec-only child.** Introduce a new internal dispatch the parent
-invokes per file: `sfn __run-test-bin <binary_path>` (a hidden subcommand, not in
-`command_def()`'s help surface), which is a bare
-`exec`-with-`argv`+`timeout`+scratch wrapper carrying **no compiler code path**.
-Its entire job: set up per-child scratch, `exec` the prebuilt binary, forward its
-stdout/stderr and per-test JSON sub-frame events, and exit with the binary's code.
-The bounded pool loop (`test.sfn:705-856`) is retargeted to spawn *these*
-exec-only children instead of full `sfn test <file>` children. Fault isolation is
-identical to today — a crashing test still dies in its own subprocess, still
-retried on 137/139 via the existing gate, still killed by `timeout` on hang — but
-the child no longer runs a compiler.
+If a future design does move compilation into one long-lived parent process
+(the Accepted shape), it must **first** make per-file memory reclamation real,
+because `SAILFIN_USE_ARENA` is off by default and the OOM is otherwise
+guaranteed at ~400 heavy files (Finding 3). Concretely, one of:
 
-The exec-only child does **not** need `SAILFIN_TEST_RUNTIME_OBJDIR`,
-`SAILFIN_TEST_RUNTIME_STAMP`, the resolver, or the interface loader, because the
-binary is already linked. It needs only `PATH`/`HOME`/`TMPDIR` (for any `![io]`
-test that itself spawns), its own scratch, and the JSON sub-frame flag. This
-*shrinks* the per-child env surface (`_pool_child_env`).
+- **Arena-as-default** — turn `SAILFIN_USE_ARENA` on by default *and validate
+  it* (correctness + peak-RSS) across the full combined suite, so
+  `arena_mark`/`arena_rewind` actually reclaims per-file allocations. This is a
+  prerequisite the Accepted text silently assumed; it is its own validation
+  effort (SFEP-0022 Darwin budget, seedcheck peak-RSS guard).
+- **Bounded subprocess batching** — keep process teardown for memory hygiene but
+  amortize the frontend across a *batch* of files per subprocess (e.g. N files
+  per worker process, each worker sharing one warm resolve for its batch),
+  bounding resident set to one batch while still cutting the per-file frontend
+  tax by ~1/N. This is a middle path between "one process compiles everything"
+  (OOM) and "one process per file" (full recompute).
 
-**Phase C — parallel compile (optional, gated, deferred).** Phase A compiles
-serially in the parent. If serial parent-compile becomes the new bottleneck once
-the ~41 s tax is gone (it will not for macOS's 3-vCPU runners, but may for large
-many-core CI hosts), a follow-up can fan the *compile* step across a bounded
-thread pool. This is explicitly **out of scope for the shipping phases** — it
-depends on the structured-concurrency runtime maturing and on the compiler being
-proven thread-safe across concurrent in-process compiles (the zero-mutable-state
-finding above is necessary but the arena is a shared bump allocator, so
-concurrent compiles would need per-thread arenas first). Serial parent-compile
-already hits the target.
+Neither is free, and both must clear the combined-suite gate. Direction (iv) is
+**not** independently shippable ahead of a decision on (i)/(ii)/(iii); it is the
+memory-safety floor any in-process variant must stand on.
 
-### 3.3 Interplay with existing caches (must keep working)
+### 3.5 Salvage — the exec-only child (independently landable)
 
-- **Test-bin content cache (`test_bin_cache_key`, `build_cache.sfn:1281`).**
-  Unchanged and *more* effective: the parent now populates and reads it
-  in-process, so a warm cache means the parent skips lower+link and just writes
-  the binary path for the exec-only child. Its key still folds test source +
-  dep closure + compiler identity + runtime identity — none of which this SFEP
-  alters.
-- **#2013 dep `.ll`→`.o` cache (PR #2014).** Unchanged — it accelerates the link
-  the parent now performs, which is exactly where its ~7 s→~1 s win lands. The
-  parent linking many binaries against the same warm dep `.o` set is the ideal
-  consumer of this cache.
-- **SFEP-0044 runtime-identity stamp (#1996).** Still written by the parent warm;
-  now *consumed by the parent's own compile loop* (which computes
-  `_test_bin_runtime_identity` once, `test.sfn:1149`) rather than by children.
-  The stamp's per-child value evaporates — but the parent path was always its
-  cheaper consumer. The stamp file remains for the single-file leaf path and for
-  seedcheck's pinned-objdir runs.
+Independent of how the compile side is resolved, the exec-only child is sound
+and shippable **now** against the *existing fork path*:
 
-### 3.4 Worked shape
+- Introduce a hidden internal dispatch `sfn __run-test-bin <binary_path>` (not
+  in `command_def()`'s help surface) that carries **no compiler code path**: set
+  up per-child scratch, `exec` the prebuilt binary under `timeout`, forward
+  stdout/stderr and per-test JSON sub-frame events, exit with the binary's code.
+- The parent compiles+links each test binary (via whatever compile strategy is
+  in force — today, that is still per-file, so this can land *before* any
+  resolver sharing) into a stable per-file path, then the bounded pool
+  (`test.sfn:705-856`) spawns `__run-test-bin` children instead of full
+  `sfn test <file>` children.
 
-```
-parent (one `sfn test <dir>` process):
-  partition test_files into resolver groups          [existing, test.sfn:970]
-  for each group:
-    prepare_project_capsules_for_test(group)          [existing, ~32s ONCE/group]
-    load_imported_interfaces_from_paths(group)        [existing]
-  warm runtime objects -> sub_root; write stamp       [existing, test.sfn:657]
-  arena_mark()
-  for each test_file:                                 [MOVED UP from leaf path]
-    if test_bin_cache hit -> restore binary
-    else compile_tests_to_llvm_file_with_module_imports(...)  [~cheap, interfaces resident]
-         llvm_assemble + clang link -> sub_root/bin/<file>
-         store test-bin cache
-    record (binary_path, entries)
-    arena_rewind()
-  pool (--jobs N) over recorded binaries:
-    spawn `sfn __run-test-bin <binary_path>` with per-child scratch + timeout
-    reap in order; retry 137/139; aggregate JSON sub-frames   [existing pool logic]
-```
+This preserves fault isolation exactly (a crashing test still dies in its own
+subprocess, still retried on 137/139, still killed by `timeout` on hang) while
+shrinking the per-child env surface (`_pool_child_env` no longer needs the
+resolver/objdir/stamp env). It delivers value on its own — the pool no longer
+re-links per child on a warm test-bin cache — and it is the natural *consumer*
+for any later parent-compile sharing without itself depending on that sharing.
+Per `.claude/rules/seed-dependency.md` there is **no seed dependency** (pure
+`![io]` driver orchestration using capabilities the pinned seed already has), so
+it bundles cleanly with whatever produces the binaries and needs no seed cut.
 
-The pool loop, reaping, retry gate, JSON aggregation, and suite-banner
-attribution (`test.sfn:705-960`) are **reused verbatim** — only the spawned argv
-(`_pool_child_argv`) and env (`_pool_child_env`) change, and the thing being
-spawned is a linked binary rather than a compiler.
+### 3.6 Decomposition into workable issues
+
+Ordered, groomable SFN-issue candidates with one-line scope + dependencies.
+Dependency ordering is explicit so `/groom` can turn this into Linear issues and
+`blockedBy` relations directly.
+
+1. **Compiler-issue: giant-function codegen miscompile in `test.sfn::run`.**
+   Scope: root-cause and fix the layout-sensitive `bounds_check` abort that
+   shifts/vanishes with a gated `print.err` / helper extraction (Finding /
+   incidental note). *Depends on:* nothing. *Independent* — a compiler bug, not
+   part of the runner design, but it destabilizes any work in this file, so land
+   it first.
+
+2. **Land the exec-only child (`__run-test-bin`) against the existing fork
+   path.** Scope: add the hidden dispatch; the parent compiles+links binaries
+   per-file as it does today and the pool spawns exec-only children; shrink
+   `_pool_child_env`. *No resolver sharing yet.* *Depends on:* (1) for a stable
+   file to edit. *Independently shippable* (Finding 4 salvage; §3.5). One PR,
+   no seed cut.
+
+3. **Prerequisite: resolve the within-project descriptor ambiguity
+   (#633-class).** Scope: ensure a single project cannot resolve one symbol name
+   to two incompatible ABIs — `number_to_string` int-vs-`double`,
+   `runtime_object_cache_key[_with_identity]` — via distinct mangling, a single
+   canonical descriptor, or a resolve-time `E0xxx` diagnostic (§3.1). *Depends
+   on:* nothing (but blocks 5/6). Likely warrants its own SFEP or a #633
+   follow-up given resolver+mangling blast radius. *Validation:* the combined
+   compiler suite resolves with no ABI-mismatch / unknown-signature fatals when
+   its entry paths are unioned.
+
+4. **Arena-as-default validation OR subprocess-batched compile.** Scope: either
+   (a) enable `SAILFIN_USE_ARENA` by default and validate correctness + peak-RSS
+   on the full combined suite (SFEP-0022 budget, seedcheck guard), or (b) design
+   bounded subprocess batching so one warm resolve amortizes across N files per
+   worker (§3.4). *Depends on:* nothing to start the design; its *outcome* gates
+   any in-process compile-all. Choose (a) or (b) at groom time.
+
+5. **Shared staged-artifact / import-context cache across forked children
+   (Direction iii).** Scope: parent produces a group-keyed `ImportedModuleSymbols`
+   cache; forked children consume it and skip re-parse/re-stage while still
+   resolving their own import set (no union). *Depends on:* (2) for the
+   exec-only consumer shape; does **not** require (3) (no union → no conflict).
+   The safest first *sharing* step; measure how much of the ~41 s it removes
+   before committing to (6).
+
+6. **Parent-compiles-once per conflict-free (sub-)group (Direction i+ii+iv
+   combined).** Scope: the original Accepted shape, but only after (3) removes
+   the descriptor conflict and (4) makes reclamation real; optionally
+   sub-partition (Direction ii) any residual conflicts. *Depends on:* (3) AND
+   (4) AND (2). *Validation gate is the combined `make test`/`make check`
+   suite*, not small dirs. This is the biggest, riskiest issue and must not be
+   groomed as ready until its predecessors land.
+
+Recommended shipping order: **1 → 2** (immediate value, no risk to the
+sharing question) then **3 and 4 in parallel** (both are prerequisites and
+independent of each other) then **5** (conservative sharing win) and only then
+**6** if 5's measured win is insufficient.
 
 ## 4. Effect & capability impact
 
-None. All changes are within `![io]` build/test-driver code
-(`compiler/src/cli/commands/test.sfn`, plus a hidden `__run-test-bin` dispatch).
-The new exec-only child carries a *smaller* effect surface than today's child
-(no resolver/frontend), and the parent's in-process compile uses the same
-`![io]` entrypoints (`compile_tests_to_llvm_file_with_module_imports`,
-`assemble_runtime_capsule_link_inputs`, `llvm_assemble`) already invoked on the
-serial path. No user-facing effect surface changes; no capsule-manifest surface
-changes.
+None. All changes remain within `![io]` build/test-driver code
+(`compiler/src/cli/commands/test.sfn`, `compiler/src/capsule_resolver.sfn`, plus
+a hidden `__run-test-bin` dispatch). The exec-only child carries a *smaller*
+effect surface than today's child (no resolver/frontend). Direction (i)'s
+resolver/mangling change is internal to the compiler and does not alter the
+user-facing effect surface or capsule-manifest surface. No new capability is
+introduced.
 
 ## 5. Self-hosting impact
 
-No compiler *pass* changes — lexer → parser → AST → typecheck → effects →
-emitter → LLVM lowering are all untouched. The change is entirely in the
-test-runner orchestration:
+The salvageable and prerequisite work spans more than pure orchestration now,
+because Direction (i) touches the resolver and mangling:
 
-- `compiler/src/cli/commands/test.sfn` — hoist the compile loop into the
-  multi-file parent; add the exec-only child dispatch; retarget the pool.
+- **Issue 2 (exec-only child)** and **issue 5 (shared import-context)** are
+  test-runner orchestration in `test.sfn` — no compiler *pass* changes; they
+  self-host because the binaries they exec/consume are produced by the same
+  compile path the serial leaf uses.
+- **Issue 3 (descriptor ambiguity)** changes name resolution / mangling in
+  `capsule_resolver.sfn` (and possibly the lowering mangle pass). This *is* a
+  compiler-pass change and must self-host under `make compile`, then be gated by
+  `make check` (whose seedcheck suite runs through this very runner — a
+  divergence between the two `number_to_string` callees would fail the suite by
+  construction).
+- **Issue 4 (arena / batching)** changes memory-management defaults or the
+  subprocess topology; self-hosting is preserved because the single-file compile
+  path is unchanged and the combined suite is the gate.
 
-The self-hosting invariant is preserved because (a) the *serial single-file*
-compile path is unchanged and already self-hosts, and (b) `make check`'s
-seedcheck suite runs through this exact runner — if the parent-compile path
-produced a different binary than the per-child path, the suite would fail. Each
-phase self-hosts independently:
-
-- **Phase A** hoists an *existing, proven* loop up one level and gates the fork
-  behind it. Intermediate state: parent compiles in-process **and** still forks
-  full children (belt-and-suspenders) → correct, just not yet faster; then flip
-  children to exec-only. In practice A+B land together (see bundling below).
-- **Phase B** is the exec-only child; it self-hosts because the binary it execs
-  is produced by the same compile path the serial leaf uses.
-
-**Seed dependency: NONE.** This is pure driver orchestration in
-`compiler/src/*.sfn` using capabilities the seed already has
-(`process.spawn_with_env`, `process.handle_wait`, arena intrinsics, the existing
-compile entrypoints). Per `.claude/rules/seed-dependency.md`, no language/runtime
-capability absent from the pinned seed is introduced. `make compile` builds the
-new runner from the old seed in one pass; no seed cut, no `/pin-seed`.
-
-**Bundling (per `.claude/rules/seed-dependency.md`).** Phases A and B are a single
-cohesive capability (parent-compiles) plus its single consumer (exec-only child);
-they should land **in one PR** — the exec-only child is useless without the
-parent producing binaries, and the parent producing binaries with no exec-only
-consumer is dead code. Splitting them manufactures an intermediate PR with no
-shippable value (and no seed-cut gate either way, since there is no seed
-dependency). Phase C is genuinely independent (parallel compile) and defers.
+**Seed dependency.** Issues 2, 4, and 5 are pure driver/runtime orchestration
+using capabilities the pinned seed already has → no seed cut. Issue 3 changes
+compiler-emitted symbol names; if any *other* compiler-source change depends on
+the new mangling being in the pinned seed, apply `.claude/rules/seed-dependency.md`
+(bundle with its single consumer by default). Within this SFEP, issue 3 has no
+single downstream consumer that must self-host against it before it is in-seed —
+its consumers (issues 5/6) build the new compiler from the old seed in the same
+`make compile` pass — so **no seed cut is forced** by the ordering here. Call
+out any cross-SFEP consumer at groom time.
 
 ## 6. Alternatives considered
 
-**Alternative 1 — serialized frontend snapshot.** Parent runs the resolver +
-interface load once, serializes the resolved interfaces / module graph /
-effect tables to a versioned snapshot file in the shared objdir; children
+The Accepted design ("parent compiles once per project/workspace group,
+in-process, arena-rewound; children exec only") is now itself the **rejected**
+alternative for the compiler suite — see §1a for the empirical falsification.
+Its irreducible flaws on the primary consumer: (a) a project-root group unions
+conflicting descriptors and miscompiles the losers (Finding 1); (b) in-process
+compile-all is slow (~40 min) with no landed memo (Finding 3); (c) the arena
+reclamation it depended on is off by default, reviving the OOM (Finding 3). It is
+*retained as a target* only under the strict prerequisites of §3.1 and §3.4 (see
+issue 6), not as a ready design.
+
+**Alternative 1 — serialized frontend snapshot.** Parent serializes resolved
+interfaces / module graph / effect tables to a versioned snapshot; children
 deserialize instead of recomputing, then compile the test source themselves.
-*Assessment:* the state to serialize is `Statement[]` interface ASTs +
-`LayoutManifest[]` + `native_texts: string[]` + `ImportSymbolTable` (function
-name → `effects: string[]`) + `capabilities_required: string[]`. The
-`native_texts` and interface `.sfn-asm` are **already on disk** as staged
-artifacts (`resolution.asm_paths`), so a "snapshot" is largely re-reading files
-the resolver already wrote — which is exactly the per-child cost the Phase 0
-probe attributed (the child re-parses the 130 `.sfn-asm` texts in lowering,
-~9 s post-#2016, plus the ~32 s resolver staging walk). A stable binary serialization of the parsed/typechecked interface state
-does not exist today and would require freezing an on-disk format for AST +
-`ImportSymbolTable` (interface-serialization *drift* risk: any AST/effect-table
-field change silently invalidates or misreads snapshots — a whole new versioning
-surface). And this still leaves the child running typecheck + emit + lower +
-link, so it only removes the resolver's *staging* cost, not the interface-load or
-compile cost. **Rejected:** more machinery, new format-drift risk, and it does
-not eliminate the dominant per-child work (the child still compiles). This is the
-shape 0006 flags as filesystem-IPC-bound — the very bottleneck we are trying to
-escape.
+*Reassessment in light of the failure:* now more attractive *relative to*
+in-process compile-all, because it keeps per-file process teardown (no OOM) and
+never unions conflicting descriptors (each child still compiles its own import
+set). It is essentially Direction (iii) with an explicit on-disk format. The
+cost is unchanged and real: `native_texts`/interface `.sfn-asm` are already on
+disk, so the win is bounded to skipping re-parse, and a *stable* binary
+serialization of parsed/typechecked interface state does not exist and would
+introduce a format-drift versioning surface (any AST/effect-table field change
+silently invalidates snapshots). **Not easy** — but no longer strictly dominated,
+since the approach that dominated it (in-process compile-all) has failed. Prefer
+the in-memory group-keyed cache of Direction (iii) first (no on-disk format), and
+escalate to a serialized snapshot only if cross-*process* sharing is required.
 
 **Alternative 3 — resolver daemon / IPC (the 0006 shape).** A long-lived frontend
-server holds resolved interfaces resident; children query it over IPC per
-compile. *Assessment:* the most general and the most machinery — needs a wire
-protocol, a server lifecycle, crash/restart handling, and a client in every
-child. It also re-introduces per-query IPC round-trips (0006's primary
-bottleneck) unless the payload is kept tiny, and the payload here (interface
-ASTs) is not tiny. It solves a problem we do not have: we do not need *many
-independent clients* querying a shared frontend; we need *one* process that
-already holds the frontend to also do the compiles. **Rejected as premature** —
-Alternative 2 achieves the target with no new protocol by observing that the
-parent *is* the natural frontend server and the compile *is* the query. A daemon
-is the right shape only if/when `sfn check` / `sfn build` (not just `sfn test`)
-need cross-invocation frontend sharing; that is the 0006 redesign, out of scope
-here.
+server holds resolved interfaces resident; children query it per compile.
+*Reassessment:* the reason it was rejected — "Alternative 2 achieves the target
+with no new protocol" — **no longer holds**, because Alternative 2 (in-process
+compile-all) failed. A daemon does not suffer the union conflict (each query
+carries its own import set) or the single-process OOM (the daemon holds only
+resolved interfaces, not the accumulating compile arena of ~400 files). It
+remains the **most machinery** — wire protocol, server lifecycle, crash/restart,
+a client in every child, and 0006's per-query IPC round-trips on a non-tiny
+payload (interface ASTs). It is still **not easy** and still premature relative
+to the conservative Direction (iii); but it is now the honest long-term shape if
+`sfn check` / `sfn build` (not just `sfn test`) come to need cross-invocation
+frontend sharing (the 0006 redesign). Keep it explicitly on the table as the
+end-state, not dismissed.
 
-**Why Alternative 2 wins:** it reuses the *already-proven* in-process serial
-compile path (zero new correctness surface — the serial path self-hosts today),
-introduces no serialization format and no IPC protocol, keeps every existing
-cache working, and preserves execution fault-isolation exactly. It moves one loop
-up one scope and shrinks the child, rather than building new infrastructure.
-
-**Sub-decision — keep forking for execution vs. run in-process.** Could the
-parent also *run* the tests in-process (no children at all)? **Rejected:** an
-`assert false` calls `abort()`, taking the whole runner down; a hanging test is
-unkillable without a subprocess `timeout`; and per-test process teardown is the
-only reliable way to reclaim a test that leaks fds/threads. Execution isolation
-is load-bearing and stays in children. This is precisely why the split is
-"parent compiles, child executes" and not "parent does everything."
+**Sub-decision — keep forking for execution vs. run in-process.** Still
+**rejected** to run tests in-process: an `assert false` calls `abort()`, a
+hanging test is unkillable without a subprocess `timeout`, and per-test teardown
+is the only reliable reclamation of a test that leaks fds/threads. Execution
+isolation stays in children under every direction — which is exactly why the
+exec-only child (§3.5) is salvageable independent of the compile side.
 
 ## 7. Stage1 readiness mapping
 
-Tooling change; no language surface.
+Tooling change plus (for issue 3) a resolver/mangling change; no user-facing
+language surface.
 
 - [ ] Parses — N/A (no new syntax; `__run-test-bin` is a dispatch string)
-- [ ] Type-checks / effect-checks — `test.sfn` passes `sfn check`
+- [ ] Type-checks / effect-checks — `test.sfn` and `capsule_resolver.sfn` pass
+      `sfn check`
 - [ ] Emits valid `.sfn-asm` — exercised by `make compile`
-- [ ] Lowers to LLVM IR — exercised by `make compile`
+- [ ] Lowers to LLVM IR — exercised by `make compile`; issue 3's mangling change
+      must lower cleanly for both `number_to_string` callees
 - [ ] Regression coverage — see §8
-- [ ] Self-hosts — `make compile` then `make check` (the suite runs through this
-      runner; a divergence between parent-compile and per-child-compile binaries
-      fails the suite by construction)
-- [ ] `sfn fmt --check` clean — on `test.sfn`
-- [ ] Documented in `docs/status.md` — note the test-runner architecture change;
-      this SFEP is the design record
+- [ ] Self-hosts — `make compile` then **`make check` over the combined suite**
+      (unit+integration+e2e+capsules in one invocation — the gate that exposed
+      the flaw; small-dir passing is insufficient)
+- [ ] `sfn fmt --check` clean — on every touched `.sfn`
+- [ ] Documented in `docs/status.md` — the test-runner architecture change and
+      (for issue 3) the descriptor-disambiguation semantics; this SFEP is the
+      design record
 
 ## 8. Test plan
 
-The load-bearing property is: **parent-compiled binaries are byte-equivalent in
-behavior to per-child-compiled binaries, and execution fault-isolation is
-preserved.** `make check` already exercises the whole suite through the runner,
-so the strongest regression is that `make check` stays green. Targeted additions:
+The load-bearing property is unchanged — parent/shared-compiled binaries must be
+behavior-equivalent to per-file-compiled binaries, and execution fault-isolation
+must be preserved — but the **validating invocation is now explicitly the
+combined compiler suite**, because that is what falsified the Accepted design.
 
-- `compiler/tests/e2e/parent_compile_multifile_test.sfn` — `![io]`: run a small
-  multi-file suite (2–3 fixtures with distinct imports so they exercise the
-  per-group resolver reuse) via a spawned `sfn test <dir>`; assert all pass and
-  the aggregate counts match a per-file `sfn test <file>` baseline. Proves the
-  parent-compile path produces working binaries.
-- `compiler/tests/e2e/test_runner_crash_isolation_test.sfn` — `![io]`: a suite
-  containing one fixture that `assert false`s (aborts) and one that passes;
-  assert the passing one still runs and is reported passed, the aborting one is
-  reported failed, and the runner exits nonzero — i.e. the abort did not take
-  down the runner or the sibling. Proves execution isolation survived the
-  refactor. (This is the regression that would catch an accidental "parent runs
-  in-process" mistake.)
-- `compiler/tests/e2e/test_runner_timeout_isolation_test.sfn` — `![io]`: a
-  fixture with an infinite loop; assert it is killed by the per-child `timeout`
-  (exit 124) and siblings complete. Proves hang-killing survived.
-- `compiler/tests/e2e/test_bin_cache_parent_hit_test.sfn` — `![io]`: run a suite
-  twice; assert the second run reports a high `cache.test_bin_hit_rate` (the
-  parent now populates/reads the test-bin cache in-process). Proves the #2013 /
-  `test_bin_cache_key` interplay.
+**Primary gate (non-negotiable):** `make test` and `make check` run
+`sailfin test compiler/tests/unit compiler/tests/integration compiler/tests/e2e
+capsules --jobs N` in **one** invocation and must be green. Any future design in
+§3 is not "shipped" until it clears this exact invocation. A green run on a
+standalone multi-file dir, a single-capsule dir, or `capsules` alone is **not**
+sufficient evidence — all three passed while `make test` failed 435/435.
+
+Targeted additions (per issue):
+
+- **Issue 3 (descriptor ambiguity).**
+  `compiler/tests/e2e/resolver_symbol_abi_conflict_test.sfn` — `![io]`: a suite
+  containing both a file that imports the `![pure]` int-signature
+  `number_to_string` (#633) and a file that uses the `double` runtime helper,
+  compiled through *one* resolver group; assert both link and run correctly (no
+  `ABI primitive mismatch`, no `undefined reference`). This is the direct
+  regression for Finding 1.
+- **Issue 2 (exec-only child).**
+  `compiler/tests/e2e/parent_compile_multifile_test.sfn` — `![io]`: a small
+  multi-file suite via a spawned `sfn test <dir>`; assert all pass and aggregate
+  counts match a per-file baseline.
+  `compiler/tests/e2e/test_runner_crash_isolation_test.sfn` — one fixture that
+  `assert false`s and one that passes; assert the passing one still runs, the
+  aborting one is reported failed, the runner exits nonzero (execution isolation
+  survived).
+  `compiler/tests/e2e/test_runner_timeout_isolation_test.sfn` — an infinite-loop
+  fixture killed by `timeout` (exit 124) while siblings complete.
+- **Issue 4 (arena/batching).** A peak-RSS guard: run the combined suite under
+  the SFEP-0022 Darwin budget / seedcheck's pinned-scratch full-suite run and
+  assert it stays under budget (the Finding 3 OOM regression guard). If
+  subprocess batching is chosen, assert a batch worker compiles N files in one
+  process without exceeding the per-process cap.
+- **Issue 5/6 (sharing).**
+  `compiler/tests/e2e/test_bin_cache_parent_hit_test.sfn` — run a suite twice;
+  assert a high `cache.test_bin_hit_rate` on the second run.
 - Existing `check_build_agree_module_global_test.sfn` and the JSON sub-frame
   aggregation tests continue to gate output correctness.
 
-**Perf gate (informational, not CI-blocking):** `make bench`-style timing of a
-heavy-closure suite before/after, asserting the per-file cost drops from ~43 s
-(fork path, post-#2016) to the ~1.5–2.5 s marginal the Phase 0 math projects.
-Recorded in the PR, not a test assertion (timing is host-dependent).
-
-**Memory (Darwin, SFEP-0022).** The parent now holds full frontend state
-(resolved interfaces + dep `.ll` closure for the largest resolver group) while
-children run. macOS runners are 3-vCPU/7 GiB with no `RLIMIT_AS`. Mitigation: the
-parent already holds this state on the serial path today without OOM (arena
-rewind between files keeps per-file allocations bounded; the resident set is one
-group's interface closure, not the union of all groups — groups are processed and
-their transient staging freed sequentially). The exec-only children are now
-*tiny* (a linked binary + a `timeout` wrapper) versus today's full-compiler
-children, so total concurrent RSS **drops**: N heavy compilers → 1 parent
-compiler + N thin execs. Verify with `make check` on a macOS runner and a
-`--jobs` sweep; the peak-RSS regression guard is that seedcheck (which pins
-scratch and runs the full suite) stays under budget.
+**Perf gate (informational, not CI-blocking):** record before/after per-file
+cost on a heavy-closure suite in the PR. Note that the Accepted ~1.5–2.5 s/file
+projection assumed an unlanded memo and is **not** a target any current
+direction commits to until measured.
 
 ## 9. References
 
-- **#2010** — the epic; this is the structural fix for sub-item (b). Comment
-  4918225130 carries the measured per-child breakdown quoted in §2.
-- **#1997** — the resolver-sharing follow-up SFEP-0044 §3-C deferred; this SFEP
-  is that work. Fold #1997's scope in.
+- **#2010** — the epic; this is the structural fix for sub-item (b).
+- **#1997** — the resolver-sharing follow-up SFEP-0044 §3-C deferred.
+- **#633** — the `![pure]` int-signature import fix whose descriptor coexists
+  with the `double` runtime helper; the root of the Finding 1 conflict.
 - **SFEP-0044** (`docs/proposals/0044-test-runner-invocation-cache.md`) — the
-  parent-warms-once / children-consume pattern (#940 runtime objdir, #1996
-  invocation stamp) this SFEP extends from backend artifacts to the frontend;
-  §3-C is the explicit deferral of resolver sharing gated on 0006.
-- **#2013 / PR #2014** — dep `.ll`→`.o` cache that cut the link from 8.3 s to
-  ~1 s; the parent's link consumes it (§3.3).
-- **#2016 / PR #2018** — single-parse import gather, the algorithmic fix the
-  Phase 0 probe surfaced (5 parses per imported text → 1; lowering 25.3 s →
-  ~9 s; unit tier −30.5% wall). Phase A's group-scoped memo extends the same
-  observation (`ImportedModuleSymbols` is group-constant) from "parse once
-  per compile" to "compute once per group."
+  parent-warms-once / children-consume pattern; Direction (iii) extends it from
+  backend artifacts to a shared frontend import-context; §3-C is the explicit
+  deferral of resolver sharing gated on 0006.
+- **#2013 / PR #2014** — dep `.ll`→`.o` cache (link 8.3 s → ~1 s).
+- **#2016 / PR #2018** — single-parse import gather (lowering 25.3 s → ~9 s);
+  the memo Direction (iv)/issue 6 would extend from "parse once per compile" to
+  "compute once per group" was **not** landed and is not assumed here.
 - **SFEP-0006** (`docs/proposals/0006-build-architecture.md`) — build/IPC
-  bottleneck root cause; §6 explains why Alt 1 (snapshot, filesystem-IPC-bound)
-  and Alt 3 (daemon/IPC) are the shapes to avoid here.
-- **SFEP-0022** (`docs/proposals/0022-darwin-memory-governor.md`) — Darwin memory
-  budget the parent-holds-state design must fit (§8).
+  bottleneck root cause; frames Alt 1 (snapshot) and Alt 3 (daemon/IPC).
+- **SFEP-0022** (`docs/proposals/0022-darwin-memory-governor.md`) — the Darwin
+  memory budget any in-process compile-all (issue 4/6) must fit.
 - **#848** — the multi-file per-child isolation this SFEP restructures;
-  `test.sfn:557-576` documents why forking exists.
-- **#940** — the shared-objdir runtime warm; **#1333** — per-child scratch
-  isolation; **#1236 / #1303** — the bounded worker pool + signal-kill retry gate
-  reused verbatim.
+  `test.sfn:557-576` documents why forking exists and names the
+  `number_to_string` conflict.
+- **#940** — shared-objdir runtime warm; **#1333** — per-child scratch;
+  **#1236 / #1303** — bounded worker pool + signal-kill retry gate.
 - Key code paths: `compiler/src/cli/commands/test.sfn:583` (multi-file fork
-  branch), `:657` (parent runtime warm), `:1017-1067` (per-group resolver +
-  interface load), `:1156-1420` (the serial compile+link+run loop this SFEP
-  hoists into the parent), `:705-960` (bounded pool + reap + retry + JSON
-  aggregation reused for exec-only children); `compiler/src/main.sfn:482`
+  branch — returns before the serial path, making the group loop below dead code
+  for >1 file; Finding 1); `:657` (parent runtime warm); `:1017-1067` (per-group
+  resolver + interface load — the union that conflicts); `:1078-1079` (arena
+  rewind is a **no-op** when `SAILFIN_USE_ARENA` is unset — Finding 3);
+  `:1156-1420` (the serial compile+link+run loop); `:705-960` (bounded pool +
+  reap + retry + JSON aggregation reused for exec-only children);
+  `compiler/src/main.sfn:482`
   (`compile_tests_to_llvm_file_with_module_imports`);
   `compiler/src/capsule_resolver.sfn:3476`
-  (`prepare_project_capsules_for_test`); `compiler/src/build_cache.sfn:1281`
-  (`test_bin_cache_key`).
+  (`prepare_project_capsules_for_test` — the union point);
+  `compiler/src/build_cache.sfn:1281` (`test_bin_cache_key`).

--- a/docs/proposals/0045-shared-frontend-test-runner.md
+++ b/docs/proposals/0045-shared-frontend-test-runner.md
@@ -25,7 +25,7 @@ the **parent** run the frontend (resolve + typecheck + emit + lower + link)
 children to `exec(test_binary)` under a timeout, preserving execution fault
 isolation while eliminating frontend recomputation.
 
-The originally-Accepted design (below, §6-legacy) rested on a premise that a
+The originally-Accepted design (now the rejected alternative in §6) rested on a premise that a
 real implementation **falsified**: it assumed grouping tests by
 `(project_root, workspace_root)` avoids the resolver-union descriptor conflict
 that per-file forking was built to sidestep. It does not — for the compiler's
@@ -338,7 +338,7 @@ Dependency ordering is explicit so `/groom` can turn this into Linear issues and
 
 1. **Compiler-issue: giant-function codegen miscompile in `test.sfn::run`.**
    Scope: root-cause and fix the layout-sensitive `bounds_check` abort that
-   shifts/vanishes with a gated `print.err` / helper extraction (Finding /
+   shifts/vanishes with a gated `print.err` / helper extraction (see the §1a
    incidental note). *Depends on:* nothing. *Independent* — a compiler bug, not
    part of the runner design, but it destabilizes any work in this file, so land
    it first.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -67,7 +67,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0042](./0042-nested-function-declarations.md) | Nested / Local Function Declarations (non-capturing static `fn` items) | Accepted | language |
 | [0043](./0043-phase-scoped-arena-reclamation.md) | Phase-scoped arena reclamation to reduce per-module peak RSS | Implemented | runtime |
 | [0044](./0044-test-runner-invocation-cache.md) | Invocation-scoped runtime identity + in-process sha256 for the test runner | Implemented | tooling |
-| [0045](./0045-shared-frontend-test-runner.md) | Shared-frontend test runner — parent compiles, children only execute | Accepted | tooling |
+| [0045](./0045-shared-frontend-test-runner.md) | Shared-frontend test runner — parent compiles, children only execute | Draft | tooling |
 
 ## Drafts under review (numbers assigned at merge)
 


### PR DESCRIPTION
## Summary

Demotes SFEP-0045 (Shared-frontend test runner) from `Accepted` to `Draft` and records an honest post-mortem of the end-to-end implementation attempt. The Accepted design — parent compiles once per project/workspace group in-process, children only execute — was implemented, self-hosts, and passes on small/medium suites, but **fails `make test`** (0 passed, 435 `compile failed`, ~2 h runaway) on the compiler's own suite, which is the primary consumer.

The core failure: the central claim that "grouping tests by `(project_root, workspace_root)` avoids the resolver-union descriptor conflict" is **false**. The serial group path that was supposed to validate this was dead code (never exercised with >1 file per group). When activated, all ~400 files under `compiler/tests/{unit,integration,e2e}` collapse into one resolver group whose unioned import descriptors conflict pervasively (`number_to_string` int-signature vs. double-runtime, `runtime_object_cache_key` ABI mismatches, etc.), causing miscompilation. A reactive per-file fallback re-resolve fires on a large fraction of files, degenerating to the ~2-hour runaway. In-process compile-all is also slow (~40 min serially) without a landed group-scoped memo, and the arena reclamation it depended on is off by default, reviving the pre-#848 OOM.

This revision:
- Retracts the false premise in the motivation and design
- Records four findings from the failed run in priority order (§1a)
- Reframes §3 as a set of candidate directions with explicit prerequisites and decomposition into groomable issues
- Calls out the one salvageable, independently-landable piece: the exec-only child (`__run-test-bin`)
- Retains the Accepted design as a target only under strict prerequisites (fixing the within-project descriptor conflict, validating arena-as-default or subprocess batching)

No compiler source changes in this commit — this is a documentation revision of the SFEP itself.

Fixes SFN-XXXX (SFEP-0045 revision)

## Changes

- `docs/proposals/0045-shared-frontend-test-runner.md`
  - Status: `Accepted` → `Draft`
  - §1a (new): Post-mortem with four findings from the failed implementation
  - §2: Retraction of the false grouping premise; clarification that reasons (1)–(2) apply to execution, not compilation
  - §3: Reframed as candidate directions (i–iv) with prerequisites and decomposition into workable issues (§3.6)
  - §5: Updated self-hosting impact to reflect the broader scope (resolver/mangling changes in issue 3)
  - §6: Reassessment of alternatives in light of the failure; daemon/IPC no longer strictly dominated

## Validation

- [x] N/A — docs-only change (no `.sfn` touched)

## Notes for reviewers

This is a documentation-only revision recording the empirical falsification of the Accepted design. The implementation attempt was real and thorough; the failure is honest and specific. The post-mortem is the primary value here — it unblocks the next phase by naming the actual obstacle (descriptor conflict within a project root) rather than assuming it away.

The decomposition in §3.6 is intended to be groomed directly into Linear issues with explicit dependency ordering, so the next phase can proceed in parallel on the prerequisite (issue 3: fix the descriptor ambiguity) and the salvageable piece (issue 2: exec-only child) without waiting for a single "right answer" on the compile-sharing strategy.

https://claude.ai/code/session_01Xpb9XRpXEzkaPrR9MChm27