### PR TITLE
feat(os): framed incremental reads from a live child's stdout

### DIFF
--- a/capsules/sfn/os/src/mod.sfn
+++ b/capsules/sfn/os/src/mod.sfn
@@ -11,6 +11,8 @@ extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
 
 extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
 
+extern fn free(ptr: * u8) -> void;
+
 fn env(name: string) -> string ![io] {
     // Read an environment variable. Returns an empty string if not set.
     return env.get(name);
@@ -264,13 +266,24 @@ fn handle_read_stderr(h: ProcessHandle) -> string ![io] {
     return process.handle_read_stderr(h.handle_id);
 }
 
-// Copy `s`'s bytes into a fresh libc-backed `OwnedBuf` the caller owns.
-// NUL-terminated; the copy is independent of the string's own backing,
-// so the caller frees it without disturbing capsule storage. Returns an
-// empty `OwnedBuf` on OOM. Mirrors `sfn/http`'s `_http_owned_from_str`.
+// Copy `s`'s bytes into a fresh libc-backed `OwnedBuf` the caller owns
+// (reclaim it with `owned_buf_free`). NUL-terminated; the copy is
+// independent of the string's own backing, so the free never disturbs
+// capsule storage. An empty `s` (e.g. an EOF read) needs no allocation
+// and returns the canonical empty `{0,0,0,0}` buffer, matching
+// `runtime/sfn/memory/ownedbuf.sfn`; OOM returns the same. Mirrors
+// `sfn/http`'s `_http_owned_from_str`.
 fn _owned_from_str(s: string) -> OwnedBuf {
-    let src: * u8 = s as * u8;
     let n: i64 = s.length;
+    if n == 0 {
+        return OwnedBuf {
+            ptr_addr: 0,
+            len: 0,
+            cap: 0,
+            arena_addr: 0
+        };
+    }
+    let src: * u8 = s as * u8;
     let copy: * u8 = malloc((n + 1) as usize);
     if copy as i64 == 0 {
         return OwnedBuf {
@@ -280,7 +293,7 @@ fn _owned_from_str(s: string) -> OwnedBuf {
             arena_addr: 0
         };
     }
-    if n > 0 { memcpy(copy, src, n as usize); }
+    memcpy(copy, src, n as usize);
     memset(((copy as i64) + n) as * u8, 0, 1 as usize);
     return OwnedBuf {
         ptr_addr: copy as i64,
@@ -314,6 +327,15 @@ fn handle_read_line_stdout(h: ProcessHandle) -> string? ![io] {
 fn handle_read_bytes_stdout(h: ProcessHandle, n: int) -> OwnedBuf ![io] {
     let chunk = process.handle_read_bytes_stdout(h.handle_id, n);
     return _owned_from_str(chunk);
+}
+
+// Release the libc allocation backing an `OwnedBuf` returned by
+// `handle_read_bytes_stdout`. Callers must free each buffer exactly once
+// after use — a long-lived proxy loop that skips this leaks a buffer per
+// read. A canonical empty buffer (`ptr_addr == 0`, e.g. an EOF read) owns
+// no allocation, so freeing it is a no-op and is always safe.
+fn owned_buf_free(buf: OwnedBuf) -> void {
+    if buf.ptr_addr != 0 { free(buf.ptr_addr as * u8); }
 }
 
 // Wait for the child to exit. Closes any still-open fds, reaps the

--- a/capsules/sfn/os/src/mod.sfn
+++ b/capsules/sfn/os/src/mod.sfn
@@ -2,6 +2,15 @@
 //
 // Provides access to environment variables, process execution, and
 // platform information. All operations require the `io` effect.
+// libc allocation primitives for `handle_read_bytes_stdout`'s owned
+// buffer. Redeclared per-module (the #306 cross-module-extern limit),
+// matching the `sfn/http` capsule's inlined declarations.
+extern fn malloc(size: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
 fn env(name: string) -> string ![io] {
     // Read an environment variable. Returns an empty string if not set.
     return env.get(name);
@@ -56,6 +65,18 @@ struct ProcessOutput {
 // any open stdin/stdout/stderr fds and frees the handle.
 struct ProcessHandle {
     handle_id: int;
+}
+
+// `OwnedBuf` — the runtime owned-buffer aggregate, inlined
+// byte-identically (four `i64` fields, 32 bytes, `arena_addr == 0` =
+// libc-backed). Layout MUST match `runtime/sfn/memory/ownedbuf.sfn`
+// (and the sibling inlined copies in `sfn/http`). Returned by
+// `handle_read_bytes_stdout` as a fresh buffer the caller owns.
+struct OwnedBuf {
+    ptr_addr: i64;
+    len: i64;
+    cap: i64;
+    arena_addr: i64;
 }
 
 // Return an empty `Env`. The resulting environment passed to the
@@ -241,6 +262,58 @@ fn handle_read_stdout(h: ProcessHandle) -> string ![io] {
 // idempotency contract as `handle_read_stdout`.
 fn handle_read_stderr(h: ProcessHandle) -> string ![io] {
     return process.handle_read_stderr(h.handle_id);
+}
+
+// Copy `s`'s bytes into a fresh libc-backed `OwnedBuf` the caller owns.
+// NUL-terminated; the copy is independent of the string's own backing,
+// so the caller frees it without disturbing capsule storage. Returns an
+// empty `OwnedBuf` on OOM. Mirrors `sfn/http`'s `_http_owned_from_str`.
+fn _owned_from_str(s: string) -> OwnedBuf {
+    let src: * u8 = s as * u8;
+    let n: i64 = s.length;
+    let copy: * u8 = malloc((n + 1) as usize);
+    if copy as i64 == 0 {
+        return OwnedBuf {
+            ptr_addr: 0,
+            len: 0,
+            cap: 0,
+            arena_addr: 0
+        };
+    }
+    if n > 0 { memcpy(copy, src, n as usize); }
+    memset(((copy as i64) + n) as * u8, 0, 1 as usize);
+    return OwnedBuf {
+        ptr_addr: copy as i64,
+        len: n,
+        cap: n + 1,
+        arena_addr: 0
+    };
+}
+
+// Read one `\n`-delimited line from the child's stdout (newline
+// stripped), stashing any bytes past the newline for the next call.
+// Returns `null` once stdout is at end-of-stream — distinct from a
+// genuine blank line, which returns `""`. Reads a live child without
+// requiring its pipe to close, so a proxy can frame one line-delimited
+// JSON-RPC message at a time. The final unterminated line (no trailing
+// newline) is returned before EOF.
+fn handle_read_line_stdout(h: ProcessHandle) -> string? ![io] {
+    let line = process.handle_read_line_stdout(h.handle_id);
+    if line.length > 0 { return line; }
+    // Empty result: a real blank line ("") or end-of-stream (null). The
+    // raw builtin cannot tell them apart, so consult the fd/stash state.
+    if process.handle_stdout_at_eof(h.handle_id) { return null; }
+    return line;
+}
+
+// Read at most `n` bytes from the child's stdout into a fresh
+// caller-owned `OwnedBuf`, preserving any unconsumed remainder for the
+// next call. A short read returns fewer than `n`; a zero-length buffer
+// signals EOF (or `n <= 0`). Bounded incremental read for a live child
+// that never closes its pipe.
+fn handle_read_bytes_stdout(h: ProcessHandle, n: int) -> OwnedBuf ![io] {
+    let chunk = process.handle_read_bytes_stdout(h.handle_id, n);
+    return _owned_from_str(chunk);
 }
 
 // Wait for the child to exit. Closes any still-open fds, reaps the

--- a/capsules/sfn/os/tests/handle_framed_stdio_test.sfn
+++ b/capsules/sfn/os/tests/handle_framed_stdio_test.sfn
@@ -1,0 +1,82 @@
+// Tests for sfn/os incremental/framed child-stdout reads (SFN-153, epic
+// #1540 Track A gap A1). `handle_read_line_stdout` frames one `\n`-
+// delimited line at a time from a live child and returns `null` only at
+// end-of-stream; `handle_read_bytes_stdout` does a bounded incremental
+// read into a caller-owned `OwnedBuf`. These wrap the raw framed
+// builtins (pinned by `compiler/tests/integration/process_framed_stdio_test.sfn`)
+// and add the `string?` / `OwnedBuf` typed surface. POSIX `sh`/`cat`/
+// `printf` assumed, matching the sibling `spawn_with_env` tests.
+import {
+    ProcessHandle,
+    OwnedBuf,
+    env_empty,
+    spawn_with_env,
+    handle_write,
+    handle_close_stdin,
+    handle_read_line_stdout,
+    handle_read_bytes_stdout,
+    handle_wait
+} from "../src/mod";
+
+test "handle_read_line_stdout: frames lines then yields null at EOF" ![io] {
+    let h = spawn_with_env(["sh", "-c", "printf 'one\\ntwo\\n'"], env_empty(), "");
+    assert h.handle_id != 0;
+    let a = handle_read_line_stdout(h);
+    if a == null { assert false; } else { assert strings_equal(a, "one"); }
+    let b = handle_read_line_stdout(h);
+    if b == null { assert false; } else { assert strings_equal(b, "two"); }
+    // Stream exhausted: EOF is null, not the empty string.
+    let c = handle_read_line_stdout(h);
+    assert c == null;
+    let exit = handle_wait(h);
+    assert exit == 0;
+}
+
+test "handle_read_line_stdout: a genuine blank line is empty, not EOF" ![io] {
+    // "\n\n" — two blank lines, then EOF. Blank lines return ""; only
+    // end-of-stream returns null. This is the whole reason the wrapper
+    // is `string?` rather than plain `string`.
+    let h = spawn_with_env(["sh", "-c", "printf '\\n\\n'"], env_empty(), "");
+    assert h.handle_id != 0;
+    let a = handle_read_line_stdout(h);
+    if a == null { assert false; } else { assert strings_equal(a, ""); }
+    let b = handle_read_line_stdout(h);
+    if b == null { assert false; } else { assert strings_equal(b, ""); }
+    let c = handle_read_line_stdout(h);
+    assert c == null;
+    let exit = handle_wait(h);
+    assert exit == 0;
+}
+
+test "handle_read_line_stdout: reads a frame from a live child" ![io] {
+    // `cat` echoes each frame as it reads it — read one line back while
+    // the child is still running (stdin not yet closed), proving the
+    // pipe stays open across calls.
+    let h = spawn_with_env(["cat"], env_empty(), "");
+    assert h.handle_id != 0;
+    let w = handle_write(h, "ping\n");
+    assert w == 5;
+    let l = handle_read_line_stdout(h);
+    if l == null { assert false; } else { assert strings_equal(l, "ping"); }
+    handle_close_stdin(h);
+    let exit = handle_wait(h);
+    assert exit == 0;
+}
+
+test "handle_read_bytes_stdout: bounded read into an owned buffer, empty at EOF" ![io] {
+    let h = spawn_with_env(["sh", "-c", "printf 'abcdefgh'"], env_empty(), "");
+    assert h.handle_id != 0;
+    // First call caps at 3 bytes; the remaining 5 stay buffered.
+    let p1 = handle_read_bytes_stdout(h, 3);
+    assert p1.len == 3;
+    assert strings_equal(p1.ptr_addr as * u8 as string, "abc");
+    // n exceeds what is buffered: returns the 5-byte remainder.
+    let p2 = handle_read_bytes_stdout(h, 10);
+    assert p2.len == 5;
+    assert strings_equal(p2.ptr_addr as * u8 as string, "defgh");
+    // Nothing left: EOF yields a zero-length buffer.
+    let p3 = handle_read_bytes_stdout(h, 4);
+    assert p3.len == 0;
+    let exit = handle_wait(h);
+    assert exit == 0;
+}

--- a/capsules/sfn/os/tests/handle_framed_stdio_test.sfn
+++ b/capsules/sfn/os/tests/handle_framed_stdio_test.sfn
@@ -15,6 +15,7 @@ import {
     handle_close_stdin,
     handle_read_line_stdout,
     handle_read_bytes_stdout,
+    owned_buf_free,
     handle_wait
 } from "../src/mod";
 
@@ -74,9 +75,14 @@ test "handle_read_bytes_stdout: bounded read into an owned buffer, empty at EOF"
     let p2 = handle_read_bytes_stdout(h, 10);
     assert p2.len == 5;
     assert strings_equal(p2.ptr_addr as * u8 as string, "defgh");
-    // Nothing left: EOF yields a zero-length buffer.
+    // Nothing left: EOF yields the canonical empty buffer (no allocation).
     let p3 = handle_read_bytes_stdout(h, 4);
     assert p3.len == 0;
+    assert p3.ptr_addr == 0;
+    // Reclaim the allocations: a real buffer frees, the empty one no-ops.
+    owned_buf_free(p1);
+    owned_buf_free(p2);
+    owned_buf_free(p3);
     let exit = handle_wait(h);
     assert exit == 0;
 }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -826,6 +826,13 @@ fn _rh_descriptors_05(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.handle_read_bytes_stdout", symbol: "sfn_process_handle_read_bytes_stdout", return_type: "i8*", parameter_types: ["i64", "i64"], effects: ["io"], native_signature: "sfn_process_handle_read_bytes_stdout", c_abi_return_type: null
     });
+    // SFN-153 (epic #1540 Track A, gap A1): EOF predicate for the framed
+    // stdout reads. The raw line/bytes builtins return `""` for both a
+    // genuine blank line and end-of-stream; this lets the `string?`-typed
+    // `sfn/os::handle_read_line_stdout` wrapper return `null` only at EOF.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.handle_stdout_at_eof", symbol: "sfn_process_handle_stdout_at_eof", return_type: "i1", parameter_types: ["i64"], effects: ["io"], native_signature: "sfn_process_handle_stdout_at_eof", c_abi_return_type: null
+    });
     return descriptors;
 }
 

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -1399,6 +1399,9 @@ fn sfn_process_handle_read_bytes_stdout(handle_id: i64, n: i64) -> * u8 ![io] {
 // end-of-stream to the same empty string; a `string?`-typed `sfn/os`
 // wrapper consults this to return `null` for EOF and `""` for a real
 // blank line. Reads only handle state — no syscall, so it never blocks.
+// A zero/invalid `handle_id` reports `true` (at-EOF), matching the raw
+// read builtins that treat a zero handle as an empty stream: a caller
+// framing until `null` then stops rather than spinning on a dead handle.
 fn sfn_process_handle_stdout_at_eof(handle_id: i64) -> bool ![io] {
     if handle_id == 0 { return true; }
     let h: * SailfinProcessHandle = handle_id as * SailfinProcessHandle;

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -1391,6 +1391,22 @@ fn sfn_process_handle_read_bytes_stdout(handle_id: i64, n: i64) -> * u8 ![io] {
     return _framed_consume(gb, take, take);
 }
 
+// ── process.handle_stdout_at_eof ───────────────────────────────
+// True once the child's stdout is fully consumed: the fd was closed on
+// a prior EOF/error read (`stdout_fd == -1`) AND no read-ahead bytes
+// remain in the stash. The raw `handle_read_line_stdout` /
+// `handle_read_bytes_stdout` builtins collapse a genuine blank line and
+// end-of-stream to the same empty string; a `string?`-typed `sfn/os`
+// wrapper consults this to return `null` for EOF and `""` for a real
+// blank line. Reads only handle state — no syscall, so it never blocks.
+fn sfn_process_handle_stdout_at_eof(handle_id: i64) -> bool ![io] {
+    if handle_id == 0 { return true; }
+    let h: * SailfinProcessHandle = handle_id as * SailfinProcessHandle;
+    let gb: * GrowBuf = ((h as i64) + 16) as * GrowBuf;
+    if h.stdout_fd < 0 && gb.len == 0 { return true; }
+    return false;
+}
+
 // ── process.handle_write_bytes ─────────────────────────────────
 // Write exactly `len` bytes of `data` to the child's stdin, resuming
 // short writes and EINTR. Unlike `handle_write` (which `strlen`s a


### PR DESCRIPTION
## Summary

Adds capsule-level `sfn/os` readers so a parent can consume one frame at a time from a **running** child that never closes its pipe — the MCP-proxy passthrough case (epic #1540 Track A, gap A1):

- `handle_read_line_stdout(h: ProcessHandle) -> string?` — one `\n`-delimited line (newline stripped), stashing bytes past the newline for the next call. Returns `null` only at end-of-stream, distinct from a genuine blank line which returns `""`.
- `handle_read_bytes_stdout(h: ProcessHandle, n: int) -> OwnedBuf` — bounded incremental read into a fresh caller-owned buffer; a zero-length buffer signals EOF.

The raw framed builtins from #1578 (`process.handle_read_line_stdout` / `handle_read_bytes_stdout`) collapse a genuine blank line and EOF to the same empty string, and the fd/stash state needed to tell them apart lives inside `SailfinProcessHandle` — only reachable from `runtime/sfn/process.sfn`. So this adds one additive, non-blocking `process.handle_stdout_at_eof` predicate that the `string?` wrapper consults to return `null` only at true EOF. The shipped #1578 raw builtins and their pinned integration test are **untouched**.

This bundles the predicate builtin with its sole consumer in one PR — `make compile` builds the new compiler from the old seed and that compiler compiles the capsule in the same self-host pass, so **no seed cut is required** (`.claude/rules/seed-dependency.md`).

Touches: runtime (`process.sfn`), LLVM-lowering descriptor table (`runtime_helpers.sfn`), `sfn/os` capsule, capsule tests.

Fixes SFN-153

## Changes

- **runtime** (`runtime/sfn/process.sfn`): new `sfn_process_handle_stdout_at_eof(handle_id) -> bool [io]` — true iff `stdout_fd == -1` (closed on a prior EOF read) and the stash `GrowBuf` is empty. Reads handle state only; no syscall, never blocks.
- **llvm lowering** (`compiler/src/llvm/runtime_helpers.sfn`): register `process.handle_stdout_at_eof` (`return_type: "i1"`, params `["i64"]`, effects `["io"]`), mirroring the `fs.exists` bool precedent.
- **runtime capsule** (`capsules/sfn/os/src/mod.sfn`): inline `OwnedBuf` (byte-identical to `runtime/sfn/memory/ownedbuf.sfn`, matching the `sfn/http` sibling), `malloc`/`memcpy`/`memset` externs, `_owned_from_str`, and the two public wrappers.
- **tests** (`capsules/sfn/os/tests/handle_framed_stdio_test.sfn`): line framing + null-at-EOF, blank-line-vs-EOF (`"\n\n"`), live-child echo (`cat`, pipe stays open), bounded bytes read with buffered remainder.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts with the new builtin (bundle pass)
- [ ] `make check` — full suite + seedcheck (deferred to CI)
- [x] Regression coverage added (`capsules/sfn/os/tests/handle_framed_stdio_test.sfn`; raw #1578 integration test re-run, 6/6 pass, contract intact)
- [ ] N/A — docs/config-only change (no `.sfn` touched)

New capsule test 4/4; raw `process_framed_stdio_test.sfn` 6/6 (unchanged contract); sibling `spawn_with_env_test.sfn` 7/7 (no regression).

## Stage1 readiness

- [x] Parses, type-checks, and effect-checks
- [x] Emits valid `.sfn-asm` and lowers to LLVM IR (self-hosts)
- [x] Effect enforcement wired end-to-end (`[io]` on both wrappers and the predicate; `_owned_from_str` is a pure libc copy)
- [x] `docs/status.md` reviewed for a matching entry (see Notes)

## Notes for reviewers

- **EOF-vs-blank-line invariant**: the raw line builtin only sets `stdout_fd = -1` on the same return that hands back the entire remaining buffer, so whenever it returns `""` with the fd closed, `gb.len` is provably 0 (true EOF); a pending blank line always leaves `gb.len >= 1`. The wrapper's predicate call has no intervening syscall, so nothing mutates the handle between the two calls (race-free for a single-threaded reader).
- **Out of scope** (per issue): Content-Length framing (MCP stdio is line-delimited JSON-RPC — text, no embedded NULs) and buffering-strategy tuning.
- Reviewed by the code-reviewer agent: verdict Approve; sole note was a cosmetic `s.length` vs the http sibling's `strlen` (semantically identical for a NUL-terminated cstr — kept `s.length` as cleaner string-API usage).

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6pzxYRduv2qpzApux2ctG)_