### PR TITLE
docs(agents): require SFN-NNN issue id in PR titles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,6 +140,7 @@ Update documents in this order when behaviour changes:
 ## Commit & Pull Request Guidelines
 
 - Use Conventional Commit prefixes: `feat(compiler): …`, `fix(bootstrap): …`, etc.
+- PR titles append the Linear issue id: `feat(compiler): … (SFN-NNN)` so `SFN-NNN` is visible in the PR list (see `docs/conventions/issue-naming.md` § 1); the body still carries `Fixes SFN-NNN`.
 - Keep commits atomic; mention touched capsules; co-author doc changes in the same PR.
 - PRs must include: scope summary, verification commands (`make test`, targeted runs), and notes on doc updates.
 - Releases are manually triggered via `.github/workflows/release.yml` (pure bash) — use `fix:` or `feat:` prefixes in commit messages.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,7 +140,7 @@ Update documents in this order when behaviour changes:
 ## Commit & Pull Request Guidelines
 
 - Use Conventional Commit prefixes: `feat(compiler): …`, `fix(bootstrap): …`, etc.
-- PR titles append the Linear issue id: `feat(compiler): … (SFN-NNN)` so `SFN-NNN` is visible in the PR list (see `docs/conventions/issue-naming.md` § 1); the body still carries `Fixes SFN-NNN`.
+- PR titles completing a Linear leaf append the issue id: `feat(compiler): … (SFN-NNN)` so `SFN-NNN` is visible in the PR list (omit the suffix only when there's no backing issue; see `docs/conventions/issue-naming.md` § 1); the body still carries `Fixes SFN-NNN`.
 - Keep commits atomic; mention touched capsules; co-author doc changes in the same PR.
 - PRs must include: scope summary, verification commands (`make test`, targeted runs), and notes on doc updates.
 - Releases are manually triggered via `.github/workflows/release.yml` (pure bash) — use `fix:` or `feat:` prefixes in commit messages.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,11 @@
 Sailfin PR template. Fill in each section; delete this comment and any
 inapplicable rows. Keep the Linear line — the org webhook links and closes
 the issue from it. See docs/conventions/linear-workflow.md.
+
+PR TITLE: Conventional Commit shape with the Linear issue id appended, e.g.
+  feat(typecheck): register extern fn declarations (SFN-412)
+The trailing `(SFN-NNN)` is required so SFN-NNN is visible in the PR list and
+the squashed commit. Full spec: docs/conventions/issue-naming.md § 1.
 -->
 
 ## Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,9 @@ the issue from it. See docs/conventions/linear-workflow.md.
 
 PR TITLE: Conventional Commit shape with the Linear issue id appended, e.g.
   feat(typecheck): register extern fn declarations (SFN-412)
-The trailing `(SFN-NNN)` is required so SFN-NNN is visible in the PR list and
-the squashed commit. Full spec: docs/conventions/issue-naming.md § 1.
+The trailing `(SFN-NNN)` is required on any PR completing a Linear leaf, so
+SFN-NNN is visible in the PR list and the squashed commit (omit it only for a
+PR with no backing issue). Full spec: docs/conventions/issue-naming.md § 1.
 -->
 
 ## Summary

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -84,11 +84,19 @@ bug.
 
 ### 1. Sub-task (the default — what most issues and PRs are)
 
-Conventional Commit form so the merged PR title lands as a clean commit:
+Conventional Commit form so the merged PR title lands as a clean commit,
+with the Linear issue id appended so `SFN-NNN` is visible at a glance in the
+PR list and the squashed commit:
 
 ```
-<type>(<scope>): <imperative verb phrase>
+<type>(<scope>): <imperative verb phrase> (SFN-NNN)
 ```
+
+The trailing `(SFN-NNN)` is required on any PR that completes a Linear leaf
+(omit it only for a PR with no backing issue). It keeps the Conventional
+Commit prefix parseable while surfacing the issue id in the title; the body
+still carries `Fixes SFN-NNN` as the machine-readable link that drives Linear
+workflow state.
 
 | Field      | Allowed values |
 |------------|----------------|
@@ -99,12 +107,12 @@ Conventional Commit form so the merged PR title lands as a clean commit:
 **Examples:**
 
 ```
-feat(typecheck): register extern fn declarations
-fix(lowering): emit valid LLVM for empty struct literal
-perf(ci): cache compiler binary across CI jobs
-refactor(emit): split emit_native_ops into ops/ submodule
-docs(spec): document Result and ? operator semantics
-chore(build): delete prior scripts/build.sh now retired post --work-dir cutover
+feat(typecheck): register extern fn declarations (SFN-412)
+fix(lowering): emit valid LLVM for empty struct literal (SFN-518)
+perf(ci): cache compiler binary across CI jobs (SFN-233)
+refactor(emit): split emit_native_ops into ops/ submodule (SFN-346)
+docs(spec): document Result and ? operator semantics (SFN-107)
+chore(build): delete prior scripts/build.sh now retired post --work-dir cutover (SFN-901)
 ```
 
 The `<type>` prefix and the `type:<type>` label MUST agree:


### PR DESCRIPTION
## Summary

Make the Linear issue id visible in PR titles. We already use Conventional Commit shape and carry `Fixes SFN-NNN` in the PR body, but the id wasn't surfaced in the title itself. This appends a trailing `(SFN-NNN)` to the Conventional Commit title so `SFN-NNN` is visible at a glance in the PR list and the squashed commit, without breaking the parseable `<type>(<scope>):` prefix.

Docs/config-only — no `.sfn` files touched, so the self-host gate doesn't apply.

## Changes

- **docs** — `docs/conventions/issue-naming.md` § 1: canonical PR-title spec now reads `<type>(<scope>): <verb> (SFN-NNN)`; added a note that the suffix is required for any PR completing a Linear leaf (omit only when there's no backing issue), and updated the worked examples to show it. The body still carries `Fixes SFN-NNN` as the machine-readable link that drives Linear workflow state.
- **docs** — `.github/pull_request_template.md`: added a `PR TITLE:` line to the top comment showing the required shape and pointing at the spec.
- **docs** — `.github/copilot-instructions.md`: PR guidelines note the appended `(SFN-NNN)`.

## Validation

- [x] N/A — docs/config-only change (no `.sfn` touched)

## Notes for reviewers

This PR itself has no backing Linear leaf, so per the new rule its title intentionally omits the `(SFN-NNN)` suffix. The suffix is additive to the Conventional Commit format, so existing tooling that keys off the `<type>(<scope>):` prefix is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_019kbuPT9mo5oWCSaoT7xGiH)_