### PR TITLE
build: move repo-local seed store to build/toolchains/seed (SFN-174)

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -79,8 +79,8 @@ not take "no frontend dependency" on faith. Run a throwaway `.sfn` snippet
 through the current seed:
 
 ```bash
-build/seed/bin/sailfin check /tmp/probe.sfn
-build/seed/bin/sailfin emit -o /tmp/probe.ll llvm /tmp/probe.sfn
+build/toolchains/seed/bin/sfn check /tmp/probe.sfn
+build/toolchains/seed/bin/sfn emit -o /tmp/probe.ll llvm /tmp/probe.sfn
 ```
 
 Confirm the construct can actually be expressed and emitted (not silently

--- a/.claude/commands/pin-seed.md
+++ b/.claude/commands/pin-seed.md
@@ -65,7 +65,7 @@ Before opening the PR, confirm the target binary actually downloads:
 SEED_VERSION="<target>" make fetch-seed
 ```
 
-This is non-destructive — it installs into `build/seed/versions/` and
+This is non-destructive — it installs into `build/toolchains/seed/versions/` and
 doesn't touch `.seed-version`. If the fetch fails (404, checksum,
 network), abort. If it succeeds, the binary is on disk and we know the
 pin is valid.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -15,8 +15,8 @@ else
   echo "- compiler: build/bin/sfn MISSING — run \`make compile\` to self-host from the seed"
 fi
 
-if compgen -G "build/seed/*" >/dev/null; then
-  echo "- seed: build/seed present"
+if compgen -G "build/toolchains/seed/*" >/dev/null; then
+  echo "- seed: build/toolchains/seed present"
 else
   echo "- seed: MISSING — run \`make fetch-seed\`"
 fi

--- a/.claude/skills/pin-seed/SKILL.md
+++ b/.claude/skills/pin-seed/SKILL.md
@@ -36,12 +36,12 @@ The script writes the normalized version to `.seed-version` (single line, no tra
 make fetch-seed
 ```
 
-`make fetch-seed` reads `.seed-version` and downloads the binary into `build/seed/bin/sailfin`. If the release does not exist on GitHub, the fetch fails — restore the previous pin and surface the error to the user.
+`make fetch-seed` reads `.seed-version` and downloads the binary into `build/toolchains/seed/bin/sfn`. If the release does not exist on GitHub, the fetch fails — restore the previous pin and surface the error to the user.
 
 ### 5. Smoke-verify the new seed
 
 ```bash
-build/seed/bin/sailfin version
+build/toolchains/seed/bin/sfn version
 ```
 
 Confirm the binary prints the expected version string. If it mismatches, abort and restore.

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -21,8 +21,8 @@ else
   printf -- '- compiler: build/bin/sfn MISSING — run `make compile` to self-host from the seed\n'
 fi
 
-if compgen -G 'build/seed/*' >/dev/null; then
-  printf -- '- seed: build/seed present\n'
+if compgen -G 'build/toolchains/seed/*' >/dev/null; then
+  printf -- '- seed: build/toolchains/seed present\n'
 else
   printf -- '- seed: MISSING — run `make fetch-seed` if a build needs the released seed\n'
 fi

--- a/.codex/skills/sailfin-pin-seed/SKILL.md
+++ b/.codex/skills/sailfin-pin-seed/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when asked to update `.seed-version`.
 2. Show the current pin with `cat .seed-version`.
 3. Update only `.seed-version`.
 4. Run `make fetch-seed` to download the matching release binary.
-5. Run `build/seed/bin/sailfin version` and confirm it reports the expected version.
+5. Run `build/toolchains/seed/bin/sfn version` and confirm it reports the expected version.
 6. If requested or needed before merge, run `make compile`.
 7. Commit only `.seed-version` with `chore(seed): pin seed to <VERSION>`.
 

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -77,8 +77,8 @@ runs:
       if: ${{ inputs.mode != 'skip-build' && inputs.seed_version != '' && inputs.seed_version != 'latest' }}
       uses: actions/cache@v4
       with:
-        path: build/seed
-        key: sailfin-seed-${{ inputs.target }}-${{ inputs.seed_version }}
+        path: build/toolchains/seed
+        key: sailfin-seed-store-${{ inputs.target }}-${{ inputs.seed_version }}
 
     - name: Fetch released seed compiler
       if: ${{ inputs.mode != 'skip-build' }}
@@ -92,7 +92,7 @@ runs:
         fi
         # Skip the download on a seed-cache hit. The cache key pins the
         # exact version, so a present + invokable binary is the right one.
-        if [ -x build/seed/bin/sailfin ] && build/seed/bin/sailfin version >/dev/null 2>&1; then
+        if [ -x build/toolchains/seed/bin/sfn ] && build/toolchains/seed/bin/sfn version >/dev/null 2>&1; then
           echo "[ci] seed cache hit ($seed_version) — skipping fetch"
         else
           make fetch-seed \
@@ -100,8 +100,8 @@ runs:
               SEED_VERSION="$seed_version" \
               SEED_EXCLUDE_TAG="$seed_exclude_tag"
         fi
-        echo "[ci] seed binary: build/seed/bin/sailfin"
-        build/seed/bin/sailfin version
+        echo "[ci] seed binary: build/toolchains/seed/bin/sfn"
+        build/toolchains/seed/bin/sfn version
 
     # Restore the content-addressed module IR cache (`build/cache/`,
     # written by `<seed> build -p compiler`). Keys are content-safe:
@@ -214,12 +214,12 @@ runs:
         if [ -n "${{ inputs.build_jobs }}" ]; then
           make rebuild \
             CLANG="${{ inputs.clang }}" \
-            SEED_NATIVE="build/seed/bin/sailfin" \
+            SEED_NATIVE="build/toolchains/seed/bin/sfn" \
             BUILD_JOBS="${{ inputs.build_jobs }}"
         else
           make rebuild \
             CLANG="${{ inputs.clang }}" \
-            SEED_NATIVE="build/seed/bin/sailfin"
+            SEED_NATIVE="build/toolchains/seed/bin/sfn"
         fi
         _t1=$(date +%s)
         if [ "$_measure" = "1" ]; then

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ make test             # Run unit + integration + e2e suites
 make test-unit        # Run Sailfin-native unit tests
 make test-integration # Run Sailfin-native integration tests
 make clean            # Remove dist/ artifacts
-make clean-build      # Remove build/* artifacts (keeps build/seed by default)
+make clean-build      # Remove build/* artifacts (keeps build/toolchains/seed by default)
 ```
 
 For debugging, place scripts in `/scratch`.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -121,7 +121,7 @@ jobs:
           set -euo pipefail
           echo "[bench] seed version: $SEED_VERSION"
           make fetch-seed SEED_VERSION="$SEED_VERSION"
-          build/seed/bin/sailfin version
+          build/toolchains/seed/bin/sfn version
 
       - name: Build native compiler (selfhost from released seed)
         shell: bash
@@ -135,9 +135,9 @@ jobs:
           # build/bin/sfn and build/native/import-context (both required
           # by the bench scripts).
           if [ -n "${{ inputs.build_jobs }}" ]; then
-            make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/seed/bin/sailfin" BUILD_JOBS="${{ inputs.build_jobs }}"
+            make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/toolchains/seed/bin/sfn" BUILD_JOBS="${{ inputs.build_jobs }}"
           else
-            make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/seed/bin/sailfin"
+            make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/toolchains/seed/bin/sfn"
           fi
           build/bin/sfn version
 

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -125,8 +125,8 @@ jobs:
       - name: Restore seed cache
         uses: actions/cache@v6
         with:
-          path: build/seed
-          key: sailfin-seed-linux-x86_64-${{ steps.seed.outputs.seed_version }}
+          path: build/toolchains/seed
+          key: sailfin-seed-store-linux-x86_64-${{ steps.seed.outputs.seed_version }}
 
       - name: Fetch released seed compiler
         shell: bash
@@ -135,12 +135,12 @@ jobs:
           SEED_VERSION: ${{ steps.seed.outputs.seed_version }}
         run: |
           set -euo pipefail
-          if [ -x build/seed/bin/sailfin ] && build/seed/bin/sailfin version >/dev/null 2>&1; then
+          if [ -x build/toolchains/seed/bin/sfn ] && build/toolchains/seed/bin/sfn version >/dev/null 2>&1; then
             echo "[ci] seed cache hit ($SEED_VERSION) — skipping fetch"
           else
             make fetch-seed SEED_VERSION="$SEED_VERSION"
           fi
-          build/seed/bin/sailfin version
+          build/toolchains/seed/bin/sfn version
 
       - name: Self-host the compiler (make compile)
         shell: bash
@@ -153,7 +153,7 @@ jobs:
           # (#1291), so a runaway compile can't take down the runner.
           make compile \
             CLANG="${CLANG:-clang-18}" \
-            SEED_NATIVE="build/seed/bin/sailfin"
+            SEED_NATIVE="build/toolchains/seed/bin/sfn"
           build/bin/sfn version
 
       - name: First pass (warm the cache)
@@ -343,8 +343,8 @@ jobs:
       - name: Restore seed cache
         uses: actions/cache@v6
         with:
-          path: build/seed
-          key: sailfin-seed-linux-x86_64-${{ steps.seed.outputs.seed_version }}
+          path: build/toolchains/seed
+          key: sailfin-seed-store-linux-x86_64-${{ steps.seed.outputs.seed_version }}
 
       - name: Fetch released seed compiler
         shell: bash
@@ -353,12 +353,12 @@ jobs:
           SEED_VERSION: ${{ steps.seed.outputs.seed_version }}
         run: |
           set -euo pipefail
-          if [ -x build/seed/bin/sailfin ] && build/seed/bin/sailfin version >/dev/null 2>&1; then
+          if [ -x build/toolchains/seed/bin/sfn ] && build/toolchains/seed/bin/sfn version >/dev/null 2>&1; then
             echo "[ci] seed cache hit ($SEED_VERSION) — skipping fetch"
           else
             make fetch-seed SEED_VERSION="$SEED_VERSION"
           fi
-          build/seed/bin/sailfin version
+          build/toolchains/seed/bin/sfn version
 
       # Warm module-IR cache for a fast compile. Unlike the determinism
       # gate, this job has no cold-build requirement, so restoring is safe
@@ -380,7 +380,7 @@ jobs:
           set -euo pipefail
           make compile \
             CLANG="${CLANG:-clang-18}" \
-            SEED_NATIVE="build/seed/bin/sailfin"
+            SEED_NATIVE="build/toolchains/seed/bin/sfn"
           build/bin/sfn version
 
       # Run the full `.sfn` suite with the test-bin cache ENABLED (no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           set -euo pipefail
           make fetch-seed SEED_VERSION="$SEED_VERSION"
-          build/seed/bin/sailfin version
+          build/toolchains/seed/bin/sfn version
 
       - name: sfn check compiler/src/ (parse + typecheck + effect-check)
         shell: bash
@@ -133,7 +133,7 @@ jobs:
           # runner VM and killing the runner agent (the #1243 failure
           # mode). time -v records the peak RSS either way.
           SAILFIN_USE_ARENA=1 /usr/bin/time -v \
-            build/seed/bin/sailfin check compiler/src/
+            build/toolchains/seed/bin/sfn check compiler/src/
 
   # One compiler build per OS, shared by every shard leg below (#1234,
   # "Lever 1 step 1b" of docs/proposals/0011-ci-test-speed.md §6 step 2).
@@ -473,7 +473,7 @@ jobs:
           # the freshly-checked-out sources. A nested `make compile` (run
           # by make_result_contract_test / make_report_contract_test) then
           # sees the binary as stale -> triggers `make rebuild` -> and,
-          # since build/seed is not bundled, fetches the seed over the
+          # since build/toolchains/seed is not bundled, fetches the seed over the
           # network (unauthenticated, no GITHUB_TOKEN in the test child
           # env) and fails -> status != "pass" -> the test aborts (134).
           # The binary IS up-to-date for this commit, so mark it current
@@ -851,7 +851,7 @@ jobs:
           # the freshly-checked-out sources. A nested `make compile` (run
           # by make_result_contract_test / make_report_contract_test) then
           # sees the binary as stale -> triggers `make rebuild` -> and,
-          # since build/seed is not bundled, fetches the seed over the
+          # since build/toolchains/seed is not bundled, fetches the seed over the
           # network (unauthenticated, no GITHUB_TOKEN in the test child
           # env) and fails -> status != "pass" -> the test aborts (134).
           # The binary IS up-to-date for this commit, so mark it current

--- a/.github/workflows/nightly-selfhost.yml
+++ b/.github/workflows/nightly-selfhost.yml
@@ -111,7 +111,7 @@ jobs:
           set -euo pipefail
           echo "[nightly] seed version: $SEED_VERSION"
           make fetch-seed SEED_VERSION="$SEED_VERSION"
-          build/seed/bin/sailfin version
+          build/toolchains/seed/bin/sfn version
 
       - name: make check (first pass → seedcheck → stage3)
         shell: bash
@@ -123,7 +123,7 @@ jobs:
           SELFHOST_STRICT: ${{ matrix.selfhost_strict }}
         run: |
           set -euo pipefail
-          export SEED_NATIVE="build/seed/bin/sailfin"
+          export SEED_NATIVE="build/toolchains/seed/bin/sfn"
           make check SELFHOST_STRICT="$SELFHOST_STRICT"
 
       - name: Surface non-empty phase_types diagnostics

--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           set -euo pipefail
           make fetch-seed SEED_VERSION="$SEED_VERSION"
-          build/seed/bin/sailfin version
+          build/toolchains/seed/bin/sfn version
 
       - name: Build native compiler (timed clean self-host)
         id: build
@@ -122,7 +122,7 @@ jobs:
           # cached one. This wall time is the whole-build budget metric — it is
           # NOT the compile bench's serial sum of isolated per-module emits.
           start=$(date +%s)
-          make rebuild CLANG="clang-18" SEED_NATIVE="build/seed/bin/sailfin"
+          make rebuild CLANG="clang-18" SEED_NATIVE="build/toolchains/seed/bin/sfn"
           end=$(date +%s)
           build/bin/sfn version
           echo "wall_s=$((end - start))" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ make test-e2e         # Sailfin-native e2e tests
 make bench            # Benchmark per-module compile time and memory
 make fetch-seed       # Download the pinned seed (.seed-version)
 make clean            # Remove dist/ artifacts
-make clean-build      # Remove build/* artifacts (keeps build/seed) — destructive, gate on approval
+make clean-build      # Remove build/* artifacts (keeps build/toolchains/seed) — destructive, gate on approval
 make mcp-server       # Build the MCP server wrapper
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -294,16 +294,22 @@ test-impl:
 SEED_REPO ?= SailfinIO/sailfin
 SEED_VERSION ?= $(strip $(shell cat .seed-version 2>/dev/null))
 SEED_EXCLUDE_TAG ?=
-SEED_INSTALL_BASE ?= build/seed/versions
-SEED_GLOBAL_BIN_DIR ?= build/seed/bin
+# Repo-local seed toolchain store (SFN-174). The fetched pinned seed lives
+# under build/toolchains/seed — a store that names what it holds (a released
+# toolchain) rather than the legacy build/seed cache. The user-facing installer
+# store (~/.local/share/sailfin/versions) is unaffected.
+SEED_INSTALL_BASE ?= build/toolchains/seed/versions
+SEED_GLOBAL_BIN_DIR ?= build/toolchains/seed/bin
 
 # Default seed compiler used for self-hosting.
 # Points to the fetched seed binary (0.5.7+ — the first release whose
 # binary image does not carry the re-export miscompilation documented
-# in docs/rca/2026-04-18-reexport-diagnostic-gep.md).
-SEED ?= build/seed/bin/sailfin
+# in docs/rca/2026-04-18-reexport-diagnostic-gep.md). install.sh installs the
+# release binary as `sailfin` and always writes an `sfn` alias into
+# SEED_GLOBAL_BIN_DIR, so the canonical seed path is the `sfn` alias.
+SEED ?= build/toolchains/seed/bin/sfn
 
-FETCHED_SEED ?= $(SEED_GLOBAL_BIN_DIR)/sailfin$(EXE_EXT)
+FETCHED_SEED ?= $(SEED_GLOBAL_BIN_DIR)/sfn$(EXE_EXT)
 
 fetch-seed:
 	@if [ -z "$(SEED_VERSION)" ]; then \
@@ -317,7 +323,7 @@ fetch-seed:
 		exit 1; \
 	fi
 	@echo "[fetch-seed] installing seed $(SEED_VERSION) into $(SEED_INSTALL_BASE)"
-	@mkdir -p build/seed
+	@mkdir -p build/toolchains/seed
 	@REPO="$(SEED_REPO)" VERSION="$(SEED_VERSION)" EXCLUDE_TAG="$(SEED_EXCLUDE_TAG)" \
 		GLOBAL_BIN_DIR="$(SEED_GLOBAL_BIN_DIR)" INSTALL_BASE="$(SEED_INSTALL_BASE)" \
 		BINARY="sailfin" ./install.sh
@@ -529,14 +535,16 @@ clean:
 mcp-server:
 	cd tools/mcp-server && npm ci --no-audit --no-fund && npm run build
 
-# Remove local build artifacts (keeps downloaded seed by default).
-# Use KEEP_SEED=0 to also delete build/seed.
+# Remove local build artifacts (keeps the downloaded seed toolchain by default).
+# The pinned seed lives under build/toolchains/seed (SFN-174); preserve the
+# whole build/toolchains store so KEEP_SEED keeps it intact.
+# Use KEEP_SEED=0 to also delete build/toolchains.
 .PHONY: clean-build clean-all
 clean-build:
 	@mkdir -p build
 	@for d in build/*; do \
 		base="$$(basename "$$d")"; \
-		if [ "$$base" = "seed" ] && [ "${KEEP_SEED:-1}" != "0" ]; then \
+		if [ "$$base" = "toolchains" ] && [ "${KEEP_SEED:-1}" != "0" ]; then \
 			continue; \
 		fi; \
 		rm -rf "$$d"; \

--- a/Makefile
+++ b/Makefile
@@ -306,8 +306,11 @@ SEED_GLOBAL_BIN_DIR ?= build/toolchains/seed/bin
 # binary image does not carry the re-export miscompilation documented
 # in docs/rca/2026-04-18-reexport-diagnostic-gep.md). install.sh installs the
 # release binary as `sailfin` and always writes an `sfn` alias into
-# SEED_GLOBAL_BIN_DIR, so the canonical seed path is the `sfn` alias.
-SEED ?= build/toolchains/seed/bin/sfn
+# SEED_GLOBAL_BIN_DIR, so the canonical seed path is that `sfn` alias. Build it
+# from SEED_GLOBAL_BIN_DIR + EXE_EXT so it matches the fetched alias on every
+# platform (Windows writes `sfn.exe`); a bare `.../sfn` would look "missing" on
+# Windows and force a re-fetch every rebuild.
+SEED ?= $(SEED_GLOBAL_BIN_DIR)/sfn$(EXE_EXT)
 
 FETCHED_SEED ?= $(SEED_GLOBAL_BIN_DIR)/sfn$(EXE_EXT)
 

--- a/docs/proposals/0004-check-architecture.md
+++ b/docs/proposals/0004-check-architecture.md
@@ -1722,7 +1722,7 @@ pre-commit hook for contributors who want it.
     shell: bash {0}
     run: |
       set -euo pipefail
-      build/seed/bin/sailfin check compiler/src/ runtime/
+      build/toolchains/seed/bin/sfn check compiler/src/ runtime/
   ```
 
   Runs after `fetch-seed` but before any `make compile`. Failures

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -242,7 +242,7 @@ re-running the script with the right environment. The driver
 Flow:
 
 1. **Seed acquisition.** `make fetch-seed` downloads a released compiler
-   (default `0.5.3-alpha.1`) to `build/seed/bin/sailfin` via `install.sh`.
+   (default `0.5.3-alpha.1`) to `build/toolchains/seed/bin/sfn` via `install.sh`.
    The seed must support `emit native` or the rebuild aborts.
 2. **Source discovery.** `build.sh` walks `compiler/src/**/*.sfn` plus
    `runtime/**/*.sfn`, then parses `[dependencies]` in

--- a/docs/proposals/0021-windows-native-selfhost.md
+++ b/docs/proposals/0021-windows-native-selfhost.md
@@ -327,7 +327,7 @@ true unblocker — almost everything depends on de-shelling.
 
 **Mapping the brief's issues:** #1482 → M2; #1483 → M0. New issues: M1
 (host-OS), M3 (run_capture), M4 (child-spawn), M5 (fs-enum), M6 (driver target),
-M7–M12 (build/seed/CI).
+M7–M12 (build/toolchains/seed/CI).
 
 **Bundling note (decomposition discipline):** M5's fs-enum *capability* (the
 `fs_list_dir` sentinel) and its sole consumer (the Windows leg) land in **one

--- a/docs/proposals/0046-toolchain-pinning.md
+++ b/docs/proposals/0046-toolchain-pinning.md
@@ -79,7 +79,7 @@ rather than invent a novel mechanism.
 
 `make`/`install.sh` are the compiler-repo bootstrap. A downstream capsule has no
 `Makefile` and must never inherit the seed ritual — that plumbing knows about
-`.seed-version`, the seed cache under `build/seed`, and `<seed> build -p
+`.seed-version`, the seed cache under `build/toolchains/seed`, and `<seed> build -p
 compiler`, none of which are meaningful to a product. The user story is `sfn
 init` → edit code → `sfn build`, with the toolchain pinned **in the same manifest
 the user already edits**.

--- a/docs/proposals/design-notes/unit-test-import-envelope.md
+++ b/docs/proposals/design-notes/unit-test-import-envelope.md
@@ -76,7 +76,7 @@ missing symbol.
 Open question 2 asked for a live reproduction (build a light-import test and a
 heavy-import test, capture the actual error). **This could not be executed in the
 spike environment:** there is no prebuilt `build/bin/sfn` and no seed
-binary on disk (`.seed-version` pins `0.7.0-alpha.19` but `build/seed/` is
+binary on disk (`.seed-version` pins `0.7.0-alpha.19` but `build/toolchains/seed/` is
 empty), and a from-scratch `make compile` is a 60–90 min self-host that exceeds
 the spike's tooling budget. The root cause above is therefore established by
 **static import-graph analysis plus existing passing-test precedent**, which is

--- a/docs/rca/2026-04-18-reexport-diagnostic-gep.md
+++ b/docs/rca/2026-04-18-reexport-diagnostic-gep.md
@@ -90,7 +90,7 @@ and 8 other opaque types that should have concrete layouts (`SymbolEntry`,
 
    ```bash
    ulimit -v 8388608
-   timeout 540 build/seed/bin/sailfin emit llvm compiler/src/main.sfn > main.ll
+   timeout 540 build/toolchains/seed/bin/sfn emit llvm compiler/src/main.sfn > main.ll
    llvm-as-18 -disable-output main.ll
    # error: base element of getelementptr must be sized
    ```
@@ -102,7 +102,7 @@ A cheaper reproducer, which skips most of the lowering and isolates the
 upstream cause:
 
 ```bash
-timeout 60 build/seed/bin/sailfin emit llvm compiler/src/native_ir_api.sfn 2>&1 \
+timeout 60 build/toolchains/seed/bin/sfn emit llvm compiler/src/native_ir_api.sfn 2>&1 \
   | grep "unknown function"
 # test llvm: diagnostic llvm lowering: call to unknown function `starts_with`
 # test llvm: diagnostic llvm lowering: unable to lower if condition in
@@ -519,7 +519,7 @@ Once we knew the failure mode was "call to unknown function" on a
 re-exported symbol, the minimal reproducer is:
 
 ```bash
-timeout 60 build/seed/bin/sailfin emit llvm compiler/src/native_ir_api.sfn 2>&1 \
+timeout 60 build/toolchains/seed/bin/sfn emit llvm compiler/src/native_ir_api.sfn 2>&1 \
   | grep "unknown function"
 ```
 

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -442,9 +442,9 @@ The repository Makefile provides higher-level build orchestration for the self-h
 | `make test-integration` | Run integration tests from `compiler/tests/integration/*_test.sfn`. |
 | `make test-e2e` | Run end-to-end tests from `compiler/tests/e2e/*_test.sfn`. |
 | `make package` | Build and package native artifacts into `dist/`. Used for release artifacts. |
-| `make fetch-seed` | Download the latest released seed compiler from GitHub Releases into `build/seed/`. Requires `GITHUB_TOKEN`. |
+| `make fetch-seed` | Download the latest released seed compiler from GitHub Releases into `build/toolchains/seed/`. Requires `GITHUB_TOKEN`. |
 | `make clean` | Remove `dist/` packaged artifacts. Does not remove build intermediates. |
-| `make clean-build` | Remove `build/` artifacts (keeps `build/seed/` by default). Pass `KEEP_SEED=0` to also remove the downloaded seed. |
+| `make clean-build` | Remove `build/` artifacts (keeps `build/toolchains/seed/` by default). Pass `KEEP_SEED=0` to also remove the downloaded seed. |
 | `make clean-all` | Remove both `dist/` and `build/` artifacts completely. |
 | `make help` | Print a summary of available targets. |
 
@@ -476,7 +476,7 @@ These environment variables influence the behavior of `sfn` and the Makefile bui
 | `SEED_VERSION` | Makefile | Version tag of the seed to fetch. Defaults to `latest`. |
 | `NATIVE_OPT` | Makefile | Optimization level passed to `clang` when compiling LLVM IR. Defaults to `-O2`. |
 | `CLANG` | Makefile | `clang` executable to use. Defaults to `clang`. |
-| `KEEP_SEED` | `make clean-build` | Set to `0` to delete `build/seed/` during `make clean-build`. Defaults to `1` (seed is preserved). |
+| `KEEP_SEED` | `make clean-build` | Set to `0` to delete `build/toolchains/seed/` during `make clean-build`. Defaults to `1` (seed is preserved). |
 
 ### Debug and trace variables
 
@@ -514,7 +514,7 @@ When `sfn test` is used, a non-zero exit code means at least one test failed. Al
 | `workspace.toml` | Workspace manifest — shared policies for multi-capsule projects |
 | `*.sfn-asm` | Native IR intermediate representation produced by `sfn emit native` |
 | `build/bin/sfn` | Default output path for the self-hosted compiler binary |
-| `build/seed/bin/sailfin` | Default path for the downloaded seed compiler |
+| `build/toolchains/seed/bin/sfn` | Default path for the downloaded seed compiler |
 | `dist/` | Release packaging output directory |
 
 ---

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -442,9 +442,9 @@ The repository Makefile provides higher-level build orchestration for the self-h
 | `make test-integration` | Run integration tests from `compiler/tests/integration/*_test.sfn`. |
 | `make test-e2e` | Run end-to-end tests from `compiler/tests/e2e/*_test.sfn`. |
 | `make package` | Build and package native artifacts into `dist/`. Used for release artifacts. |
-| `make fetch-seed` | Download the latest released seed compiler from GitHub Releases into `build/toolchains/seed/`. Requires `GITHUB_TOKEN`. |
+| `make fetch-seed` | Download the pinned seed compiler (`.seed-version`, override with `SEED_VERSION`) from GitHub Releases into `build/toolchains/seed/`. Requires `GITHUB_TOKEN`. |
 | `make clean` | Remove `dist/` packaged artifacts. Does not remove build intermediates. |
-| `make clean-build` | Remove `build/` artifacts (keeps `build/toolchains/seed/` by default). Pass `KEEP_SEED=0` to also remove the downloaded seed. |
+| `make clean-build` | Remove `build/` artifacts (keeps the seed toolchain under `build/toolchains/` by default). Pass `KEEP_SEED=0` to also remove `build/toolchains/`. |
 | `make clean-all` | Remove both `dist/` and `build/` artifacts completely. |
 | `make help` | Print a summary of available targets. |
 
@@ -472,11 +472,11 @@ These environment variables influence the behavior of `sfn` and the Makefile bui
 | `GITHUB_TOKEN` | `make fetch-seed` | GitHub personal access token used to download seed releases from the `SailfinIO/sailfin` repository. Required for `make fetch-seed`. |
 | `BUILD_JOBS` | Makefile | Number of parallel compile jobs. Default: `1`. |
 | `BUILD_ARGS` | Makefile | Extra arguments passed through to the build orchestrator script. |
-| `SEED` | Makefile | Path to (or name of) the seed compiler used as the bootstrap. Defaults to `sfn` (resolved from `PATH`). |
+| `SEED` | Makefile | Path to (or name of) the seed compiler used as the bootstrap. Defaults to the fetched repo-local seed alias, `build/toolchains/seed/bin/sfn` (`sfn.exe` on Windows). |
 | `SEED_VERSION` | Makefile | Version tag of the seed to fetch. Defaults to `latest`. |
 | `NATIVE_OPT` | Makefile | Optimization level passed to `clang` when compiling LLVM IR. Defaults to `-O2`. |
 | `CLANG` | Makefile | `clang` executable to use. Defaults to `clang`. |
-| `KEEP_SEED` | `make clean-build` | Set to `0` to delete `build/toolchains/seed/` during `make clean-build`. Defaults to `1` (seed is preserved). |
+| `KEEP_SEED` | `make clean-build` | Set to `0` to also delete `build/toolchains/` during `make clean-build`. Defaults to `1` (the seed toolchain is preserved). |
 
 ### Debug and trace variables
 


### PR DESCRIPTION
## Summary

Move the compiler repo's fetched seed toolchain cache out of `build/seed` and into `build/toolchains/seed` — a store whose path names what it holds (a released toolchain) ahead of SFEP-0046's native toolchain stores and dispatch. The canonical seed binary is now the `sfn` alias at `build/toolchains/seed/bin/sfn` (install.sh already emits that alias). This is internal bootstrap plumbing only; the public installer store (`~/.local/share/sailfin/versions`) is unchanged.

Fixes SFN-174

## Changes

- **driver / build (`Makefile`):** `SEED_INSTALL_BASE`, `SEED_GLOBAL_BIN_DIR`, `SEED`, and `FETCHED_SEED` defaults now point under `build/toolchains/seed`; `SEED`/`FETCHED_SEED` resolve to the `sfn` alias. `fetch-seed` creates `build/toolchains/seed`. `clean-build`'s `KEEP_SEED` preservation now keeps the `build/toolchains` store instead of `build/seed`.
- **CI (`.github/actions/sailfin-build`, `build-quality`, `ci`, `benchmark`, `perf-history`, `nightly-selfhost`):** cache `path: build/toolchains/seed` with a bumped `sailfin-seed-store-*` key (forces a one-time cold fetch so a stale `build/seed`-archived cache can't restore into the new path); `SEED_NATIVE`, seed cache-hit checks, and seed `version`/`check` invocations use `build/toolchains/seed/bin/sfn`.
- **docs / instructions:** `CLAUDE.md`, `.github/copilot-instructions.md`, `.claude`/`.codex` session-start hooks, pin-seed skills/commands, `groom.md`, `cli.md`, and proposal/RCA repro commands reference the new path. Historical framing preserved; path tokens only.

No compatibility shim — the canonical path is `build/toolchains/seed/bin/sfn`.

## Validation

- [x] `sfn fmt --check` — N/A (no `.sfn` files touched)
- [x] `sfn check` — N/A (no `.sfn` files touched)
- [x] `make fetch-seed` — installs to `build/toolchains/seed/bin/sfn`; `sfn version` reports `0.8.0-alpha.2`
- [x] `make compile` — self-hosts from the new default `SEED` (`seed=build/toolchains/seed/bin/sfn`), `status:pass`
- [x] `make clean-build` — preserves `build/toolchains/seed`, removes the rest
- [x] `rg "build/seed"` — no active references remain (only one intentional historical mention in a Makefile comment)
- [x] N/A — docs/config-only change (no `.sfn` touched)

## Acceptance Criteria

- [x] `make fetch-seed` installs the pinned seed to `build/toolchains/seed/bin/sfn` and verifies it with `sfn version`.
- [x] `make rebuild`/`make compile` works from a clean checkout using the new default `SEED` path.
- [x] CI workflows cache and restore `build/toolchains/seed` instead of `build/seed`.
- [x] Active documentation and contributor instructions no longer tell users/agents to run `build/seed/bin/sailfin`.
- [x] No compatibility layer provided; the canonical path is `build/toolchains/seed/bin/sfn`.

## Map reconciliation

Advisory `Files Affected` matched the tree. The issue named `install.sh` for a "binary/install-name setup"; no edit was needed there — `install.sh` already writes an `sfn` alias into `GLOBAL_BIN_DIR` unconditionally, so pointing `FETCHED_SEED`/`SEED` at that alias (with `BINARY="sailfin"` kept for release-asset name resolution) delivers the required `sfn` seed path. `compiler/tests/e2e/make_result_contract_test.sfn` uses the `SEED_NATIVE` var name (not a `build/seed` path literal), so it needed no change.

## Notes for reviewers

- The seed cache-key bump (`sailfin-seed-` → `sailfin-seed-store-`) is deliberate: it forces one cold seed fetch per target so a cache archived from the old `build/seed` path isn't restored into `build/toolchains/seed`. Steady-state caching is unaffected.
- `build/toolchains/seed/versions/<ver>/` still holds the release binary under its asset name (`sailfin`); the `bin/sfn` alias is the canonical entry point, matching the recommended layout's `build/toolchains/seed/bin/sfn`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLoj7uQxQHBH18RjEpmnhZ)_