### PR TITLE
refactor(runtime): single source of truth for pthread handle layouts (SFN-28)

### DIFF
--- a/runtime/capsule.toml
+++ b/runtime/capsule.toml
@@ -46,7 +46,7 @@ ll-sources = []
 #   `compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh`.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["sfn/runtime_globals.sfn", "sfn/memory/arena.sfn", "sfn/memory/rc.sfn", "sfn/memory/mem.sfn", "sfn/memory/ownedbuf.sfn", "sfn/string.sfn", "sfn/array.sfn", "sfn/clock.sfn", "sfn/process.sfn", "sfn/io.sfn", "sfn/exception.sfn", "sfn/assert.sfn", "sfn/type_meta.sfn", "sfn/platform/exec.sfn", "sfn/platform/rlimit.sfn", "sfn/platform/tls.sfn", "sfn/adapters/filesystem.sfn", "sfn/adapters/http.sfn", "sfn/adapters/websocket.sfn", "sfn/adapters/net.sfn", "sfn/concurrency/scheduler.sfn", "sfn/concurrency/nursery.sfn", "sfn/concurrency/future.sfn", "sfn/concurrency/channel.sfn", "sfn/concurrency/parallel.sfn", "sfn/concurrency/serve.sfn"]
+sfn-sources = ["sfn/runtime_globals.sfn", "sfn/memory/arena.sfn", "sfn/memory/rc.sfn", "sfn/memory/mem.sfn", "sfn/memory/ownedbuf.sfn", "sfn/string.sfn", "sfn/array.sfn", "sfn/clock.sfn", "sfn/process.sfn", "sfn/io.sfn", "sfn/exception.sfn", "sfn/assert.sfn", "sfn/type_meta.sfn", "sfn/platform/exec.sfn", "sfn/platform/rlimit.sfn", "sfn/platform/tls.sfn", "sfn/platform/pthread_layout.sfn", "sfn/adapters/filesystem.sfn", "sfn/adapters/http.sfn", "sfn/adapters/websocket.sfn", "sfn/adapters/net.sfn", "sfn/concurrency/scheduler.sfn", "sfn/concurrency/nursery.sfn", "sfn/concurrency/future.sfn", "sfn/concurrency/channel.sfn", "sfn/concurrency/parallel.sfn", "sfn/concurrency/serve.sfn"]
 include-dirs = []
 # `-lssl -lcrypto`: OpenSSL, linked into every Sailfin binary for the
 # native runtime's TLS surface (`sfn/platform/tls.sfn`, SFEP-0036). The

--- a/runtime/sfn/concurrency/channel.sfn
+++ b/runtime/sfn/concurrency/channel.sfn
@@ -93,9 +93,10 @@ extern fn pthread_cond_broadcast(c: * PthreadCond) -> i32;
 extern fn pthread_cond_destroy(c: * PthreadCond) -> i32;
 
 // ── Layout helpers ────────────────────────────────────────────────
-// Byte offset of the `closed` field.  `closed` is the LAST field,
-// appended after the two conds.  With the max-sized 64-byte mutex
-// (#1265) the struct layout is:
+// Byte offset of the `closed` field, which sits after the two conds. The
+// trailing `elem_owned` i64 was appended after `closed` (#1476), so
+// `closed` keeps its offset 208 and `elem_owned` is the final field. With
+// the max-sized 64-byte mutex (#1265) the struct layout is:
 //   [0..48)    six i64 cursors
 //   [48..112)  PthreadMutex (64 B)
 //   [112..160) not_empty PthreadCond (48 B)

--- a/runtime/sfn/concurrency/channel.sfn
+++ b/runtime/sfn/concurrency/channel.sfn
@@ -22,40 +22,21 @@
 // Heap pointers stored in struct fields are `i64` addresses, cast to
 // typed `* T` views at the use site — matching scheduler.sfn.
 //
-// ── Struct layout (Linux x86_64, glibc) ──────────────────────────
-//   Channel byte size: six i64 fields (48 B) + PthreadMutex (40 B)
-//     + two PthreadCond (96 B) = 184 bytes.
+// ── Struct layout ────────────────────────────────────────────────
+//   Channel byte size (max-sized handles): six i64 fields (48 B) +
+//     PthreadMutex (64 B) + two PthreadCond (96 B) + `closed` i64 (8 B) +
+//     `elem_owned` i64 (8 B) = 224 bytes. The `Channel` struct and
+//     `_sfn_channel_struct_size_full` below carry the field offsets.
 //
-// ── Externs (re-declared inline) ─────────────────────────────────
-// Declared inline rather than imported from pthread.sfn / libc.sfn,
-// matching the scheduler.sfn precedent (#306).
-// Opaque storage for a `pthread_mutex_t`.  64 bytes — eight 8-byte slots,
-// sized to the larger macOS arm64 layout (`pthread_mutex_t` = 64 B; Linux
-// glibc uses only the first 40, the slack is never read).  Under-sizing to
-// 40 B overran the embedded handle on macOS arm64, corrupting heap metadata
-// under parallel load (#1265).  Opaque to Sailfin; libpthread owns the bytes.
-struct PthreadMutex {
-    _opaque0: i64;
-    _opaque1: i64;
-    _opaque2: i64;
-    _opaque3: i64;
-    _opaque4: i64;
-    _opaque5: i64;
-    _opaque6: i64;
-    _opaque7: i64;
-}
-
-// Opaque storage for a `pthread_cond_t`.  48 bytes on both supported
-// targets (Linux x86_64 glibc and macOS arm64) — six 8-byte slots, so
-// unlike the mutex it needs no max-sizing.
-struct PthreadCond {
-    _opaque0: i64;
-    _opaque1: i64;
-    _opaque2: i64;
-    _opaque3: i64;
-    _opaque4: i64;
-    _opaque5: i64;
-}
+// ── Opaque pthread-handle storage ────────────────────────────────
+// The `PthreadMutex` (64 B) / `PthreadCond` (48 B) opaque byte storage
+// embedded by value in `Channel` is the single source of truth in
+// `runtime/sfn/platform/pthread_layout.sfn`, imported here rather than
+// hand-copied — a stale copy is exactly the #1265 heap-corruption hazard
+// this de-duplication closes. The C-ABI `pthread_*` extern declarations
+// below stay re-declared inline per the #306 precedent (they reference the
+// imported struct as an opaque pointee).
+import { PthreadMutex, PthreadCond } from "../platform/pthread_layout";
 
 // Bounded MPMC channel.  `buffer_addr` points at a flat `capacity *
 // elem_size` byte array; slots are addressed by
@@ -112,9 +93,6 @@ extern fn pthread_cond_broadcast(c: * PthreadCond) -> i32;
 extern fn pthread_cond_destroy(c: * PthreadCond) -> i32;
 
 // ── Layout helpers ────────────────────────────────────────────────
-// Channel struct size without the trailing `closed` flag: 208 bytes.
-fn _sfn_channel_struct_size() -> i64 { return 208; }
-
 // Byte offset of the `closed` field.  `closed` is the LAST field,
 // appended after the two conds.  With the max-sized 64-byte mutex
 // (#1265) the struct layout is:

--- a/runtime/sfn/concurrency/nursery.sfn
+++ b/runtime/sfn/concurrency/nursery.sfn
@@ -44,20 +44,15 @@
 // - `faulted`: set when a registration cannot grow its list (OOM).
 //   `sfn_nursery_exit` returns the fault code so the lowering has a
 //   seam to later propagate a child fault as a thrown error.
-// ── Opaque pthread handle storage ─────────────────────────────
-// Mirrors scheduler.sfn exactly: a `PthreadMutex` is 64 bytes (max-sized
-// for macOS arm64; Linux glibc reads only the first 40). Opaque to
-// Sailfin — libpthread owns the bytes through a `* PthreadMutex` view.
-struct PthreadMutex {
-    _opaque0: i64;
-    _opaque1: i64;
-    _opaque2: i64;
-    _opaque3: i64;
-    _opaque4: i64;
-    _opaque5: i64;
-    _opaque6: i64;
-    _opaque7: i64;
-}
+// ── Opaque pthread-handle storage ─────────────────────────────
+// The opaque `PthreadMutex` (64 B) byte storage embedded by value in
+// `Nursery` is the single source of truth in
+// `runtime/sfn/platform/pthread_layout.sfn`, imported here rather than
+// hand-copied (a stale copy is the #1265 heap-corruption hazard this
+// de-duplication closes). The `pthread_mutex_*` externs below stay
+// re-declared inline per the #306 precedent, referencing the imported
+// struct as an opaque pointee.
+import { PthreadMutex } from "../platform/pthread_layout";
 
 // A nursery: the owner of the tasks spawned in a `routine` scope.
 // `parent` is the enclosing nursery on this thread's stack (0 if

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -44,61 +44,20 @@
 // call site, exactly as the adapter layer does for
 // `pthread_create`'s `start`.
 //
-// ── Opaque pthread-handle sizing ──────────────────────────────
-// `PthreadMutex` and `PthreadCond` are embedded **by value** in
-// `Task` (and `TaskQueue`) so that `pthread_mutex_init` /
-// `pthread_cond_init` can be handed `&task.mutex` once the queue
-// code lands — no separate allocation per handle. The design
-// (§2.6.1, §2.9 open question Q7) calls for them to be "opaque
-// byte arrays sized to the target platform's
-// `sizeof(pthread_mutex_t)` / `sizeof(pthread_cond_t)`". Sailfin
-// has no fixed-size array type yet, so — matching the
-// `ArenaPage`/`SailfinProcessHandle` precedent — the byte storage
-// is expressed as a run of 8-byte `i64` slots whose total size
-// equals the platform `sizeof`.
-//
-// The two self-hosting build targets disagree on `pthread_mutex_t`:
-//   - Linux x86_64 (glibc): `pthread_mutex_t` = 40 bytes, `pthread_cond_t` = 48 bytes
-//   - macOS arm64 (LP64):   `pthread_mutex_t` = 64 bytes (8-byte sig + 56-byte
-//     opaque), `pthread_cond_t` = 48 bytes (8-byte sig + 40-byte opaque)
-// A platform-conditional split (per §2.9 Q7) is deferred until Sailfin
-// grows `cfg`-style conditional compilation. Until then the opaque storage
-// is sized to the **maximum** across both targets so neither platform's
-// `pthread_*_init` overruns the embedded handle: mutex -> 64 bytes (8 slots,
-// covering macOS; the 24-byte slack on Linux is never read), cond -> 48 bytes
-// (6 slots, identical on both). Under-sizing the mutex to 40 bytes overran the
-// `Task` allocation by 24 bytes on macOS arm64, corrupting heap metadata and
-// faulting a later `malloc` inside the allocator under parallel load (#1265).
-// The handles are opaque: only libpthread reads or writes their bytes, so the
-// slot names are deliberately generic.
-// Opaque storage for a `pthread_mutex_t`. 64 bytes — eight 8-byte slots,
-// sized to the larger macOS arm64 layout (Linux glibc uses only the first
-// 40). Never read field-by-field from Sailfin; the bytes belong to
-// libpthread, reached through a `* PthreadMutex` view passed to
-// `pthread_mutex_*`.
-struct PthreadMutex {
-    _opaque0: i64;
-    _opaque1: i64;
-    _opaque2: i64;
-    _opaque3: i64;
-    _opaque4: i64;
-    _opaque5: i64;
-    _opaque6: i64;
-    _opaque7: i64;
-}
-
-// Opaque storage for a `pthread_cond_t`. 48 bytes on both supported
-// targets (Linux x86_64 glibc and macOS arm64) — six 8-byte slots, so
-// unlike the mutex it needs no max-sizing. Opaque to Sailfin; libpthread
-// owns the bytes via a `* PthreadCond` view passed to `pthread_cond_*`.
-struct PthreadCond {
-    _opaque0: i64;
-    _opaque1: i64;
-    _opaque2: i64;
-    _opaque3: i64;
-    _opaque4: i64;
-    _opaque5: i64;
-}
+// ── Opaque pthread-handle storage ─────────────────────────────
+// `PthreadMutex` and `PthreadCond` are embedded **by value** in `Task`
+// (and `TaskQueue`) so that `pthread_mutex_init` / `pthread_cond_init` can
+// be handed `q.mutex` — no separate allocation per handle. Their opaque
+// byte layouts (mutex 64 B / 8 slots, cond 48 B / 6 slots, max-sized across
+// Linux x86_64 and macOS arm64 so neither platform's `pthread_*_init`
+// overruns the embedding — the #1265 heap-corruption fix) are the single
+// source of truth in `runtime/sfn/platform/pthread_layout.sfn`, imported
+// here rather than hand-copied. See that module for the full sizing
+// rationale. A struct type used only as an embedded field / extern pointee
+// generates no cross-module call symbol, so the import resolves from
+// typecheck and lowers correctly under both the capsule build (#1288
+// import-context staging) and a standalone `sfn emit`.
+import { PthreadMutex, PthreadCond } from "../platform/pthread_layout";
 
 // A single unit of deferred work. Mirrors the §2.6.1 `Task`
 // layout. `fn_ptr` is the worker entry (`fn(* u8) -> * u8`) stored

--- a/runtime/sfn/platform/pthread_layout.sfn
+++ b/runtime/sfn/platform/pthread_layout.sfn
@@ -1,0 +1,65 @@
+// runtime/sfn/platform/pthread_layout.sfn
+//
+// The single source of truth for the opaque pthread synchronization-object
+// storage layouts embedded by the concurrency runtime. `PthreadMutex` and
+// `PthreadCond` are opaque byte blocks that libpthread owns; Sailfin never
+// reads them field-by-field — they are reached only through a
+// `* PthreadMutex` / `* PthreadCond` view handed to `pthread_mutex_*` /
+// `pthread_cond_*`. Companion to `runtime/sfn/platform/pthread.sfn` (the
+// extern function surface); this module owns the layout, that one owns the
+// calls.
+//
+// Consumers (`concurrency/scheduler.sfn`, `channel.sfn`, `nursery.sfn`)
+// import these structs instead of re-declaring them inline. A struct type
+// used as an embedded-by-value field or a pointer pointee generates no
+// cross-module call symbol, so the layout resolves from the parsed import
+// at typecheck and lowers correctly under both the capsule build
+// (`_compile_runtime_sfn_sources`, import-context staged per #1288) and a
+// standalone `sfn emit`. Centralizing them here is what closes the
+// hand-copy-divergence hazard that made #1265 (under-sized mutex → heap
+// corruption on macOS arm64) a multi-file manual sync.
+//
+// ── Sizing (the byte-size source of truth) ────────────────────
+// The two self-hosting build targets disagree on `pthread_mutex_t`:
+//   - Linux x86_64 (glibc): `pthread_mutex_t` = 40 bytes, `pthread_cond_t` = 48 bytes
+//   - macOS arm64 (LP64):   `pthread_mutex_t` = 64 bytes (8-byte sig + 56-byte
+//     opaque), `pthread_cond_t` = 48 bytes (8-byte sig + 40-byte opaque)
+// A platform-conditional split (per `docs/proposals/0025-native-runtime-architecture.md`
+// §2.9 Q7) is deferred until Sailfin grows `cfg`-style conditional compilation.
+// Until then the opaque storage is sized to the MAXIMUM across both targets so
+// neither platform's `pthread_*_init` overruns an embedded handle: mutex ->
+// 64 bytes (8 slots, covering macOS; the 24-byte slack on Linux is never
+// read), cond -> 48 bytes (6 slots, identical on both). Under-sizing the mutex
+// to 40 bytes overran the embedding allocation by 24 bytes on macOS arm64,
+// corrupting heap metadata and faulting a later `malloc` under parallel load
+// (#1265). Sailfin has no fixed-size array type yet, so — matching the
+// `ArenaPage` / `SailfinProcessHandle` precedent — the byte storage is a run
+// of 8-byte `i64` slots whose total size equals the platform `sizeof`.
+// Opaque storage for a `pthread_mutex_t`. 64 bytes — eight 8-byte slots,
+// sized to the larger macOS arm64 layout (Linux glibc uses only the first
+// 40). Never read field-by-field from Sailfin; the bytes belong to
+// libpthread, reached through a `* PthreadMutex` view passed to
+// `pthread_mutex_*`.
+struct PthreadMutex {
+    _opaque0: i64;
+    _opaque1: i64;
+    _opaque2: i64;
+    _opaque3: i64;
+    _opaque4: i64;
+    _opaque5: i64;
+    _opaque6: i64;
+    _opaque7: i64;
+}
+
+// Opaque storage for a `pthread_cond_t`. 48 bytes on both supported targets
+// (Linux x86_64 glibc and macOS arm64) — six 8-byte slots, so unlike the
+// mutex it needs no max-sizing. Opaque to Sailfin; libpthread owns the bytes
+// via a `* PthreadCond` view passed to `pthread_cond_*`.
+struct PthreadCond {
+    _opaque0: i64;
+    _opaque1: i64;
+    _opaque2: i64;
+    _opaque3: i64;
+    _opaque4: i64;
+    _opaque5: i64;
+}


### PR DESCRIPTION
## Summary

De-duplicates the opaque `PthreadMutex` / `PthreadCond` byte-storage structs that were hand-copied across the concurrency runtime (`scheduler.sfn`, `channel.sfn`, `nursery.sfn`), so a future platform/layout fix is a single-site change rather than the error-prone multi-file manual sync that made the #1265 heap-corruption fix touch three files. Touches only the runtime (`runtime/sfn/concurrency/*`, `runtime/sfn/platform/*`, `runtime/capsule.toml`); no compiler-pass changes.

Fixes SFN-28

## Changes

- **runtime:** Add `runtime/sfn/platform/pthread_layout.sfn` — the single home for the opaque `PthreadMutex` (64 B / 8 slots) and `PthreadCond` (48 B / 6 slots) layouts. The byte size stays implicit in the struct field count; a `let`-constant is deliberately **not** exported (module globals are a fragile cross-link case in the sfn-source path).
- **runtime:** `scheduler.sfn`, `channel.sfn`, `nursery.sfn` now `import` those structs instead of re-declaring them inline. A struct type used only as an embedded-by-value field / extern pointee generates no cross-module call symbol, so it resolves at typecheck and lowers correctly under both the capsule build (#1288 import-context staging) and standalone `sfn emit` — the same pattern `runtime/sfn/string.sfn` already rides for `OwnedBuf`. The `pthread_*` C-ABI externs stay re-declared inline per the #306 precedent (Out-of-scope resolver policy left untouched).
- **runtime:** Register `sfn/platform/pthread_layout.sfn` in `runtime/capsule.toml` `sfn-sources` (single-line array preserved) so its `.sfn-asm` is staged into the #1288 import-context; without staging the capsule build emits `%PthreadMutex` as opaque and the embedded-field GEP fails to link.
- **runtime:** Remove the `_sfn_channel_struct_size()` footgun (returned 208, excluding the trailing `closed`/`elem_owned` fields; zero callers). `_sfn_channel_struct_size_full()` (224) is the real allocator size.
- **runtime:** Fix a stale `channel.sfn` header comment (pre-#1265 "40 B / 184 bytes" → 64 B / 224 B).

Byte layouts preserved exactly (verified in emitted IR): mutex 64, cond 48, task 152, task queue 200, channel 224, nursery 104.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes — standalone check of all three consumers ok
- [x] `make compile` — compiler self-hosts (`make clean-build` first; structural change adding a module + manifest entry)
- [ ] `make check` — not run (refactor; the concurrency e2e/unit family below is the targeted gate)
- [x] Regression coverage: existing concurrency e2e + unit suite is the guard (any layout divergence surfaces as heap corruption); no new test needed for a layout-neutral refactor
- [ ] N/A — docs/config-only change

Concurrency test family (Linux x86_64, `--jobs 6` where applicable), all green:
- e2e: channel (8/8), scheduler (2/2), nursery (1/1), parallel (5/5), `spawn_capture_env_free`, `serve_request_leak` (3/3, ASAN best-effort), `runtime_serve`, `sc_nprocessors_onln_sentinel` (5/5), `concurrency_lowering_ir`, `concurrency_ownedbuf_asan_interleave` (the #1265/#1550-class corruption guard), `escape_promotion_channel_send`
- unit: `runtime_pthread_skeleton`, `routine_nursery`, `concurrency_emit` (8/8), `concurrency_lowering`, `concurrency_typecheck` (15/15), `channel_typed_binding` (13/13)

## Notes for reviewers

- The macOS arm64 leg from the issue's AC could not run in this Linux environment; the mutex is max-sized (64 B) precisely for that target, and the layout is unchanged from the current tree, so the Linux runs exercise the same embedding offsets.
- Reviewed by the code-reviewer gate: layout-neutral, de-duplication complete (no consumer missed — `future.sfn`/`parallel.sfn`/`serve.sfn` don't reference these types), removed helper has zero callers.
- `runtime/sfn/platform/pthread.sfn` (the extern-surface smoke target, not in `sfn-sources`) is intentionally left untouched — it uses `* PthreadMutex` only as an opaque extern pointee and never defined a struct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTTuPSrssBQPYsnCifXED2)_