### PR TITLE
docs(sfep-0046): record groomed leaf issues in tracking

### DIFF
--- a/docs/proposals/0046-toolchain-pinning.md
+++ b/docs/proposals/0046-toolchain-pinning.md
@@ -6,7 +6,7 @@ type: tooling
 created: 2026-07-09
 updated: 2026-07-09
 author: "agent:compiler-architect; human review: Michael Curtis"
-tracking: SFN-167, SFN-168
+tracking: SFN-167, SFN-168, SFN-169, SFN-170, SFN-171, SFN-172
 supersedes:
 superseded-by:
 graduates-to:


### PR DESCRIPTION
Follow-up to #2055 (merged). Grooming split the two phase-sized issues into six session-sized leaves (SFN-169 semver, SFN-170 Ed25519 verify, SFN-171 sign releases, plus the reshaped SFN-167/168 and new SFN-172 dispatch). This records them in the SFEP's `tracking` front-matter.

Docs-only; no design change.