### PR TITLE
docs: purge issue-lifecycle state-as-label guidance from live docs (SFN-177)

### DIFF
--- a/.claude/rules/proposals.md
+++ b/.claude/rules/proposals.md
@@ -37,8 +37,13 @@ the issue body is enough. When unsure, see the decision tree in SFEP-0001 §1.
 ## Lifecycle
 
 `Draft → Accepted → Implemented` (+ terminal `Withdrawn` / `Rejected` /
-`Superseded`). Map to the issue labels: `needs-design` → Draft,
-`design-approved` → Accepted, Stage1-readiness met → Implemented.
+`Superseded`). The SFEP's own `status:` front-matter is the source of truth,
+mirrored by the implementing Linear issue's native status — **not** by GitHub
+labels. (The `design-approved` workflow-state label is retired; `needs-design`
+survives only as a public GitHub external-intake hint and is never applied to a
+Linear-native `SFN-NNN` issue — Linear status carries the design-gate state.)
+Loosely: an ungroomed design is `Draft`, a design-gate-passed proposal is
+`Accepted`, and Stage1-readiness-met is `Implemented`.
 
 - Move to **Accepted** only when the design gate is passed (user/owner approval).
 - Move to **Implemented** only when the work clears the `CLAUDE.md` Stage1

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -72,7 +72,7 @@ Codex to:
 
 Use `prompts/pickup.md` for autonomous issue work. It instructs Codex to:
 
-1. Query Linear `Ready` issues first, falling back to GitHub `claude-ready` labels only when Linear is unavailable, and rank them with the same priority order as Claude's `/pickup` command.
+1. Query Linear `Ready` issues (workflow state is Linear-native; there is no GitHub `claude-ready` label fallback — it is retired), and rank them with the same priority order as Claude's `/pickup` command.
 2. Verify pinned-seed freshness only when a compiler-source capability must already be present in the pinned seed.
 3. Claim the Linear issue, best-effort sync any GitHub mirror, and branch as `codex/SFN-123-<slug>` for Linear pickup.
 4. File out-of-scope bugs or obvious gaps as Sailfin Linear follow-ups using the templates in `docs/conventions/linear-templates.md`.

--- a/.codex/prompts/pickup.md
+++ b/.codex/prompts/pickup.md
@@ -5,7 +5,7 @@ Use this prompt in Codex web or CLI when you want the Claude `/pickup` experienc
 ```text
 Pick up the next Sailfin issue and drive it to a pull request.
 
-Follow this repository's AGENTS.md and use the Sailfin pickup workflow in .codex/skills/sailfin-pickup/SKILL.md. If I provide `SFN-123`, use that Linear issue. If I provide a bare number, use that GitHub issue and resolve its Linear mirror. Otherwise select the highest-priority pickable issue in Linear's native `Ready` status, falling back to GitHub `claude-ready` labels only when Linear is unreachable.
+Follow this repository's AGENTS.md and use the Sailfin pickup workflow in .codex/skills/sailfin-pickup/SKILL.md. If I provide `SFN-123`, use that Linear issue. If I provide a bare number, use that GitHub issue and resolve its Linear mirror. Otherwise select the highest-priority pickable issue in Linear's native `Ready` status. Workflow state is Linear-native — there is no GitHub `claude-ready` label fallback (it is retired); if Linear is unreachable, stop and report rather than guessing from a GitHub label.
 
 Required workflow:
 1. Query Linear `Ready` issues for the Sailfin team and choose/validate the issue; fall back to `gh` for GitHub-only issues.

--- a/.codex/skills/sailfin-pickup/SKILL.md
+++ b/.codex/skills/sailfin-pickup/SKILL.md
@@ -18,12 +18,10 @@ Issue identifiers are accepted in two forms:
 
 With no explicit issue, prefer Linear. Query Sailfin (`SFN`) Linear issues in
 the native `Ready` status, then filter out any issue that is assigned to someone
-else, canceled, completed, or externally blocked. If Linear is unreachable, fall
-back to GitHub's public compatibility label:
-
-   ```bash
-   gh issue list --label "claude-ready" --state open --json number,title,labels,assignees,body --limit 50
-   ```
+else, canceled, completed, or externally blocked. Workflow state is
+Linear-native — there is no GitHub `claude-ready` label to fall back to (it is
+retired). If the Linear tools are unreachable, stop and report that rather than
+guessing a pick from a GitHub label.
 
 Rank remaining issues by:
 
@@ -58,14 +56,12 @@ For Linear-native pickup, claim Linear first:
 
 - set state to `In Progress`;
 - assign to `me` when the Linear tools support it;
-- do not add Linear status labels such as `blocked` or `in-progress`; Linear has
-  native statuses for that.
+- do not add GitHub workflow-state labels such as `blocked`, `in-progress`, or
+  `claude-ready` (all retired) — Linear's native status is the single source of
+  truth.
 
-If a GitHub mirror exists, update it best-effort too:
-
-```bash
-gh issue edit <N> --add-label "in-progress" --remove-label "claude-ready"
-```
+A GitHub mirror (external-intake issue) needs no status-label sync: its state is
+derived from the Linear issue you have already advanced.
 
 Create the branch as `codex/SFN-123-<slug>` for Linear-native pickup, or
 `codex/<N>-<slug>` for GitHub-only fallback.

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -44,21 +44,27 @@ You are the Sailfin Architect agent. Your role is to review design decisions, ev
 
 ## Orchestration & Handoff
 
-You are part of an automated agent pipeline. When you complete your review:
+Record the design-gate outcome in **Linear-native status**, not GitHub labels
+(the `design-approved` / `needs-design` / `needs-discussion` workflow-state
+labels that gated the retired GitHub Agentic Workflows pipeline are gone —
+`design-approved` is deleted, and `needs-design` survives only as a public
+GitHub external-intake hint, never on a Linear-native `SFN-NNN` issue). When you
+complete your review:
 
 ### If the design is sound:
-1. Remove the `needs-design` label from the issue
-2. Add the `design-approved` label — this triggers the Engineer agent to begin implementation
-3. Comment with your full review (see Output Format below)
+1. Advance the design record: flip the SFEP `status:` front-matter to `Accepted`
+   (and its registry row) if one governs the work, and move the Linear issue to
+   `Ready` so it is pickable for implementation.
+2. Comment with your full review (see Output Format below).
 
 ### If the design needs changes:
-1. Add the `needs-discussion` label
-2. Comment with your concerns and what needs to change
-3. Do NOT add `design-approved` until concerns are resolved
+1. Leave the Linear issue out of `Ready` (keep it in `Backlog`/`Triage`); note a
+   blocked-by relation if it is waiting on another issue.
+2. Comment with your concerns and what needs to change; do not advance the SFEP
+   to `Accepted` until they are resolved.
 
 ### If a follow-up comment resolves your concerns:
-1. Remove `needs-discussion`
-2. Add `design-approved` to advance the pipeline
+1. Move the Linear issue to `Ready` and advance the SFEP to `Accepted`.
 
 ## Output Format
 
@@ -68,4 +74,4 @@ When reviewing, structure your response as:
 2. **Alignment** — How it fits with roadmap and stabilization goals
 3. **Risks** — Architectural concerns, self-hosting impact, complexity increase
 4. **Recommendations** — Concrete suggestions with file references
-5. **Verdict** — `design-approved` or `needs-discussion` with reasons
+5. **Verdict** — **Design approved** (advance to `Accepted` / Linear `Ready`) or **Needs discussion** (hold), with reasons

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -26,17 +26,19 @@ status field already carries grooming/design state.
   GitHub intake (external contributors only)
   ┌──────────────────────────────────────────┐
   │ human files issue → mirrors into Linear;  │
-  │ optional needs-grooming / needs-design    │
-  │ hint only sets the initial status         │
+  │ the initial Linear status comes from the  │
+  │ intake signal (see § Status semantics):   │
+  │ no hint → Triage, a needs-grooming /      │
+  │ needs-design hint → Backlog               │
   └───────────────────────┬──────────────────┘
-                          ▼
+                          ▼ (no hint)
   Linear status (source of truth)
         ┌──────────┐   /groom shapes scope,
         │  Triage  │   criteria, estimate, type
         └────┬─────┘
              ▼
-        ┌──────────┐   groomed but not yet
-        │ Backlog  │   scheduled / design pending
+        ┌──────────┐   groomed but not yet scheduled / design pending;
+        │ Backlog  │   ◄── intake with a grooming/design hint enters here
         └────┬─────┘
              ▼
         ┌──────────┐  ── eligible for /pickup

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -15,40 +15,47 @@ Cycle, blockers, and assignee.
 
 ## Lifecycle (Linear state machine)
 
+Workflow state is **Linear-native** — every node below is a Linear *status*, not
+a GitHub label. GitHub is only an intake surface: an external-contributor issue
+mirrors into Linear and its optional `needs-grooming` / `needs-design` **intake
+hints** (see § *Status semantics (GitHub intake → Linear)*) just pick the initial
+status. Those hints are never applied to a Linear-native `SFN-NNN` issue — the
+status field already carries grooming/design state.
+
 ```
-                                       ┌────────────────┐
-                                  ┌────►│ needs-grooming │
-                                  │     │ (placeholder)  │
-                                  │     └────────┬───────┘
-              human files issue ──┘              │  fill scope/criteria
-                                                 ▼
-                                       ┌────────────────┐
-                              ┌───────►│  needs-design  │◄──── grooming agent
-                              │        │  (architect    │
-                              │        │   queue)       │
-                              │        └────────┬───────┘
-                              │                 │
-                              │  needs-discussion (parked, awaits human)
-                              │                 │
-                              │                 ▼
-                              │        ┌────────────────┐
-                              │        │     Ready      │  ── eligible for /pickup
-                              │        └────────┬───────┘
-                              │                 │
-                              │                 ▼
-                              │        ┌────────────────┐
-                              │        │  In Progress   │
-                              │        └────────┬───────┘
-                              │                 │
-                              │                 ▼
-                              │        ┌────────────────┐
-                              │        │   PR opened    │
-                              │        │  (In Review;   │
-                              │        │  Done on merge │
-                              │        │  Fixes SFN-N)  │
-                              │        └────────────────┘
-                              │
-                  ── if blocker found anywhere above ──► Blocked
+  GitHub intake (external contributors only)
+  ┌──────────────────────────────────────────┐
+  │ human files issue → mirrors into Linear;  │
+  │ optional needs-grooming / needs-design    │
+  │ hint only sets the initial status         │
+  └───────────────────────┬──────────────────┘
+                          ▼
+  Linear status (source of truth)
+        ┌──────────┐   /groom shapes scope,
+        │  Triage  │   criteria, estimate, type
+        └────┬─────┘
+             ▼
+        ┌──────────┐   groomed but not yet
+        │ Backlog  │   scheduled / design pending
+        └────┬─────┘
+             ▼
+        ┌──────────┐  ── eligible for /pickup
+        │  Ready   │
+        └────┬─────┘
+             ▼
+        ┌────────────┐
+        │ In Progress│  ── /pickup claims + branches claude/sfn-N-…
+        └────┬───────┘
+             ▼
+        ┌────────────┐  PR opened (Fixes SFN-N);
+        │ In Review  │  Done on merge via Linear's GitHub integration
+        └────┬───────┘
+             ▼
+        ┌──────────┐
+        │   Done   │
+        └──────────┘
+
+  ── a blocker anywhere above ──► Blocked (via a Linear blocked-by relation)
 ```
 
 ## PR lifecycle

--- a/docs/proposals/0001-sfep-process.md
+++ b/docs/proposals/0001-sfep-process.md
@@ -139,9 +139,13 @@ Draft ──▶ Accepted ──▶ Implemented
 | **Rejected** | Considered and declined. Kept for the record. |
 | **Superseded** | Replaced by a newer SFEP. Set `superseded-by`. |
 
-**Mapping to issue labels** (see `docs/conventions/issue-naming.md`):
-`needs-design` → Draft · `design-approved` → Accepted · Stage1-readiness met →
-Implemented.
+**Where the status lives** (see `docs/conventions/issue-naming.md`): the SFEP's
+`status:` front-matter is authoritative, mirrored by the implementing Linear
+issue's native status — not GitHub labels. The `design-approved` workflow-state
+label is retired, and `needs-design` survives only as a public GitHub
+external-intake hint (never applied to a Linear-native `SFN-NNN` issue). Loosely,
+the design maps `Draft` → ungroomed, `Accepted` → design gate passed, and
+`Implemented` → Stage1-readiness met.
 
 **The bar for `Implemented`** is the Stage1 Readiness Checklist in `CLAUDE.md`:
 parses → type/effect-checks → emits `.sfn-asm` → lowers to LLVM IR → has
@@ -200,8 +204,8 @@ to continue. The system records this honestly rather than hiding it:
   `; human review` or a name when a human meaningfully shaped or signed off on it.
 - **Provenance is tracked, not gated.** There is no required human "sponsor"
   field. Acceptance authority lives where it already does: PR review plus the
-  issue labels (`design-approved`). A human reviewing and approving the PR *is*
-  the human gate — we do not add a second one.
+  SFEP/Linear status advance to `Accepted`. A human reviewing and approving the
+  PR *is* the human gate — we do not add a second one.
 - The required sections in §6 are the real quality bar. They apply identically to
   human and agent drafts. A proposal is judged on whether it clears that bar, not
   on who or what wrote it.


### PR DESCRIPTION
## Summary

Removes the residual "state-as-label" guidance that still taught agents to track issue/SFEP lifecycle via GitHub labels instead of Linear-native status. Workflow state is Linear-native (Triage→Backlog→Ready→In Progress→In Review→Done); `claude-ready`/`in-progress`/`blocked`/`design-approved` are retired (and deleted in `.github/labels.yml`); `needs-grooming`/`needs-design` survive **only** as public GitHub external-intake hints, never applied to a Linear-native `SFN-NNN` issue.

Motivated by a concrete slip: an agent applied `needs-grooming` to a Linear issue already in `Triage` — redundant state-as-label. An audit traced it to live, currently-loaded docs that still presented GitHub labels as the lifecycle/tracking mechanism without the Linear/GitHub-intake distinction.

Fixes SFN-177

## Changes

- **`.claude/rules/proposals.md`** (always-loaded rule) — SFEP status lives in `status:` front-matter + the Linear issue's native status, not the `needs-design → Draft, design-approved → Accepted` label mapping.
- **`docs/proposals/0001-sfep-process.md`** — same fix in the canonical SFEP process doc; acceptance authority is the SFEP/Linear status advance to `Accepted`, not a `design-approved` label.
- **`docs/conventions/issue-naming.md`** — rewrite the `## Lifecycle (Linear state machine)` diagram whose nodes were GitHub *label* names into the actual Linear status machine, with the GitHub-intake hints shown as a clearly-separated upstream lane. (The single strongest source of the original slip.)
- **`.github/agents/architect.agent.md`** — replace the orphaned retired-pipeline handoff (`design-approved`/`needs-design`/`needs-discussion` issue labels) with Linear-native status advancement; fix the Output Format verdict wording too.
- **`.codex/skills/sailfin-pickup/SKILL.md`, `.codex/prompts/pickup.md`, `.codex/README.md`** — remove the retired `claude-ready`/`in-progress` GitHub fallback labels (SKILL.md was self-contradictory within a few lines: "do not add `in-progress`" then a `gh issue edit --add-label in-progress`).

## Scope

- **Out — historical SFEP records** (`0009`, `0010`, `0026`) that reference pre-migration `claude-ready`: dated design records, left as-is (not live instructions).
- **Out — PR-review handoff labels** (`needs-review`/`needs-changes`/`approved`/`agent-authored`): a separate, still-legitimate axis for the autonomous agent pyramid; untouched.
- The legitimate GitHub external-intake hint framing for `needs-grooming`/`needs-design` (the `claude-task.md` template, `labels.yml` registry, the intake→Linear-status derivation table) is preserved.

## Validation

- [x] `sfn fmt --check` — N/A, docs-only change (no `.sfn` touched)
- [x] `sfn check` — N/A, docs-only
- [x] `make compile` — N/A, no compiler/runtime source touched
- [x] Grep sweep: no touched file presents `claude-ready`/`in-progress`/`blocked`/`design-approved` as usable; all remaining mentions are in "retired"/"deleted"/"never applied" context
- [x] N/A — docs/config-only change

## Files Changed

`.claude/rules/proposals.md`, `docs/proposals/0001-sfep-process.md`, `docs/conventions/issue-naming.md`, `.github/agents/architect.agent.md`, `.codex/skills/sailfin-pickup/SKILL.md`, `.codex/prompts/pickup.md`, `.codex/README.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTTuPSrssBQPYsnCifXED2)_