### PR TITLE
refactor(build): rename in-tree compiler artifact build/native/sailfin -> build/bin/sfn (SFN-173)

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -30,7 +30,7 @@ orchestrator's job, not yours.
 2. Make the change with `Edit`/`Write`, one pipeline stage at a time when the
    spec spans stages (lexer → parser → ast → typecheck → effects → emit → llvm).
 3. After touching any `.sfn` file, run `sfn fmt --write` then `sfn fmt --check`
-   on it (`build/native/sailfin fmt ...` if `sfn` isn't on PATH), and
+   on it (`build/bin/sfn fmt ...` if `sfn` isn't on PATH), and
    `sfn check <files>` for fast static validation. Wrap single-file compiles with
    `timeout 60`. (`.claude/rules/formatting.md`, `.claude/rules/compiler-safety.md`.)
 4. Report a tight diff summary: files touched, what changed, `fmt --check` and

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -19,7 +19,7 @@ prefix is needed.
 For single-file compiler invocations, wrap with `timeout 60` (hang guard):
 
 ```bash
-timeout 60 build/native/sailfin run path/to/file.sfn
+timeout 60 build/bin/sfn run path/to/file.sfn
 ```
 
 For `make` targets, the Makefile handles its own timeouts:
@@ -40,7 +40,7 @@ make test
 | `make compile` | Self-hosting check (compiler compiles itself) | Before committing any `compiler/src/*.sfn` change (self-host invariant) |
 | `make check` | Full triple-pass validation (build + test + seedcheck) | Before declaring a feature shipped, before a release, or after a structural change |
 
-**Validation ladder — don't skip to the slow gate.** `sfn check` and `make check` are different tools: `sfn check` is a fast static lint (catches type/effect/parse errors without emitting IR or proving self-host), while `make check` is the heavyweight self-host + suite gate (~15–20 min). Iterate with `sfn check <the-files-you-touched>` for immediate feedback, run `make compile` to confirm self-host before committing, and reserve `make check` for ship/release/structural validation. Use `build/native/sailfin check <path>` if `sfn` is not on `PATH`.
+**Validation ladder — don't skip to the slow gate.** `sfn check` and `make check` are different tools: `sfn check` is a fast static lint (catches type/effect/parse errors without emitting IR or proving self-host), while `make check` is the heavyweight self-host + suite gate (~15–20 min). Iterate with `sfn check <the-files-you-touched>` for immediate feedback, run `make compile` to confirm self-host before committing, and reserve `make check` for ship/release/structural validation. Use `build/bin/sfn check <path>` if `sfn` is not on `PATH`.
 
 Test files live in:
 - `compiler/tests/unit/` — Unit tests for individual compiler modules
@@ -73,13 +73,13 @@ When tests fail:
 To run a specific test file:
 
 ```bash
-timeout 60 build/native/sailfin test compiler/tests/unit/specific_test.sfn
+timeout 60 build/bin/sfn test compiler/tests/unit/specific_test.sfn
 ```
 
 To run a specific example:
 
 ```bash
-timeout 60 build/native/sailfin run examples/basics/hello-world.sfn
+timeout 60 build/bin/sfn run examples/basics/hello-world.sfn
 ```
 
 ## What to Report

--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -193,7 +193,7 @@ Field mapping (canonical — see `docs/conventions/linear-workflow.md`):
 
 ## Verification
 ```bash
-timeout 60 build/native/sailfin run path/to/example.sfn
+timeout 60 build/bin/sfn run path/to/example.sfn
 ```
 
 ## Required in pinned seed

--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -29,7 +29,7 @@ Record:
 If the target is a hot path that's not directly visible in `make bench`, write a focused micro-benchmark — a small `.sfn` file that exercises the path heavily — and time it:
 
 ```bash
-/usr/bin/time -v build/native/sailfin emit native /tmp/bench_hotpath.sfn 2>&1 | tee build/bench-baseline-hotpath.txt
+/usr/bin/time -v build/bin/sfn emit native /tmp/bench_hotpath.sfn 2>&1 | tee build/bench-baseline-hotpath.txt
 ```
 
 Save the baseline numbers in a comment for later comparison.

--- a/.claude/commands/test-feature.md
+++ b/.claude/commands/test-feature.md
@@ -13,7 +13,7 @@ Run targeted tests for a specific compiler feature or area.
 
 2. Run the targeted tests:
    ```
-   timeout 60 build/native/sailfin test <test_file>
+   timeout 60 build/bin/sfn test <test_file>
    ```
 
 3. If tests pass, also run the full suite to check for regressions:

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,11 +8,11 @@ cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 echo "## Sailfin session bootstrap"
 
-if [[ -x build/native/sailfin ]]; then
-  version=$(timeout 5 build/native/sailfin version 2>/dev/null | head -n1 || echo "(version probe failed)")
-  echo "- compiler: build/native/sailfin present — $version"
+if [[ -x build/bin/sfn ]]; then
+  version=$(timeout 5 build/bin/sfn version 2>/dev/null | head -n1 || echo "(version probe failed)")
+  echo "- compiler: build/bin/sfn present — $version"
 else
-  echo "- compiler: build/native/sailfin MISSING — run \`make compile\` to self-host from the seed"
+  echo "- compiler: build/bin/sfn MISSING — run \`make compile\` to self-host from the seed"
 fi
 
 if compgen -G "build/seed/*" >/dev/null; then
@@ -21,8 +21,8 @@ else
   echo "- seed: MISSING — run \`make fetch-seed\`"
 fi
 
-if [[ -x build/native/sailfin-seedcheck ]]; then
-  echo "- seedcheck: build/native/sailfin-seedcheck present"
+if [[ -x build/bin/sfn-seedcheck ]]; then
+  echo "- seedcheck: build/bin/sfn-seedcheck present"
 else
   echo "- seedcheck: not built (only needed for \`make check\`)"
 fi

--- a/.claude/rules/compiler-safety.md
+++ b/.claude/rules/compiler-safety.md
@@ -25,7 +25,7 @@ The contract:
   old `ulimit -v` rule had. The budget is load-bearing on Linux/WSL only.
 
 **Timeouts still apply.** Wrap single-file compiler invocations with
-`timeout 60` (e.g. `timeout 60 build/native/sailfin run file.sfn`) — the
+`timeout 60` (e.g. `timeout 60 build/bin/sfn run file.sfn`) — the
 memory budget does not guard against hangs. `make` targets handle their
 own timeouts.
 

--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -4,7 +4,7 @@ routinely forget this step and discover it via a red CI run after pushing.
 
 Before committing changes that touch any `.sfn` file:
 
-1. Run `sfn fmt --write <files>` (or `build/native/sailfin fmt --write
+1. Run `sfn fmt --write <files>` (or `build/bin/sfn fmt --write
    compiler/src/ runtime/`) on every modified file. The formatter is
    zero-configuration — there is no formatting decision to make.
 2. Then run `sfn fmt --check` on the same paths to confirm a clean

--- a/.claude/rules/no-bash-e2e.md
+++ b/.claude/rules/no-bash-e2e.md
@@ -34,7 +34,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 test "guillermo: command exits 0" ![io] {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,11 +15,11 @@
       "Bash(touch *)",
       "Bash(chmod *)",
       "Bash(ulimit *)",
-      "Bash(build/native/sailfin *)",
-      "Bash(timeout * build/native/sailfin *)",
-      "Bash(build/native/sailfin-seedcheck *)",
-      "Bash(timeout * build/native/sailfin-seedcheck *)",
-      "Bash(timeout 120 valgrind --tool=memcheck --track-origins=yes --error-exitcode=0 build/native/sailfin-seedcheck test compiler/tests/unit/function_signatures_test.sfn)",
+      "Bash(build/bin/sfn *)",
+      "Bash(timeout * build/bin/sfn *)",
+      "Bash(build/bin/sfn-seedcheck *)",
+      "Bash(timeout * build/bin/sfn-seedcheck *)",
+      "Bash(timeout 120 valgrind --tool=memcheck --track-origins=yes --error-exitcode=0 build/bin/sfn-seedcheck test compiler/tests/unit/function_signatures_test.sfn)",
       "Bash(git status*)",
       "Bash(git log*)",
       "Bash(git diff*)",
@@ -109,7 +109,7 @@
   "autoMode": {
     "allow": [
       "$defaults",
-      "Project build, test, and formatting commands are safe: make compile, make rebuild, make check, make test (and its make test-* variants), make bench, make fetch-seed, make clean, make clean-build, sfn, and build/native/sailfin invocations. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts, never files outside the repo, so treat them as routine, not destructive. This does not extend to make install, which writes to PREFIX/bin outside the repo.",
+      "Project build, test, and formatting commands are safe: make compile, make rebuild, make check, make test (and its make test-* variants), make bench, make fetch-seed, make clean, make clean-build, sfn, and build/bin/sfn invocations. make clean-build and make clean only remove the repository's own build/ and dist/ artifacts, never files outside the repo, so treat them as routine, not destructive. This does not extend to make install, which writes to PREFIX/bin outside the repo.",
       "Scheduling and trigger tools from the Claude_Code_Remote MCP server are safe and must never prompt: mcp__Claude_Code_Remote__send_later, mcp__Claude_Code_Remote__create_trigger, mcp__Claude_Code_Remote__update_trigger, mcp__Claude_Code_Remote__delete_trigger, mcp__Claude_Code_Remote__fire_trigger, and mcp__Claude_Code_Remote__list_triggers. These only schedule, re-arm, fire, list, and cancel this session's own wake-ups (Routines) — routine agent self-management with no external blast radius. Approve every one of them without prompting, including send_later and delete_trigger.",
       "All tools from the sailfin MCP server (mcp__sailfin__*: sailfin_check, sailfin_diagnostics, sailfin_fmt_check, sailfin_fmt_write, sailfin_build, sailfin_test, sailfin_emit_native, sailfin_emit_llvm, sailfin_version) are safe. They are the project's own in-repo developer tooling — each is a pure passthrough to a single `sailfin` subcommand, path-restricted to the workspace root, and exists specifically for agents to use during development. Never prompt for them.",
       "Non-delete Linear MCP tools are safe and must never prompt. Linear is the project's planning source of truth (team SFN), so all Linear reads (mcp__Linear__list_*, mcp__Linear__get_*, mcp__Linear__search_*) and all non-destructive Linear writes (mcp__Linear__save_issue, save_project, save_comment, save_milestone, save_document, save_status_update, save_customer, save_customer_need, save_release, save_release_note, and any mcp__Linear__create_* mutation) are routine agent work — approve them without prompting, without needing an exhaustive per-tool enumeration. NEVER auto-approve a destructive Linear tool: the mcp__Linear__delete_* family (which includes the deny-listed delete_comment, delete_attachment, delete_customer, delete_customer_need, delete_status_update) must always be blocked or prompt, and any unrecognized mcp__Linear__delete_* — or any other Linear tool whose name implies destruction — must be treated as unsafe and prompt."

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -36,7 +36,7 @@ The four failure surfaces, in order of likelihood:
 
 This skill is the heavyweight self-host gate (~15–20 min). Most edit-cycle validation should *not* reach for it:
 
-- **To catch type / effect / parse errors while iterating**, run `sfn check <the-files-you-touched>` (or `build/native/sailfin check <path>` if `sfn` is not on `PATH`). It runs parse + typecheck + effect-check with no IR, no `clang`, and no self-host — seconds for a few files, ~5 min for the whole `compiler/src/` tree. It does **not** prove self-hosting, so it complements rather than replaces `make compile`.
+- **To catch type / effect / parse errors while iterating**, run `sfn check <the-files-you-touched>` (or `build/bin/sfn check <path>` if `sfn` is not on `PATH`). It runs parse + typecheck + effect-check with no IR, no `clang`, and no self-host — seconds for a few files, ~5 min for the whole `compiler/src/` tree. It does **not** prove self-hosting, so it complements rather than replaces `make compile`.
 - **For a single-pass self-host check after a small edit**, `make compile` is faster than the full triple-pass.
 - **For focused test runs**, spawn the `test-runner` agent instead.
 

--- a/.claude/skills/debug-compile/scripts/isolate.sh
+++ b/.claude/skills/debug-compile/scripts/isolate.sh
@@ -21,8 +21,8 @@ fi
 
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-if [[ ! -x build/native/sailfin ]]; then
-  echo "build/native/sailfin missing — run \`make compile\` first" >&2
+if [[ ! -x build/bin/sfn ]]; then
+  echo "build/bin/sfn missing — run \`make compile\` first" >&2
   exit 69
 fi
 
@@ -35,7 +35,7 @@ ll="build/debug/${base}.ll"
 ll_err="build/debug/${base}.ll.stderr"
 
 echo "==> emit native -> $asm"
-if timeout 60 build/native/sailfin emit native "$file" >"$asm" 2>"$asm_err"; then
+if timeout 60 build/bin/sfn emit native "$file" >"$asm" 2>"$asm_err"; then
   lines=$(wc -l <"$asm")
   echo "    ok ($lines lines of .sfn-asm)"
 else
@@ -45,7 +45,7 @@ else
 fi
 
 echo "==> emit llvm  -> $ll"
-if timeout 60 build/native/sailfin emit llvm "$file" >"$ll" 2>"$ll_err"; then
+if timeout 60 build/bin/sfn emit llvm "$file" >"$ll" 2>"$ll_err"; then
   lines=$(wc -l <"$ll")
   echo "    ok ($lines lines of LLVM IR)"
 else

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -10,15 +10,15 @@ cd "$repo_root"
 
 printf '## Sailfin Codex session bootstrap\n'
 
-if [[ -x build/native/sailfin ]]; then
-  version=$(timeout 5 build/native/sailfin version 2>/dev/null | head -n1 || true)
+if [[ -x build/bin/sfn ]]; then
+  version=$(timeout 5 build/bin/sfn version 2>/dev/null | head -n1 || true)
   if [[ -n "$version" ]]; then
-    printf -- '- compiler: build/native/sailfin present — %s\n' "$version"
+    printf -- '- compiler: build/bin/sfn present — %s\n' "$version"
   else
-    printf -- '- compiler: build/native/sailfin present — version probe failed\n'
+    printf -- '- compiler: build/bin/sfn present — version probe failed\n'
   fi
 else
-  printf -- '- compiler: build/native/sailfin MISSING — run `make compile` to self-host from the seed\n'
+  printf -- '- compiler: build/bin/sfn MISSING — run `make compile` to self-host from the seed\n'
 fi
 
 if compgen -G 'build/seed/*' >/dev/null; then
@@ -27,8 +27,8 @@ else
   printf -- '- seed: MISSING — run `make fetch-seed` if a build needs the released seed\n'
 fi
 
-if [[ -x build/native/sailfin-seedcheck ]]; then
-  printf -- '- seedcheck: build/native/sailfin-seedcheck present\n'
+if [[ -x build/bin/sfn-seedcheck ]]; then
+  printf -- '- seedcheck: build/bin/sfn-seedcheck present\n'
 else
   printf -- '- seedcheck: not built (only needed for `make check`)\n'
 fi

--- a/.codex/skills/sailfin-check/SKILL.md
+++ b/.codex/skills/sailfin-check/SKILL.md
@@ -11,13 +11,13 @@ Use this skill whenever a task touches Sailfin compiler sources, runtime code, t
 
 - The compiler self-caps memory at 8 GiB on Linux (`SAILFIN_MEM_LIMIT` overrides); do not add `ulimit` prefixes or PreToolUse guards for ordinary runs.
 - Wrap direct single-file compiler invocations with `timeout 60`; `make` targets handle their own timeouts.
-- If `.sfn` files under `compiler/src/` or `runtime/` changed, run the formatter before final verification: `sfn fmt --write <files>` followed by `sfn fmt --check <files>` (or `build/native/sailfin ...` when `sfn` is not on `PATH`).
+- If `.sfn` files under `compiler/src/` or `runtime/` changed, run the formatter before final verification: `sfn fmt --write <files>` followed by `sfn fmt --check <files>` (or `build/bin/sfn ...` when `sfn` is not on `PATH`).
 - If `compiler/src/*.sfn` changed, run `make compile` before test-only validation so tests do not use a stale compiler binary.
 
 ## Verification ladder
 
 1. Documentation/config-only change: run a fast syntax/readability check when available, otherwise `git diff --check`.
-2. Sailfin source edit inner loop: run `sfn check <touched files>` (or `build/native/sailfin check <path>`) to catch parse/type/effect errors quickly.
+2. Sailfin source edit inner loop: run `sfn check <touched files>` (or `build/bin/sfn check <path>`) to catch parse/type/effect errors quickly.
 3. Test-only or example change: run the targeted test first, then `make test` when a compiler binary exists.
 4. Compiler/runtime source change: run `make compile` before `make test`; use `make check` when declaring a shipped feature, cutting a release, or after higher-risk changes.
 5. Structural compiler change: run `make clean-build` before rebuilding.

--- a/.codex/skills/sailfin-debug-compile/SKILL.md
+++ b/.codex/skills/sailfin-debug-compile/SKILL.md
@@ -9,7 +9,7 @@ Use this skill whenever `sfn check`, `make compile`, a single `.sfn` build, or L
 
 ## Phase 1 — Isolate
 
-- For frontend errors, start with `sfn check <file>` or `build/native/sailfin check <file>`.
+- For frontend errors, start with `sfn check <file>` or `build/bin/sfn check <file>`.
 - For a direct compile/run reproduction, wrap the compiler invocation with `timeout 60`.
 - For self-hosting failures, capture the failing `make compile` output and preserve the log path.
 

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -90,7 +90,7 @@ a phantom scope violation. List paths as starting points only.
 
 <!-- Exact commands a reviewer can run to confirm the change works. -->
 ```bash
-timeout 60 build/native/sailfin run path/to/example.sfn
+timeout 60 build/bin/sfn run path/to/example.sfn
 ```
 
 ## Size

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -248,12 +248,12 @@ runs:
       shell: bash {0}
       run: |
         set -euo pipefail
-        if [ ! -x build/native/sailfin ]; then
-          echo "[ci][error] skip-build mode: build/native/sailfin missing or not executable" >&2
-          ls -l build/native 2>/dev/null || true
+        if [ ! -x build/bin/sfn ]; then
+          echo "[ci][error] skip-build mode: build/bin/sfn missing or not executable" >&2
+          ls -l build/bin build/native 2>/dev/null || true
           exit 1
         fi
-        build/native/sailfin version
+        build/bin/sfn version
 
     - name: Prepare test artifacts
       if: ${{ inputs.mode != 'build-only' && inputs.mode != 'build-package' }}

--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -44,7 +44,7 @@ Update documents in this order when behavior changes:
 
 - Be precise and concise — this is a language reference, not a tutorial
 - Use the project's terminology: capsule (not package), fleet (not workspace), generation card (not trace)
-- Include code examples only when they compile and run (verify with `build/native/sailfin run` if possible)
+- Include code examples only when they compile and run (verify with `build/bin/sfn run` if possible)
 - Mark planned/unimplemented features clearly: *"Planned for 1.0"* or *"Parsed but not yet enforced"*
 - Keep effect annotations in examples accurate and minimal
 
@@ -61,7 +61,7 @@ search compiler/tests/ for related test names
 read docs/status.md
 
 # Run an example to verify it works
-make compile && build/native/sailfin run examples/<category>/<file>.sfn
+make compile && build/bin/sfn run examples/<category>/<file>.sfn
 ```
 
 ## Issue Reporting

--- a/.github/agents/product.agent.md
+++ b/.github/agents/product.agent.md
@@ -51,7 +51,7 @@ The `examples/` directory is how developers first experience Sailfin. Review exa
 - **Progressive complexity** — `basics/` should be trivial, `advanced/` should showcase Sailfin's strengths
 - **Real-world relevance** — Do examples solve problems developers actually have?
 - **Effect annotations** — Are they minimal and well-explained with comments?
-- **Correctness** — Verify examples actually compile: `build/native/sailfin run examples/<file>.sfn`
+- **Correctness** — Verify examples actually compile: `build/bin/sfn run examples/<file>.sfn`
 
 ## Roadmap & Prioritization
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -132,14 +132,14 @@ jobs:
           set -euo pipefail
           # `make rebuild` forces a clean self-host so the bench measures this
           # commit's compiler, not a cached one. It produces both
-          # build/native/sailfin and build/native/import-context (both required
+          # build/bin/sfn and build/native/import-context (both required
           # by the bench scripts).
           if [ -n "${{ inputs.build_jobs }}" ]; then
             make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/seed/bin/sailfin" BUILD_JOBS="${{ inputs.build_jobs }}"
           else
             make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/seed/bin/sailfin"
           fi
-          build/native/sailfin version
+          build/bin/sfn version
 
       - name: Prepare output dir
         shell: bash

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -154,7 +154,7 @@ jobs:
           make compile \
             CLANG="${CLANG:-clang-18}" \
             SEED_NATIVE="build/seed/bin/sailfin"
-          build/native/sailfin version
+          build/bin/sfn version
 
       - name: First pass (warm the cache)
         shell: bash
@@ -168,7 +168,7 @@ jobs:
           # diff. Keeping pass1.json on disk makes failures easier to
           # bisect after the fact (the diff of pass1.cache vs.
           # pass2.cache is the smoking gun for cache-key drift).
-          build/native/sailfin build -p compiler \
+          build/bin/sfn build -p compiler \
             --work-dir build/det-pass1 --json | tee pass1.json
           echo ""
           echo "[pass1] cache summary:"
@@ -203,7 +203,7 @@ jobs:
           # empty — triage via the printed `binary_sha256_{a,b}` and
           # `binary_path_{a,b}` instead. Foreign `-p` builds with
           # scope/name form get full per-module diffs.
-          build/native/sailfin build -p compiler \
+          build/bin/sfn build -p compiler \
             --check-determinism \
             --work-dir build/det-pass2 \
             --json | tee pass2.json
@@ -381,7 +381,7 @@ jobs:
           make compile \
             CLANG="${CLANG:-clang-18}" \
             SEED_NATIVE="build/seed/bin/sailfin"
-          build/native/sailfin version
+          build/bin/sfn version
 
       # Run the full `.sfn` suite with the test-bin cache ENABLED (no
       # `--no-test-cache`), populating `build/cache/test-bin/v<schema>`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          paths="build/native/sailfin build/native/import-context"
+          paths="build/bin/sfn build/native/import-context"
           if [ -f build/native/.build-stamp ]; then
             paths="$paths build/native/.build-stamp"
           fi
@@ -371,7 +371,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          paths="build/native/sailfin build/native/import-context"
+          paths="build/bin/sfn build/native/import-context"
           if [ -f build/native/.build-stamp ]; then
             paths="$paths build/native/.build-stamp"
           fi
@@ -472,9 +472,9 @@ jobs:
           # env) and fails -> status != "pass" -> the test aborts (134).
           # The binary IS up-to-date for this commit, so mark it current
           # and `make compile` becomes the intended no-op.
-          touch build/native/sailfin
+          touch build/bin/sfn
           [ -f build/native/.build-stamp ] && touch build/native/.build-stamp || true
-          ls -lh build/native/sailfin
+          ls -lh build/bin/sfn
 
       # Per-shard test-binary cache restore (#2008, SFEP-0044). The
       # build-tree artifact deliberately excludes build/cache/test-bin;
@@ -518,9 +518,9 @@ jobs:
         shell: bash {0}
         run: |
           set -euo pipefail
-          ls -lh build/native/sailfin
-          (file build/native/sailfin || true)
-          build/native/sailfin version || build/native/sailfin --version || true
+          ls -lh build/bin/sfn
+          (file build/bin/sfn || true)
+          build/bin/sfn version || build/bin/sfn --version || true
 
       # Examples regression sweep (epic #549). Every runnable example under
       # examples/ must still `check` + `run` end-to-end. The KNOWN_FAILING
@@ -555,7 +555,7 @@ jobs:
           fail=0
 
           # --- Missing-effect input must fail `sailfin check`. ---
-          if out="$(build/native/sailfin check "$BAD" 2>&1)"; then
+          if out="$(build/bin/sfn check "$BAD" 2>&1)"; then
             echo "[effect-gate] FAIL: sailfin check on $BAD exited 0 (expected non-zero)."
             echo "$out"
             fail=$((fail + 1))
@@ -575,7 +575,7 @@ jobs:
           fi
 
           # --- Missing-effect input must also fail `sailfin emit llvm`. ---
-          if build/native/sailfin emit llvm "$BAD" >/dev/null 2>&1; then
+          if build/bin/sfn emit llvm "$BAD" >/dev/null 2>&1; then
             echo "[effect-gate] FAIL: sailfin emit llvm on $BAD exited 0 (expected non-zero)."
             fail=$((fail + 1))
           else
@@ -583,7 +583,7 @@ jobs:
           fi
 
           # --- Clean-file control must succeed. ---
-          if ! ok_out="$(build/native/sailfin check "$OK" 2>&1)"; then
+          if ! ok_out="$(build/bin/sfn check "$OK" 2>&1)"; then
             echo "[effect-gate] FAIL: sailfin check on $OK exited non-zero (expected 0)."
             echo "$ok_out"
             fail=$((fail + 1))
@@ -611,7 +611,7 @@ jobs:
           fail=0
           # Per-file loop to avoid OOM on bulk --check
           while IFS= read -r f; do
-            if ! build/native/sailfin fmt --check "$f" > /dev/null 2>&1; then
+            if ! build/bin/sfn fmt --check "$f" > /dev/null 2>&1; then
               echo "[fmt] needs formatting: $f"
               fail=$((fail + 1))
             fi
@@ -647,7 +647,7 @@ jobs:
           )
           fail=0
           for f in "${canary_files[@]}"; do
-            if ! log="$(build/native/sailfin emit llvm "$f" 2>&1 1>/dev/null)"; then
+            if ! log="$(build/bin/sfn emit llvm "$f" 2>&1 1>/dev/null)"; then
               echo "[canary] emit crashed for $f"
               fail=$((fail + 1))
               continue
@@ -683,7 +683,7 @@ jobs:
         shell: bash {0}
         run: |
           set -euo pipefail
-          build/native/sailfin check compiler/src runtime
+          build/bin/sfn check compiler/src runtime
 
       - name: Fixed-point rebuild check (linux-x86_64)
         if: >-
@@ -713,31 +713,31 @@ jobs:
           rm -rf build/selfhost/native-selfhost1 build/selfhost/native-selfhost2
           mkdir -p build/selfhost/native-selfhost1 build/selfhost/native-selfhost2
           SAILFIN_TEST_SCRATCH="build/selfhost/native-selfhost1/scratch" \
-            build/native/sailfin build --no-cache -p compiler \
+            build/bin/sfn build --no-cache -p compiler \
               --work-dir build/selfhost/native-selfhost1 \
-              -o build/native/sailfin-selfhost1
+              -o build/bin/sfn-selfhost1
           SAILFIN_TEST_SCRATCH="build/selfhost/native-selfhost2/scratch" \
-            build/native/sailfin-selfhost1 build --no-cache -p compiler \
+            build/bin/sfn-selfhost1 build --no-cache -p compiler \
               --work-dir build/selfhost/native-selfhost2 \
-              -o build/native/sailfin-selfhost2
-          ls -lh build/native/sailfin-selfhost1 build/native/sailfin-selfhost2
-          (file build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 || true)
-          build/native/sailfin-selfhost1 version || true
-          build/native/sailfin-selfhost2 version || true
+              -o build/bin/sfn-selfhost2
+          ls -lh build/bin/sfn-selfhost1 build/bin/sfn-selfhost2
+          (file build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 || true)
+          build/bin/sfn-selfhost1 version || true
+          build/bin/sfn-selfhost2 version || true
           echo "[ci] fixed-point sha256:"
-          (sha256sum build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 2>/dev/null || shasum -a 256 build/native/sailfin-selfhost1 build/native/sailfin-selfhost2)
+          (sha256sum build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 2>/dev/null || shasum -a 256 build/bin/sfn-selfhost1 build/bin/sfn-selfhost2)
           if [ "${RUNNER_OS}" = "Linux" ]; then
-            if ! cmp -s build/native/sailfin-selfhost1 build/native/sailfin-selfhost2; then
+            if ! cmp -s build/bin/sfn-selfhost1 build/bin/sfn-selfhost2; then
               echo "[ci][error] fixed-point rebuild mismatch (binaries differ)" >&2
-              (cmp -l build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 | head -n 20 || true)
+              (cmp -l build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 | head -n 20 || true)
               exit 1
             fi
           else
             # macOS binaries (Mach-O) embed a per-link UUID (LC_UUID), so byte-for-byte
             # equality is not a stable determinism signal. Instead, assert the second
             # selfhosted compiler can run a minimal unit test.
-            (dwarfdump --uuid build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 || true)
-            build/native/sailfin-selfhost2 test compiler/tests/unit/cli_version_test.sfn
+            (dwarfdump --uuid build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 || true)
+            build/bin/sfn-selfhost2 test compiler/tests/unit/cli_version_test.sfn
           fi
 
       # NOTE (#1234): the Windows cross-compile + its installer upload
@@ -840,9 +840,9 @@ jobs:
           # env) and fails -> status != "pass" -> the test aborts (134).
           # The binary IS up-to-date for this commit, so mark it current
           # and `make compile` becomes the intended no-op.
-          touch build/native/sailfin
+          touch build/bin/sfn
           [ -f build/native/.build-stamp ] && touch build/native/.build-stamp || true
-          ls -lh build/native/sailfin
+          ls -lh build/bin/sfn
 
       # Per-shard test-binary cache restore (#2008, SFEP-0044) — same
       # contract as the Linux leg: prefix-restore from the latest prior
@@ -913,9 +913,9 @@ jobs:
         shell: bash {0}
         run: |
           set -euo pipefail
-          ls -lh build/native/sailfin
-          (file build/native/sailfin || true)
-          build/native/sailfin version || build/native/sailfin --version || true
+          ls -lh build/bin/sfn
+          (file build/bin/sfn || true)
+          build/bin/sfn version || build/bin/sfn --version || true
 
       # Regression guard for #615 / #807 — see the build-linux twin for
       # the full background. Runs on macOS arm64 too because the
@@ -930,7 +930,7 @@ jobs:
           fail=0
 
           # --- Missing-effect input must fail `sailfin check`. ---
-          if out="$(build/native/sailfin check "$BAD" 2>&1)"; then
+          if out="$(build/bin/sfn check "$BAD" 2>&1)"; then
             echo "[effect-gate] FAIL: sailfin check on $BAD exited 0 (expected non-zero)."
             echo "$out"
             fail=$((fail + 1))
@@ -950,7 +950,7 @@ jobs:
           fi
 
           # --- Missing-effect input must also fail `sailfin emit llvm`. ---
-          if build/native/sailfin emit llvm "$BAD" >/dev/null 2>&1; then
+          if build/bin/sfn emit llvm "$BAD" >/dev/null 2>&1; then
             echo "[effect-gate] FAIL: sailfin emit llvm on $BAD exited 0 (expected non-zero)."
             fail=$((fail + 1))
           else
@@ -958,7 +958,7 @@ jobs:
           fi
 
           # --- Clean-file control must succeed. ---
-          if ! ok_out="$(build/native/sailfin check "$OK" 2>&1)"; then
+          if ! ok_out="$(build/bin/sfn check "$OK" 2>&1)"; then
             echo "[effect-gate] FAIL: sailfin check on $OK exited non-zero (expected 0)."
             echo "$ok_out"
             fail=$((fail + 1))
@@ -986,7 +986,7 @@ jobs:
           fail=0
           # Per-file loop to avoid OOM on bulk --check
           while IFS= read -r f; do
-            if ! build/native/sailfin fmt --check "$f" > /dev/null 2>&1; then
+            if ! build/bin/sfn fmt --check "$f" > /dev/null 2>&1; then
               echo "[fmt] needs formatting: $f"
               fail=$((fail + 1))
             fi
@@ -1016,7 +1016,7 @@ jobs:
           )
           fail=0
           for f in "${canary_files[@]}"; do
-            if ! log="$(build/native/sailfin emit llvm "$f" 2>&1 1>/dev/null)"; then
+            if ! log="$(build/bin/sfn emit llvm "$f" 2>&1 1>/dev/null)"; then
               echo "[canary] emit crashed for $f"
               fail=$((fail + 1))
               continue
@@ -1046,7 +1046,7 @@ jobs:
         shell: bash {0}
         run: |
           set -euo pipefail
-          build/native/sailfin check compiler/src runtime
+          build/bin/sfn check compiler/src runtime
 
       - name: Enable test runner trace (macOS)
         if: ${{ matrix.primary }}
@@ -1063,7 +1063,7 @@ jobs:
         shell: bash {0}
         run: |
           set -euo pipefail
-          build/native/sailfin test compiler/tests/unit/cli_version_test.sfn
+          build/bin/sfn test compiler/tests/unit/cli_version_test.sfn
 
       - name: Fixed-point rebuild check (macos-arm64)
         if: >-
@@ -1093,31 +1093,31 @@ jobs:
           rm -rf build/selfhost/native-selfhost1 build/selfhost/native-selfhost2
           mkdir -p build/selfhost/native-selfhost1 build/selfhost/native-selfhost2
           SAILFIN_TEST_SCRATCH="build/selfhost/native-selfhost1/scratch" \
-            build/native/sailfin build --no-cache -p compiler \
+            build/bin/sfn build --no-cache -p compiler \
               --work-dir build/selfhost/native-selfhost1 \
-              -o build/native/sailfin-selfhost1
+              -o build/bin/sfn-selfhost1
           SAILFIN_TEST_SCRATCH="build/selfhost/native-selfhost2/scratch" \
-            build/native/sailfin-selfhost1 build --no-cache -p compiler \
+            build/bin/sfn-selfhost1 build --no-cache -p compiler \
               --work-dir build/selfhost/native-selfhost2 \
-              -o build/native/sailfin-selfhost2
-          ls -lh build/native/sailfin-selfhost1 build/native/sailfin-selfhost2
-          (file build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 || true)
-          build/native/sailfin-selfhost1 version || true
-          build/native/sailfin-selfhost2 version || true
+              -o build/bin/sfn-selfhost2
+          ls -lh build/bin/sfn-selfhost1 build/bin/sfn-selfhost2
+          (file build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 || true)
+          build/bin/sfn-selfhost1 version || true
+          build/bin/sfn-selfhost2 version || true
           echo "[ci] fixed-point sha256:"
-          (sha256sum build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 2>/dev/null || shasum -a 256 build/native/sailfin-selfhost1 build/native/sailfin-selfhost2)
+          (sha256sum build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 2>/dev/null || shasum -a 256 build/bin/sfn-selfhost1 build/bin/sfn-selfhost2)
           if [ "${RUNNER_OS}" = "Linux" ]; then
-            if ! cmp -s build/native/sailfin-selfhost1 build/native/sailfin-selfhost2; then
+            if ! cmp -s build/bin/sfn-selfhost1 build/bin/sfn-selfhost2; then
               echo "[ci][error] fixed-point rebuild mismatch (binaries differ)" >&2
-              (cmp -l build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 | head -n 20 || true)
+              (cmp -l build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 | head -n 20 || true)
               exit 1
             fi
           else
             # macOS binaries (Mach-O) embed a per-link UUID (LC_UUID), so byte-for-byte
             # equality is not a stable determinism signal. Instead, assert the second
             # selfhosted compiler can run a minimal unit test.
-            (dwarfdump --uuid build/native/sailfin-selfhost1 build/native/sailfin-selfhost2 || true)
-            build/native/sailfin-selfhost2 test compiler/tests/unit/cli_version_test.sfn
+            (dwarfdump --uuid build/bin/sfn-selfhost1 build/bin/sfn-selfhost2 || true)
+            build/bin/sfn-selfhost2 test compiler/tests/unit/cli_version_test.sfn
           fi
 
       - name: Upload native artifacts

--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -124,7 +124,7 @@ jobs:
           start=$(date +%s)
           make rebuild CLANG="clang-18" SEED_NATIVE="build/seed/bin/sailfin"
           end=$(date +%s)
-          build/native/sailfin version
+          build/bin/sfn version
           echo "wall_s=$((end - start))" >> "$GITHUB_OUTPUT"
           echo "[perf-history] clean build wall time: $((end - start))s (budget ${BUILD_BUDGET_S}s)"
 

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -127,6 +127,6 @@ jobs:
               shell: bash {0}
               run: |
                   set -euo pipefail
-                  ls -lh build/native/sailfin
-                  (file build/native/sailfin || true)
-                  build/native/sailfin version || build/native/sailfin --version || true
+                  ls -lh build/bin/sfn
+                  (file build/bin/sfn || true)
+                  build/bin/sfn version || build/bin/sfn --version || true

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -154,7 +154,7 @@ jobs:
           set -euo pipefail
           # The compiler self-applies its 8 GiB memory budget on Linux
           # (#1291) — no step-level ulimit needed.
-          out="$(build/native/sailfin run examples/basics/hello-world.sfn)"
+          out="$(build/bin/sfn run examples/basics/hello-world.sfn)"
           echo "$out"
           if ! printf '%s' "$out" | grep -q "Hello, Sailfin!"; then
             echo "[ci][error] hello-world smoke failed: expected 'Hello, Sailfin!' in output" >&2
@@ -171,7 +171,7 @@ jobs:
             echo "[ci][error] compiler/capsule.toml has '$file_version', expected '$expected'" >&2
             exit 1
           fi
-          actual="$(build/native/sailfin version | sed -n 's/.*sfn //p')"
+          actual="$(build/bin/sfn version | sed -n 's/.*sfn //p')"
           if [ "$actual" != "$expected" ]; then
             echo "[ci][error] built compiler reports '$actual', expected '$expected'" >&2
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Build, Test, and Development Commands
 
-- `sfn check <files>` (or `build/native/sailfin check <files>`) is the fast inner loop for parse/type/effect checking; it does not prove codegen, linking, or self-hosting.
+- `sfn check <files>` (or `build/bin/sfn check <files>`) is the fast inner loop for parse/type/effect checking; it does not prove codegen, linking, or self-hosting.
 - `make compile` self-hosts the compiler from the released seed pinned by `.seed-version`.
 - `make rebuild` forces a rebuild from the seed.
 - `make check` compiles if needed and runs the full validation gate, including seedcheck self-host validation.
@@ -31,7 +31,7 @@
 
 - `docs/style-guide.md` is the single source of truth for coding conventions (naming, comments, effect-annotation style, error handling, file size budgets); `.claude/rules/code-style.md` is the always-loaded summary. Headline rules: effects spelled explicitly and listed alphabetically (`fn foo() -> Bar ![io, model]`); `snake_case` functions/locals, `PascalCase` types, `_underscore` private helpers; comments explain *why* and cite issues/SFEPs — never `TODO`s, commented-out code, or "this PR" language.
 - Align terminology with the language spec at `site/src/content/docs/docs/reference/spec/` (capsule, fleet, provenance card) and note currency or latency literals as comments until syntax support arrives.
-- Before committing touched `.sfn` files under `compiler/src/` or `runtime/`, run `sfn fmt --write <files>` and then `sfn fmt --check <files>` (or the equivalent `build/native/sailfin` commands).
+- Before committing touched `.sfn` files under `compiler/src/` or `runtime/`, run `sfn fmt --write <files>` and then `sfn fmt --check <files>` (or the equivalent `build/bin/sfn` commands).
 - Stage regression tests beside related coverage in `compiler/tests/`; prefer Sailfin-native tests and slim fixtures over recorded generated output.
 - When adding language surface or runtime behavior, extend coverage and update `docs/status.md` first, then the relevant spec/preview page and roadmap if needed.
 - For non-trivial design changes, create or update an SFEP under `docs/proposals/` rather than burying design in issues or PR prose. Do not mark an SFEP `Implemented` until the feature meets the Stage1 readiness bar end-to-end and self-hosts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ make clean-build      # Remove build/* artifacts (keeps build/seed) — destruct
 make mcp-server       # Build the MCP server wrapper
 ```
 
-Run examples: `make compile && build/native/sailfin run examples/basics/hello-world.sfn`.
+Run examples: `make compile && build/bin/sfn run examples/basics/hello-world.sfn`.
 See `examples/README.md` for per-example capability requirements.
 
 **Validation ladder — use the cheapest tool that catches the error.** `sfn check`
@@ -72,7 +72,7 @@ and `make check` are different tools, not fast/slow versions of the same one:
    declaring a feature shipped, cutting a release, or after a structural change.
 
 Don't burn `make check` to discover a type or effect error `sfn check` would have
-caught in seconds. (Use `build/native/sailfin check <path>` if `sfn` is not on `PATH`.)
+caught in seconds. (Use `build/bin/sfn check <path>` if `sfn` is not on `PATH`.)
 
 **MCP tools (agentic clients).** When running as an MCP client (e.g. Claude Code
 with the `sailfin` server registered in `.mcp.json`), prefer the `sailfin_*` tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ bash scripts/install_precommit.sh --remove  # uninstall
 ```
 
 The hook only runs when staged changes touch `compiler/src/` or `runtime/`,
-and is silently skipped when `build/native/sailfin` is missing. Bypass with
+and is silently skipped when `build/bin/sfn` is missing. Bypass with
 `SAILFIN_SKIP_PRECOMMIT=1 git commit ...` or the standard `--no-verify`.
 
 ### Notes on Release Automation

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ CLANG_LL_COMPILE := $(TIMEOUT_CMD) --kill-after=10 $(NATIVE_LL_TIMEOUT_SECONDS) 
 endif
 
 NATIVE_OBJ_DIR ?= build/native/obj
-NATIVE_OUT ?= build/native/sailfin$(EXE_EXT)
+NATIVE_OUT ?= build/bin/sfn$(EXE_EXT)
 NATIVE_LINK_EXTRA ?=
 
 # Preferred local path for the native compiler binary.
-NATIVE_BIN ?= build/native/sailfin$(EXE_EXT)
+NATIVE_BIN ?= build/bin/sfn$(EXE_EXT)
 
 # Which compiler binary to use for running Sailfin-native tests.
 # Default: the native compiler alias produced by `make compile`.
@@ -557,7 +557,7 @@ compile-impl:
 		: "rebuild propagates its non-zero exit instead of being masked by"; \
 		: "the trailing echo. With ; the if-compound returned the echo's 0,"; \
 		: "so make compile exited 0 / status:pass on a broken self-host and"; \
-		: "silently kept the stale build/native/sailfin."; \
+		: "silently kept the stale build/bin/sfn."; \
 		$(MAKE) rebuild && \
 		echo "[compile] built $(NATIVE_OUT)"; \
 	fi
@@ -577,7 +577,7 @@ check-strict:
 
 check-impl:
 	@$(MAKE) compile NATIVE_OPT="$(SELFHOST1_OPT)"
-	@seed="build/native/sailfin"; \
+	@seed="build/bin/sfn"; \
 	if [ ! -x "$$seed" ]; then \
 		echo "[check][error] missing $$seed (run: make compile)"; \
 		exit 1; \
@@ -595,19 +595,19 @@ check-impl:
 	@# (escape hatch for bisect / pre-release double-check).
 ifeq ($(CHECK_FULL_PASS1),1)
 	@echo "[check] CHECK_FULL_PASS1=1: running full suite on first-pass binary (jobs=$(CHECK_TEST_JOBS), test-timeout=$(CHECK_TEST_TIMEOUT)s)..."
-	@$(CHECK_TEST_TIMEOUT_ENV) $(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@$(CHECK_TEST_TIMEOUT_ENV) $(MAKE) test NATIVE_BIN=build/bin/sfn TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 else
 	@echo "[check] pass1 smoke gate: hello-world + sfn/test capsule tests (jobs=$(CHECK_TEST_JOBS))..."
 	@t60=""; \
 	if command -v timeout >/dev/null 2>&1; then t60="timeout 60"; \
 	elif command -v gtimeout >/dev/null 2>&1; then t60="gtimeout 60"; fi; \
-	$$t60 build/native/sailfin run examples/basics/hello-world.sfn
+	$$t60 build/bin/sfn run examples/basics/hello-world.sfn
 	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		build/native/sailfin test capsules/sfn/test/tests --jobs $(CHECK_TEST_JOBS) --json | tee build/agent-test.check-pass1.jsonl || exit $$?; \
+		build/bin/sfn test capsules/sfn/test/tests --jobs $(CHECK_TEST_JOBS) --json | tee build/agent-test.check-pass1.jsonl || exit $$?; \
 	else \
-		build/native/sailfin test capsules/sfn/test/tests --jobs $(CHECK_TEST_JOBS) || exit $$?; \
+		build/bin/sfn test capsules/sfn/test/tests --jobs $(CHECK_TEST_JOBS) || exit $$?; \
 	fi
 endif
 	@echo "[check] pass1 smoke passed — validating self-host (stage2/stage3 fixed point)..."
@@ -627,16 +627,16 @@ endif
 	@# so `NATIVE_OPT` overrides for stage2/stage3 are still ignored (no
 	@# regression — the prior shell had the same gap). The suite legs and
 	@# the first-pass `make compile` stay Make-driven (issue `Out:` scope).
-	@build/native/sailfin selfhost \
+	@build/bin/sfn selfhost \
 		--work-dir build/selfhost \
-		--first-pass build/native/sailfin \
-		--seedcheck-out build/native/sailfin-seedcheck \
-		--stage3-out build/native/sailfin-stage3 \
+		--first-pass build/bin/sfn \
+		--seedcheck-out build/bin/sfn-seedcheck \
+		--stage3-out build/bin/sfn-stage3 \
 		--promote-to $(NATIVE_BIN) \
 		--smoke-timeout 10 \
 		$(SELFHOST_STRICT_FLAG)
 	@echo "[check] running full test suite with seedcheck binary (cold backstop, jobs=$(CHECK_TEST_JOBS), test-timeout=$(CHECK_TEST_TIMEOUT)s)..."
-	@$(CHECK_TEST_TIMEOUT_ENV) $(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@$(CHECK_TEST_TIMEOUT_ENV) $(MAKE) test NATIVE_BIN=build/bin/sfn-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 
 # Fast PR-feedback gate: run `sfn check` against the compiler tree and
 # the runtime prelude. No codegen, no clang, just parse + typecheck +
@@ -717,7 +717,7 @@ package: compile
 # Verify the build artifacts the Sailfin-native test runner expects
 # (import-context) are present at their canonical location.
 #
-# `make rebuild` is the only path to producing `build/native/sailfin`,
+# `make rebuild` is the only path to producing `build/bin/sfn`,
 # so `build/native/import-context/` is guaranteed to land directly.
 # #941: the former `build/native/obj/runtime/prelude.o` check was
 # dropped — post-#940 the test runner links the runtime through the
@@ -766,7 +766,7 @@ ci-package-installer:
 #   make rebuild
 #   make rebuild SEED_NATIVE=path/to/sailfin
 # Output:
-#   build/native/sailfin
+#   build/bin/sfn
 #
 # Routes through `<seed> build -p compiler` as the only path. The
 # pinned seed (`.seed-version`) ships the cumulative source-side
@@ -879,7 +879,7 @@ rebuild-impl:
 		if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then rm -f build/native/.build-report.json; fi; \
 		exit 1; \
 	fi
-	@mkdir -p build/native
+	@mkdir -p build/native $(dir $(NATIVE_OUT))
 	@cp -f build/sailfin/program $(NATIVE_OUT)
 	@chmod +x $(NATIVE_OUT)
 	@# Save .ll files to a location `make test` won't clobber. Each

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ throttled.
 ## Building From Source
 
 The compiler self-hosts from a released seed binary. `make compile` fetches
-the seed if needed and builds `build/native/sailfin`.
+the seed if needed and builds `build/bin/sfn`.
 
 ```sh
 make compile          # Build the self-hosted native compiler
@@ -166,9 +166,9 @@ make clean            # Remove packaged artifacts under dist/
 After compiling:
 
 ```sh
-build/native/sailfin --version
-build/native/sailfin run examples/basics/hello-world.sfn
-build/native/sailfin check compiler/src/
+build/bin/sfn --version
+build/bin/sfn run examples/basics/hello-world.sfn
+build/bin/sfn check compiler/src/
 ```
 
 If installed:

--- a/benchmarks/runtime/README.md
+++ b/benchmarks/runtime/README.md
@@ -41,7 +41,7 @@ bash scripts/bench_runtime.sh --iterations 10 --csv /tmp/baseline.csv
 bash scripts/bench_runtime.sh --budget-time 1000 --budget-mem 1048576
 ```
 
-Script flags: `--seed <bin>` (default `build/native/sailfin`), `--csv PATH`,
+Script flags: `--seed <bin>` (default `build/bin/sfn`), `--csv PATH`,
 `--top N`, `--iterations K` (default 5), `--workload <name>` (repeatable, default
 all), `--budget-time MS`, `--budget-mem KB`, `--work-dir DIR` (default
 `build/bench-runtime`). The script exits non-zero on any build failure, run

--- a/capsules/sfn/test/src/compile_assert.sfn
+++ b/capsules/sfn/test/src/compile_assert.sfn
@@ -27,7 +27,7 @@
 // `io`.
 //
 // Hermeticity: the `sfn` binary is resolved from `$SAILFIN_BIN` with a
-// documented fallback of `build/native/sailfin` (the self-hosted binary,
+// documented fallback of `build/bin/sfn` (the self-hosted binary,
 // relative to the repo root the test runs from), so CI can point the
 // assertions at any compiler without editing the test. The child is
 // spawned with an empty environment — `sfn check` on an import-free
@@ -90,7 +90,7 @@ fn _outcome_failed(raw: string) -> _CheckOutcome {
 fn _resolve_sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _join_effects(effects: string[]) -> string {

--- a/capsules/sfn/test/tests/compile_assert_test.sfn
+++ b/capsules/sfn/test/tests/compile_assert_test.sfn
@@ -1,7 +1,7 @@
 // Tests for the sfn/test compile-as-test assertions (#974).
 //
 // Each test shells out to the real `sfn check --json` (resolved via
-// `$SAILFIN_BIN`, falling back to `build/native/sailfin`) over a snippet
+// `$SAILFIN_BIN`, falling back to `build/bin/sfn`) over a snippet
 // written to a fresh temp file, then asserts on the returned
 // `MatchResult`. They are `![io]`: `assert_compiles` /
 // `assert_does_not_compile` spawn a child process and write a temp file.

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -3197,7 +3197,7 @@ fn _cr_effective_isolation_exe(sailfin_exe: string, binary_dir: string, source_c
     if source_count < _cr_positional_isolation_threshold() {
         return sailfin_exe;
     }
-    return binary_dir + "/sailfin";
+    return binary_dir + "/sfn";
 }
 
 fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consumer: ResolverConsumer, sailfin_exe: string, work_dir: string, binary_dir: string) -> ProjectCapsuleResult ![io] {

--- a/compiler/src/cli/commands/build.sfn
+++ b/compiler/src/cli/commands/build.sfn
@@ -310,7 +310,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     // below for that decision). Small closures stay in-process.
     let mut sailfin_exe: string = "";
     if walk_src {
-        if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sailfin"; }
+        if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sfn"; }
     }
     let capsule_result = prepare_project_capsules(input_path, cache_config, consumer, sailfin_exe, work_dir, binary_dir);
     // Issue #991: a per-module emit failure (e.g. an effect-gate

--- a/compiler/src/cli/commands/package.sfn
+++ b/compiler/src/cli/commands/package.sfn
@@ -51,7 +51,7 @@ import { _is_safe_capsule_version_cmd, _package_basename } from "./cmd_shared";
 // Without `-p`: packages the compiler. Reads `compiler/capsule.toml`
 // for version (the compiler's `[capsule].name` is single-segment so
 // no per-capsule sidecar exists for it). Default `--compiler-bin =
-// build/native/sailfin`. Tarball stem `sailfin-native-<target>-<version>`.
+// build/bin/sfn`. Tarball stem `sailfin-native-<target>-<version>`.
 //
 // With `-p <path>`: packages a user capsule. Reads the C2c sidecar at
 // `<path>/build/capsules/<scope>/<name>/manifest.json` (must exist —
@@ -75,7 +75,7 @@ fn handle_package_command(args: string[]) -> int ![io] {
     // Parse args.
     let mut target_arg: string = "";
     let mut out_dir: string = "dist";
-    let mut compiler_bin: string = "build/native/sailfin";
+    let mut compiler_bin: string = "build/bin/sfn";
     let mut capsule_path: string = "";
     let mut installer_mode: boolean = false;
     let mut argi: int = 1;
@@ -729,13 +729,13 @@ fn _package_find_substring(haystack: string, needle: string, start: int) -> int 
 // `with_subcommand`. Four optional value flags, one boolean flag, and one
 // short value flag `-p`.
 fn command_def() -> Command {
-    return with_flag(with_flag(with_flag(with_flag(with_flag(command("package", "Package a capsule or the compiler for distribution"), flag_value("target", "Platform target (e.g. linux-x86_64); auto-detected if absent")), flag_value("out", "Output directory (default: dist)")), flag_value("compiler-bin", "Path to the compiler binary (default: build/native/sailfin)")), flag("installer", "Package the compiler installer bundle")), flag_value_short("p", "p", "Capsule path to package (user-capsule mode)"));
+    return with_flag(with_flag(with_flag(with_flag(with_flag(command("package", "Package a capsule or the compiler for distribution"), flag_value("target", "Platform target (e.g. linux-x86_64); auto-detected if absent")), flag_value("out", "Output directory (default: dist)")), flag_value("compiler-bin", "Path to the compiler binary (default: build/bin/sfn)")), flag("installer", "Package the compiler installer bundle")), flag_value_short("p", "p", "Capsule path to package (user-capsule mode)"));
 }
 
 // Reconstruct the legacy positional args slice from the typed matches and
 // delegate to `handle_package_command` verbatim. Absent flags are omitted
 // from the slice so the handler applies its own defaults (`out` → "dist",
-// `compiler-bin` → "build/native/sailfin") and its own mutual-exclusion
+// `compiler-bin` → "build/bin/sfn") and its own mutual-exclusion
 // check exactly as before. `ctx` is part of the per-command contract but
 // unused here (package sources no driver state).
 fn run(matches: Matches, ctx: CliContext) -> int ![io] {

--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -2272,8 +2272,17 @@ fn _emit_crash_diagnostic(basename: string, exit_code: int) -> void ![io] {
 // that `exe_path()` (#968) threads `binary_dir` portably.
 fn _resolve_test_self_path(binary_dir: string) -> string ![io] {
     if binary_dir.length > 0 {
-        let candidate = _path_join_cmd(binary_dir, "sailfin");
-        if fs.exists(candidate) { return candidate; }
+        // Probe the canonical `sfn` name first, then the legacy
+        // `sailfin` name (a binary that predates the build/bin/sfn
+        // rename), mirroring `_resolve_self_path`'s host-neutral list.
+        let names: string[] = ["sfn", "sailfin"];
+        let mut i: int = 0;
+        loop {
+            if i >= names.length { break; }
+            let candidate = _path_join_cmd(binary_dir, names[i]);
+            if fs.exists(candidate) { return candidate; }
+            i += 1;
+        }
     }
     return "";
 }

--- a/compiler/src/cli_selfhost.sfn
+++ b/compiler/src/cli_selfhost.sfn
@@ -24,7 +24,7 @@
 //      stage3 are compared (reusing the `--check-determinism` diff
 //      structs/renderers from `build_report.sfn`).
 //   5. promotion: the validated seedcheck binary is copied over the
-//      canonical `build/native/sailfin`.
+//      canonical `build/bin/sfn`.
 //
 // Per-stage isolation is load-bearing: the per-module `.ll` scratch
 // root is resolved from `SAILFIN_TEST_SCRATCH` (not `--work-dir`) by
@@ -69,10 +69,10 @@ struct SelfhostConfig {
 fn _selfhost_default_config() -> SelfhostConfig {
     return SelfhostConfig {
         work_dir: "build/selfhost",
-        first_pass: "build/native/sailfin",
-        seedcheck_out: "build/native/sailfin-seedcheck",
-        stage3_out: "build/native/sailfin-stage3",
-        promote_to: "build/native/sailfin",
+        first_pass: "build/bin/sfn",
+        seedcheck_out: "build/bin/sfn-seedcheck",
+        stage3_out: "build/bin/sfn-stage3",
+        promote_to: "build/bin/sfn",
         smoke_timeout: "10",
         json: false,
         no_promote: false,

--- a/compiler/tests/README.md
+++ b/compiler/tests/README.md
@@ -4,7 +4,7 @@ This folder contains Sailfin-native tests that are executed by the self-hosted n
 
 Preferred invocations:
 
-- `build/native/sailfin test <path>` (built binary produced by `make compile`)
+- `build/bin/sfn test <path>` (built binary produced by `make compile`)
 - `sfn test <path>` (installed compiler on PATH, e.g. after `make install`)
 
 The test runner discovers files named `*_test.sfn` under `<path>` (recursively), compiles each file with a synthesized harness, and executes it.

--- a/compiler/tests/e2e/abi_value_return_test.sfn
+++ b/compiler/tests/e2e/abi_value_return_test.sfn
@@ -27,7 +27,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `emit` neither links nor spawns clang, but `run_capture`'s empty array is the

--- a/compiler/tests/e2e/add_registry_index_test.sfn
+++ b/compiler/tests/e2e/add_registry_index_test.sfn
@@ -24,7 +24,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Absolute path of the runner's working directory (repo root).
@@ -37,7 +37,7 @@ fn _pwd() -> string ![io] {
 }
 
 // Absolute compiler path: the tests `cd` into a temp dir before running,
-// so a repo-relative `build/native/sailfin` would not resolve.
+// so a repo-relative `build/bin/sfn` would not resolve.
 fn _sfn_bin_abs() -> string ![io] {
     let bin = _sfn_bin();
     if bin.length > 0 && bin[0] == "/" { return bin; }

--- a/compiler/tests/e2e/arena_default_on_test.sfn
+++ b/compiler/tests/e2e/arena_default_on_test.sfn
@@ -32,7 +32,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Base child env for the spawned `sfn run`: PATH/HOME/TMPDIR so the

--- a/compiler/tests/e2e/arena_loop_rewind_test.sfn
+++ b/compiler/tests/e2e/arena_loop_rewind_test.sfn
@@ -21,7 +21,7 @@ import { count } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/arena_phase_rewind_ll_identity_test.sfn
+++ b/compiler/tests/e2e/arena_phase_rewind_ll_identity_test.sfn
@@ -14,7 +14,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/array_aggregate_shape_test.sfn
+++ b/compiler/tests/e2e/array_aggregate_shape_test.sfn
@@ -26,7 +26,7 @@ import { contains, split, ends_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/array_filter_closure_test.sfn
+++ b/compiler/tests/e2e/array_filter_closure_test.sfn
@@ -19,7 +19,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/array_map_closure_test.sfn
+++ b/compiler/tests/e2e/array_map_closure_test.sfn
@@ -19,7 +19,7 @@ import { find, trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/array_map_reduce_chain_test.sfn
+++ b/compiler/tests/e2e/array_map_reduce_chain_test.sfn
@@ -19,7 +19,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/array_reduce_closure_test.sfn
+++ b/compiler/tests/e2e/array_reduce_closure_test.sfn
@@ -20,7 +20,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/async_coerce_refusal_test.sfn
+++ b/compiler/tests/e2e/async_coerce_refusal_test.sfn
@@ -33,7 +33,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn test <fixture>` compiles AND runs the fixture, so the spawned

--- a/compiler/tests/e2e/atomic_add_sub_compile_test.sfn
+++ b/compiler/tests/e2e/atomic_add_sub_compile_test.sfn
@@ -17,7 +17,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/atomic_cas_compile_test.sfn
+++ b/compiler/tests/e2e/atomic_cas_compile_test.sfn
@@ -17,7 +17,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/bare_struct_literal_annotation_test.sfn
+++ b/compiler/tests/e2e/bare_struct_literal_annotation_test.sfn
@@ -11,7 +11,7 @@ import { contains, split, trim } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn` invocations. `process.run_capture`

--- a/compiler/tests/e2e/binary_capsule_walker_test.sfn
+++ b/compiler/tests/e2e/binary_capsule_walker_test.sfn
@@ -19,7 +19,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/bool_numeric_coercion_test.sfn
+++ b/compiler/tests/e2e/bool_numeric_coercion_test.sfn
@@ -22,7 +22,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _refuse_fixture() -> string {

--- a/compiler/tests/e2e/build_diagnostics_format_test.sfn
+++ b/compiler/tests/e2e/build_diagnostics_format_test.sfn
@@ -26,7 +26,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // A build-spawning `sfn run` needs PATH (clang + linker) and an

--- a/compiler/tests/e2e/build_json_schema_test.sfn
+++ b/compiler/tests/e2e/build_json_schema_test.sfn
@@ -23,7 +23,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/cache_command_test.sfn
+++ b/compiler/tests/e2e/cache_command_test.sfn
@@ -17,7 +17,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch() -> string ![io] {

--- a/compiler/tests/e2e/call_emission_no_polling_test.sfn
+++ b/compiler/tests/e2e/call_emission_no_polling_test.sfn
@@ -30,7 +30,7 @@ let _SYMBOL: string = "@sailfin_runtime_has_exception";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/capability_cross_check_test.sfn
+++ b/compiler/tests/e2e/capability_cross_check_test.sfn
@@ -34,7 +34,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child env for the spawned `sfn check`: `run_capture`'s `[]` is the

--- a/compiler/tests/e2e/capsule_artifact_sidecar_test.sfn
+++ b/compiler/tests/e2e/capsule_artifact_sidecar_test.sfn
@@ -26,7 +26,7 @@ import { contains, find, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/capsule_build_test.sfn
+++ b/compiler/tests/e2e/capsule_build_test.sfn
@@ -20,7 +20,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/capsule_byname_import_link_test.sfn
+++ b/compiler/tests/e2e/capsule_byname_import_link_test.sfn
@@ -26,7 +26,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/capsule_dead_strip_guard_test.sfn
+++ b/compiler/tests/e2e/capsule_dead_strip_guard_test.sfn
@@ -32,7 +32,7 @@ import { contains, ends_with, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/capsule_ir_layout_test.sfn
+++ b/compiler/tests/e2e/capsule_ir_layout_test.sfn
@@ -47,7 +47,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/channel_owned_element_roundtrip_test.sfn
+++ b/compiler/tests/e2e/channel_owned_element_roundtrip_test.sfn
@@ -35,7 +35,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Empty `run_capture` env is the EMPTY environment, not "inherit"; a nested

--- a/compiler/tests/e2e/channel_producer_consumer_exec_test.sfn
+++ b/compiler/tests/e2e/channel_producer_consumer_exec_test.sfn
@@ -41,7 +41,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Empty `run_capture` env is the EMPTY environment, not "inherit"; a nested

--- a/compiler/tests/e2e/channel_producer_consumer_ir_test.sfn
+++ b/compiler/tests/e2e/channel_producer_consumer_ir_test.sfn
@@ -16,7 +16,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/channel_runtime_roundtrip_test.sfn
+++ b/compiler/tests/e2e/channel_runtime_roundtrip_test.sfn
@@ -36,7 +36,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `process.run_capture`'s empty array is the *empty* environment, not

--- a/compiler/tests/e2e/check_build_agree_module_global_test.sfn
+++ b/compiler/tests/e2e/check_build_agree_module_global_test.sfn
@@ -30,7 +30,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The representative module-global program: an empty-array-literal global

--- a/compiler/tests/e2e/check_compiler_src_test.sfn
+++ b/compiler/tests/e2e/check_compiler_src_test.sfn
@@ -41,7 +41,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/check_cross_module_conformance_test.sfn
+++ b/compiler/tests/e2e/check_cross_module_conformance_test.sfn
@@ -15,7 +15,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // For sfn check on cross-module code: no capsule deps, so the fixture can

--- a/compiler/tests/e2e/check_effect_call_site_caret_test.sfn
+++ b/compiler/tests/e2e/check_effect_call_site_caret_test.sfn
@@ -22,7 +22,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `noisy_helper` is declared at line 4, but the offending `print.info`

--- a/compiler/tests/e2e/check_effect_try_block_escape_test.sfn
+++ b/compiler/tests/e2e/check_effect_try_block_escape_test.sfn
@@ -21,7 +21,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 struct _CheckRun {

--- a/compiler/tests/e2e/check_json_schema_test.sfn
+++ b/compiler/tests/e2e/check_json_schema_test.sfn
@@ -20,7 +20,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Pure-frontend `sfn check` needs no clang, but thread PATH/HOME so a

--- a/compiler/tests/e2e/check_resolver_scan_memo_test.sfn
+++ b/compiler/tests/e2e/check_resolver_scan_memo_test.sfn
@@ -27,7 +27,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env_base() -> string[] ![io] {

--- a/compiler/tests/e2e/check_unresolved_import_test.sfn
+++ b/compiler/tests/e2e/check_unresolved_import_test.sfn
@@ -17,7 +17,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/cli_bare_file_dispatch_test.sfn
+++ b/compiler/tests/e2e/cli_bare_file_dispatch_test.sfn
@@ -24,7 +24,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Bare dispatch compiles+runs the file, so the spawned compiler needs a

--- a/compiler/tests/e2e/cli_help_json_test.sfn
+++ b/compiler/tests/e2e/cli_help_json_test.sfn
@@ -8,7 +8,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/cli_v2_exit_codes_test.sfn
+++ b/compiler/tests/e2e/cli_v2_exit_codes_test.sfn
@@ -39,7 +39,7 @@ import { find, starts_with, trim } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The version-printing legs do not compile anything (no linker, no

--- a/compiler/tests/e2e/clock_gettime_reader_test.sfn
+++ b/compiler/tests/e2e/clock_gettime_reader_test.sfn
@@ -38,7 +38,7 @@ import { contains, find, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/clock_monotonic_id_sentinel_test.sfn
+++ b/compiler/tests/e2e/clock_monotonic_id_sentinel_test.sfn
@@ -35,7 +35,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/closure_capture_inferred_pivot_test.sfn
+++ b/compiler/tests/e2e/closure_capture_inferred_pivot_test.sfn
@@ -16,7 +16,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/closure_capture_test.sfn
+++ b/compiler/tests/e2e/closure_capture_test.sfn
@@ -33,7 +33,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/compiler_debug_toggle_env_vars_test.sfn
+++ b/compiler/tests/e2e/compiler_debug_toggle_env_vars_test.sfn
@@ -35,7 +35,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // A trivial program exercising both the lowering trace path (function

--- a/compiler/tests/e2e/concurrency_lowering_ir_test.sfn
+++ b/compiler/tests/e2e/concurrency_lowering_ir_test.sfn
@@ -15,7 +15,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/concurrency_ownedbuf_asan_interleave_test.sfn
+++ b/compiler/tests/e2e/concurrency_ownedbuf_asan_interleave_test.sfn
@@ -57,7 +57,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build + relink LINK a binary (clang/gcc + ld), needing the full

--- a/compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn
+++ b/compiler/tests/e2e/concurrent_runtime_objkey_race_test.sfn
@@ -28,7 +28,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_base() -> string ![io] {

--- a/compiler/tests/e2e/config_test.sfn
+++ b/compiler/tests/e2e/config_test.sfn
@@ -14,7 +14,7 @@ import { find, contains, to_lower_all } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 struct CfgRun {

--- a/compiler/tests/e2e/crash_attribution_test.sfn
+++ b/compiler/tests/e2e/crash_attribution_test.sfn
@@ -14,15 +14,15 @@
 //
 // Native e2e per `.claude/rules/no-bash-e2e.md`: drives subprocesses via
 // `process.run_capture` and asserts on captured output with `sfn/strings`.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 // The compiler-under-test: $SAILFIN_BIN if set, else the self-hosted
 // binary relative to the repo root the runner starts from.
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // A fixture whose second test overflows the stack — non-tail recursion

--- a/compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn
+++ b/compiler/tests/e2e/cross_dir_method_struct_import_context_test.sfn
@@ -45,7 +45,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested `clang` + linker, so the child needs `PATH`

--- a/compiler/tests/e2e/cross_module_char_at_signature_test.sfn
+++ b/compiler/tests/e2e/cross_module_char_at_signature_test.sfn
@@ -22,7 +22,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested `clang` + linker, so the child needs `PATH`

--- a/compiler/tests/e2e/cross_module_int_signature_ir_test.sfn
+++ b/compiler/tests/e2e/cross_module_int_signature_ir_test.sfn
@@ -28,7 +28,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/cross_module_signature_resolution_test.sfn
+++ b/compiler/tests/e2e/cross_module_signature_resolution_test.sfn
@@ -26,7 +26,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested `clang` + linker, so the child needs `PATH`

--- a/compiler/tests/e2e/dep_closure_prewarm_test.sfn
+++ b/compiler/tests/e2e/dep_closure_prewarm_test.sfn
@@ -23,7 +23,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Two compiler unit tests that each pull in a large dep closure and

--- a/compiler/tests/e2e/dep_object_cache_test.sfn
+++ b/compiler/tests/e2e/dep_object_cache_test.sfn
@@ -18,7 +18,7 @@ import { find, split, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env(scratch: string, objdir: string) -> string[] ![io] {

--- a/compiler/tests/e2e/drop_emission_escape_promotion_test.sfn
+++ b/compiler/tests/e2e/drop_emission_escape_promotion_test.sfn
@@ -24,7 +24,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Count non-overlapping occurrences of `needle` in `haystack`.

--- a/compiler/tests/e2e/drop_emission_function_body_test.sfn
+++ b/compiler/tests/e2e/drop_emission_function_body_test.sfn
@@ -27,7 +27,7 @@ import { count, split, starts_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/drop_emission_mid_exit_test.sfn
+++ b/compiler/tests/e2e/drop_emission_mid_exit_test.sfn
@@ -24,7 +24,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // True iff `ll` contains a bare drop temp: a `.drop` slot followed (after

--- a/compiler/tests/e2e/drop_emission_try_catch_test.sfn
+++ b/compiler/tests/e2e/drop_emission_try_catch_test.sfn
@@ -27,7 +27,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Count non-overlapping occurrences of `needle` in `haystack`.

--- a/compiler/tests/e2e/effect_gate_build_path_entry_test.sfn
+++ b/compiler/tests/e2e/effect_gate_build_path_entry_test.sfn
@@ -32,7 +32,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn build -p` spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/effect_gate_build_path_test.sfn
+++ b/compiler/tests/e2e/effect_gate_build_path_test.sfn
@@ -24,7 +24,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // A private scratch dir under the runner's scratch (or /tmp), keyed by

--- a/compiler/tests/e2e/effect_unknown_block_level_test.sfn
+++ b/compiler/tests/e2e/effect_unknown_block_level_test.sfn
@@ -30,7 +30,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Pure-frontend `sfn check` needs no clang, but thread PATH/HOME so a

--- a/compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
+++ b/compiler/tests/e2e/emit_llvm_unresolved_callee_exit_test.sfn
@@ -25,7 +25,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/enum_same_name_field_conflict_test.sfn
+++ b/compiler/tests/e2e/enum_same_name_field_conflict_test.sfn
@@ -33,7 +33,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/enum_tag_access_test.sfn
+++ b/compiler/tests/e2e/enum_tag_access_test.sfn
@@ -28,7 +28,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit` / `sfn run`.

--- a/compiler/tests/e2e/env_value_abi_test.sfn
+++ b/compiler/tests/e2e/env_value_abi_test.sfn
@@ -17,13 +17,13 @@
 // `SAILFIN_TEST_SCRATCH` (routes the `program.ll` build-cache dir per-
 // invocation under the parallel pool, #1333). The fixture's own env (the var
 // under test) is passed to the *run*, not the build.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/errno_locator_test.sfn
+++ b/compiler/tests/e2e/errno_locator_test.sfn
@@ -39,7 +39,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/errno_reader_test.sfn
+++ b/compiler/tests/e2e/errno_reader_test.sfn
@@ -34,7 +34,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Base child env: PATH/HOME/TMPDIR so the spawned compile finds its tools,

--- a/compiler/tests/e2e/escape_promotion_channel_send_test.sfn
+++ b/compiler/tests/e2e/escape_promotion_channel_send_test.sfn
@@ -38,7 +38,7 @@ import { find, contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment, not "inherit".

--- a/compiler/tests/e2e/exe_path_intrinsic_test.sfn
+++ b/compiler/tests/e2e/exe_path_intrinsic_test.sfn
@@ -40,7 +40,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/exe_path_reader_test.sfn
+++ b/compiler/tests/e2e/exe_path_reader_test.sfn
@@ -23,7 +23,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _exec_sfn() -> string { return "runtime/sfn/platform/exec.sfn"; }

--- a/compiler/tests/e2e/export_from_test.sfn
+++ b/compiler/tests/e2e/export_from_test.sfn
@@ -28,13 +28,13 @@
 // build-spawning test threads `SAILFIN_TEST_SCRATCH` (and `PATH` for the
 // linker) through to its nested `sfn build` — see `_child_env` and
 // `.claude/rules/no-bash-e2e.md`.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The fixture's entry module. Relative imports (`./middle`, `./origin`)

--- a/compiler/tests/e2e/extern_var_emit_test.sfn
+++ b/compiler/tests/e2e/extern_var_emit_test.sfn
@@ -20,7 +20,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/float_array_index_mutate_test.sfn
+++ b/compiler/tests/e2e/float_array_index_mutate_test.sfn
@@ -10,7 +10,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/fmt_test.sfn
+++ b/compiler/tests/e2e/fmt_test.sfn
@@ -18,7 +18,7 @@ import { trim_right, find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Per-test scratch dir: the runner's per-file `SAILFIN_TEST_SCRATCH` when

--- a/compiler/tests/e2e/fn_reference_pthread_test.sfn
+++ b/compiler/tests/e2e/fn_reference_pthread_test.sfn
@@ -40,7 +40,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/generic_fn_monomorphization_test.sfn
+++ b/compiler/tests/e2e/generic_fn_monomorphization_test.sfn
@@ -21,7 +21,7 @@ import { contains, find, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/generic_sort_run_test.sfn
+++ b/compiler/tests/e2e/generic_sort_run_test.sfn
@@ -25,7 +25,7 @@ import { contains, find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/generic_struct_monomorphization_test.sfn
+++ b/compiler/tests/e2e/generic_struct_monomorphization_test.sfn
@@ -23,7 +23,7 @@ import { contains, find, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/guillermo_test.sfn
+++ b/compiler/tests/e2e/guillermo_test.sfn
@@ -22,7 +22,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 test "guillermo: command exits 0" ![io] {

--- a/compiler/tests/e2e/higher_order_named_fn_callback_test.sfn
+++ b/compiler/tests/e2e/higher_order_named_fn_callback_test.sfn
@@ -18,7 +18,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/http_capsule_serve_gate_test.sfn
+++ b/compiler/tests/e2e/http_capsule_serve_gate_test.sfn
@@ -29,7 +29,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/ice_banner_test.sfn
+++ b/compiler/tests/e2e/ice_banner_test.sfn
@@ -17,7 +17,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // A trivially valid program: it clears every pipeline stage on a clean run,

--- a/compiler/tests/e2e/inline_export_cross_module_test.sfn
+++ b/compiler/tests/e2e/inline_export_cross_module_test.sfn
@@ -15,7 +15,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The nested `sfn build` spawns clang + a linker, so the child needs PATH;

--- a/compiler/tests/e2e/interface_dispatch_test.sfn
+++ b/compiler/tests/e2e/interface_dispatch_test.sfn
@@ -22,7 +22,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/interface_vtable_consumer_declares_test.sfn
+++ b/compiler/tests/e2e/interface_vtable_consumer_declares_test.sfn
@@ -32,7 +32,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Inherit the full parent environment so the nested clang/ld the build

--- a/compiler/tests/e2e/io_read_fd_effect_test.sfn
+++ b/compiler/tests/e2e/io_read_fd_effect_test.sfn
@@ -13,7 +13,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `reader` omits `![io]` but calls `io.read_line(0)`, so the effect

--- a/compiler/tests/e2e/is_type_guard_test.sfn
+++ b/compiler/tests/e2e/is_type_guard_test.sfn
@@ -19,7 +19,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/lifecycle_hook_ordering_test.sfn
+++ b/compiler/tests/e2e/lifecycle_hook_ordering_test.sfn
@@ -21,7 +21,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Inherit the full parent environment: PATH/HOME/TMPDIR (plus any macOS

--- a/compiler/tests/e2e/linker_selection_test.sfn
+++ b/compiler/tests/e2e/linker_selection_test.sfn
@@ -29,7 +29,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/lock_test.sfn
+++ b/compiler/tests/e2e/lock_test.sfn
@@ -19,8 +19,8 @@
 // (and on out-of-tree marker files that survive the temp-dir teardown) after
 // the closure returns — the `sfn/test` idiom (see
 // `compiler/tests/e2e/sailfin_main_entry_test.sfn`).
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 // The compiler-under-test: `$SAILFIN_BIN` if set, else the self-hosted
 // binary relative to the repo root the runner starts from. Mirrors
@@ -28,7 +28,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // A fresh marker-file path under the runner's scratch dir (or `/tmp`), with

--- a/compiler/tests/e2e/login_test.sfn
+++ b/compiler/tests/e2e/login_test.sfn
@@ -14,7 +14,7 @@ import { find, contains, to_lower_all } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 struct LoginRun {

--- a/compiler/tests/e2e/macos_sdk_link_flags_test.sfn
+++ b/compiler/tests/e2e/macos_sdk_link_flags_test.sfn
@@ -22,7 +22,7 @@ import { contains, find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/make_result_contract_test.sfn
+++ b/compiler/tests/e2e/make_result_contract_test.sfn
@@ -205,7 +205,7 @@ fn _fakeseed_script() -> string {
 test "make result: failed cold rebuild reports status=fail (no stale fallback)" ![io] {
     // #1192 regression: a failed cold self-host rebuild must make `make
     // compile` FAIL (status:"fail"), not silently fall back to the prior
-    // build/native/sailfin and report status:"pass". Force the rebuild
+    // build/bin/sfn and report status:"pass". Force the rebuild
     // branch (FORCE=1) with a stub seed; FORCE / SEED_NATIVE are read from
     // the child env by the recipe, not as make-command-line variables.
     let dir = _scratch_dir();

--- a/compiler/tests/e2e/mem_limit_selfcap_test.sfn
+++ b/compiler/tests/e2e/mem_limit_selfcap_test.sfn
@@ -44,12 +44,12 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the
 // variables the toolchain needs. The bash-c cases additionally rely on
-// PATH so the runner-cwd-relative `build/native/sailfin` (passed as the
+// PATH so the runner-cwd-relative `build/bin/sfn` (passed as the
 // bash `$0`) and the shell itself resolve. Per-case SAILFIN_* trace/limit
 // vars are appended by the caller.
 fn _child_env() -> string[] ![io] {
@@ -106,7 +106,7 @@ fn _run_direct(extra: string[]) -> string ![io] {
 // Spawn through bash with an inherited `ulimit -v 4194304` (4 GiB) cap in
 // effect, then `exec "$0" version` so the compiler inherits the cap. The
 // SAILFIN_* trace vars are threaded via the env array. `$0` is the sfn
-// binary path (runner-cwd-relative `build/native/sailfin` resolves
+// binary path (runner-cwd-relative `build/bin/sfn` resolves
 // because PATH and the runner cwd are honored). Returns captured stderr.
 fn _run_under_cap(extra: string[]) -> string ![io] {
     let mut e = _child_env();

--- a/compiler/tests/e2e/module_global_runtime_init_test.sfn
+++ b/compiler/tests/e2e/module_global_runtime_init_test.sfn
@@ -20,13 +20,13 @@
 // Build/parallel-runner hygiene (temp-dir build, threaded `_child_env`
 // with `PATH` + `SAILFIN_TEST_SCRATCH`) mirrors `sailfin_main_entry_test`
 // — see `.claude/rules/no-bash-e2e.md` for the why.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/monotonic_millis_advances_test.sfn
+++ b/compiler/tests/e2e/monotonic_millis_advances_test.sfn
@@ -35,13 +35,13 @@
 // nested build still threads `SAILFIN_TEST_SCRATCH` through `_child_env`
 // so its `program.ll` cache stays per-invocation under the parallel pool
 // (#1333), while `PATH` lets the nested build find `clang` and its linker.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn build`. `process.run_capture`

--- a/compiler/tests/e2e/nested_function_declaration_test.sfn
+++ b/compiler/tests/e2e/nested_function_declaration_test.sfn
@@ -16,7 +16,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/no_duplicate_declares_test.sfn
+++ b/compiler/tests/e2e/no_duplicate_declares_test.sfn
@@ -28,7 +28,7 @@ import { split, starts_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned compiler. `process.run_capture` treats an

--- a/compiler/tests/e2e/numeric_bitwise_test.sfn
+++ b/compiler/tests/e2e/numeric_bitwise_test.sfn
@@ -28,7 +28,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/numeric_cast_test.sfn
+++ b/compiler/tests/e2e/numeric_cast_test.sfn
@@ -30,7 +30,7 @@ import { contains, split, starts_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/numeric_int_default_test.sfn
+++ b/compiler/tests/e2e/numeric_int_default_test.sfn
@@ -23,7 +23,7 @@ import { contains, split, starts_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/numeric_int_float_test.sfn
+++ b/compiler/tests/e2e/numeric_int_float_test.sfn
@@ -28,7 +28,7 @@ import { contains, starts_with, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/openssl_prefix_honored_test.sfn
+++ b/compiler/tests/e2e/openssl_prefix_honored_test.sfn
@@ -28,7 +28,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _is_darwin() -> boolean ![io] {

--- a/compiler/tests/e2e/owned_buf_grow_determinism_test.sfn
+++ b/compiler/tests/e2e/owned_buf_grow_determinism_test.sfn
@@ -41,7 +41,7 @@ import { split, starts_with, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/owned_buf_roundtrip_test.sfn
+++ b/compiler/tests/e2e/owned_buf_roundtrip_test.sfn
@@ -21,7 +21,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch(tag: string) -> string ![io] {

--- a/compiler/tests/e2e/parallel_concurrent_execution_test.sfn
+++ b/compiler/tests/e2e/parallel_concurrent_execution_test.sfn
@@ -29,7 +29,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Empty `run_capture` env is the EMPTY environment, not "inherit"; a

--- a/compiler/tests/e2e/plain_fn_ptr_call_test.sfn
+++ b/compiler/tests/e2e/plain_fn_ptr_call_test.sfn
@@ -26,7 +26,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn` invocations. `process.run_capture`

--- a/compiler/tests/e2e/pointer_read_intrinsic_test.sfn
+++ b/compiler/tests/e2e/pointer_read_intrinsic_test.sfn
@@ -25,7 +25,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/process_run_capture_windows_test.sfn
+++ b/compiler/tests/e2e/process_run_capture_windows_test.sfn
@@ -26,7 +26,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // True when the test runner is a Windows binary (the only platform whose

--- a/compiler/tests/e2e/publish_test.sfn
+++ b/compiler/tests/e2e/publish_test.sfn
@@ -32,7 +32,7 @@ fn _is_hex_char(ch: string) -> boolean {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/push_in_struct_method_test.sfn
+++ b/compiler/tests/e2e/push_in_struct_method_test.sfn
@@ -35,7 +35,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Inherit the full parent environment so the nested clang/ld the build
@@ -66,8 +66,7 @@ fn _builder_src() -> string {
 }
 
 fn _main_src() -> string {
-    return "import { Builder } from \"./builder\";\n"
-        + "\n"
+    return "import { Builder } from \"./builder\";\n" + "\n"
         + "fn main() -> int ![io] {\n"
         + "    let b = Builder{};\n"
         + "    let out = b.make([\"a\", \"b\"]);\n"
@@ -77,9 +76,7 @@ fn _main_src() -> string {
 }
 
 fn _capsule_toml() -> string {
-    return "[capsule]\n"
-        + "name = \"pushcap1700\"\n"
-        + "version = \"0.1.0\"\n"
+    return "[capsule]\n" + "name = \"pushcap1700\"\n" + "version = \"0.1.0\"\n"
         + "\n"
         + "[capabilities]\n"
         + "allow = [\"io\"]\n";

--- a/compiler/tests/e2e/reexport_test.sfn
+++ b/compiler/tests/e2e/reexport_test.sfn
@@ -25,7 +25,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned compiler. `process.run_capture` treats an

--- a/compiler/tests/e2e/result_prelude_discriminant_test.sfn
+++ b/compiler/tests/e2e/result_prelude_discriminant_test.sfn
@@ -27,7 +27,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture() -> string {

--- a/compiler/tests/e2e/routine_nursery_test.sfn
+++ b/compiler/tests/e2e/routine_nursery_test.sfn
@@ -44,7 +44,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _nursery_path() -> string { return "runtime/sfn/concurrency/nursery.sfn"; }

--- a/compiler/tests/e2e/run_cache_flags_test.sfn
+++ b/compiler/tests/e2e/run_cache_flags_test.sfn
@@ -34,7 +34,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Build env for sfn run: PATH (clang/linker), HOME, TMPDIR,

--- a/compiler/tests/e2e/run_scratch_isolation_test.sfn
+++ b/compiler/tests/e2e/run_scratch_isolation_test.sfn
@@ -17,7 +17,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child env = the full parent environment (PATH/HOME/TMPDIR + macOS

--- a/compiler/tests/e2e/runner_jobs_parallel_test.sfn
+++ b/compiler/tests/e2e/runner_jobs_parallel_test.sfn
@@ -24,7 +24,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/runner_json_multifile_test.sfn
+++ b/compiler/tests/e2e/runner_json_multifile_test.sfn
@@ -33,7 +33,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/runner_state_marker_test.sfn
+++ b/compiler/tests/e2e/runner_state_marker_test.sfn
@@ -25,7 +25,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child env: PATH/HOME/TMPDIR (the nested compile runs clang + linker),

--- a/compiler/tests/e2e/runtime_adapter_filesystem_test.sfn
+++ b/compiler/tests/e2e/runtime_adapter_filesystem_test.sfn
@@ -39,7 +39,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_adapter_http_test.sfn
+++ b/compiler/tests/e2e/runtime_adapter_http_test.sfn
@@ -40,7 +40,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_adapter_websocket_test.sfn
+++ b/compiler/tests/e2e/runtime_adapter_websocket_test.sfn
@@ -39,7 +39,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_array_test.sfn
+++ b/compiler/tests/e2e/runtime_array_test.sfn
@@ -21,7 +21,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn` invocations. `process.run_capture`

--- a/compiler/tests/e2e/runtime_char_from_code_test.sfn
+++ b/compiler/tests/e2e/runtime_char_from_code_test.sfn
@@ -20,13 +20,13 @@
 // per-invocation under the parallel pool (#1333). The `expect_*` matchers
 // are `![pure]` and unusable from an `![io]` test, so output is asserted
 // with `sfn/strings::find`.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/runtime_exception_frames_test.sfn
+++ b/compiler/tests/e2e/runtime_exception_frames_test.sfn
@@ -35,7 +35,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_exec_path_test.sfn
+++ b/compiler/tests/e2e/runtime_exec_path_test.sfn
@@ -23,7 +23,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch(tag: string) -> string ![io] {

--- a/compiler/tests/e2e/runtime_helper_declare_integrity_test.sfn
+++ b/compiler/tests/e2e/runtime_helper_declare_integrity_test.sfn
@@ -45,7 +45,7 @@ fn _sweeps() -> int { return 6; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `emit llvm` neither links nor spawns clang, so no PATH is required; thread

--- a/compiler/tests/e2e/runtime_http_chunked_decode_test.sfn
+++ b/compiler/tests/e2e/runtime_http_chunked_decode_test.sfn
@@ -26,7 +26,7 @@ import { find, contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment, not "inherit".

--- a/compiler/tests/e2e/runtime_identity_stamp_test.sfn
+++ b/compiler/tests/e2e/runtime_identity_stamp_test.sfn
@@ -37,7 +37,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Thread PATH/HOME/TMPDIR through to the nested `sfn test` child with an

--- a/compiler/tests/e2e/runtime_implicit_capsule_link_test.sfn
+++ b/compiler/tests/e2e/runtime_implicit_capsule_link_test.sfn
@@ -35,7 +35,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH.

--- a/compiler/tests/e2e/runtime_int_helpers_legacy_path_test.sfn
+++ b/compiler/tests/e2e/runtime_int_helpers_legacy_path_test.sfn
@@ -28,7 +28,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Base child env: PATH/HOME/TMPDIR so the spawned compile finds its tools,

--- a/compiler/tests/e2e/runtime_io_print_test.sfn
+++ b/compiler/tests/e2e/runtime_io_print_test.sfn
@@ -16,13 +16,13 @@
 // test must thread `SAILFIN_TEST_SCRATCH` (+ `PATH` for clang/linker) to
 // its nested build to avoid clobbering a sibling build under the pool.
 // See `.claude/rules/no-bash-e2e.md` and `sailfin_main_entry_test.sfn`.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/runtime_memory_arena_mark_test.sfn
+++ b/compiler/tests/e2e/runtime_memory_arena_mark_test.sfn
@@ -20,7 +20,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch(tag: string) -> string ![io] {

--- a/compiler/tests/e2e/runtime_memory_arena_test.sfn
+++ b/compiler/tests/e2e/runtime_memory_arena_test.sfn
@@ -54,7 +54,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_memory_mem_test.sfn
+++ b/compiler/tests/e2e/runtime_memory_mem_test.sfn
@@ -36,7 +36,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_memory_rc_test.sfn
+++ b/compiler/tests/e2e/runtime_memory_rc_test.sfn
@@ -37,7 +37,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_obj_shared_cache_test.sfn
+++ b/compiler/tests/e2e/runtime_obj_shared_cache_test.sfn
@@ -34,7 +34,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child env for a nested build: PATH (clang/linker), HOME, TMPDIR, the

--- a/compiler/tests/e2e/runtime_parallel_combinator_test.sfn
+++ b/compiler/tests/e2e/runtime_parallel_combinator_test.sfn
@@ -19,7 +19,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch(tag: string) -> string ![io] {

--- a/compiler/tests/e2e/runtime_process_test.sfn
+++ b/compiler/tests/e2e/runtime_process_test.sfn
@@ -28,7 +28,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The Sailfin-native process runtime module, relative to the repo root the

--- a/compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn
+++ b/compiler/tests/e2e/runtime_scheduler_skeleton_test.sfn
@@ -60,7 +60,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scheduler_path() -> string {

--- a/compiler/tests/e2e/runtime_serve_test.sfn
+++ b/compiler/tests/e2e/runtime_serve_test.sfn
@@ -39,7 +39,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_sfn_sources_active_test.sfn
+++ b/compiler/tests/e2e/runtime_sfn_sources_active_test.sfn
@@ -7,7 +7,7 @@
 // `test_runtime_sfn_sources_active.sh` (test-infra Phase 3, epic #842;
 // `.claude/rules/no-bash-e2e.md`). Pins the production link path: when
 // `runtime/capsule.toml` declares `sfn-sources = ["sfn/memory/arena.sfn"]`,
-// the resulting `build/native/sailfin` binary exports five
+// the resulting `build/bin/sfn` binary exports five
 // `sfn_arena_sfn_*` symbols sourced from Sailfin emission, plus the bare
 // arena-core exports #1309 moved into Sailfin
 // (`sfn_arena_create`/`alloc`/`global`/`enabled`), and the surviving bare
@@ -33,7 +33,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_sfn_sources_link_consumer_test.sfn
+++ b/compiler/tests/e2e/runtime_sfn_sources_link_consumer_test.sfn
@@ -41,7 +41,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH (an

--- a/compiler/tests/e2e/runtime_sfn_sources_struct_import_test.sfn
+++ b/compiler/tests/e2e/runtime_sfn_sources_struct_import_test.sfn
@@ -25,7 +25,7 @@
 //      i64 probe fn).
 //   2. Runs `sfn build -p <ws>/capsules/sfn/test-app --work-dir <ws>/build`.
 //      The `--work-dir` rebases the cache dir to `<ws>/build/sailfin` and
-//      the default binary to `<ws>/build/native/sailfin` — giving the same
+//      the default binary to `<ws>/build/bin/sfn` — giving the same
 //      predictable artifact paths the bash test got from `cd "$ws"`
 //      without a cwd lever (`run_capture` has none).
 //   3. Asserts the build succeeds (fails with the lowering fatal pre-#1288).
@@ -42,7 +42,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH (an

--- a/compiler/tests/e2e/runtime_string_allocating_test.sfn
+++ b/compiler/tests/e2e/runtime_string_allocating_test.sfn
@@ -19,7 +19,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch(tag: string) -> string ![io] {
@@ -48,7 +48,7 @@ fn _env() -> string[] ![io] {
 fn _repo_root() -> string ![io] {
     // The test runner runs from the repo root; derive it from a known path.
     // Use the scratch parent as a fallback but prefer CWD-relative detection
-    // via env. The repo root is where build/native/sailfin lives.
+    // via env. The repo root is where build/bin/sfn lives.
     let configured = env.get("SAILFIN_REPO_ROOT");
     if configured.length > 0 { return configured; }
     return ".";

--- a/compiler/tests/e2e/runtime_string_basic_test.sfn
+++ b/compiler/tests/e2e/runtime_string_basic_test.sfn
@@ -37,7 +37,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/runtime_string_utf8_numeric_test.sfn
+++ b/compiler/tests/e2e/runtime_string_utf8_numeric_test.sfn
@@ -11,7 +11,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch(tag: string) -> string ![io] {

--- a/compiler/tests/e2e/runtime_tls_https_client_test.sfn
+++ b/compiler/tests/e2e/runtime_tls_https_client_test.sfn
@@ -102,7 +102,7 @@ fn _tlp_connect(port: i64) -> i32 {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Full parent environment for the build + server + client subprocesses

--- a/compiler/tests/e2e/runtime_tls_verify_failure_test.sfn
+++ b/compiler/tests/e2e/runtime_tls_verify_failure_test.sfn
@@ -96,7 +96,7 @@ fn _tvf_connect(port: i64) -> i32 {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Full parent environment for the build + server subprocesses

--- a/compiler/tests/e2e/runtime_type_meta_test.sfn
+++ b/compiler/tests/e2e/runtime_type_meta_test.sfn
@@ -27,7 +27,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/sailfin_main_entry_test.sfn
+++ b/compiler/tests/e2e/sailfin_main_entry_test.sfn
@@ -43,13 +43,13 @@
 // `capsules/sfn/test/tests/fixtures_test.sfn`). Captured stdout is
 // stashed to an out-of-tree marker file so it survives the temp-dir
 // teardown and can be asserted after the fixture returns.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/sailfin_main_panic_test.sfn
+++ b/compiler/tests/e2e/sailfin_main_panic_test.sfn
@@ -34,13 +34,13 @@
 // is unavailable (e.g. macOS dev boxes) the spawn fails and the check
 // is skipped rather than failed — CI is Linux, where it is the
 // canonical path.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/sailfin_trace_link_test.sfn
+++ b/compiler/tests/e2e/sailfin_trace_link_test.sfn
@@ -14,7 +14,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/sc_nprocessors_onln_sentinel_test.sfn
+++ b/compiler/tests/e2e/sc_nprocessors_onln_sentinel_test.sfn
@@ -34,7 +34,7 @@ import { contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _scratch_dir() -> string ![io] {

--- a/compiler/tests/e2e/self_param_lowering_test.sfn
+++ b/compiler/tests/e2e/self_param_lowering_test.sfn
@@ -14,7 +14,7 @@
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/serve_keepalive_test.sfn
+++ b/compiler/tests/e2e/serve_keepalive_test.sfn
@@ -61,7 +61,7 @@ fn _kp_port_str() -> string { return "18792"; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Full parent environment for the build + server/client subprocesses (the

--- a/compiler/tests/e2e/serve_loopback_test.sfn
+++ b/compiler/tests/e2e/serve_loopback_test.sfn
@@ -83,7 +83,7 @@ fn _lb_port_str() -> string { return "18790"; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the build + server subprocesses. The build LINKS

--- a/compiler/tests/e2e/serve_request_leak_test.sfn
+++ b/compiler/tests/e2e/serve_request_leak_test.sfn
@@ -48,7 +48,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment, not "inherit".

--- a/compiler/tests/e2e/serve_reuseaddr_restart_test.sfn
+++ b/compiler/tests/e2e/serve_reuseaddr_restart_test.sfn
@@ -53,7 +53,7 @@ fn _rr_port_str() -> string { return "18791"; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The nested build LINKS a binary (clang + ld), so thread the parent's

--- a/compiler/tests/e2e/serve_tls_loopback_test.sfn
+++ b/compiler/tests/e2e/serve_tls_loopback_test.sfn
@@ -30,7 +30,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Full parent environment for the build + client subprocesses. The build

--- a/compiler/tests/e2e/sfn_package_test.sfn
+++ b/compiler/tests/e2e/sfn_package_test.sfn
@@ -24,7 +24,7 @@ import { find, contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Absolute path to the compiler binary (needed for --compiler-bin, which the

--- a/compiler/tests/e2e/short_lambda_closure_pair_test.sfn
+++ b/compiler/tests/e2e/short_lambda_closure_pair_test.sfn
@@ -24,7 +24,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/sleep_eintr_resume_test.sfn
+++ b/compiler/tests/e2e/sleep_eintr_resume_test.sfn
@@ -38,7 +38,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/sleep_routes_to_sfn_clock_test.sfn
+++ b/compiler/tests/e2e/sleep_routes_to_sfn_clock_test.sfn
@@ -21,7 +21,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn emit`. `process.run_capture` treats

--- a/compiler/tests/e2e/sleep_unit_semantics_test.sfn
+++ b/compiler/tests/e2e/sleep_unit_semantics_test.sfn
@@ -33,13 +33,13 @@
 // nested build still threads `SAILFIN_TEST_SCRATCH` through `_child_env`
 // so its `program.ll` cache stays per-invocation under the parallel pool
 // (#1333), while `PATH` lets the nested build find `clang` and its linker.
-import { with_tmp_dir } from "sfn/test";
 import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
 
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn build`. `process.run_capture`

--- a/compiler/tests/e2e/spawn_await_concurrent_execution_test.sfn
+++ b/compiler/tests/e2e/spawn_await_concurrent_execution_test.sfn
@@ -28,7 +28,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Empty `run_capture` env is the EMPTY environment, not "inherit"; a

--- a/compiler/tests/e2e/spawn_capture_env_free_test.sfn
+++ b/compiler/tests/e2e/spawn_capture_env_free_test.sfn
@@ -44,7 +44,7 @@ import { find, contains, split } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the EMPTY environment, not "inherit".

--- a/compiler/tests/e2e/stateful_http_users_server_test.sfn
+++ b/compiler/tests/e2e/stateful_http_users_server_test.sfn
@@ -27,7 +27,7 @@ fn _su_port() -> i64 { return 18882; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] { return process.environ(); }

--- a/compiler/tests/e2e/string_aggregate_shape_test.sfn
+++ b/compiler/tests/e2e/string_aggregate_shape_test.sfn
@@ -27,7 +27,7 @@ import { contains, split, ends_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/string_cstr_boundary_test.sfn
+++ b/compiler/tests/e2e/string_cstr_boundary_test.sfn
@@ -32,7 +32,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/string_length_aware_lv_test.sfn
+++ b/compiler/tests/e2e/string_length_aware_lv_test.sfn
@@ -27,7 +27,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/string_to_number_lv_test.sfn
+++ b/compiler/tests/e2e/string_to_number_lv_test.sfn
@@ -29,7 +29,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/struct_field_pointer_roundtrip_test.sfn
+++ b/compiler/tests/e2e/struct_field_pointer_roundtrip_test.sfn
@@ -31,7 +31,7 @@ import {
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned `sfn` invocations. `process.run_capture`

--- a/compiler/tests/e2e/struct_field_separator_test.sfn
+++ b/compiler/tests/e2e/struct_field_separator_test.sfn
@@ -25,7 +25,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/subprocess_emit_clean_env_test.sfn
+++ b/compiler/tests/e2e/subprocess_emit_clean_env_test.sfn
@@ -28,7 +28,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Base child env for sfn emit invocations: PATH so clang is found,

--- a/compiler/tests/e2e/sync_rejects_unimplemented_concurrency_test.sfn
+++ b/compiler/tests/e2e/sync_rejects_unimplemented_concurrency_test.sfn
@@ -36,7 +36,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child environment for the spawned compiles. `process.run_capture`

--- a/compiler/tests/e2e/test_bin_cache_test.sfn
+++ b/compiler/tests/e2e/test_bin_cache_test.sfn
@@ -44,7 +44,7 @@ import { find } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Child env for the nested `sfn test`: PATH (clang/linker for any lower),

--- a/compiler/tests/e2e/thread_local_lowering_test.sfn
+++ b/compiler/tests/e2e/thread_local_lowering_test.sfn
@@ -30,7 +30,7 @@ import { find, contains, starts_with } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _child_env() -> string[] ![io] {

--- a/compiler/tests/e2e/tls_loopback_test.sfn
+++ b/compiler/tests/e2e/tls_loopback_test.sfn
@@ -119,7 +119,7 @@ fn _plain_port_str() -> string { return "18895"; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // Full parent environment for the build + server + client subprocesses

--- a/compiler/tests/e2e/tostring_member_access_test.sfn
+++ b/compiler/tests/e2e/tostring_member_access_test.sfn
@@ -28,7 +28,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/try_catch_frames_test.sfn
+++ b/compiler/tests/e2e/try_catch_frames_test.sfn
@@ -32,7 +32,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`'s empty array is the *empty* environment; thread the

--- a/compiler/tests/e2e/union_named_variant_match_test.sfn
+++ b/compiler/tests/e2e/union_named_variant_match_test.sfn
@@ -26,7 +26,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 fn _fixture_src() -> string ![io] {

--- a/compiler/tests/e2e/untyped_lambda_callback_test.sfn
+++ b/compiler/tests/e2e/untyped_lambda_callback_test.sfn
@@ -16,7 +16,7 @@ import { trim_right } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `sfn run` compiles+links+executes the fixture, so the spawned compiler

--- a/compiler/tests/e2e/update_snapshots_flag_test.sfn
+++ b/compiler/tests/e2e/update_snapshots_flag_test.sfn
@@ -27,7 +27,7 @@ import { with_tmp_dir } from "sfn/test";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The runner exports SAILFIN_UPDATE_SNAPSHOTS=1 iff `--update-snapshots`

--- a/compiler/tests/e2e/websocket_serve_loopback_test.sfn
+++ b/compiler/tests/e2e/websocket_serve_loopback_test.sfn
@@ -63,7 +63,7 @@ fn _lb_port2_str() -> string { return "18885"; }
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // `run_capture`/`spawn_with_env`'s empty env is the EMPTY environment, not

--- a/compiler/tests/e2e/work_dir_flag_test.sfn
+++ b/compiler/tests/e2e/work_dir_flag_test.sfn
@@ -22,7 +22,7 @@ import { find, contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The build spawns a nested clang + linker, so the child needs PATH

--- a/compiler/tests/e2e/work_dir_parity_test.sfn
+++ b/compiler/tests/e2e/work_dir_parity_test.sfn
@@ -29,7 +29,7 @@ import { contains } from "sfn/strings";
 fn _sfn_bin() -> string ![io] {
     let configured = env.get("SAILFIN_BIN");
     if configured.length > 0 { return configured; }
-    return "build/native/sailfin";
+    return "build/bin/sfn";
 }
 
 // The self-host build spawns nested clang + linker, so the child needs

--- a/compiler/tests/integration/check_staging_equivalence_test.sfn
+++ b/compiler/tests/integration/check_staging_equivalence_test.sfn
@@ -11,7 +11,7 @@
 // The acceptance contract is *equivalence*: the staged artifact set
 // produced by the subprocess path must be byte-identical to the set
 // the legacy in-process path produces. This test drives both paths
-// end-to-end through the *shipped* `build/native/sailfin` binary:
+// end-to-end through the *shipped* `build/bin/sfn` binary:
 //
 //   - Run A invokes the binary normally. `fn main` threads
 //     `binary_dir` from `exe_path()`, `_resolve_check_self_path`
@@ -64,7 +64,7 @@ test "check staging: subprocess path stages byte-identical artifacts to in-proce
     // `printf '%s'` strips the trailing newline `realpath` emits —
     // a raw capture would split the `sh -c` scripts below in two
     // (same pattern as `_host_path` in `emit_retry_test.sfn`).
-    let exe = _shell_capture("printf '%s' \"$(realpath build/native/sailfin)\"");
+    let exe = _shell_capture("printf '%s' \"$(realpath build/bin/sfn)\"");
     assert exe.length > 0;
 
     // Run A: shipped binary under its real name -> `binary_dir`
@@ -125,7 +125,7 @@ test "check staging: warm re-run is a cache hit (staged artifacts untouched)" ![
     // `printf '%s'` strips the trailing newline `realpath` emits —
     // a raw capture would split the `sh -c` scripts below in two
     // (same pattern as `_host_path` in `emit_retry_test.sfn`).
-    let exe = _shell_capture("printf '%s' \"$(realpath build/native/sailfin)\"");
+    let exe = _shell_capture("printf '%s' \"$(realpath build/bin/sfn)\"");
     assert exe.length > 0;
 
     let work = root + "/work";

--- a/compiler/tests/integration/emit_retry_test.sfn
+++ b/compiler/tests/integration/emit_retry_test.sfn
@@ -10,7 +10,7 @@
 // corruption flake.
 //
 // The retry path is driven end-to-end through the *shipped*
-// `build/native/sailfin` binary, seeded with `SAILFIN_INJECT_FAULT=N`
+// `build/bin/sfn` binary, seeded with `SAILFIN_INJECT_FAULT=N`
 // (the production fault-injection env var `emit_llvm_with_retry`
 // reads). This is deliberate: the alternative — importing
 // `emit_helpers` and calling the in-process emitter from inside this
@@ -52,7 +52,7 @@ fn _retry_fixture() -> string ![io] {
 // the child exit code. Streams are drained so a later capture can't
 // hand back this run's buffers.
 fn _emit_with_faults(src: string, out: string, attempts: string, validate: boolean, faults: string) -> i64 ![io] {
-    let mut argv: string[] = ["build/native/sailfin", "emit"];
+    let mut argv: string[] = ["build/bin/sfn", "emit"];
     if validate { argv.push("--validate"); } else {
         argv.push("--no-validate");
     }

--- a/compiler/tests/integration/is_effect_walk_test.sfn
+++ b/compiler/tests/integration/is_effect_walk_test.sfn
@@ -34,14 +34,14 @@ fn _mint_fixture(name: string, source: string) -> string ![io] {
 }
 
 fn _check_output(path: string) -> string ![io] {
-    let _rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let _rc = process.run_capture(["build/bin/sfn", "check", path], []);
     let out = process.capture_take_stdout();
     let err = process.capture_take_stderr();
     return out + err;
 }
 
 fn _check_exit(path: string) -> i64 ![io] {
-    let rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let rc = process.run_capture(["build/bin/sfn", "check", path], []);
     let _o = process.capture_take_stdout();
     let _e = process.capture_take_stderr();
     return rc;

--- a/compiler/tests/integration/undefined_function_check_test.sfn
+++ b/compiler/tests/integration/undefined_function_check_test.sfn
@@ -15,8 +15,8 @@
 // callee must check clean.
 //
 // Runs from the repo root (`make test-integration` invokes
-// `build/native/sailfin test compiler/tests/integration`), so the
-// `build/native/sailfin` binary resolves relative to that cwd. The
+// `build/bin/sfn test compiler/tests/integration`), so the
+// `build/bin/sfn` binary resolves relative to that cwd. The
 // child is launched with an *empty* environment on purpose: the binary
 // is named by an explicit slashed path (so `posix_spawnp` never
 // consults `PATH`), the runtime root is resolved exe-relative rather
@@ -51,18 +51,18 @@ fn _mint_fixture(name: string, source: string) -> string ![io] {
     return path;
 }
 
-// Run `build/native/sailfin check <path>` capturing both streams, and
+// Run `build/bin/sfn check <path>` capturing both streams, and
 // return the combined stdout+stderr so a case can assert on diagnostic
 // text regardless of which stream the renderer used.
 fn _check_output(path: string) -> string ![io] {
-    let _rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let _rc = process.run_capture(["build/bin/sfn", "check", path], []);
     let out = process.capture_take_stdout();
     let err = process.capture_take_stderr();
     return out + err;
 }
 
 fn _check_exit(path: string) -> i64 ![io] {
-    let rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let rc = process.run_capture(["build/bin/sfn", "check", path], []);
     // Drain the stashed capture buffers so a later `_check_output` /
     // `capture_take_*` call doesn't hand back this run's streams.
     let _o = process.capture_take_stdout();

--- a/compiler/tests/unit/build_report_determinism_test.sfn
+++ b/compiler/tests/unit/build_report_determinism_test.sfn
@@ -36,7 +36,7 @@ test "empty_determinism_snapshot: zero-valued fields" {
 // --------------------------------------------------------------
 test "compare_for_determinism: identical snapshots produce matched=true" {
     let a = DeterminismSnapshot {
-        binary_path: "build/native/sailfin",
+        binary_path: "build/bin/sfn",
         binary_sha256: "deadbeef",
         modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb")]
     };
@@ -229,7 +229,7 @@ test "determinism_diff_to_json: matched=false on cache_key mismatch" {
 
 test "determinism_diff_to_json: binary mismatch surfaces both sha256s" {
     let a = DeterminismSnapshot {
-        binary_path: "build/native/sailfin",
+        binary_path: "build/bin/sfn",
         binary_sha256: "aa",
         modules: []
     };
@@ -243,7 +243,7 @@ test "determinism_diff_to_json: binary mismatch surfaces both sha256s" {
     assert _contains(json, "\"binary_match\":false");
     assert _contains(json, "\"binary_sha256_a\":\"aa\"");
     assert _contains(json, "\"binary_sha256_b\":\"bb\"");
-    assert _contains(json, "\"binary_path_a\":\"build/native/sailfin\"");
+    assert _contains(json, "\"binary_path_a\":\"build/bin/sfn\"");
 }
 
 // --------------------------------------------------------------

--- a/docs/conventions/unit-test-import-envelope.md
+++ b/docs/conventions/unit-test-import-envelope.md
@@ -79,7 +79,7 @@ When in doubt, author a throwaway test that imports the symbol and run
 it under the cap:
 
 ```bash
-timeout 60 build/native/sailfin test /tmp/probe_test.sfn
+timeout 60 build/bin/sfn test /tmp/probe_test.sfn
 ```
 
 A light import links and passes in seconds; a heavy import surfaces as an

--- a/docs/proposals/0004-check-architecture.md
+++ b/docs/proposals/0004-check-architecture.md
@@ -1315,8 +1315,8 @@ ulimit -v 8388608 && timeout 300 make compile
 ulimit -v 8388608 && timeout 60 make test-unit
 
 # Stage 2: effect-checker uses spans
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/unit/effect_checker_test.sfn
-ulimit -v 8388608 && timeout 30 bash compiler/tests/e2e/test_check_effect_call_site_caret.sh build/native/sailfin
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/unit/effect_checker_test.sfn
+ulimit -v 8388608 && timeout 30 bash compiler/tests/e2e/test_check_effect_call_site_caret.sh build/bin/sfn
 
 # Stage 3: full self-host validation
 ulimit -v 8388608 && timeout 1800 make check
@@ -1427,10 +1427,10 @@ within current string-length tolerances.
 
 ```bash
 ulimit -v 8388608 && timeout 300 make compile
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/unit/diagnostics_json_test.sfn
-ulimit -v 8388608 && timeout 60 bash compiler/tests/e2e/test_check_json_schema.sh build/native/sailfin
-ulimit -v 8388608 && timeout 30 build/native/sailfin check --json compiler/src/main.sfn | jq .
-ulimit -v 8388608 && timeout 30 build/native/sailfin check --json compiler/src/ | jq '.summary'
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/unit/diagnostics_json_test.sfn
+ulimit -v 8388608 && timeout 60 bash compiler/tests/e2e/test_check_json_schema.sh build/bin/sfn
+ulimit -v 8388608 && timeout 30 build/bin/sfn check --json compiler/src/main.sfn | jq .
+ulimit -v 8388608 && timeout 30 build/bin/sfn check --json compiler/src/ | jq '.summary'
 
 # MCP smoke
 make mcp-server
@@ -1554,8 +1554,8 @@ ulimit -v 8388608 && timeout 300 make compile
 ulimit -v 8388608 && timeout 60 make test-unit
 
 # Stage 2: full B3
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/unit/diagnostics_render_test.sfn
-ulimit -v 8388608 && timeout 30 bash compiler/tests/e2e/test_check_json_suggestion.sh build/native/sailfin
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/unit/diagnostics_render_test.sfn
+ulimit -v 8388608 && timeout 30 bash compiler/tests/e2e/test_check_json_suggestion.sh build/bin/sfn
 
 # Stage 3: triple-pass fixed-point
 ulimit -v 8388608 && timeout 1800 make check
@@ -1627,7 +1627,7 @@ to the build path.
 ```bash
 ulimit -v 8388608 && timeout 300 make compile
 ulimit -v 8388608 && timeout 60 make test
-ulimit -v 8388608 && timeout 60 bash compiler/tests/integration/build_diagnostics_format_test.sh build/native/sailfin
+ulimit -v 8388608 && timeout 60 bash compiler/tests/integration/build_diagnostics_format_test.sh build/bin/sfn
 ulimit -v 8388608 && timeout 1800 make check
 ```
 

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -281,7 +281,7 @@ Flow:
    `native_driver.c`) plus `runtime_globals.ll` and the Sailfin
    `runtime/prelude.sfn` (compiled separately to `prelude.o`) are compiled.
 8. **Final link.** `clang` links the compiler object, the runtime objects,
-   and the prelude object into `build/native/sailfin`.
+   and the prelude object into `build/bin/sfn`.
 
 ### 1.2 Building a user program (`sfn build`, `sfn run`)
 
@@ -1176,7 +1176,7 @@ Its only job is to put the schema on disk so Stage B can lean on it.
 - `ulimit -v 8388608 && make compile` — unchanged behavior.
 - `ulimit -v 8388608 && make test-unit` — new tests pass.
 - `ulimit -v 8388608 && make check` — fixed-point still holds.
-- Manual: `build/native/sailfin emit native workspace.toml` is **not**
+- Manual: `build/bin/sfn emit native workspace.toml` is **not**
   expected to do anything meaningful; this stage adds parsing, not
   loading semantics.
 

--- a/docs/proposals/0008-effect-validation.md
+++ b/docs/proposals/0008-effect-validation.md
@@ -174,7 +174,7 @@ draws a normal caret-bearing diagnostic.
   `compiler/src/main.sfn` (test compilation; called by `sfn test`).
 - The build pipeline historically orchestrated by `scripts/build.sh` (since retired in Stage E PR7 / #383; orchestration now lives in the driver's resolver).
 
-This means: every `make compile` run, every `build/native/sailfin run foo.sfn`
+This means: every `make compile` run, every `build/bin/sfn run foo.sfn`
 invocation, every CI run that doesn't explicitly call `sfn check` ships with
 zero effect validation. The compiler tree itself has never seen an enforced
 effect-check run.
@@ -772,7 +772,7 @@ fn is_canonical_effect(name: string) -> boolean                 // NEW
 
 ```bash
 ulimit -v 8388608 && timeout 180 make compile
-ulimit -v 8388608 && timeout 30 build/native/sailfin check compiler/src/main.sfn
+ulimit -v 8388608 && timeout 30 build/bin/sfn check compiler/src/main.sfn
 # Expect: effect diagnostics now show file:line:column with caret.
 ulimit -v 8388608 && timeout 60 make test-unit
 ```
@@ -963,7 +963,7 @@ declarations now fail the build by default.
 ```bash
 ulimit -v 8388608 && timeout 240 make compile
 # Expect: succeeds without env override.
-ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn
+ulimit -v 8388608 && timeout 30 build/bin/sfn run examples/basics/hello-world.sfn
 # Expect: example still runs; main has correct ![io].
 ulimit -v 8388608 && timeout 600 make check
 ulimit -v 8388608 && timeout 60 make test-integration
@@ -1504,7 +1504,7 @@ across phases:
 
 ```bash
 # After Phase A
-ulimit -v 8388608 && timeout 30 build/native/sailfin check compiler/src/main.sfn 2>&1 \
+ulimit -v 8388608 && timeout 30 build/bin/sfn check compiler/src/main.sfn 2>&1 \
     | grep -E '\[E04(00|01)\]' \
     | head -5
 # Expect: each line shows --> file:line:column.
@@ -1529,7 +1529,7 @@ cat > /tmp/test_e0402.sfn <<'TEST'
 import { fetch } from "./helpers";  // helpers declares fetch ![net]
 fn run() { fetch("http://x"); }     // missing ![net]
 TEST
-ulimit -v 8388608 && timeout 30 build/native/sailfin check /tmp/test_e0402.sfn
+ulimit -v 8388608 && timeout 30 build/bin/sfn check /tmp/test_e0402.sfn
 # Expect: E0402 with caret on `fetch`.
 
 # After Phase F (synthetic test)
@@ -1542,7 +1542,7 @@ TOML
 cat > /tmp/cap_test/src/lib.sfn <<'LIB'
 fn fetch() ![net] { ... }
 LIB
-ulimit -v 8388608 && timeout 30 build/native/sailfin check /tmp/cap_test/
+ulimit -v 8388608 && timeout 30 build/bin/sfn check /tmp/cap_test/
 # Expect: E0403 — net outside capability surface.
 ```
 

--- a/docs/proposals/0011-ci-test-speed.md
+++ b/docs/proposals/0011-ci-test-speed.md
@@ -164,7 +164,7 @@ the 1.5-3 min build. Two options:
   because shards run concurrently. The only cost is runner-minute
   consumption (4x build instead of 1x). Acceptable for Phase 1; ship it.
 - **1b (Phase 2, optimization):** split the build into its own job that
-  uploads `build/native/sailfin` + `build/native/import-context` +
+  uploads `build/bin/sfn` + `build/native/import-context` +
   `build/cache` as a workflow artifact (or `actions/cache` with a
   per-run key), and have each shard `needs:` that job and download
   instead of rebuilding. Saves the redundant build runner-minutes and

--- a/docs/proposals/0012-result-and-question-operator.md
+++ b/docs/proposals/0012-result-and-question-operator.md
@@ -591,22 +591,22 @@ the file list is the implementation map for R.1–R.5.)
 ```bash
 # After R.1 (parser/AST only — no prelude change yet):
 ulimit -v 8388608 && make compile
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/unit/result_parse_test.sfn
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/unit/result_parse_test.sfn
 
 # After R.2 (generic enum monomorphisation + prelude Result/Error):
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/unit/result_enum_lowering_test.sfn
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/unit/result_enum_lowering_test.sfn
 
 # After R.3 (type rules):
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/unit/result_question_typecheck_test.sfn
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/unit/result_question_typecheck_test.sfn
 
 # After R.4 (emitter):
-ulimit -v 8388608 && timeout 60 build/native/sailfin test compiler/tests/integration/result_types_test.sfn
+ulimit -v 8388608 && timeout 60 build/bin/sfn test compiler/tests/integration/result_types_test.sfn
 
 # Full self-host + suite:
 make clean-build && make check
 
 # Formatting gate (every touched .sfn):
-build/native/sailfin fmt --check compiler/src/ runtime/
+build/bin/sfn fmt --check compiler/src/ runtime/
 ```
 
 ## Test Plan (R.1–R.5 round-trip cases)

--- a/docs/proposals/0020-compiler-decomposition.md
+++ b/docs/proposals/0020-compiler-decomposition.md
@@ -50,7 +50,7 @@ No source is moved here.
 ## 2. Current state (measured)
 
 All counts below are extracted statically from `compiler/src/` on
-2026-06-22 (`build/native/sailfin` is absent in this environment; every claim
+2026-06-22 (`build/bin/sfn` is absent in this environment; every claim
 is grounded in a path + line, not a compiler run).
 
 - **166** `.sfn` files, **99,093** LOC total.
@@ -439,9 +439,9 @@ IR lands at `build/capsules/sfn/compiler/ir/*.ll` and the legacy
    `sfn/compiler/ir/`. **Fix:** the flatten loop is path-generic; verify it
    captures `sfn/compiler` and, if the legacy flat-copy line is now redundant for
    the compiler, leave it (harmless) but rely on the scoped sweep.
-2. **`build/native/sailfin` output filename is unchanged.** The *binary* name
+2. **`build/bin/sfn` output filename is unchanged.** The *binary* name
    (`name = "sailfin"` → `sfn/compiler`) is decoupled from the *output path*
-   (`build/native/sailfin`) — the latter is `$(NATIVE_OUT)` in the Makefile and
+   (`build/bin/sfn`) — the latter is `$(NATIVE_OUT)` in the Makefile and
    the `cp -f build/sailfin/program $(NATIVE_OUT)` step, driven by the binary
    capsule's `[build] entry`/`kind`, not its `name`. Confirm the binary capsule
    continues to emit `program`/`program.ll` to `build/sailfin/` (the binary
@@ -761,8 +761,8 @@ Targeted checks:
   defaults `true`, parses `publish = false`, and `handle_publish_command` exits
   non-zero on a `publish=false` manifest; resolver refuses a `publish=false`
   registry candidate.
-- **Rename (#3):** `make compile` + `build/native/sailfin --version`; confirm
-  `build/native/sailfin` filename unchanged; `build/capsules/sfn/compiler/ir/`
+- **Rename (#3):** `make compile` + `build/bin/sfn --version`; confirm
+  `build/bin/sfn` filename unchanged; `build/capsules/sfn/compiler/ir/`
   populated; `make ci-cross-windows` links.
 - **Cycle break (#5):** `rg 'from ".*native_ir"' compiler-frontend/` returns
   only CO imports; `rg 'from ".*/(parser|typecheck|ast)' compiler-backend/`

--- a/docs/proposals/0022-darwin-memory-governor.md
+++ b/docs/proposals/0022-darwin-memory-governor.md
@@ -385,7 +385,7 @@ Mirror `mem_limit_selfcap_test.sfn` and the sanitizer-skip discipline. All
 
 ## 11. Verification commands
 
-- Per step: `build/native/sailfin check <touched .sfn>` then `make compile`.
+- Per step: `build/bin/sfn check <touched .sfn>` then `make compile`.
 - Step 1 local sanity: confirm `_cr_resolve_jobs` still 8 on this box (a debug
   trace or the unit test on the extracted formula).
 - Full gate before "shipped": `make check` (triple-pass self-host + suite),

--- a/docs/proposals/0036-tls-runtime.md
+++ b/docs/proposals/0036-tls-runtime.md
@@ -108,7 +108,7 @@ that needs no Sailfin→C callback:**
   existing socket timeouts bound them.
 
 **Feasibility probe results (run against the freshly self-hosted
-`build/native/sailfin`):**
+`build/bin/sfn`):**
 
 1. **Opaque-pointer externs — PASS.** A 19-extern `SSL_CTX_*`/`SSL_*` surface
    spelled with opaque `* u8` handles (`SSL_CTX_new(method: * u8) -> * u8`,

--- a/docs/proposals/design-notes/1502-selfhost-check.md
+++ b/docs/proposals/design-notes/1502-selfhost-check.md
@@ -92,12 +92,12 @@ sfn selfhost [--work-dir DIR] [--first-pass BIN] [--seedcheck-out BIN]
 
 Defaults reproduce the current Makefile paths byte-for-byte:
 - `--work-dir build/selfhost`
-- `--first-pass build/native/sailfin` (the binary `make compile` produced; also
+- `--first-pass build/bin/sfn` (the binary `make compile` produced; also
   the running `sfn` — but we take it as a flag so the seed-vs-self distinction
   is explicit and testable)
-- `--seedcheck-out build/native/sailfin-seedcheck`
-- `--stage3-out build/native/sailfin-stage3`
-- `--promote-to build/native/sailfin`
+- `--seedcheck-out build/bin/sfn-seedcheck`
+- `--stage3-out build/bin/sfn-stage3`
+- `--promote-to build/bin/sfn`
 - `--timeout` = unset (no per-build timeout) unless provided; Make threads its
   `TIMEOUT_CMD` budget in.
 
@@ -162,7 +162,7 @@ binary. The orchestration is a straight port of the Makefile data-flow:
 2. **Stage2 (seedcheck) build:** spawn
    `sh -c "SAILFIN_TEST_SCRATCH=<s2-scratch> <first_pass> build --no-cache -p compiler --work-dir <s2-dir> -o <seedcheck-out>"`.
    The orchestrator may itself BE the first-pass binary (`make compile`
-   promotes it to `build/native/sailfin`), but it still spawns the named binary
+   promotes it to `build/bin/sfn`), but it still spawns the named binary
    as a subprocess rather than re-entering its own `build` codepath — this keeps
    the three stages as three honest, separately-resolvable binaries (mirrors
    `_run_determinism_pass2`'s "spawn the resolved self_exe" model,
@@ -273,17 +273,17 @@ The new `.ll`-dir snapshot loader (`_selfhost_snapshot_from_ll_dir`) lives in
 check-impl:
 	@$(MAKE) compile NATIVE_OPT="$(SELFHOST1_OPT)"
 	@echo "[check] running test suite on first-pass binary (early gate)..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@$(MAKE) test NATIVE_BIN=build/bin/sfn TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 	@echo "[check] verifying self-host (stage2/stage3 fixed point)..."
-	@build/native/sailfin selfhost \
+	@build/bin/sfn selfhost \
 		--work-dir build/selfhost \
-		--first-pass build/native/sailfin \
-		--seedcheck-out build/native/sailfin-seedcheck \
-		--stage3-out build/native/sailfin-stage3 \
-		--promote-to build/native/sailfin \
+		--first-pass build/bin/sfn \
+		--seedcheck-out build/bin/sfn-seedcheck \
+		--stage3-out build/bin/sfn-stage3 \
+		--promote-to build/bin/sfn \
 		$(SELFHOST_TIMEOUT_FLAG)
 	@echo "[check] running test suite with seedcheck binary..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
+	@$(MAKE) test NATIVE_BIN=build/bin/sfn-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache TEST_JOBS=$(CHECK_TEST_JOBS)
 ```
 
 The **build + smoke + fixed-point diff + promote core is one `sfn selfhost`
@@ -366,9 +366,9 @@ most coverage:
   inherits this limitation; stage2/stage3 are always `-O2`. Not a regression
   (Make has the same gap today), but document it so nobody expects
   `--opt` to flow through.
-- **R2 — promotion safety:** promotion `cp -f seedcheck → build/native/sailfin`
+- **R2 — promotion safety:** promotion `cp -f seedcheck → build/bin/sfn`
   overwrites the canonical binary mid-`make check`. If `sfn selfhost` is itself
-  `build/native/sailfin` (the running process), overwriting its own on-disk image
+  `build/bin/sfn` (the running process), overwriting its own on-disk image
   is safe on Linux (the running inode persists), but `--no-promote` in tests
   avoids the question entirely. Keep promotion as the **last** step after the
   diff renders.

--- a/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
+++ b/docs/proposals/design-notes/1627-fail-closed-raw-unknown-effects.md
@@ -645,7 +645,7 @@ checker cannot resolve structurally contribute **zero effects, silently**:
   (`effect_checker.sfn:531`) has no `"Unknown"` arm and falls through to
   `return []` (`:621`).
 
-Reproduced and confirmed **live end to end** (`build/native/sailfin` 0.7.0-alpha.49):
+Reproduced and confirmed **live end to end** (`build/bin/sfn` 0.7.0-alpha.49):
 `fn f() { let x = print.info("hi") as * i64; }` passes `sfn check` (exit 0) with
 and without `SAILFIN_EFFECT_ENFORCE=1`, **and fires the side effect at runtime**
 (`[info] SIDE EFFECT FIRED`, run exits 0). An effectful operation reaches codegen

--- a/docs/proposals/design-notes/sfn-154-io-typed-reads.md
+++ b/docs/proposals/design-notes/sfn-154-io-typed-reads.md
@@ -325,8 +325,8 @@ No further splitting — one honest S/M issue, one PR, no seed cut.
   `compiler/src/llvm/runtime_helpers.sfn` (CI gate).
 - `make compile` — self-host from the pinned seed (mandatory for the io.sfn body +
   descriptor change; not structural, no `make clean-build`).
-- `build/native/sailfin test compiler/tests/integration/io_read_fd_test.sfn` and
-  `build/native/sailfin test compiler/tests/e2e/io_read_fd_effect_test.sfn` — the
+- `build/bin/sfn test compiler/tests/integration/io_read_fd_test.sfn` and
+  `build/bin/sfn test compiler/tests/e2e/io_read_fd_effect_test.sfn` — the
   retyped assertions, incl. the new EOF-null and blank-line cases and E0400.
 - `make check` — full triple-pass self-host + suite before declaring shipped.
 

--- a/docs/proposals/design-notes/unit-test-import-envelope.md
+++ b/docs/proposals/design-notes/unit-test-import-envelope.md
@@ -75,7 +75,7 @@ missing symbol.
 
 Open question 2 asked for a live reproduction (build a light-import test and a
 heavy-import test, capture the actual error). **This could not be executed in the
-spike environment:** there is no prebuilt `build/native/sailfin` and no seed
+spike environment:** there is no prebuilt `build/bin/sfn` and no seed
 binary on disk (`.seed-version` pins `0.7.0-alpha.19` but `build/seed/` is
 empty), and a from-scratch `make compile` is a 60–90 min self-host that exceeds
 the spike's tooling budget. The root cause above is therefore established by
@@ -165,7 +165,7 @@ future test authors know which `compiler/src` modules are unit-test-linkable.
 1. At least one test in `check_tool_test.sfn` imports a real exported symbol from the `tools/check.sfn` analysis area's dependency graph (`diagnostics_render`'s `join_effects` / `code_for_missing_effect`, which `tools/check.sfn:29` itself imports) instead of a `_local_*` copy.
 2. The `_local_*` helpers that have a linkable real peer are deleted from `check_tool_test.sfn` (`_local_join_effects`, `_local_code_for_first_description`; optionally `_local_build_effect_message`). The header comment documents which helpers remain (`_local_num_to_string`, `_local_render_summary`) and that the reason is heavy import closure, not linker capability.
 3. Mutating the real symbol (e.g. changing `join_effects`'s separator or `code_for_missing_effect`'s prefix logic in `compiler/src/diagnostics_render.sfn`) makes the migrated test FAIL — proving it exercises the real code, not a copy. (Verified by a temporary local edit during review; reverted.)
-4. No new segfaults or link failures: `build/native/sailfin test compiler/tests/unit/check_tool_test.sfn` passes, and the full `make test-unit` is green.
+4. No new segfaults or link failures: `build/bin/sfn test compiler/tests/unit/check_tool_test.sfn` passes, and the full `make test-unit` is green.
 5. `docs/conventions/` describes the supported test-import envelope (which `src` modules/symbols are linkable from unit tests and why heavy ones are not).
 
 ### Files Affected (corrected)
@@ -187,26 +187,26 @@ ulimit -v 8388608; make compile
 
 # 1. LIVE ROOT-CAUSE REPRO (record outputs in the PR).
 #    Light import — expected to LINK + PASS:
-ulimit -v 8388608; timeout 60 build/native/sailfin test \
+ulimit -v 8388608; timeout 60 build/bin/sfn test \
   compiler/tests/unit/check_tool_test.sfn
 #    Heavy import — author a throwaway test importing `number_to_string`
 #    from ../../src/main (or render_summary from ../../src/tools/check)
 #    and capture the actual failure (undefined ref / OOM / timeout):
-ulimit -v 8388608; timeout 60 build/native/sailfin test /tmp/heavy_import_test.sfn
+ulimit -v 8388608; timeout 60 build/bin/sfn test /tmp/heavy_import_test.sfn
 
 # 2. Migrated canary passes:
-ulimit -v 8388608; timeout 60 build/native/sailfin test \
+ulimit -v 8388608; timeout 60 build/bin/sfn test \
   compiler/tests/unit/check_tool_test.sfn
 
 # 3. AC#3 mutation check (temporary): change the ", " separator in
 #    diagnostics_render.join_effects, rebuild, confirm the migrated test
 #    FAILS, then revert.
 ulimit -v 8388608; make compile && \
-  build/native/sailfin test compiler/tests/unit/check_tool_test.sfn   # expect FAIL, then revert
+  build/bin/sfn test compiler/tests/unit/check_tool_test.sfn   # expect FAIL, then revert
 
 # 4. Full unit suite green + formatting:
 ulimit -v 8388608; make test-unit
-ulimit -v 8388608; timeout 30 build/native/sailfin fmt --check \
+ulimit -v 8388608; timeout 30 build/bin/sfn fmt --check \
   compiler/tests/unit/check_tool_test.sfn
 ```
 

--- a/docs/runbooks/build-quality.md
+++ b/docs/runbooks/build-quality.md
@@ -29,11 +29,11 @@ is a single command; everything else is reading its output.
 make compile                             # self-host from the pinned seed
 
 # First pass — warm the cache. Mirrors the workflow.
-build/native/sailfin build -p compiler \
+build/bin/sfn build -p compiler \
   --work-dir build/det-pass1 --json | tee pass1.json
 
 # Second pass — runs determinism check + emits the warm-cache BuildReport.
-build/native/sailfin build -p compiler \
+build/bin/sfn build -p compiler \
   --check-determinism \
   --work-dir build/det-pass2 --json | tee pass2.json
 
@@ -79,9 +79,9 @@ git bisect good <known-good-sha>          # last successful build-quality.yml ru
 git bisect run bash -c '
   set -euo pipefail
   make compile >/dev/null 2>&1 || exit 125    # 125 = skip (build broken here)
-  build/native/sailfin build -p compiler \
+  build/bin/sfn build -p compiler \
     --work-dir build/det-pass1 --json >/dev/null
-  build/native/sailfin build -p compiler \
+  build/bin/sfn build -p compiler \
     --check-determinism --work-dir build/det-pass2 --json > pass2.json
   jq -se ".[] | select(.check == \"determinism\") | .matches" pass2.json | grep -q true
 '

--- a/docs/status.md
+++ b/docs/status.md
@@ -130,7 +130,7 @@ here.
 ## Compiler Pipeline (Current)
 
 - `compiler/src/` is the primary toolchain; `make compile` produces
-  `build/native/sailfin`. Pipeline: Lexer → Parser → Type Checker →
+  `build/bin/sfn`. Pipeline: Lexer → Parser → Type Checker →
   Effect Checker → Native Emitter (`.sfn-asm`) → LLVM Lowering.
 - **Backend seam** (`compiler/src/backend.sfn`, #1112; SFEP-15 Stage 0):
   every codegen/link `clang` invocation routes through a `Backend` interface

--- a/examples/concurrency/parallel.sfn
+++ b/examples/concurrency/parallel.sfn
@@ -6,7 +6,7 @@
 // shared slot via a top-level worker, and `main` reads the joined totals
 // after the fan-out returns (the join establishes happens-before).
 //
-// Run: build/native/sailfin run examples/concurrency/parallel.sfn
+// Run: build/bin/sfn run examples/concurrency/parallel.sfn
 let mut g_results: int[] = [0, 0];
 
 fn computeTask1() -> int {

--- a/examples/web/http-server.sfn
+++ b/examples/web/http-server.sfn
@@ -11,7 +11,7 @@
 //     [dependencies]
 //     "sfn/http" = "*"
 //
-// then, from the capsule root:  build/native/sailfin run src/main.sfn
+// then, from the capsule root:  build/bin/sfn run src/main.sfn
 //
 // (Capsule functions are only staged into a consumer's codegen through a
 // declared dependency — running this file in place under examples/web/,

--- a/runtime/sfn/memory/rc.sfn
+++ b/runtime/sfn/memory/rc.sfn
@@ -1,7 +1,7 @@
 // runtime/sfn/memory/rc.sfn
 //
-// Sailfin-native reference counting primitive shipped into the
-// `build/bin/sfn` binary alongside the C runtime. M2.3
+// Sailfin-native reference counting primitive linked into the
+// `build/bin/sfn` binary. M2.3
 // (issue #395, epic #389) lights up the second Sailfin-defined
 // runtime module after `runtime/sfn/memory/arena.sfn`.
 //

--- a/runtime/sfn/memory/rc.sfn
+++ b/runtime/sfn/memory/rc.sfn
@@ -1,7 +1,7 @@
 // runtime/sfn/memory/rc.sfn
 //
 // Sailfin-native reference counting primitive shipped into the
-// `build/native/sailfin` binary alongside the C runtime. M2.3
+// `build/bin/sfn` binary alongside the C runtime. M2.3
 // (issue #395, epic #389) lights up the second Sailfin-defined
 // runtime module after `runtime/sfn/memory/arena.sfn`.
 //

--- a/runtime/sfn/platform/exec.sfn
+++ b/runtime/sfn/platform/exec.sfn
@@ -296,18 +296,18 @@ fn exe_path() -> * u8 ![io] {
 // scratch dirs); otherwise walks three candidates relative to
 // `binary_dir(exe_path)` in this exact order:
 //
-//   1. `<exe_dir>/runtime`         — dev-tree (the binary at
-//                                     `build/bin/sfn`
-//                                     sits next to
-//                                     `build/native/runtime/`).
+//   1. `<exe_dir>/runtime`         — runtime staged directly
+//                                     beside the binary (some
+//                                     packaged bin layouts).
 //   2. `<exe_dir>/../runtime`      — installed tree (binary at
-//                                     `~/.local/bin/sailfin`
-//                                     sits next to
-//                                     `~/.local/runtime/`).
-//   3. `<exe_dir>/../../runtime`   — packaged-bundle layout
-//                                     (binary nested two
-//                                     levels deep under a
-//                                     distribution prefix).
+//                                     `~/.local/bin/sfn` sits
+//                                     next to `~/.local/runtime/`).
+//   3. `<exe_dir>/../../runtime`   — dev-tree (`build/bin/sfn`,
+//                                     two levels under the repo
+//                                     root that holds `runtime/`)
+//                                     and packaged-bundle layouts
+//                                     nesting the binary two
+//                                     levels deep.
 //
 // Each candidate is `fs.exists`-probed; the first hit is
 // canonicalized via `realpath` and returned. Returns `""`

--- a/runtime/sfn/platform/exec.sfn
+++ b/runtime/sfn/platform/exec.sfn
@@ -297,7 +297,7 @@ fn exe_path() -> * u8 ![io] {
 // `binary_dir(exe_path)` in this exact order:
 //
 //   1. `<exe_dir>/runtime`         — dev-tree (the binary at
-//                                     `build/native/sailfin`
+//                                     `build/bin/sfn`
 //                                     sits next to
 //                                     `build/native/runtime/`).
 //   2. `<exe_dir>/../runtime`      — installed tree (binary at

--- a/scripts/bench_compile.sh
+++ b/scripts/bench_compile.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 #   bash scripts/bench_compile.sh --csv build/bench.csv
 #   bash scripts/bench_compile.sh --budget-time 60 --budget-mem 512000
 
-SEED="${SEED:-build/native/sailfin}"
+SEED="${SEED:-build/bin/sfn}"
 WORK_DIR="${WORK_DIR:-build/bench}"
 IMPORT_CONTEXT="${IMPORT_CONTEXT:-build/native/import-context}"
 CSV_OUT=""

--- a/scripts/bench_runtime.sh
+++ b/scripts/bench_runtime.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 #   bash scripts/bench_runtime.sh --csv build/runtime.csv
 #   bash scripts/bench_runtime.sh --top 3 --budget-time 1000 --budget-mem 512000
 
-SEED="${SEED:-build/native/sailfin}"
+SEED="${SEED:-build/bin/sfn}"
 WORK_DIR="${WORK_DIR:-build/bench-runtime}"
 CSV_OUT=""
 TOP_N=0

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -30,7 +30,7 @@
 
 set -u
 
-SAILFIN_BIN="${SAILFIN_BIN:-build/native/sailfin}"
+SAILFIN_BIN="${SAILFIN_BIN:-build/bin/sfn}"
 TIMEOUT="${SAILFIN_EXAMPLES_TIMEOUT:-25}"
 TSV=0
 [ "${1:-}" = "--tsv" ] && TSV=1

--- a/scripts/diag_determinism_sweep.sh
+++ b/scripts/diag_determinism_sweep.sh
@@ -10,12 +10,12 @@
 # Usage:
 #   scripts/diag_determinism_sweep.sh [--seed PATH] [--jobs N] [--iters N]
 #
-# Defaults: --seed build/native/sailfin  --jobs 4  --iters 10
+# Defaults: --seed build/bin/sfn  --jobs 4  --iters 10
 # Output:   /tmp/sailfin-diag-det/results.tsv + per-module .ll files
 
 set -u
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SEED="${SEED:-$REPO_ROOT/build/native/sailfin}"
+SEED="${SEED:-$REPO_ROOT/build/bin/sfn}"
 PAR=4
 ITERS=10
 

--- a/scripts/test_arena.sh
+++ b/scripts/test_arena.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 #   bash scripts/test_arena.sh examples/basics/functions.sfn  # specific module
 #   bash scripts/test_arena.sh --all                          # all basics/
 
-SEED="${SEED:-build/native/sailfin}"
+SEED="${SEED:-build/bin/sfn}"
 WORK_DIR="${WORK_DIR:-build/arena-test}"
 IMPORT_CONTEXT="${IMPORT_CONTEXT:-build/native/import-context}"
 

--- a/site/src/content/docs/docs/getting-started/install.md
+++ b/site/src/content/docs/docs/getting-started/install.md
@@ -272,7 +272,7 @@ sfn --version
 You can also run the binary directly without installing:
 
 ```bash
-build/native/sailfin --version
+build/bin/sfn --version
 ```
 
 > **Note:** `make compile` routes through `<seed> build -p compiler` — the

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -513,7 +513,7 @@ When `sfn test` is used, a non-zero exit code means at least one test failed. Al
 | `capsule.toml` | Capsule manifest — declares name, version, dependencies, and required capabilities |
 | `workspace.toml` | Workspace manifest — shared policies for multi-capsule projects |
 | `*.sfn-asm` | Native IR intermediate representation produced by `sfn emit native` |
-| `build/native/sailfin` | Default output path for the self-hosted compiler binary |
+| `build/bin/sfn` | Default output path for the self-hosted compiler binary |
 | `build/seed/bin/sailfin` | Default path for the downloaded seed compiler |
 | `dist/` | Release packaging output directory |
 
@@ -556,7 +556,7 @@ make rebuild
 **Run only unit tests in a specific directory:**
 
 ```bash
-build/native/sailfin test compiler/tests/unit/
+build/bin/sfn test compiler/tests/unit/
 ```
 
 **Run the CI validation gate locally:**

--- a/site/src/content/docs/docs/reference/runtime-abi.md
+++ b/site/src/content/docs/docs/reference/runtime-abi.md
@@ -113,7 +113,7 @@ define i32 @main(i32 %argc, i8** %argv) {
 ```
 
 In LLVM IR the entry symbol is spelled `@main`; after linking, tools
-like `nm` show it without the `@` sigil. `nm build/native/sailfin |
+like `nm` show it without the `@` sigil. `nm build/bin/sfn |
 grep -E ' T main$'` shows exactly one `T main` row, sourced from the
 Sailfin-emitted definition in `compiler/src/llvm/lowering/` (see
 the Runtime Migration table in `docs/status.md` for the pipeline trace).

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -8,15 +8,15 @@ Part of the "AI agents are users" strategy described in [`CLAUDE.md`](../../CLAU
 
 | Tool | Compiler invocation | Purpose |
 |---|---|---|
-| `sailfin_version` | `sailfin version` | Smoke test — returns the compiler version. Fails loudly if `build/bin/sfn` is missing. |
-| `sailfin_check` | `sailfin check <path>` | Type + effect check a single `.sfn` file. Fast feedback during edits. |
-| `sailfin_diagnostics` | `sailfin check --json <path>` | Same analysis as `sailfin_check`, returned as the `sailfin-check/1` JSON envelope for programmatic consumption. |
-| `sailfin_emit_native` | `sailfin emit native <path>` | Emit `.sfn-asm` intermediate representation. Use for emit-stage diagnosis. |
-| `sailfin_emit_llvm` | `sailfin emit llvm <path>` | Emit LLVM IR. Use for lowering-stage or linker diagnosis. |
-| `sailfin_fmt_check` | `sailfin fmt --check <path>` | Report formatting differences without rewriting. |
-| `sailfin_fmt_write` | `sailfin fmt --write <path>` | Reformat a file or directory in place (canonical). Run before committing to satisfy the CI `fmt --check` gate. |
-| `sailfin_build` | `sailfin build <file>` / `-p <capsule>` | Build a single `.sfn` file or a capsule to a native binary. **Not** the compiler self-host (see below). |
-| `sailfin_test` | `sailfin test <path> [-k <name>] [--jobs N] [--json]` | Run a targeted suite directory or a single `_test.sfn` file. `path` required. |
+| `sailfin_version` | `sfn version` | Smoke test — returns the compiler version. Fails loudly if `build/bin/sfn` is missing. |
+| `sailfin_check` | `sfn check <path>` | Type + effect check a single `.sfn` file. Fast feedback during edits. |
+| `sailfin_diagnostics` | `sfn check --json <path>` | Same analysis as `sailfin_check`, returned as the `sailfin-check/1` JSON envelope for programmatic consumption. |
+| `sailfin_emit_native` | `sfn emit native <path>` | Emit `.sfn-asm` intermediate representation. Use for emit-stage diagnosis. |
+| `sailfin_emit_llvm` | `sfn emit llvm <path>` | Emit LLVM IR. Use for lowering-stage or linker diagnosis. |
+| `sailfin_fmt_check` | `sfn fmt --check <path>` | Report formatting differences without rewriting. |
+| `sailfin_fmt_write` | `sfn fmt --write <path>` | Reformat a file or directory in place (canonical). Run before committing to satisfy the CI `fmt --check` gate. |
+| `sailfin_build` | `sfn build <file>` / `-p <capsule>` | Build a single `.sfn` file or a capsule to a native binary. **Not** the compiler self-host (see below). |
+| `sailfin_test` | `sfn test <path> [-k <name>] [--jobs N] [--json]` | Run a targeted suite directory or a single `_test.sfn` file. `path` required. |
 
 **Design rule:** every tool is a *pure passthrough* to one `sailfin` subcommand — no build/test orchestration lives in the server. In particular, `sailfin_build` does **not** self-host the compiler: that build needs seed resolution and extern pre-staging (`make rebuild`), and the tool deliberately does not replicate it. Use `make compile` for the self-host build until that orchestration folds into the driver.
 

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -8,7 +8,7 @@ Part of the "AI agents are users" strategy described in [`CLAUDE.md`](../../CLAU
 
 | Tool | Compiler invocation | Purpose |
 |---|---|---|
-| `sailfin_version` | `sailfin version` | Smoke test — returns the compiler version. Fails loudly if `build/native/sailfin` is missing. |
+| `sailfin_version` | `sailfin version` | Smoke test — returns the compiler version. Fails loudly if `build/bin/sfn` is missing. |
 | `sailfin_check` | `sailfin check <path>` | Type + effect check a single `.sfn` file. Fast feedback during edits. |
 | `sailfin_diagnostics` | `sailfin check --json <path>` | Same analysis as `sailfin_check`, returned as the `sailfin-check/1` JSON envelope for programmatic consumption. |
 | `sailfin_emit_native` | `sailfin emit native <path>` | Emit `.sfn-asm` intermediate representation. Use for emit-stage diagnosis. |
@@ -53,7 +53,7 @@ npx @modelcontextprotocol/inspector node tools/mcp-server/dist/index.js
 ## Contract
 
 - Tools **never throw** on compiler non-zero exit — they return `isError: true` with structured `{exit, stdout, stderr, duration_ms, timed_out}` so the caller can iterate on diagnostics.
-- If `build/native/sailfin` is missing, every tool returns a clean error telling the caller to run `make compile`.
+- If `build/bin/sfn` is missing, every tool returns a clean error telling the caller to run `make compile`.
 - Paths outside the workspace (e.g. `/etc/passwd`, `../../elsewhere`) are rejected before invocation.
 
 ## Roadmap

--- a/tools/mcp-server/src/sailfin.ts
+++ b/tools/mcp-server/src/sailfin.ts
@@ -1,4 +1,4 @@
-// Wrapper around `build/native/sailfin` invocations.
+// Wrapper around `build/bin/sfn` invocations.
 //
 // Every call from the MCP server funnels through `runSailfin` so the
 // memory cap, timeout, and workspace-path check live in exactly one place.
@@ -40,14 +40,14 @@ export function workspaceRoot(): string {
 
 export function compilerPath(): string {
   const suffix = process.platform === "win32" ? ".exe" : "";
-  return path.join(workspaceRoot(), "build", "native", `sailfin${suffix}`);
+  return path.join(workspaceRoot(), "build", "bin", `sfn${suffix}`);
 }
 
 export function assertCompilerExists(): void {
   const bin = compilerPath();
   if (!existsSync(bin)) {
     throw new SailfinError(
-      `build/native/sailfin not found at ${bin}. Run \`make compile\` first.`,
+      `build/bin/sfn not found at ${bin}. Run \`make compile\` first.`,
     );
   }
 }
@@ -111,7 +111,7 @@ export async function runSailfin(
   // compiler self-applies its 8 GiB memory budget on Linux, #1291.)
   //
   // `-l` sources the user's login profile (~/.bash_profile etc.). This
-  // is deliberate — we need the user's PATH so `build/native/sailfin`
+  // is deliberate — we need the user's PATH so `build/bin/sfn`
   // can locate `clang` and the rest of the toolchain. It does mean a
   // poisoned shell profile can influence the execution environment;
   // acceptable for a local dev tool, revisit if this server ever runs

--- a/tools/mcp-server/test/smoke.test.ts
+++ b/tools/mcp-server/test/smoke.test.ts
@@ -30,7 +30,7 @@ interface Rpc {
 
 /**
  * Create a temporary workspace containing a stub compiler at
- * build/native/sailfin. The stub echoes a predictable payload on stdout
+ * build/bin/sfn. The stub echoes a predictable payload on stdout
  * so tests can assert on the MCP response shape.
  */
 function makeStubWorkspace(opts: {
@@ -43,7 +43,7 @@ function makeStubWorkspace(opts: {
   const stderrBody = opts.stderrBody ?? "";
 
   const root = mkdtempSync(path.join(tmpdir(), "sailfin-mcp-test-"));
-  mkdirSync(path.join(root, "build", "native"), { recursive: true });
+  mkdirSync(path.join(root, "build", "bin"), { recursive: true });
 
   const stub = `#!/usr/bin/env bash
 # Stub compiler for MCP smoke tests.
@@ -51,7 +51,7 @@ printf '%s' ${JSON.stringify(stdoutBody)}
 >&2 printf '%s' ${JSON.stringify(stderrBody)}
 exit ${exit}
 `;
-  const stubPath = path.join(root, "build", "native", "sailfin");
+  const stubPath = path.join(root, "build", "bin", "sfn");
   writeFileSync(stubPath, stub);
   chmodSync(stubPath, 0o755);
   return root;
@@ -241,7 +241,7 @@ test("workspace-boundary guard rejects /etc/passwd before invoking the compiler"
 });
 
 test("missing compiler binary returns a clean actionable error", async () => {
-  // Fresh temp dir with no build/native/sailfin stub.
+  // Fresh temp dir with no build/bin/sfn stub.
   const empty = mkdtempSync(path.join(tmpdir(), "sailfin-mcp-empty-"));
   await withServer(empty, async (client) => {
     const resp = await client.request("tools/call", {


### PR DESCRIPTION
## Summary

Renames the compiler binary this checkout produces from the Python-bootstrap-era `build/native/sailfin` path to the CLI name users actually install and run: `build/bin/sfn` (`.exe` on Windows). The installed command was already `sfn` (`INSTALL_NAME`); this makes the in-tree artifact, build logs, CI artifacts, MCP messages, and docs match it. Repo/build-layout cleanup only — packaged CLI behavior is unchanged.

Fixes SFN-173

## Changes

- **Makefile** — `NATIVE_OUT`/`NATIVE_BIN` → `build/bin/sfn$(EXE_EXT)`; selfhost first-pass/seedcheck/stage3 → `build/bin/sfn{,-seedcheck,-stage3}`; `mkdir -p $(dir $(NATIVE_OUT))` so `build/bin` exists before the canonical copy. `make install` still installs `$(INSTALL_NAME)` (`sfn`) from `build/bin/sfn`.
- **CI** (`.github/workflows/*`, `actions/sailfin-build`) — cache `paths=`, artifact upload/download, `touch`/`ls`, and direct invocations → `build/bin/sfn`. The out-of-scope siblings `build/native/{import-context,obj,raw,.build-stamp,.build-report.json}` are retained.
- **MCP server** — `compilerPath()` and the smoke-test stub → `build/bin/sfn` (segment-built paths, hand-edited).
- **driver / tests** — `compiler/src` self-exe **name** reconstructions that the literal rename could not reach: `_cr_effective_isolation_exe` (`capsule_resolver.sfn`), the `-p` emit binary (`build.sfn:313`), and `_resolve_test_self_path` (`test.sfn`) rebuilt the running binary's name as `sailfin` from a dynamic dir → non-existent `build/bin/sailfin` (parallel test runner `Error 127`). Now `sfn` / probe-both; this also fixes a latent break for an *installed* `sfn` compiler. All 200+ e2e/capsule `_sfn_bin()` / `_resolve_sfn_bin` fallbacks → `build/bin/sfn`.
- **docs / scripts / runbooks / templates / agent instructions / active proposals** → `build/bin/sfn`.

`fmt --write` additionally normalized pre-existing import-order / string-concat drift in 12 touched e2e test files (test files aren't in the CI fmt gate, so the drift was latent); kept as canonical fmt output.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (via `make check-fast`) — 238 files ok
- [x] `make compile` — compiler self-hosts; artifact at `build/bin/sfn`
- [ ] `make check` — not run (build/bin path change; `make compile` self-host + full unit suite + check-fast cover it; the seedcheck/stage3 paths are exercised by the Makefile flag change)
- [x] Regression coverage: existing suites exercise the changed paths (MCP smoke stub, parallel test runner, e2e `_sfn_bin`); no new test needed for a path rename
- [x] `build/bin/sfn version` → `sfn 0.8.0-alpha.2`; `make test-unit` → green; `tools/mcp-server` `npm test` → 13/13

## Acceptance criteria

- [x] `make compile` produces `build/bin/sfn`; `build/native/sailfin` is no longer canonical
- [x] `make install` installs `$(INSTALL_NAME)` from `build/bin/sfn`
- [x] `make check` invokes first-pass/seedcheck/stage3 from `build/bin/...`
- [x] MCP tooling reports the new path
- [x] CI caches/uploads/downloads/invokes the new path
- [x] Repo-wide search: gone except intentional historical/archive text
- [x] Docs verification commands updated to `build/bin/sfn`

## Map reconciliation

Advisory `## Files Affected` matched the tree. Reconciled additions the map didn't enumerate but that fall under the same `In:` units: the 200+ e2e/capsule test `_sfn_bin()` fallbacks, `capsules/sfn/test/src/compile_assert.sfn`, the compiler self-exe name reconstructions, and `.claude`/`.codex`/`.github` agent instructions. Out-of-scope items left untouched: `build/native/import-context`, the `build/sailfin` cache dir, `<work-dir>/native/sailfin` selfhost scratch, the package/installer `sailfin` distribution label, and the seed at `build/seed/bin/sailfin`.

## Notes for reviewers

- Residual `build/native/sailfin` survives only in the historical carve-out (`docs/rca/`, `docs/proposals/archive/`) — archive text describing past state.
- No compatibility symlink was added: the rename is comprehensive (every live reference updated), so a `build/native/sailfin -> ../bin/sfn` shim would only reintroduce the string the acceptance criterion wants gone.
- Non-blocking follow-up (not actioned — mechanical rename): the two hardcoded `binary_dir + "/sfn"` isolation-exe builders could route through the fs-probing `_resolve_self_path` for full future-proofing; correct as written since the built binary is invariantly `sfn`.
- Reviewed by the Opus `code-reviewer` (self-exe reconstructions, no sed over-match, self-host safety, CI/Makefile/MCP consistency): no blocking issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKh6TSA2UbjQAzrrd4YnXe)_