### PR TITLE
fix(effects): don't propagate `pure` as a caller requirement (SFN-184)

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -1053,6 +1053,16 @@ fn _propagate_imported_callee_effects(name: string, imports: ImportSymbolTable, 
     loop {
         if e >= entry.effects.length { break; }
         let effect = entry.effects[e];
+        // `pure` is a no-op marker, not a capability (effect_taxonomy.sfn):
+        // it "never satisfies a real effect requirement", so it must never
+        // *be* propagated as one — otherwise an effectful caller of an
+        // imported `![pure]` function (e.g. the SFN-167 toolchain gate
+        // calling `semver_parse`) is spuriously flagged E0402 for a `pure`
+        // it can never legally declare (`![io, pure]` is contradictory).
+        if is_universally_allowed_effect(effect) {
+            e += 1;
+            continue;
+        }
         required = append_requirement(required, EffectRequirement {
             effect: effect, description: prefix + effect + "]", trigger: callee_trigger
         });
@@ -1095,6 +1105,12 @@ fn _propagate_imported_member_effects(member: string, imports: ImportSymbolTable
     loop {
         if e >= entry.effects.length { break; }
         let effect = entry.effects[e];
+        // `pure` is a no-op marker, never a real requirement (see the
+        // matching guard in `_propagate_imported_callee_effects`).
+        if is_universally_allowed_effect(effect) {
+            e += 1;
+            continue;
+        }
         required = append_requirement(required, EffectRequirement {
             effect: effect, description: prefix + effect + "]", trigger: member_trigger
         });

--- a/compiler/tests/unit/effect_imports_test.sfn
+++ b/compiler/tests/unit/effect_imports_test.sfn
@@ -236,6 +236,31 @@ test "validate_effects_with_imports: imported callee surfaces E0402-shaped viola
     assert prefix_match;
 }
 
+test "validate_effects_with_imports: imported ![pure] callee never surfaces E0402 (SFN-184)" {
+    // Regression (SFN-184): `pure` is a no-op marker — the taxonomy
+    // (`effect_taxonomy.sfn`) says it "never satisfies a real effect
+    // requirement" and is "not a capability", so it must never be
+    // *propagated as* a caller requirement either. Before the fix,
+    // `_propagate_imported_callee_effects` propagated `pure` like any
+    // other declared effect, so a caller of an imported `![pure]`
+    // function was spuriously flagged E0402 for a `pure` it can never
+    // legally declare (`![io, pure]` is contradictory). This broke the
+    // SFN-167 toolchain gate's `![io]` call into the `![pure]` semver
+    // primitive (SFN-169) at self-host time.
+    //
+    // `_routine_calling` builds `run()` with no declared effects — the
+    // strictest caller — calling an imported `pure_parse` declaring
+    // `![pure]`. Post-fix the propagated requirement set is empty, so
+    // there is no violation.
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "pure_parse", ["pure"]);
+    let import_stmt = _import_decl("pure_parse", null, "semver");
+    let routine_stmt = _routine_calling("run", "pure_parse", 5);
+    let program = Program { statements: [import_stmt, routine_stmt] };
+    let violations = validate_effects_with_imports(program, global);
+    assert violations.length == 0;
+}
+
 test "validate_effects_with_imports: aliased import resolves under the local name" {
     // Same setup as the previous test but with `import { fetch as
     // get }` — the call site reads `get()`. Localization must
@@ -429,6 +454,20 @@ test "member resolution: object-agnostic name match fires (pinned policy)" {
     let violations = validate_effects_with_imports(program, table);
     assert violations.length == 1;
     assert violations[0].routine_name == "run";
+}
+
+test "member resolution: imported ![pure] member callee never surfaces E0402 (SFN-184)" {
+    // Mirror of the direct-callee `![pure]` regression on the member
+    // path (`_propagate_imported_member_effects`): a `mod.pure_member()`
+    // whose imported target declares `![pure]` must not require `pure` of
+    // the caller. Pins both propagation guards so a future edit can't
+    // silently fix one and leave the other propagating `pure`.
+    let import_stmt = _import_decl("pure_member", null, "semver");
+    let caller = _routine_member_calling("run", "mod", "pure_member", 5);
+    let program = Program { statements: [import_stmt, caller] };
+    let table = append_import_function(empty_import_symbols(), "pure_member", ["pure"]);
+    let violations = validate_effects_with_imports(program, table);
+    assert violations.length == 0;
 }
 
 test "collision: a same-module local fn shadows a same-named import" {


### PR DESCRIPTION
## Summary

The effect checker's cross-module propagation (`effect_checker.sfn`) appended **every** declared callee effect to the caller's required-effect set, only short-circuiting when the callee's *whole* effect set was empty. A callee declaring exactly `[pure]` has `effects == ["pure"]` (length 1), so `pure` was propagated as a caller requirement — spuriously flagging `E0402: missing required effects: [pure]` on any effectful caller of an imported `[pure]` function. Since `[io, pure]` is contradictory (`pure` = "no effects"), the caller can never satisfy the bogus requirement. `pure` is a no-op marker (`effect_taxonomy.sfn`: it "never satisfies a real effect requirement" and is "not a capability"), so it must never *be* a requirement either.

`semver.sfn` (SFN-169) is the first exported `[pure]` surface consumed outside pure tests, so **SFN-167**'s `[io]` toolchain gate calling `semver_parse` is the first caller to expose this — the seed rejects it, breaking `make compile`. This fix is the **seed-blocker predecessor** that unblocks it.

Fixes SFN-184

## Changes

- **effect_checker** — in both cross-module propagation sites (`_propagate_imported_callee_effects` and `_propagate_imported_member_effects`), skip effects where `is_universally_allowed_effect(effect)` is true (i.e. `pure`) before adding them to the requirement set. Subtractive only: every canonical effect (`io/net/model/gpu/rand/clock`) still propagates, so no genuine missing-effect can go unflagged, and a defensive `["pure", "net"]` import still requires `net`.
- **tests** — `effect_imports_test.sfn`: two regressions asserting an imported `[pure]` callee surfaces no E0402, on both the direct-`Identifier` and member-`obj.fn()` paths (pins both guards so a future edit can't diverge them).

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts (`status: pass`)
- [ ] `make check` — not run (surgical, subtractive core-pass change; effect suite + self-host cover it)
- [x] Regression coverage added under `compiler/tests/unit/effect_imports_test.sfn` (20/20 pass)
- Also ran the broader effect suite: `effect_checker`, `effect_checker_main`, `effect_capabilities`, `effect_detection`, `effect_gate`, `nested_function_effect`, `concurrency_effect` — all pass.

## Notes for reviewers

- Reviewed by the `code-reviewer` agent (approve): the guard is sound (per-effect, drops nothing real) and symmetric across both propagation sites; the builtin-registry propagation path never emits `pure` so needs no guard.
- **Seed impact:** this is a `seed-blocker`. After merge, queue a cadence seed bump + `/pin-seed` so a seed carrying this fix exists; then **SFN-167**'s toolchain gate can self-host and be re-picked-up. The full SFN-167 implementation is written and validated (against a gate-aware compiler) and preserved in the SFN-167 issue notes — it was intentionally kept out of this PR so the predecessor lands clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bxda5DhqfkT2UWKGmz7ELU)_