### PR TITLE
feat(crypto): add verify-only Ed25519 to sfn/crypto (SFN-170)

### DIFF
--- a/capsules/sfn/crypto/src/ed25519.sfn
+++ b/capsules/sfn/crypto/src/ed25519.sfn
@@ -71,7 +71,10 @@ fn _ed_hex_to_bytes(hex: string, expect_len: int) -> int[] {
 // idiom). Returns `null` on allocation failure. Caller frees.
 fn _ed_bytes_to_native(bytes: int[]) -> * u8 {
     if bytes.length == 0 {
+        // OpenSSL reads no bytes here (tbslen is 0), but zero the byte so
+        // the helper never hands back uninitialized memory.
         let empty_buf: * u8 = malloc(1 as usize);
+        if empty_buf as i64 != 0 { memset(empty_buf, 0, 1 as usize); }
         return empty_buf;
     }
     let buf: * u8 = malloc(bytes.length as usize);
@@ -157,7 +160,7 @@ fn ed25519_verify(public_key_hex: string, message: int[], signature_hex: string)
 }
 
 // Convenience for a NUL-free text message (e.g. a SHA256SUMS manifest).
-// Hashes the string's raw bytes. Delegates to ed25519_verify.
+// Verifies over the string's raw bytes. Delegates to ed25519_verify.
 fn ed25519_verify_utf8(public_key_hex: string, message: string, signature_hex: string) -> bool {
     return ed25519_verify(public_key_hex, _ed_string_to_bytes(message), signature_hex);
 }

--- a/capsules/sfn/crypto/src/ed25519.sfn
+++ b/capsules/sfn/crypto/src/ed25519.sfn
@@ -1,0 +1,163 @@
+// capsules/sfn/crypto/src/ed25519.sfn
+//
+// Verify-only Ed25519 (RFC 8032) for the sfn/crypto capsule — the crypto
+// primitive the signed-toolchain trust model rests on (SFEP-0046 §3.5).
+// Backed by OpenSSL libcrypto via extern: `-lcrypto` is already linked
+// into every Sailfin binary for TLS (SFEP-0036), so this adds no new
+// dependency. Fail-closed: any malformed input or OpenSSL error yields
+// `false`, never a panic. A pure-Sailfin port is deferred post-1.0
+// (SFEP-0046 §3.5).
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn EVP_PKEY_new_raw_public_key(key_type: i32, e: * u8, key: * u8, keylen: usize) -> * u8;
+
+extern fn EVP_PKEY_free(pkey: * u8) -> void;
+
+extern fn EVP_MD_CTX_new() -> * u8;
+
+extern fn EVP_MD_CTX_free(ctx: * u8) -> void;
+
+extern fn EVP_DigestVerifyInit(ctx: * u8, pctx: * * u8, md_type: * u8, e: * u8, pkey: * u8) -> i32;
+
+extern fn EVP_DigestVerify(ctx: * u8, sig: * u8, siglen: usize, tbs: * u8, tbslen: usize) -> i32;
+
+// `_ed_ptr_off(p, off)` — byte-stride pointer arithmetic for a variable
+// offset (copy of the net.sfn / http.sfn helper).
+fn _ed_ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+// Map a single hex character to its 0-15 value, or -1 if `c` is not a hex
+// digit.
+fn _ed_hex_val(c: string) -> int {
+    let code: int = char_code(c) & 255;
+    if code >= 48 && code <= 57 {
+        return code - 48;
+    }  // '0'..'9'
+    if code >= 97 && code <= 102 {
+        return code - 97 + 10;
+    }  // 'a'..'f'
+    if code >= 65 && code <= 70 {
+        return code - 65 + 10;
+    }  // 'A'..'F'
+    return -1;
+}
+
+// Decode `hex` into `expect_len` raw bytes. Fail-closed: returns `[]` if
+// `hex` is not exactly `expect_len * 2` hex characters.
+fn _ed_hex_to_bytes(hex: string, expect_len: int) -> int[] {
+    if hex.length != expect_len * 2 { return []; }
+    let mut out: int[] = [];
+    let mut j: int = 0;
+    loop {
+        if j >= expect_len { break; }
+        let hi: int = _ed_hex_val(hex[2 * j]);
+        let lo: int = _ed_hex_val(hex[2 * j + 1]);
+        if hi < 0 { return []; }
+        if lo < 0 { return []; }
+        out.push((hi << 4) | lo);
+        j += 1;
+    }
+    return out;
+}
+
+// Copy `bytes` into a freshly `malloc`ed native buffer, one byte at a time
+// (no pointer_write intrinsic exists, so `memset` with n=1 is the write
+// idiom). Returns `null` on allocation failure. Caller frees.
+fn _ed_bytes_to_native(bytes: int[]) -> * u8 {
+    if bytes.length == 0 {
+        let empty_buf: * u8 = malloc(1 as usize);
+        return empty_buf;
+    }
+    let buf: * u8 = malloc(bytes.length as usize);
+    if buf as i64 == 0 { return null; }
+    let mut i: i64 = 0;
+    loop {
+        if i >= bytes.length as i64 { break; }
+        memset(_ed_ptr_off(buf, i), (bytes[i] & 255) as i32, 1 as usize);
+        i += 1;
+    }
+    return buf;
+}
+
+// Decode a string's raw bytes into an `int[]` (byte-oriented, matching
+// `sha256_hex`'s decode loop).
+fn _ed_string_to_bytes(s: string) -> int[] {
+    let mut bytes: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= s.length { break; }
+        bytes.push(char_code(s[i]) & 255);
+        i += 1;
+    }
+    return bytes;
+}
+
+// Verify an Ed25519 signature (RFC 8032) over a raw byte message.
+// public_key_hex: 64 hex chars (32-byte raw Ed25519 public key).
+// signature_hex:  128 hex chars (64-byte signature).
+// Returns true iff the signature is valid; fail-closed (false, never panic)
+// on any malformed input or OpenSSL error.
+fn ed25519_verify(public_key_hex: string, message: int[], signature_hex: string) -> bool {
+    let key_bytes: int[] = _ed_hex_to_bytes(public_key_hex, 32);
+    if key_bytes.length != 32 { return false; }
+    let sig_bytes: int[] = _ed_hex_to_bytes(signature_hex, 64);
+    if sig_bytes.length != 64 { return false; }
+
+    let key_buf: * u8 = _ed_bytes_to_native(key_bytes);
+    if key_buf as i64 == 0 { return false; }
+
+    // NID_ED25519 / EVP_PKEY_ED25519 = 1087 (decimal; no hex literals).
+    let pkey: * u8 = EVP_PKEY_new_raw_public_key(1087, null, key_buf, 32 as usize);
+    free(key_buf);  // OpenSSL copies the key.
+    if pkey as i64 == 0 { return false; }
+
+    let ctx: * u8 = EVP_MD_CTX_new();
+    if ctx as i64 == 0 {
+        EVP_PKEY_free(pkey);
+        return false;
+    }
+
+    // Ed25519 is a single-shot signature scheme: md and pctx are null.
+    let init_rc: i32 = EVP_DigestVerifyInit(ctx, null, null, null, pkey);
+    if init_rc != 1 {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        return false;
+    }
+
+    let sig_buf: * u8 = _ed_bytes_to_native(sig_bytes);
+    if sig_buf as i64 == 0 {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        return false;
+    }
+    let msg_buf: * u8 = _ed_bytes_to_native(message);
+    if msg_buf as i64 == 0 {
+        free(sig_buf);
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        return false;
+    }
+    let msg_len: int = message.length;
+
+    let rc: i32 = EVP_DigestVerify(ctx, sig_buf, 64 as usize, msg_buf, msg_len as usize);
+
+    free(sig_buf);
+    free(msg_buf);
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+
+    return rc == 1;
+}
+
+// Convenience for a NUL-free text message (e.g. a SHA256SUMS manifest).
+// Hashes the string's raw bytes. Delegates to ed25519_verify.
+fn ed25519_verify_utf8(public_key_hex: string, message: string, signature_hex: string) -> bool {
+    return ed25519_verify(public_key_hex, _ed_string_to_bytes(message), signature_hex);
+}

--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -2,7 +2,8 @@
 //
 // Provides secure hash functions for data integrity, checksums, and
 // content-addressable storage. No effects required — pure computation.
-//
+export { ed25519_verify, ed25519_verify_utf8 } from "./ed25519";
+
 // SHA-256 is implemented in pure Sailfin (FIPS 180-4). All arithmetic is
 // performed on i64 values masked to 32 bits after every operation, because
 // `>>` lowers to LLVM `ashr` (arithmetic shift): keeping every intermediate

--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -1,7 +1,8 @@
-// sfn/crypto — Cryptographic hashing and digest functions for Sailfin.
+// sfn/crypto — Cryptographic hashing, encoding, and signature functions.
 //
-// Provides secure hash functions for data integrity, checksums, and
-// content-addressable storage. No effects required — pure computation.
+// Provides SHA-256 hashing (data integrity, checksums, content-addressable
+// storage), base64 encode/decode, and verify-only Ed25519 signature
+// verification (RFC 8032). No effects required — pure computation.
 export { ed25519_verify, ed25519_verify_utf8 } from "./ed25519";
 
 // SHA-256 is implemented in pure Sailfin (FIPS 180-4). All arithmetic is

--- a/capsules/sfn/crypto/tests/ed25519_test.sfn
+++ b/capsules/sfn/crypto/tests/ed25519_test.sfn
@@ -1,0 +1,87 @@
+// Tests for sfn/crypto verify-only Ed25519 (RFC 8032, OpenSSL-backed).
+//
+// Known-answer vectors from RFC 8032 §7.1 (TEST 1-3), a positive
+// ed25519_verify_utf8 vector (so the text-message path is proven live,
+// not only rejected), plus tamper cases (a flipped signature byte, a
+// mismatched message, a mismatched key/message pair) and fail-closed
+// malformed-input cases that must return false without panicking.
+import { ed25519_verify, ed25519_verify_utf8 } from "../src/mod";
+
+test "ed25519_verify: RFC 8032 TEST 1 (empty message)" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b";
+    assert ed25519_verify(pk, [], sig) == true;
+}
+
+test "ed25519_verify: RFC 8032 TEST 2 (1-byte message)" {
+    let pk = "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+    let sig = "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00";
+    assert ed25519_verify(pk, [114], sig) == true;
+}
+
+test "ed25519_verify: RFC 8032 TEST 3 (2-byte message)" {
+    let pk = "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025";
+    let sig = "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a";
+    assert ed25519_verify(pk, [175, 130], sig) == true;
+}
+
+test "ed25519_verify_utf8: valid text-message signature" {
+    // Generated with OpenSSL Ed25519 over the ASCII message below; proves
+    // the utf8 delegation path accepts a genuine signature (guards against
+    // a silent degrade-to-always-false in _ed_string_to_bytes).
+    let pk = "d481212055e305d0b05b591760df527f31fd3cb2cf448deeecdc04f4e45c2f1d";
+    let sig = "48c2680fd085d2132c9bf3940a1a9336fc71d50380443414097f36d754e4aa3f66c3b3d12427c926051a2ad09d43fc099ca6596455f3258820d07e0be0b4730d";
+    assert ed25519_verify_utf8(pk, "sailfin toolchain v1", sig) == true;
+}
+
+test "ed25519_verify: tamper - flipped last hex digit of signature" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100c";
+    assert ed25519_verify(pk, [], sig) == false;
+}
+
+test "ed25519_verify: tamper - wrong message against TEST 1 key/sig" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b";
+    assert ed25519_verify(pk, [1], sig) == false;
+}
+
+test "ed25519_verify: tamper - mismatched key/message/signature pairing" {
+    let pk3 = "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025";
+    let sig2 = "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00";
+    assert ed25519_verify(pk3, [175, 130], sig2) == false;
+}
+
+test "ed25519_verify: fail-closed - public key hex too short" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f70751";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b";
+    assert ed25519_verify(pk, [], sig) == false;
+}
+
+test "ed25519_verify: fail-closed - signature hex too short" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100";
+    assert ed25519_verify(pk, [], sig) == false;
+}
+
+test "ed25519_verify: fail-closed - non-hex character in public key" {
+    let pk = "z75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b";
+    assert ed25519_verify(pk, [], sig) == false;
+}
+
+test "ed25519_verify: fail-closed - empty public key" {
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b";
+    assert ed25519_verify("", [], sig) == false;
+}
+
+test "ed25519_verify: fail-closed - empty signature" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    assert ed25519_verify(pk, [], "") == false;
+}
+
+test "ed25519_verify_utf8: tamper - wrong text message" {
+    let pk = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    let sig = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b";
+    assert ed25519_verify_utf8(pk, "not the signed message", sig) == false;
+}


### PR DESCRIPTION
## Summary

Adds RFC 8032 Ed25519 **signature verification** to the `sfn/crypto` capsule — the crypto primitive the signed-toolchain trust model rests on (SFEP-0046 §3.5, which SFN-168 toolchain auto-dispatch depends on). `sfn/crypto` had SHA-256 but no signature verification.

Implemented as an **extern over OpenSSL libcrypto** (decided at the design gate over a ~2,000-LOC pure-Sailfin ref10 build). `-lcrypto` is already linked into every Sailfin binary for TLS (SFEP-0036), so this adds **no new dependency** and does not move the pure-toolchain needle. Correctness is delegated to OpenSSL's FIPS-grade primitive; a pure-Sailfin port is deferred post-1.0.

Fixes SFN-170

## Changes

- **runtime/adapters (capsule):** new `capsules/sfn/crypto/src/ed25519.sfn` — EVP externs (`EVP_PKEY_new_raw_public_key`, `EVP_DigestVerifyInit`, `EVP_DigestVerify`, `EVP_MD_CTX_*`, `EVP_PKEY_free`) as opaque `* u8` handles mirroring `tls.sfn`; fail-closed hex decode; byte marshalling via `memset` (n=1) mirroring `net.sfn`.
  - Public API: `ed25519_verify(public_key_hex: string, message: int[], signature_hex: string) -> bool` and `ed25519_verify_utf8(public_key_hex, message: string, signature_hex) -> bool` for NUL-free text. Effect-free (pure in-memory extern calls).
- **capsule:** `mod.sfn` re-exports both functions.
- **tests:** new `capsules/sfn/crypto/tests/ed25519_test.sfn` — RFC 8032 §7.1 TEST 1-3 positive vectors, a positive `ed25519_verify_utf8` vector (OpenSSL-generated), 3 tamper cases, 5 fail-closed malformed-input cases.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes — `checked 2 files: ok`
- [ ] ~~`make compile`~~ — N/A: change is isolated to `capsules/sfn/crypto`; no `compiler/src/*.sfn` touched. The compiler does not import this capsule (it vendors its own `build/hash.sfn`), so the self-host closure is unaffected; the compiler self-hosted from seed this session.
- [x] Regression coverage added: `capsules/sfn/crypto/tests/ed25519_test.sfn` (13 tests)
- Verification command from the issue: `build/native/sailfin test capsules/sfn/crypto/tests` → **3/3 files, 13/13 Ed25519 tests, 52 total pass**

## Stage1 readiness

- [x] Parses, type-checks, and effect-checks (effect-free by design — pure computation)
- [x] Lowers and links against `-lcrypto` (already on every Sailfin link line); tests build and run to a real binary
- [x] Behavior enforced end-to-end (RFC 8032 vectors verify true; tampered/malformed inputs return false — not annotation-only)
- [ ] `docs/status.md` / spec chapter — deferred to the SFN-168 consumer wiring (this PR ships the capsule primitive + its own tests)

## Notes for reviewers

- **Fail-closed contract:** every malformed input (wrong hex length, non-hex char, empty string, OpenSSL error, bad signature) returns `false`, never panics. `return rc == 1` is strict — `0` (invalid) and negative (error) both yield `false`.
- **Memory safety:** every `malloc`/`EVP_*_new` handle is freed on every exit path (`key_buf` freed right after OpenSSL copies it; `sig_buf`/`msg_buf`/`ctx`/`pkey` after verify); no double-free / use-after-free. Reviewed by the Opus code-reviewer — approved, no blocking findings.
- **Consumer wiring is SFN-168's:** when the driver needs `verify`, SFN-168 chooses to add `sfn/crypto` to the compiler deps or vendor `ed25519.sfn` (mirroring the `build/hash.sfn` precedent). Bundle the embedded-key consumer there to avoid a seed-cut gate.
- **Deferred follow-up:** pure-Sailfin Ed25519 port (SHA-512 + ref10 field/point arithmetic) is post-1.0 — its own epic, needs a differential fuzzer.
- **No seed dependency** — additive capsule change, builds from the pinned seed directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpSLDY72RX5vdmTGyLmXL9)_