### PR TITLE
feat(http): router with path-param capture for sfn/http

### DIFF
--- a/capsules/sfn/http/src/mod.sfn
+++ b/capsules/sfn/http/src/mod.sfn
@@ -9,6 +9,8 @@
 //                 header, query_param, reason_phrase, response,
 //                 response_with_status, json_response, not_found
 //   - server.sfn  serve (typed HTTP server on the M4 runtime)
+//   - router.sfn  Router, Params, MatchResult, router, route, dispatch,
+//                 match_pattern, param ({param} path capture)
 //   - mod.sfn     client (get, post, fetch)
 //
 // Build-out tracked by epic #1321; design in docs/proposals/0019-sfn-http-capsule.md.
@@ -31,6 +33,18 @@ export {
 
 // ---- Server ----
 export { serve, serve_tls } from "./server";
+
+// ---- Router (path-param capture, SFN-37) ----
+export {
+    Router,
+    Params,
+    MatchResult,
+    router,
+    route,
+    dispatch,
+    match_pattern,
+    param
+} from "./router";
 
 // Local bindings for the typed client (re-export above does not create
 // local scope): `fetch` returns a `Response` and parses it via the wire

--- a/capsules/sfn/http/src/router.sfn
+++ b/capsules/sfn/http/src/router.sfn
@@ -1,0 +1,198 @@
+// sfn/http — path router with `{param}` capture.
+//
+// Adds a routing layer over `serve` so handlers stop hand-parsing
+// `req.path`. A `Router` holds an ordered list of `(method, pattern,
+// handler)` routes; `dispatch(router, req)` finds the first matching route,
+// captures any `{param}` path segments, and invokes the handler with the
+// request and the captured `Params`.
+//
+// Handler ABI. A route handler is a TOP-LEVEL `fn(Request, Params) ->
+// Response` passed address-taken, exactly like `serve`'s handler (closures
+// are not supported in v0 — E0808). The handler address is stored as an
+// `i64` in the `Route` and cast back to a code pointer at dispatch, mirroring
+// `server.sfn::_sfn_http_handler_addr`. Because both the call site and the
+// callee are ordinary Sailfin functions, the indirect call uses the normal
+// Sailfin calling convention — unlike the runtime's `fn(OwnedBuf)->OwnedBuf`
+// boundary, there is no cross-ABI aggregate hazard here.
+//
+// Composing with `serve`. `serve` takes a single `fn(Request) -> Response`,
+// so a router is wired in through a module-global `Router` and a top-level
+// dispatch wrapper (the same single-server-per-process shape `serve` uses):
+//
+//   import { serve, router, route, dispatch, param } from "sfn/http";
+//
+//   let mut ROUTER: Router = router();
+//
+//   fn get_user(req: Request, params: Params) -> Response {
+//       let id = param(params, "id");            // captured, no substring math
+//       if id == null { return not_found(); }
+//       return response("user " + id);
+//   }
+//
+//   fn handle(req: Request) -> Response { return dispatch(ROUTER, req); }
+//
+//   fn main() ![net, io] {
+//       ROUTER = route(ROUTER, "GET", "/users/{id}",
+//           get_user as * fn (Request, Params) -> Response);
+//       serve(handle as * fn (Request) -> Response, 8080);
+//   }
+//
+// v0 scope: exact literal segments (case-sensitive) and single-segment
+// `{name}` captures only. No wildcard/splat, regex routes, middleware
+// chains, content negotiation, or an `Allow` header on the 405 (post-1.0 —
+// see SFN-37 / epic #1321).
+import { Request, Response } from "./types";
+import { not_found, response_with_status } from "./wire";
+
+// Captured path parameters, as parallel name/value arrays (the prelude
+// exposes no map to capsules yet; the array pair keeps the lookup obvious
+// and order-preserving). `param` reads a value by name.
+struct Params {
+    names: string[];
+    values: string[];
+}
+
+// `param(params, name)` — captured value for `name`, or null if the pattern
+// declared no such `{name}` segment. On a duplicate capture name (e.g.
+// `/{id}/{id}`), the first binding wins.
+fn param(params: Params, name: string) -> string? {
+    let mut i = 0;
+    loop {
+        if i >= params.names.length { break; }
+        if strings_equal(params.names[i], name) { return params.values[i]; }
+        i = i + 1;
+    }
+    return null;
+}
+
+// A single registered route. `handler` is the address of a top-level
+// `fn(Request, Params) -> Response` (stored as `i64`, cast back at dispatch).
+struct Route {
+    method: string;
+    pattern: string;
+    handler: i64;
+}
+
+// An ordered list of routes; `dispatch` scans it in registration order and
+// the first match wins (registration order IS the precedence — register a
+// static route before an overlapping `{param}` route to prefer the static
+// one).
+struct Router {
+    routes: Route[];
+}
+
+// `router()` — a new empty router.
+fn router() -> Router {
+    return Router { routes: [] };
+}
+
+// `route(r, method, pattern, handler)` — return a router with one more route
+// appended. `handler` is a top-level `fn(Request, Params) -> Response` passed
+// address-taken (the address is retained as `i64`). Returns a new `Router`
+// so callers reassign (`ROUTER = route(ROUTER, ...)`) — no reliance on
+// struct-field aliasing.
+fn route(r: Router, method: string, pattern: string, handler: * fn (Request, Params) -> Response) -> Router {
+    let mut routes = r.routes;
+    routes.push(Route {
+        method: method, pattern: pattern, handler: handler as i64
+    });
+    return Router { routes: routes };
+}
+
+// Whether a pattern matched a path, plus any captured params. `params` is
+// empty when `matched` is false.
+struct MatchResult {
+    matched: boolean;
+    params: Params;
+}
+
+// `_split_segments(path)` — split a '/'-delimited path into its non-empty
+// segments. Leading/trailing slashes and empty segments (from "//") are
+// dropped, so "/users/42" and "/users/42/" both yield ["users", "42"] and
+// "/" yields the empty list.
+fn _split_segments(path: string) -> string[] {
+    let mut segs: string[] = [];
+    let total = path.length;
+    let mut cursor = 0;
+    loop {
+        if cursor >= total { break; }
+        let slash = find_char(path, "/", cursor);
+        let mut end = total;
+        if slash >= 0 { end = slash; }
+        if end > cursor { segs.push(substring(path, cursor, end)); }
+        if slash < 0 { break; }
+        cursor = slash + 1;
+    }
+    return segs;
+}
+
+// `_is_param_seg(seg)` — true if `seg` is a "{name}" capture segment, which
+// requires at least one character between the braces (so "{}" is NOT a
+// capture — it is treated as a literal segment).
+fn _is_param_seg(seg: string) -> boolean {
+    let n = seg.length;
+    if n < 3 { return false; }
+    return strings_equal(grapheme_at(seg, 0), "{") && strings_equal(grapheme_at(seg, n - 1), "}");
+}
+
+// `match_pattern(pattern, path)` — does `pattern` match `path`, capturing
+// `{param}` segments? Segment counts must be equal (no wildcard/splat in
+// v0); literal segments compare exactly (case-sensitive); a "{name}" segment
+// captures the corresponding path segment under `name`.
+fn match_pattern(pattern: string, path: string) -> MatchResult {
+    let pat = _split_segments(pattern);
+    let seg = _split_segments(path);
+    let empty = Params { names: [], values: [] };
+    if pat.length != seg.length {
+        return MatchResult { matched: false, params: empty };
+    }
+    let mut names: string[] = [];
+    let mut values: string[] = [];
+    let mut i = 0;
+    loop {
+        if i >= pat.length { break; }
+        let p = pat[i];
+        if _is_param_seg(p) {
+            names.push(substring(p, 1, p.length - 1));
+            values.push(seg[i]);
+        } else {
+            if !strings_equal(p, seg[i]) {
+                return MatchResult { matched: false, params: empty };
+            }
+        }
+        i = i + 1;
+    }
+    return MatchResult {
+        matched: true,
+        params: Params { names: names, values: values }
+    };
+}
+
+// `dispatch(r, req)` — route `req` to the first registered route whose
+// pattern matches `req.path` AND whose method equals `req.method`, invoking
+// its handler with the captured params. A path that matches some route's
+// pattern but no route's method yields 405; a path that matches no pattern at
+// all yields 404. The returned `Response` is the handler's own. Composable
+// into `serve`'s `fn(Request) -> Response` via a top-level wrapper over a
+// module-global `Router` (see the module header).
+fn dispatch(r: Router, req: Request) -> Response {
+    let mut i = 0;
+    let mut path_matched = false;
+    loop {
+        if i >= r.routes.length { break; }
+        let rt = r.routes[i];
+        let m = match_pattern(rt.pattern, req.path);
+        if m.matched {
+            if strings_equal(rt.method, req.method) {
+                let h: * fn (Request, Params) -> Response = rt.handler as * fn (Request, Params) -> Response;
+                return h(req, m.params);
+            }
+            path_matched = true;
+        }
+        i = i + 1;
+    }
+    if path_matched {
+        return response_with_status(405, "Method Not Allowed");
+    }
+    return not_found();
+}

--- a/capsules/sfn/http/src/router.sfn
+++ b/capsules/sfn/http/src/router.sfn
@@ -184,6 +184,13 @@ fn dispatch(r: Router, req: Request) -> Response {
         let m = match_pattern(rt.pattern, req.path);
         if m.matched {
             if strings_equal(rt.method, req.method) {
+                // A well-formed route always carries a real handler address
+                // (`route` takes a `* fn`), but guard the sentinel `0` so an
+                // unsafe null cast fails controlled (500) rather than calling
+                // a null code pointer — mirrors `server.sfn::_sfn_http_trampoline`.
+                if rt.handler == 0 {
+                    return response_with_status(500, "Internal Server Error");
+                }
                 let h: * fn (Request, Params) -> Response = rt.handler as * fn (Request, Params) -> Response;
                 return h(req, m.params);
             }

--- a/capsules/sfn/http/tests/router_test.sfn
+++ b/capsules/sfn/http/tests/router_test.sfn
@@ -1,0 +1,161 @@
+// Tests for the sfn/http router (SFN-37): path-pattern matching with
+// `{param}` capture, dispatch precedence, and the 404/405 fallbacks.
+//
+// Pure match/dispatch coverage — no runtime, socket, or serve path is
+// exercised here. `dispatch` invokes registered top-level handlers through
+// their retained addresses, so the handlers below double as the fn-pointer
+// round-trip coverage.
+import {
+    Params,
+    Router,
+    dispatch,
+    match_pattern,
+    param,
+    route,
+    router
+} from "../src/mod";
+import { Request, Response } from "../src/types";
+import { response } from "../src/wire";
+
+// ── test handlers (top-level so their addresses are bare code pointers) ──
+// Echo the captured `id` so a dispatch test can assert the param reached the
+// handler without any substring parsing on the request path.
+fn _h_user(req: Request, params: Params) -> Response {
+    let id = param(params, "id");
+    if id == null { return response("user <none>"); }
+    return response("user " + id);
+}
+
+// Static-route handler used for the precedence test (registered before the
+// overlapping `{id}` route so registration order prefers it).
+fn _h_user_me(req: Request, params: Params) -> Response {
+    return response("me");
+}
+
+// Two-segment capture handler — proves multiple params are captured in order.
+fn _h_comment(req: Request, params: Params) -> Response {
+    let uid = param(params, "uid");
+    let cid = param(params, "cid");
+    let mut u = "?";
+    let mut c = "?";
+    if uid != null { u = uid; }
+    if cid != null { c = cid; }
+    return response(u + "/" + c);
+}
+
+fn _req(method: string, path: string) -> Request {
+    return Request {
+        method: method,
+        path: path,
+        query: "",
+        headers: [],
+        body: ""
+    };
+}
+
+fn _one_route(method: string, pattern: string, handler: * fn (Request, Params) -> Response) -> Router {
+    return route(router(), method, pattern, handler);
+}
+
+test "match_pattern: {id} captures the path segment" {
+    let m = match_pattern("/users/{id}", "/users/42");
+    assert m.matched;
+    let id = param(m.params, "id");
+    assert id != null;
+    if id != null { assert strings_equal(id, "42"); }
+}
+
+test "match_pattern: literal segment mismatch does not match" {
+    let m = match_pattern("/users/{id}", "/posts/42");
+    assert ! m.matched;
+}
+
+test "match_pattern: differing segment count does not match" {
+    let extra = match_pattern("/users/{id}", "/users/42/comments");
+    assert ! extra.matched;
+    let fewer = match_pattern("/users/{id}", "/users");
+    assert ! fewer.matched;
+}
+
+test "match_pattern: exact static pattern matches with no params" {
+    let m = match_pattern("/health", "/health");
+    assert m.matched;
+    assert m.params.names.length == 0;
+    assert param(m.params, "anything") == null;
+}
+
+test "match_pattern: trailing slash is ignored" {
+    let m = match_pattern("/users/{id}", "/users/42/");
+    assert m.matched;
+    let id = param(m.params, "id");
+    assert id != null;
+    if id != null { assert strings_equal(id, "42"); }
+}
+
+test "match_pattern: multiple captures bind in order" {
+    let m = match_pattern("/users/{uid}/comments/{cid}", "/users/7/comments/99");
+    assert m.matched;
+    let uid = param(m.params, "uid");
+    let cid = param(m.params, "cid");
+    assert uid != null;
+    assert cid != null;
+    if uid != null { assert strings_equal(uid, "7"); }
+    if cid != null { assert strings_equal(cid, "99"); }
+}
+
+test "match_pattern: root pattern matches root path with no params" {
+    let m = match_pattern("/", "/");
+    assert m.matched;
+    assert m.params.names.length == 0;
+}
+
+test "match_pattern: empty-brace segment {} is a literal, not a capture" {
+    // "{}" declares no name, so it is matched literally (not captured).
+    let lit = match_pattern("/x/{}", "/x/{}");
+    assert lit.matched;
+    assert lit.params.names.length == 0;
+    let miss = match_pattern("/x/{}", "/x/42");
+    assert ! miss.matched;
+}
+
+test "dispatch: an empty router yields 404" {
+    let resp = dispatch(router(), _req("GET", "/anything"));
+    assert resp.status == 404;
+}
+
+test "dispatch: GET /users/{id} runs the handler with the captured id" {
+    let r = _one_route("GET", "/users/{id}", _h_user as * fn (Request, Params) -> Response);
+    let resp = dispatch(r, _req("GET", "/users/42"));
+    assert resp.status == 200;
+    assert strings_equal(resp.body, "user 42");
+}
+
+test "dispatch: multi-segment capture reaches the handler" {
+    let r = _one_route("GET", "/users/{uid}/comments/{cid}", _h_comment as * fn (Request, Params) -> Response);
+    let resp = dispatch(r, _req("GET", "/users/7/comments/99"));
+    assert resp.status == 200;
+    assert strings_equal(resp.body, "7/99");
+}
+
+test "dispatch: method mismatch on a matched path yields 405" {
+    let r = _one_route("GET", "/users/{id}", _h_user as * fn (Request, Params) -> Response);
+    let resp = dispatch(r, _req("POST", "/users/42"));
+    assert resp.status == 405;
+}
+
+test "dispatch: no matching path yields 404" {
+    let r = _one_route("GET", "/users/{id}", _h_user as * fn (Request, Params) -> Response);
+    let resp = dispatch(r, _req("GET", "/orders/42"));
+    assert resp.status == 404;
+}
+
+test "dispatch: registration order is precedence (static before {id})" {
+    let mut r = router();
+    r = route(r, "GET", "/users/me", _h_user_me as * fn (Request, Params) -> Response);
+    r = route(r, "GET", "/users/{id}", _h_user as * fn (Request, Params) -> Response);
+    let me = dispatch(r, _req("GET", "/users/me"));
+    assert strings_equal(me.body, "me");
+    // A non-static path still falls through to the {id} route.
+    let other = dispatch(r, _req("GET", "/users/42"));
+    assert strings_equal(other.body, "user 42");
+}

--- a/capsules/sfn/http/tests/router_test.sfn
+++ b/capsules/sfn/http/tests/router_test.sfn
@@ -149,6 +149,14 @@ test "dispatch: no matching path yields 404" {
     assert resp.status == 404;
 }
 
+test "dispatch: a null handler address fails controlled with 500" {
+    // A null handler is only reachable via an unsafe cast; dispatch must not
+    // call a null code pointer — it returns 500 instead.
+    let r = route(router(), "GET", "/x", 0 as * fn (Request, Params) -> Response);
+    let resp = dispatch(r, _req("GET", "/x"));
+    assert resp.status == 500;
+}
+
 test "dispatch: registration order is precedence (static before {id})" {
     let mut r = router();
     r = route(r, "GET", "/users/me", _h_user_me as * fn (Request, Params) -> Response);

--- a/docs/proposals/0019-sfn-http-capsule.md
+++ b/docs/proposals/0019-sfn-http-capsule.md
@@ -167,7 +167,7 @@ env-aware dispatch) and is listed as an open question below.
 | Request body (POST) | no — documented GET-only | Wave 3 (Content-Length drain) | — |
 | Header/query accessors (`header(req, n)`, `query_param(req, n)`) | yes (Wave 1, pure capsule) | — | — |
 | Typed client (`fetch`-style → `Response` with status/headers) | no — `get`/`post` body-string wrappers stay | Wave 4 (needs additive `sfn_http_request_raw` returning the full raw response) | — |
-| Routing (`Router`) | no — handler-side `if req.path == ...` idiom | post-v0 capsule work (blocked on closure-handler story) | — |
+| Routing (`Router`) | no — handler-side `if req.path == ...` idiom | **shipped** (SFN-37 — `Router`/`route`/`dispatch` with `{param}` path capture in `router.sfn`; handlers are top-level `fn(Request, Params) -> Response` registered by address, sidestepping the closure-handler story; 405 on method mismatch, 404 on no match) | — |
 | Keep-alive | no (`Connection: close` default) | **shipped** (#1711 — the serve connection worker loops recv→dispatch→send; `serialize_response` is negotiation-aware; a native single-connection-reuse client `sfn_http_conn_*` lands in the adapter) | — |
 | Closure handlers | no (top-level fn only, documented) | follow-up | — |
 | `ServerConfig.host` binding | dropped from v0 API | with host-bind runtime support | — |


### PR DESCRIPTION
## Summary

Adds a routing layer to the `sfn/http` capsule so handlers stop hand-parsing `req.path`. A `Router` holds an ordered list of `(method, pattern, handler)` routes; `dispatch(router, req)` finds the first matching route, captures `{param}` path segments, and invokes the handler with the request and captured `Params`. This is a capsule/library change only — no `compiler/src` or runtime touched.

The design resolves the `Router` row in `docs/proposals/0019-sfn-http-capsule.md`, which had listed routing as "blocked on closure-handler story": route handlers are top-level `fn(Request, Params) -> Response` registered **by address** (stored as `i64`, cast back to a code pointer at dispatch) — exactly the pattern `serve` already uses via `_sfn_http_handler_addr`, so no closures are needed.

Fixes SFN-37

## Changes

- **New `capsules/sfn/http/src/router.sfn`** — `Params` / `Route` / `Router` / `MatchResult` structs; `router()`, `route()`, `match_pattern()`, `dispatch()`, `param()`, plus `_split_segments()` / `_is_param_seg()` helpers. Segment-wise matching with `{name}` capture; registration-order precedence; method-mismatch → 405, no-match → 404.
- **`capsules/sfn/http/src/mod.sfn`** — barrel re-exports the router surface (`Router, Params, MatchResult, router, route, dispatch, match_pattern, param`) + layout comment.
- **New `capsules/sfn/http/tests/router_test.sfn`** — 14 tests (match/capture, literal & count mismatch, root `/`, trailing slash, `{}`-as-literal, multi-capture ordering, dispatch happy path, multi-segment dispatch, 405, 404, empty-router 404, registration-order precedence).
- **`docs/proposals/0019-sfn-http-capsule.md`** — flipped the Routing row from "post-v0, blocked on closures" to shipped.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes — via the capsule test build
- [x] `make compile` — compiler self-hosts (unaffected: additive capsule-only change, no `compiler/src` touched)
- [x] `build/native/sailfin test capsules/sfn/http/tests` — **30/30 pass** (14 router + 16 wire)
- [ ] N/A — no `compiler/src/*.sfn` change, so `make check`/seedcheck not required; full `make test` no-regression run in progress

Regression coverage: 14 router tests added under `capsules/sfn/http/tests/router_test.sfn` (capsule tests run in `make test` via the `capsules` BFS).

## Notes for reviewers

- Reviewed by the Opus `code-reviewer` (approved): the `i64` handler round-trip and `h(req, m.params)` indirect call are a normal Sailfin→Sailfin call (matching call-site/callee types) — no cross-ABI aggregate hazard like the runtime `fn(OwnedBuf)->OwnedBuf` boundary. `route()` returns a new `Router` (no struct-field aliasing).
- v0 scope (deliberately minimal, per SFN-37 `Out:`): exact literal + single-segment `{name}` only — no wildcard/splat, regex routes, middleware, content negotiation, or an `Allow` header on the 405. Documented in the module header.
- Effect note: like `serve`, effect enforcement rides on the caller's `[net, io]` — the fn-pointer address round-trip is opaque to the effect row (pre-existing boundary, not widened here).

---
_Generated by [Claude Code](https://claude.ai/code/session_014fW8m9ZVxq7uQxW1hATPGC)_