### PR TITLE
feat(crypto): base64 decode (RFC 4648) mirroring the existing encoder

### DIFF
--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -218,3 +218,94 @@ fn base64_encode(data: string) -> string {
 
     return out;
 }
+
+// Map a single standard-alphabet base64 character to its 6-bit value, or -1
+// if `c` is not an alphabet character (`=` padding included). Byte-oriented:
+// `char_code(c)` is the raw 0-255 byte, so the ASCII ranges select directly.
+fn base64_sextet(c: string) -> int {
+    let code: int = char_code(c) & 255;
+    if code >= 65 && code <= 90 {
+        return code - 65;
+    }  // 'A'..'Z' → 0..25
+    if code >= 97 && code <= 122 {
+        return code - 97 + 26;
+    }  // 'a'..'z' → 26..51
+    if code >= 48 && code <= 57 {
+        return code - 48 + 52;
+    }  // '0'..'9' → 52..61
+    if code == 43 {
+        return 62;
+    }  // '+' → 62
+    if code == 47 {
+        return 63;
+    }  // '/' → 63
+    return -1;
+}
+
+fn base64_decode(s: string) -> string {
+    // Decode standard RFC 4648 base64 (with `=` padding) back to the raw byte
+    // string, reversing `base64_encode`. Pure Sailfin: byte-oriented over the
+    // raw input, no effects. Malformed input — length not a multiple of 4, a
+    // character outside the standard alphabet, misplaced `=`, or non-canonical
+    // trailing bits — yields "" (the sentinel contract, matching the
+    // effect-free, non-`Result` encoder shape). This is strict RFC 4648: any
+    // embedded whitespace or newline is out-of-alphabet, so MIME/PEM-wrapped
+    // (line-broken) base64 also yields "" — feed it compact input.
+    //
+    // Usage:
+    //   let decoded = base64_decode("aGVsbG8gd29ybGQ=");
+    //   // decoded == "hello world"
+    //
+    let len: int = s.length;
+    if len == 0 { return ""; }
+    if (len & 3) != 0 { return ""; }
+
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= len { break; }
+
+        let d0: int = base64_sextet(s[i]);
+        let d1: int = base64_sextet(s[i + 1]);
+        if d0 < 0 { return ""; }
+        if d1 < 0 { return ""; }
+
+        let c2: string = s[i + 2];
+        let c3: string = s[i + 3];
+        let pad2: bool = c2 == "=";
+        let pad3: bool = c3 == "=";
+
+        // `=` is only legal in the final quad, and `X=Y=` (pad in position 2
+        // without one in position 3) is never a valid encoding.
+        if (pad2 || pad3) && (i + 4 != len) { return ""; }
+        if pad2 && !pad3 { return ""; }
+
+        // Byte 0 is present in every quad.
+        let b0: int = ((d0 << 2) | (d1 >> 4)) & 255;
+        out = out + char_from_code(b0);
+
+        if pad2 {
+            // "XX==" → one output byte; the low 4 bits of d1 must be zero.
+            if (d1 & 15) != 0 { return ""; }
+        } else {
+            let d2: int = base64_sextet(c2);
+            if d2 < 0 { return ""; }
+            let b1: int = ((d1 << 4) | (d2 >> 2)) & 255;
+            out = out + char_from_code(b1);
+
+            if pad3 {
+                // "XXX=" → two output bytes; the low 2 bits of d2 must be zero.
+                if (d2 & 3) != 0 { return ""; }
+            } else {
+                let d3: int = base64_sextet(c3);
+                if d3 < 0 { return ""; }
+                let b2: int = ((d2 << 6) | d3) & 255;
+                out = out + char_from_code(b2);
+            }
+        }
+
+        i += 4;
+    }
+
+    return out;
+}

--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -252,6 +252,13 @@ fn base64_decode(s: string) -> string {
     // embedded whitespace or newline is out-of-alphabet, so MIME/PEM-wrapped
     // (line-broken) base64 also yields "" — feed it compact input.
     //
+    // Under the current NUL-terminated `string` model a decoded 0x00 byte is
+    // unrepresentable (`char_from_code(0)` is ""), so any input whose decoded
+    // output would contain a 0x00 byte also yields the "" sentinel rather than
+    // a truncated result. This covers text payloads (HTTP Basic, JSON-RPC,
+    // tokens); fully general binary decode arrives with the SfnString aggregate
+    // (#874 M1.A.2).
+    //
     // Usage:
     //   let decoded = base64_decode("aGVsbG8gd29ybGQ=");
     //   // decoded == "hello world"
@@ -280,8 +287,13 @@ fn base64_decode(s: string) -> string {
         if (pad2 || pad3) && (i + 4 != len) { return ""; }
         if pad2 && !pad3 { return ""; }
 
-        // Byte 0 is present in every quad.
+        // Byte 0 is present in every quad. A decoded 0x00 byte is
+        // unrepresentable in the current NUL-terminated `string` model
+        // (`char_from_code(0)` yields ""), so decoding collapses to the ""
+        // sentinel rather than silently dropping the byte and returning a
+        // truncated/corrupted payload.
         let b0: int = ((d0 << 2) | (d1 >> 4)) & 255;
+        if b0 == 0 { return ""; }
         out = out + char_from_code(b0);
 
         if pad2 {
@@ -291,6 +303,7 @@ fn base64_decode(s: string) -> string {
             let d2: int = base64_sextet(c2);
             if d2 < 0 { return ""; }
             let b1: int = ((d1 << 4) | (d2 >> 2)) & 255;
+            if b1 == 0 { return ""; }
             out = out + char_from_code(b1);
 
             if pad3 {
@@ -300,6 +313,7 @@ fn base64_decode(s: string) -> string {
                 let d3: int = base64_sextet(c3);
                 if d3 < 0 { return ""; }
                 let b2: int = ((d2 << 6) | d3) & 255;
+                if b2 == 0 { return ""; }
                 out = out + char_from_code(b2);
             }
         }

--- a/capsules/sfn/crypto/tests/base64_test.sfn
+++ b/capsules/sfn/crypto/tests/base64_test.sfn
@@ -3,7 +3,7 @@
 // Known-answer vectors covering the empty string, all three padding
 // residues (0, 1, 2 trailing bytes), and a non-ASCII UTF-8 input to pin
 // the byte-oriented contract.
-import { base64_encode } from "../src/mod";
+import { base64_encode, base64_decode } from "../src/mod";
 
 test "base64_encode: empty string" { assert base64_encode("") == ""; }
 
@@ -39,4 +39,98 @@ test "base64_encode: non-ASCII UTF-8 raw bytes" {
     // "é" is the two UTF-8 bytes 0xc3 0xa9; byte-oriented indexing encodes
     // them raw, matching `printf 'é' | base64`.
     assert base64_encode("é") == "w6k=";
+}
+
+// Decode known-answer vectors — the exact reverse of the encoder table above,
+// covering every padding residue and a non-ASCII UTF-8 payload.
+test "base64_decode: empty string" { assert base64_decode("") == ""; }
+
+test "base64_decode: one trailing byte (two pad chars)" {
+    assert base64_decode("Zg==") == "f";
+}
+
+test "base64_decode: two trailing bytes (one pad char)" {
+    assert base64_decode("Zm8=") == "fo";
+}
+
+test "base64_decode: exact three-byte group (no padding)" {
+    assert base64_decode("Zm9v") == "foo";
+}
+
+test "base64_decode: four bytes" {
+    assert base64_decode("Zm9vYg==") == "foob";
+}
+
+test "base64_decode: five bytes" {
+    assert base64_decode("Zm9vYmE=") == "fooba";
+}
+
+test "base64_decode: six bytes" {
+    assert base64_decode("Zm9vYmFy") == "foobar";
+}
+
+test "base64_decode: ascii sentence" {
+    assert base64_decode("aGVsbG8gd29ybGQ=") == "hello world";
+}
+
+test "base64_decode: non-ASCII UTF-8 raw bytes" {
+    assert base64_decode("w6k=") == "é";
+}
+
+// Round-trip: decode(encode(x)) == x across every vector.
+test "base64: round-trips empty" {
+    assert base64_decode(base64_encode("")) == "";
+}
+
+test "base64: round-trips one trailing byte" {
+    assert base64_decode(base64_encode("f")) == "f";
+}
+
+test "base64: round-trips two trailing bytes" {
+    assert base64_decode(base64_encode("fo")) == "fo";
+}
+
+test "base64: round-trips exact three-byte group" {
+    assert base64_decode(base64_encode("foo")) == "foo";
+}
+
+test "base64: round-trips ascii sentence" {
+    assert base64_decode(base64_encode("hello world")) == "hello world";
+}
+
+test "base64: round-trips non-ASCII UTF-8" {
+    assert base64_decode(base64_encode("é")) == "é";
+}
+
+// Malformed input yields the sentinel "" (non-`Result` contract).
+test "base64_decode: rejects non-multiple-of-4 length" {
+    assert base64_decode("Zg=") == "";
+}
+
+test "base64_decode: rejects out-of-alphabet character" {
+    assert base64_decode("Zg!=") == "";
+}
+
+test "base64_decode: rejects misplaced padding" {
+    assert base64_decode("Z===") == "";
+}
+
+test "base64_decode: rejects non-canonical trailing bits (residue 1)" {
+    // "Zh==" — 'h' has non-zero low 4 bits that a canonical "XX==" quad must
+    // leave clear (contrast the valid "Zg==").
+    assert base64_decode("Zh==") == "";
+}
+
+test "base64_decode: rejects non-canonical trailing bits (residue 2)" {
+    // "Zm9=" — '9' has non-zero low 2 bits that a canonical "XXX=" quad must
+    // leave clear (contrast the valid "Zm8=").
+    assert base64_decode("Zm9=") == "";
+}
+
+test "base64_decode: rejects pad in position 2 without position 3" {
+    assert base64_decode("Zg=A") == "";
+}
+
+test "base64_decode: rejects padding outside the final quad" {
+    assert base64_decode("Zg==Zm8=") == "";
 }

--- a/capsules/sfn/crypto/tests/base64_test.sfn
+++ b/capsules/sfn/crypto/tests/base64_test.sfn
@@ -134,3 +134,16 @@ test "base64_decode: rejects pad in position 2 without position 3" {
 test "base64_decode: rejects padding outside the final quad" {
     assert base64_decode("Zg==Zm8=") == "";
 }
+
+// A decoded 0x00 byte is unrepresentable under the NUL-terminated `string`
+// model, so it collapses to the "" sentinel instead of silently truncating.
+test "base64_decode: rejects a decoded trailing NUL byte" {
+    // "AA==" decodes to the single byte 0x00.
+    assert base64_decode("AA==") == "";
+}
+
+test "base64_decode: rejects a decoded interior NUL byte" {
+    // "QQBB" decodes to the bytes 0x41 0x00 0x41 ("A\0A"); the interior NUL
+    // must collapse the whole result rather than yield a truncated "AA".
+    assert base64_decode("QQBB") == "";
+}


### PR DESCRIPTION
## Summary

Adds a pure, effect-free `base64_decode` to the `sfn/crypto` capsule that reverses the existing standard-alphabet `base64_encode`. Byte-oriented over the raw input; returns `""` as the sentinel on malformed input (length not a multiple of 4, out-of-alphabet character, misplaced padding, or non-canonical trailing bits) to match the encoder's non-`Result` contract. Unblocks base64 decode on the MCP-proxy path (JSON-RPC blobs, HTTP Basic credentials, token payloads).

Fixes SFN-121

## Changes

- runtime/capsule (`capsules/sfn/crypto/src/mod.sfn`):
  - `base64_decode(s: string) -> string` — decodes standard RFC 4648 base64 (`=` padding), handling all three padding residues and rejecting malformed input to `""`.
  - `base64_sextet(c: string) -> int` — maps a standard-alphabet character to its 6-bit value (`-1` if invalid), byte-oriented via `char_code`.
- tests (`capsules/sfn/crypto/tests/base64_test.sfn`):
  - 9 decode known-answer vectors (empty, all padding residues, non-ASCII UTF-8).
  - 6 `decode(encode(x)) == x` round-trips.
  - 7 malformed-input rejection cases (bad length, out-of-alphabet, misplaced padding, non-canonical trailing bits for both residues, `pad2 && !pad3`, padding outside the final quad).

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts
- [x] `make test` — full suite passes (`status: pass`)
- [x] Regression coverage added (31 base64 tests pass; sha256 unaffected)
- [ ] N/A — docs/config-only change (no `.sfn` touched)

## Acceptance Criteria

- [x] Round-trips every `base64_encode` known-answer vector (empty, 1/2/0 trailing-byte residues, non-ASCII UTF-8)
- [x] `decode(encode(x)) == x` for those vectors
- [x] No effects required (pure)
- [x] `make compile` passes
- [x] `make test` passes

## Map reconciliation

Advisory map matched the tree — decode function added alongside `base64_encode` in `src/mod.sfn`; decode + round-trip vectors added to the existing `tests/base64_test.sfn`.

## Notes for reviewers

- Scope-faithful to the issue: standard alphabet only (no URL-safe `-_`), no streaming, no `Result` surface — malformed input returns `""` by design.
- Strict RFC 4648: embedded whitespace/newlines are out-of-alphabet, so MIME/PEM line-wrapped input also yields `""` (noted in the `base64_decode` doc comment). Compact input (HTTP Basic, JSON-RPC, tokens) is unaffected.
- The `""` sentinel is ambiguous between valid-empty and malformed — inherent to the non-`Result` contract; a caller needing to distinguish should length/validity-check first.
- `base64_sextet` follows the surrounding file's un-prefixed helper convention (`sha256_rotr`, `sha256_word_hex`) rather than the repo-wide `_helper` prefix, for local consistency.

---
_Generated by [Claude Code](https://claude.ai/code/session_016H8vMppN3oewoNr7H9KqHK)_