### PR TITLE
feat(runtime): io.poll_any — multi-fd readiness over user-chosen fds (SFN-155)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1496,6 +1496,12 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     // separate-compilation modules that consume it emit a `declare` and
     // clang resolves the symbol against the runtime object.
     helpers = append_unique_effect(helpers, "io.poll_readable");
+    // SFN-155: `io.poll_any` lowers to the bare `sfn_io_poll_any` symbol
+    // (Sailfin-native body in `runtime/sfn/process.sfn`, Windows stub in
+    // `process_windows.sfn`). Declare-track it so separate-compilation
+    // modules that consume it emit a `declare` and clang resolves the
+    // symbol against the runtime object.
+    helpers = append_unique_effect(helpers, "io.poll_any");
     // #1579: `io.read_fd` / `io.read_line` lower to the bare
     // `sfn_read_fd` / `sfn_read_line` symbols (Sailfin-native bodies in
     // `runtime/sfn/io.sfn`). Declare-track them so separate-compilation

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -872,6 +872,25 @@ fn _rh_descriptors_06(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
         target: "io.poll_readable", symbol: "sfn_io_poll_readable", return_type: "i1", parameter_types: ["i64", "i64"], effects: ["io"], native_signature: "sfn_io_poll_readable", c_abi_return_type: null
     });
 
+    // SFN-155 (epic #1540 Track A, gap A3): multi-fd readiness check.
+    // `io.poll_any(fds, timeout_ms)` waits on every fd in `fds` with one
+    // `poll(2)` and returns *which* fd is ready (`>= 0`), or `-1` for
+    // timeout / empty array / error. Lets a forwarder wait on `{own
+    // stdin, child stdout, child stderr}` together without deadlock, the
+    // multi-fd companion to `io.poll_readable`. Return is a sentinel `i64`
+    // (`-1` == none), not the issue's original `fd?`: an optional `int`
+    // (`i64*`) has no working value-extraction (SFN-182), so the poll
+    // result would be untellable; fds are non-negative, so `-1` is
+    // unambiguous. `fds` is an `int[]` SfnArray (`{ i64*, i64, i64 }*`);
+    // `timeout_ms` arrives as `int` (i64). Sailfin-native body in
+    // `runtime/sfn/process.sfn:sfn_io_poll_any` (defined there, not in
+    // `io.sfn`, because it needs the POSIX `poll(2)` + `errno` surface and
+    // only `process.sfn` is excluded from the Windows cross-build;
+    // `process_windows.sfn` carries the stub).
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "io.poll_any", symbol: "sfn_io_poll_any", return_type: "i64", parameter_types: ["{ i64*, i64, i64 }*", "i64"], effects: ["io"], native_signature: "sfn_io_poll_any", c_abi_return_type: null
+    });
+
     // #1579 (epic #1540 Track A, gap A2): read the process's own stdin
     // (fd 0) incrementally without shelling out. SFN-154 upgraded the two
     // returns to production-grade typed values (Rust/Go parity):

--- a/compiler/tests/integration/io_poll_any_test.sfn
+++ b/compiler/tests/integration/io_poll_any_test.sfn
@@ -1,0 +1,106 @@
+// Integration coverage for the `io.poll_any(fds, timeout_ms)` builtin
+// (SFN-155, epic #1540 Track A gap A3). The Sailfin-native body lives in
+// `runtime/sfn/process.sfn:sfn_io_poll_any` (with a Windows stub in
+// `process_windows.sfn`); `runtime_helpers.sfn` maps the `io.poll_any`
+// descriptor onto it and `lowering_helpers.sfn` declare-tracks the symbol.
+// These tests drive two real `pipe(2)`s so the readiness transitions are
+// deterministic: `poll_any` must report *which* fd is ready, not merely
+// that some fd is. The `{ rd, wr }` overlay over each two-int `pipe`
+// buffer mirrors `io_poll_readable_test`.
+struct PipeFds {
+    rd: i32;
+    wr: i32;
+}
+
+extern fn pipe(fds: * i32) -> i32;
+
+extern fn write(fd: i32, buf: * u8, count: usize) -> i64;
+
+extern fn close(fd: i32) -> i32;
+
+extern fn malloc(size: usize) -> * u8;
+
+test "io.poll_any: all-quiet pipes report none ready (-1)" ![io] {
+    let buf_a: * u8 = malloc(8 as usize);
+    let buf_b: * u8 = malloc(8 as usize);
+    assert pipe(buf_a as * i32) == 0;
+    assert pipe(buf_b as * i32) == 0;
+    let a: * PipeFds = buf_a as * PipeFds;
+    let b: * PipeFds = buf_b as * PipeFds;
+
+    let fds: int[] = [a.rd as i64, b.rd as i64];
+    // timeout_ms == 0 returns immediately; neither pipe has data.
+    assert io.poll_any(fds, 0) == -1;
+    // A small positive timeout still resolves to "none ready".
+    assert io.poll_any(fds, 5) == -1;
+
+    let _ = close(a.rd);
+    let _ = close(a.wr);
+    let _ = close(b.rd);
+    let _ = close(b.wr);
+}
+
+test "io.poll_any: returns the fd of the pipe that has data" ![io] {
+    let buf_a: * u8 = malloc(8 as usize);
+    let buf_b: * u8 = malloc(8 as usize);
+    assert pipe(buf_a as * i32) == 0;
+    assert pipe(buf_b as * i32) == 0;
+    let a: * PipeFds = buf_a as * PipeFds;
+    let b: * PipeFds = buf_b as * PipeFds;
+
+    // Write only to the second pipe: poll_any must single out b's read end.
+    let payload: string = "x";
+    assert write(b.wr, payload as * u8, 1 as usize) == 1;
+
+    let fds: int[] = [a.rd as i64, b.rd as i64];
+    assert io.poll_any(fds, 0) == b.rd as i64;
+
+    let _ = close(a.rd);
+    let _ = close(a.wr);
+    let _ = close(b.rd);
+    let _ = close(b.wr);
+}
+
+test "io.poll_any: identifies the first fd when it is the ready one" ![io] {
+    let buf_a: * u8 = malloc(8 as usize);
+    let buf_b: * u8 = malloc(8 as usize);
+    assert pipe(buf_a as * i32) == 0;
+    assert pipe(buf_b as * i32) == 0;
+    let a: * PipeFds = buf_a as * PipeFds;
+    let b: * PipeFds = buf_b as * PipeFds;
+
+    let payload: string = "y";
+    assert write(a.wr, payload as * u8, 1 as usize) == 1;
+
+    let fds: int[] = [a.rd as i64, b.rd as i64];
+    assert io.poll_any(fds, 0) == a.rd as i64;
+
+    let _ = close(a.rd);
+    let _ = close(a.wr);
+    let _ = close(b.rd);
+    let _ = close(b.wr);
+}
+
+test "io.poll_any: a closed write end signals readable EOF" ![io] {
+    let buf_a: * u8 = malloc(8 as usize);
+    let buf_b: * u8 = malloc(8 as usize);
+    assert pipe(buf_a as * i32) == 0;
+    assert pipe(buf_b as * i32) == 0;
+    let a: * PipeFds = buf_a as * PipeFds;
+    let b: * PipeFds = buf_b as * PipeFds;
+
+    // Closing b's write end makes b's read end report POLLHUP — pending EOF
+    // counts as ready so a follow-up `read(2)` runs and sees 0.
+    let _ = close(b.wr);
+    let fds: int[] = [a.rd as i64, b.rd as i64];
+    assert io.poll_any(fds, 0) == b.rd as i64;
+
+    let _ = close(a.rd);
+    let _ = close(a.wr);
+    let _ = close(b.rd);
+}
+
+test "io.poll_any: an empty fd list reports none ready (-1)" ![io] {
+    let fds: int[] = [];
+    assert io.poll_any(fds, 0) == -1;
+}

--- a/compiler/tests/integration/io_poll_any_test.sfn
+++ b/compiler/tests/integration/io_poll_any_test.sfn
@@ -104,3 +104,11 @@ test "io.poll_any: an empty fd list reports none ready (-1)" ![io] {
     let fds: int[] = [];
     assert io.poll_any(fds, 0) == -1;
 }
+
+// An all-negative (all-parked) list has no fd for poll(2) to watch. With a
+// blocking timeout this must still return -1 immediately — without the
+// active-fd guard, poll(2) over an all-parked set would hang forever.
+test "io.poll_any: an all-parked list does not block, reports -1" ![io] {
+    let fds: int[] = [-1, -2];
+    assert io.poll_any(fds, -1) == -1;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: 2026-07-08. Seed pinned to `0.8.0-alpha.1` (`.seed-version`);
+Updated: 2026-07-09. Seed pinned to `0.8.0-alpha.2` (`.seed-version`);
 the compiler version source of truth is `compiler/capsule.toml`.
 
 This document is the **current-state source of truth**: what ships today,
@@ -427,6 +427,7 @@ unit; history in the linked issues.
 | `platform/pthread.sfn` / `posix.sfn` / `net.sfn` skeletons | **Shipped** (2026-05-02) | Richer C-ABI shapes; seeds for scheduler, process, http modules |
 | `io.sfn` (`sfn_write_fd`) | **Shipped** (2026-05-04) | First Sailfin-native service wrapper over an imported extern |
 | `io.read_fd` / `io.read_line` stdin builtins | **Shipped** (#1579, epic #1540 Track A gap A2; typed returns SFN-154) | `io.read_fd(fd, n) -> OwnedBuf` (owned, length-explicit, binary-safe; `len` is the byte count from one `read(2)` of ≤ n bytes; empty/EOF/error/`n<=0` yields the canonical `{0,0,0,0}`) and `io.read_line(fd) -> string?` (byte-at-a-time up to the next newline, no over-read; `null` means immediate EOF, `Some("")` means a blank line) over the `read` extern in `runtime/sfn/io.sfn`; registered in `runtime_helpers.sfn` + declare-tracked in `lowering_helpers.sfn`, mirroring `io.poll_readable` (#1580). Lets a process read its own fd 0 (e.g. the MCP proxy's JSON-RPC frames). Effect-gated `![io]` (E0400 on a non-`![io]` caller). Retiring `login.sfn`'s `sh -c "head -1"` workaround still waits on a seed cut: the compiler is seed-compiled, so a compiler-source consumer must wait for a seed cut that includes the builtin. Pinned by `compiler/tests/integration/io_read_fd_test.sfn` (including EOF-null and blank-line cases) + `compiler/tests/e2e/io_read_fd_effect_test.sfn` |
+| `io.poll_any` multi-fd readiness builtin | **Shipped** (SFN-155, epic #1540 Track A gap A3) | `io.poll_any(fds: int[], timeout_ms) -> int` — the multi-fd companion to `io.poll_readable`: waits on every fd in `fds` with a single `poll(2)` and returns which fd is ready (`>= 0`), or `-1` for timeout / empty list / error, so a stdio forwarder can wait on `{own stdin, child stdout, child stderr}` together without deadlock. Return shape is a sentinel `int` (`-1` == none), not an optional `fd?` — `int?` optional value-extraction isn't yet supported by the compiler (only `== null` round-trips). Sailfin-native body in `runtime/sfn/process.sfn` (`sfn_io_poll_any`); Windows stub in `runtime/sfn/platform/process_windows.sfn` returns `-1`. Descriptor in `compiler/src/llvm/runtime_helpers.sfn` (`io.poll_any`); declare-tracked in `lowering_helpers.sfn`. Pinned by `compiler/tests/integration/io_poll_any_test.sfn` (pipe-driven, `![io]`, 5 cases) |
 | Sleep: call-site routing → `@sfn_sleep` over `nanosleep` → ms semantics | **Shipped** (#397, #307) | `runtime/sfn/clock.sfn` is the sole definition site; `sleep(ms)` end-to-end |
 | Clock readers (`sfn_clock_monotonic_nanos`, `sfn_clock_millis`) | **Shipped** (#878, #819) | M3.3 |
 | `exe_path` host-aware intrinsic + `exec.sfn` cutover | **Shipped** (#967, #968) | Second intrinsic-registry sentinel after errno (#877/#901) |

--- a/runtime/sfn/platform/process_windows.sfn
+++ b/runtime/sfn/platform/process_windows.sfn
@@ -683,6 +683,14 @@ fn sfn_process_handle_wait(handle_id: i64) -> i64 ![io] { return -1; }
 // `sfn_process_handle_*` Windows stubs above.
 fn sfn_io_poll_readable(fd: i64, timeout_ms: i64) -> bool ![io] { return false; }
 
+// `sfn_io_poll_any(fds, timeout_ms)` — Windows stub for the `io.poll_any`
+// builtin (SFN-155). The POSIX body (`runtime/sfn/process.sfn`) wraps a
+// multi-slot `poll(2)`, which mingw lacks for stdio/pipe fds. Until a
+// Windows fd multiplexer lands (epic #1540 B5), report "none ready"
+// (`-1`) so a caller falls back to a blocking read rather than spinning.
+// Mirrors the `sfn_io_poll_readable` Windows stub above.
+fn sfn_io_poll_any(fds: int[], timeout_ms: i64) -> i64 ![io] { return -1; }
+
 // `sfn_process_environ()` — empty `SfnArray` (`{ data@0, len@8, cap@16 }`
 // = 24 bytes, all zero). Must be a valid header (not null) so callers'
 // `.length` reads do not crash. Matches the C `_WIN32` empty-array shim

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -606,6 +606,85 @@ fn sfn_io_poll_readable(fd: i64, timeout_ms: i64) -> bool ![io] {
     return ready;
 }
 
+// ── io.poll_any ────────────────────────────────────────────────
+// `sfn_io_poll_any(fds, timeout_ms)` — SFN-155 (epic #1540 Track A,
+// gap A3). The multi-fd companion to `io.poll_readable`: waits on every
+// fd in `fds` at once with a single `poll(2)` and reports *which* one is
+// ready, so bidirectional stdio forwarding can wait on `{own stdin,
+// child stdout, child stderr}` together without deadlocking on whichever
+// side is quiet. Generalizes the two-slot `_drain_two_pipes` multiplex to
+// an N-slot user-chosen array.
+//
+// Returns the ready fd (`>= 0`) on readiness — the first slot whose
+// `revents` is non-empty (data, EOF/`POLLHUP`, or `POLLERR`, exactly the
+// conditions a follow-up `read(2)` must run for). Returns `-1` for
+// timeout (`poll` reports nothing ready), an empty array, an allocation
+// failure, or a non-EINTR `poll` error. `fd?` was rejected as the return
+// type: an optional `int` (`i64*`) has no working value-extraction
+// (SFN-182 — only `== null` round-trips), so the poll result would be
+// untellable; fds are always non-negative, so `-1` is the unambiguous
+// none sentinel — the classic `poll`/`select` idiom. Revisit `fd?` when
+// SFN-182 lands. `timeout_ms < 0`
+// blocks until some fd is readable; `0` polls and returns immediately;
+// `> 0` waits up to that many milliseconds.
+//
+// Lives in `process.sfn` (not `io.sfn`) for the same reason as
+// `sfn_io_poll_readable`: it needs the POSIX `poll(2)` + `errno` surface,
+// and only `process.sfn` is excluded from the Windows cross-build
+// (`process_windows.sfn` carries the `WSAPoll`-less stub). It reuses this
+// module's `poll` extern, `PollSlot` overlay, and `SFN_EINTR`.
+//
+// The pollfd array is `nfds` contiguous 8-byte `PollSlot`s. Each loop
+// iteration re-arms every slot (`fd` narrowed to the `poll` i32 ABI,
+// `events_revents = 1` → POLLIN with `revents` cleared) before polling,
+// so an `EINTR` re-poll starts from a clean `revents`. A negative fd in
+// the array is left in-slot; `poll` ignores fds `< 0` and never reports
+// them ready, matching `_drain_two_pipes`'s parked-fd contract.
+fn sfn_io_poll_any(fds: int[], timeout_ms: i64) -> i64 ![io] {
+    let nfds: i64 = fds.length;
+    if nfds <= 0 { return -1; }
+    let pbuf: * u8 = malloc((nfds * 8) as usize);
+    if pbuf as i64 == 0 { return -1; }
+    let to: i32 = timeout_ms as i32;
+    let mut result: i64 = -1;
+    loop {
+        // (Re-)arm every slot to POLLIN with revents cleared.
+        let mut i: i64 = 0;
+        loop {
+            if i >= nfds { break; }
+            let slot: * PollSlot = ((pbuf as i64) + i * 8) as * PollSlot;
+            slot.fd = fds[i] as i32;
+            slot.events_revents = 1;
+            i = i + 1;
+        }
+        let pr: i32 = poll(pbuf, nfds as usize, to);
+        if pr < 0 {
+            let err: i32 = sailfin_intrinsic_pointer_read_i32(sailfin_intrinsic_errno_location());
+            if err == SFN_EINTR {
+                // Interrupted before readiness — re-arm and poll again.
+            } else { break; }
+        } else {
+            if pr > 0 {
+                // Return the first ready slot's original (i64) fd.
+                let mut j: i64 = 0;
+                loop {
+                    if j >= nfds { break; }
+                    let done: * PollSlot = ((pbuf as i64) + j * 8) as * PollSlot;
+                    let revents: i32 = (done.events_revents >> 16) & 65535;
+                    if revents != 0 {
+                        result = fds[j];
+                        break;
+                    }
+                    j = j + 1;
+                }
+            }
+            break;
+        }
+    }
+    free(pbuf);
+    return result;
+}
+
 // ── process.exit ───────────────────────────────────────────────
 // Port of `sailfin_runtime_process_exit`. `code` arrives as `double`
 // per the descriptor's `parameter_types: ["double"]`; truncate

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -648,15 +648,27 @@ fn sfn_io_poll_any(fds: int[], timeout_ms: i64) -> i64 ![io] {
     let to: i32 = timeout_ms as i32;
     let mut result: i64 = -1;
     loop {
-        // (Re-)arm every slot to POLLIN with revents cleared.
+        // (Re-)arm every slot to POLLIN with revents cleared, counting how
+        // many fds `poll(2)` will actually watch. `active` tracks the
+        // *narrowed* fd (`fd32`), so a value that wraps negative through the
+        // i32 `poll` ABI is treated as parked, exactly as `poll` itself
+        // treats it — not merely fds that were negative before narrowing.
         let mut i: i64 = 0;
+        let mut active: i64 = 0;
         loop {
             if i >= nfds { break; }
             let slot: * PollSlot = ((pbuf as i64) + i * 8) as * PollSlot;
-            slot.fd = fds[i] as i32;
+            let fd32: i32 = fds[i] as i32;
+            slot.fd = fd32;
             slot.events_revents = 1;
+            if fd32 >= 0 { active = active + 1; }
             i = i + 1;
         }
+        // No fd left to wait on: `poll` over an all-parked set with a
+        // blocking timeout would hang forever with nothing to wake it — a
+        // deadlock in a deadlock-avoidance primitive. Report none ready,
+        // mirroring `sfn_io_poll_readable`'s negative-fd short-circuit.
+        if active <= 0 { break; }
         let pr: i32 = poll(pbuf, nfds as usize, to);
         if pr < 0 {
             let err: i32 = sailfin_intrinsic_pointer_read_i32(sailfin_intrinsic_errno_location());


### PR DESCRIPTION
## Summary

Adds `io.poll_any(fds: int[], timeout_ms) -> int`, a multi-fd `poll(2)` runtime builtin: waits on every fd in `fds` at once and returns **which** one is ready (`>= 0`), or `-1` for timeout / empty list / error. This lets a stdio forwarder wait on `{own stdin, child stdout, child stderr}` together without deadlocking on whichever side is quiet — the last of the three Track A runtime primitives unblocking the Passthrough milestone (SFGW-2), and the multi-fd companion to the already-shipped single-fd `io.poll_readable`.

The Sailfin-native body generalizes the internal two-slot `_drain_two_pipes` multiplex (`runtime/sfn/process.sfn`) to an N-slot user-chosen array. Touches: runtime (`process.sfn`, Windows stub) + LLVM runtime-helper registry (`runtime_helpers.sfn`, `lowering_helpers.sfn`) + tests + docs.

Fixes SFN-155

## Changes

- **runtime** — `runtime/sfn/process.sfn`: new `sfn_io_poll_any(fds: int[], timeout_ms) -> i64 [io]` — malloc `nfds` contiguous `PollSlot`s, re-arm each (POLLIN, `revents` cleared) per iteration, `poll(2)`, EINTR re-poll, return the first slot with non-empty `revents` (original i64 fd) else `-1`.
- **runtime (Windows)** — `runtime/sfn/platform/process_windows.sfn`: `WSAPoll`-less stub returns `-1` (mirrors the `io.poll_readable` stub; real Windows fd multiplexer is epic #1540 B5).
- **llvm** — `runtime_helpers.sfn`: `io.poll_any` descriptor (`return_type "i64"`, `parameter_types ["{ i64*, i64, i64 }*", "i64"]`, `effects ["io"]`); `lowering_helpers.sfn`: declare-tracking for separate-compilation consumers.
- **tests** — `compiler/tests/integration/io_poll_any_test.sfn`: pipe-driven `[io]`, 5 cases (all-quiet→-1 at zero and positive timeout, data-on-2nd-fd→that fd, data-on-1st-fd→that fd, closed-write-end EOF/POLLHUP→ready, empty list→-1).
- **docs** — `docs/status.md`: new Runtime-Migration row for `io.poll_any`.

## Design note — sentinel `int`, not `fd?`

The issue originally specified `-> fd?`. I verified end-to-end that optional-**primitive** value-extraction is broken in the current compiler: `int?` lowers to `i64*`, and while `== null` round-trips, there is no working way to read the int back (`!` → E0818; no `match`/`if let`; flow-typed `let v: int = c` compiles but silently drops the value). A poll that can't tell you *which* fd is ready is useless, so — with the issue author's confirmation — the return is a sentinel `int` (`-1` == none; fds are non-negative so `-1` is unambiguous), the classic `poll`/`select` idiom. The underlying compiler gap is filed as **SFN-182** and cited in the code as the removal condition for revisiting `fd?`.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts (`status: pass`)
- [x] `make test` — full suite passes (42/42 capsules, no regressions)
- [x] Regression coverage added under `compiler/tests/` (`io_poll_any_test.sfn`, 5/5)
- [ ] `make check` — full suite + seedcheck (ran `make test`; not the triple-pass seedcheck gate)

## Stage1 readiness

- [x] Parses, type-checks, and effect-checks
- [x] Emits valid `.sfn-asm` and lowers to LLVM IR (runtime helper + descriptor; 5/5 test compiles, links, runs against live pipes)
- [x] Effect enforcement wired end-to-end (`[io]` on body + Windows stub, `effects ["io"]` in descriptor)
- [x] `docs/status.md` updated (no spec §N chapter — this is a runtime builtin tracked in status.md, matching `io.poll_readable`/`io.read_fd`)

## Notes for reviewers

- **New `int[]` runtime-helper param.** This is the first `int[]`-typed runtime-helper parameter (`{ i64*, i64, i64 }*`, the i64-element analogue of `run_capture`'s `string[]` → `{ i8**, i64, i64 }*`). The 5/5-passing integration test compiles, links, and runs the real body against live pipes, empirically confirming caller-side coercion and the compiled body's signature agree.
- **Purely additive.** No `compiler/src` code consumes `io.poll_any`, so the compiler binary's behavior is unchanged; the self-host pass compiles the new capability from the old seed and then compiles the consuming test in one pass — no seed cut.
- **Follow-up:** SFN-182 (optional-primitive value-extraction) — revisit the `fd?` return once it lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NqNMP4CgXTZG3XSbR4QY3x)_