### PR TITLE
refactor(build): retire build/native/import-context as the canonical import cache path (SFN-175)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -132,7 +132,7 @@ jobs:
           set -euo pipefail
           # `make rebuild` forces a clean self-host so the bench measures this
           # commit's compiler, not a cached one. It produces both
-          # build/bin/sfn and build/native/import-context (both required
+          # build/bin/sfn and build/compiler/import-context (both required
           # by the bench scripts).
           if [ -n "${{ inputs.build_jobs }}" ]; then
             make rebuild CLANG="${{ inputs.clang }}" SEED_NATIVE="build/toolchains/seed/bin/sfn" BUILD_JOBS="${{ inputs.build_jobs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          paths="build/bin/sfn build/native/import-context"
+          paths="build/bin/sfn build/compiler/import-context"
           if [ -f build/native/.build-stamp ]; then
             paths="$paths build/native/.build-stamp"
           fi
@@ -371,7 +371,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          paths="build/bin/sfn build/native/import-context"
+          paths="build/bin/sfn build/compiler/import-context"
           if [ -f build/native/.build-stamp ]; then
             paths="$paths build/native/.build-stamp"
           fi

--- a/Makefile
+++ b/Makefile
@@ -474,13 +474,13 @@ bench:
 		echo "[bench] missing $(NATIVE_BIN); run 'make compile' first"; \
 		exit 1; \
 	fi
-	@if [ ! -d build/native/import-context ]; then \
+	@if [ ! -d build/compiler/import-context ]; then \
 		echo "[bench] missing import-context; run 'make compile' first"; \
 		exit 1; \
 	fi
 	@bash scripts/bench_compile.sh \
 		--seed "$(NATIVE_BIN)" \
-		--import-context build/native/import-context \
+		--import-context build/compiler/import-context \
 		$(BENCH_ARGS)
 
 # Benchmark compiled-program runtime execution (the counterpart to `bench`,
@@ -521,12 +521,12 @@ test-arena:
 		echo "[test-arena] missing $(NATIVE_BIN); run 'make compile' first"; \
 		exit 1; \
 	fi
-	@if [ ! -d build/native/import-context ]; then \
+	@if [ ! -d build/compiler/import-context ]; then \
 		echo "[test-arena] missing import-context; run 'make compile' first"; \
 		exit 1; \
 	fi
 	@SEED="$(NATIVE_BIN)" \
-		IMPORT_CONTEXT=build/native/import-context \
+		IMPORT_CONTEXT=build/compiler/import-context \
 		bash scripts/test_arena.sh $(ARENA_ARGS)
 
 clean:
@@ -729,18 +729,19 @@ package: compile
 # (import-context) are present at their canonical location.
 #
 # `make rebuild` is the only path to producing `build/bin/sfn`,
-# so `build/native/import-context/` is guaranteed to land directly.
+# so `build/compiler/import-context/` is guaranteed to land directly
+# (rebuild copies the seed-written tree to the canonical path; SFN-175).
 # #941: the former `build/native/obj/runtime/prelude.o` check was
 # dropped — post-#940 the test runner links the runtime through the
 # declarative runtime-capsule path (emit-from-source + per-work-dir
 # cache), so no pre-staged `prelude.o` exists or is needed.
 ci-prepare-test-artifacts:
 	@set -eu; \
-	if [ ! -d build/native/import-context ] || [ -z "$$(find build/native/import-context -name '*.sfn-asm' -print -quit 2>/dev/null)" ]; then \
-		echo "[ci-prepare-test-artifacts][error] missing build/native/import-context — run 'make rebuild' first" >&2; \
+	if [ ! -d build/compiler/import-context ] || [ -z "$$(find build/compiler/import-context -name '*.sfn-asm' -print -quit 2>/dev/null)" ]; then \
+		echo "[ci-prepare-test-artifacts][error] missing build/compiler/import-context — run 'make rebuild' first" >&2; \
 		exit 1; \
 	fi; \
-	echo "[ci-prepare-test-artifacts] build/native/import-context present"
+	echo "[ci-prepare-test-artifacts] build/compiler/import-context present"
 
 # Package native compiler + installer artifacts for a given target label.
 # Stage C4 migration: this target now delegates to `sfn package`
@@ -893,6 +894,17 @@ rebuild-impl:
 	@mkdir -p build/native $(dir $(NATIVE_OUT))
 	@cp -f build/sailfin/program $(NATIVE_OUT)
 	@chmod +x $(NATIVE_OUT)
+	@# SFN-175: the canonical import-context tree is `build/compiler/import-context`,
+	@# but the pinned seed still stages `build/native/import-context` (its baked
+	@# path — see the pre-stage block above, which the seed's `build -p compiler`
+	@# reads). Copy (not move) the seed-written tree old->new so every post-compile
+	@# consumer (test/bench/arena/package/CI) reads the canonical path while the
+	@# seed's warm-build cache survives at the old path. Retires at the next seed
+	@# bump, when the seed itself stages the new path (pre-stage + this copy + the
+	@# `imports.sfn` old-path read fallback all delete together).
+	@rm -rf build/compiler/import-context
+	@mkdir -p build/compiler
+	@cp -a build/native/import-context build/compiler/import-context
 	@# Save .ll files to a location `make test` won't clobber. Each
 	@# integration / e2e test's own `sfn build` overwrites
 	@# `build/sailfin/capsules/*.ll` and `build/sailfin/program.ll`
@@ -956,12 +968,12 @@ rebuild-impl:
 	@# build for cold-emit resolution) so the loop below re-emits them
 	@# with NATIVE_OUT — the canonical proper-pointee signatures, matching
 	@# the pre-#812 final state.
-	@rm -f build/native/import-context/runtime/sfn/platform/*.sfn-asm build/native/import-context/runtime/sfn/platform/*.layout-manifest
-	@mkdir -p build/native/import-context/runtime/sfn/platform
+	@rm -f build/compiler/import-context/runtime/sfn/platform/*.sfn-asm build/compiler/import-context/runtime/sfn/platform/*.layout-manifest
+	@mkdir -p build/compiler/import-context/runtime/sfn/platform
 	@set -e; \
 	for mod in libc posix pthread net; do \
-		asm_path="build/native/import-context/runtime/sfn/platform/$$mod.sfn-asm"; \
-		manifest_path="build/native/import-context/runtime/sfn/platform/$$mod.layout-manifest"; \
+		asm_path="build/compiler/import-context/runtime/sfn/platform/$$mod.sfn-asm"; \
+		manifest_path="build/compiler/import-context/runtime/sfn/platform/$$mod.layout-manifest"; \
 		if [ ! -f "$$asm_path" ]; then \
 			echo "[rebuild] staging runtime/sfn/platform/$$mod.sfn-asm..."; \
 			if ! $(NATIVE_OUT) emit --module-name "runtime/sfn/platform/$$mod" -o "$$asm_path" native "runtime/sfn/platform/$$mod.sfn" >/dev/null; then \
@@ -991,11 +1003,11 @@ rebuild-impl:
 	@# layout-manifest (the struct layout) is required alongside the fn
 	@# signature, not just the signature. Same staging shape as the
 	@# platform loop above; the rm forces a canonical NATIVE_OUT re-emit.
-	@rm -f build/native/import-context/runtime/sfn/memory/ownedbuf.sfn-asm build/native/import-context/runtime/sfn/memory/ownedbuf.layout-manifest
-	@mkdir -p build/native/import-context/runtime/sfn/memory
+	@rm -f build/compiler/import-context/runtime/sfn/memory/ownedbuf.sfn-asm build/compiler/import-context/runtime/sfn/memory/ownedbuf.layout-manifest
+	@mkdir -p build/compiler/import-context/runtime/sfn/memory
 	@set -e; \
-	ob_asm="build/native/import-context/runtime/sfn/memory/ownedbuf.sfn-asm"; \
-	ob_manifest="build/native/import-context/runtime/sfn/memory/ownedbuf.layout-manifest"; \
+	ob_asm="build/compiler/import-context/runtime/sfn/memory/ownedbuf.sfn-asm"; \
+	ob_manifest="build/compiler/import-context/runtime/sfn/memory/ownedbuf.layout-manifest"; \
 	if [ ! -f "$$ob_asm" ]; then \
 		echo "[rebuild] staging runtime/sfn/memory/ownedbuf.sfn-asm..."; \
 		if ! $(NATIVE_OUT) emit --module-name "runtime/sfn/memory/ownedbuf" -o "$$ob_asm" native "runtime/sfn/memory/ownedbuf.sfn" >/dev/null; then \

--- a/compiler/src/build/runtime_objs.sfn
+++ b/compiler/src/build/runtime_objs.sfn
@@ -588,7 +588,7 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
 // under `out_dir` (`build/sailfin` by default, work-dir aware).
 //
 // Deliberately NOT the shared cwd-relative
-// `build/native/import-context/` tree: artifacts staged there are
+// `build/compiler/import-context/` tree: artifacts staged there are
 // consulted by `collect_imported_module_context_for_module`'s
 // on-disk lookup during EVERY emit in that cwd. The prelude imports
 // the runtime modules (`runtime/prelude.sfn` → `./sfn/array`,

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -5,7 +5,7 @@
 // Replaces the text-level `inline_imports_for_source` hack in cli_commands.sfn
 // with real separate-compilation of capsule modules, using the same
 // import-context machinery the compiler uses on itself (the staged
-// .sfn-asm + .layout-manifest files under build/native/import-context).
+// .sfn-asm + .layout-manifest files under build/compiler/import-context).
 //
 // Flow invoked by `sfn build` and `sfn run`:
 //
@@ -23,7 +23,7 @@
 //
 //   3. stage_capsule_imports(sources, project_root)
 //        Emits .sfn-asm + .layout-manifest for each capsule source into
-//        build/native/import-context/<slug>.* so `compile_to_llvm_file_with_module`
+//        build/compiler/import-context/<slug>.* so `compile_to_llvm_file_with_module`
 //        on the main source sees the capsule's layout and symbols.
 //
 //   4. compile_capsule_modules(sources, project_root)
@@ -256,7 +256,7 @@ struct WorkspaceMember {
 // `asm_paths` is the list of staged `.sfn-asm` files the typechecker
 // should consume for cross-module interface conformance.
 struct CheckCapsuleResolution {
-    asm_paths: string[];  // build/native/import-context/<slug>.sfn-asm
+    asm_paths: string[];  // build/compiler/import-context/<slug>.sfn-asm
     capsule_count: int;  // post-dedupe count, for diagnostic output
     staging_failed: boolean;  // true on slug collision or stage-write failure
     // Phase F (`docs/proposals/0008-effect-validation.md` §5): the
@@ -279,7 +279,7 @@ struct CheckCapsuleResolution {
 // once `_collect_test_files_cmd`'s trailing-slash bug — which had
 // been masking the resolver's correctness — was fixed.)
 struct TestCapsuleResolution {
-    asm_paths: string[];  // build/native/import-context/<slug>.sfn-asm
+    asm_paths: string[];  // build/compiler/import-context/<slug>.sfn-asm
     // build/capsules/<scope>/<name>/ir/<rel>.ll (or legacy
     // build/sailfin/capsules/<mangled>.ll fallback). See
     // `CapsuleSource.ll_path` for the routing rules.
@@ -390,17 +390,20 @@ fn _cr_ensure_dir(path: string) -> void ![io] {
 
 // Resolve the import-context root (`.sfn-asm` + `.layout-manifest`
 // staging area). When `work_dir` is empty (the default `sfn build`
-// path with no `--work-dir`), this is the legacy `build/native/import-context`
+// path with no `--work-dir`), this is the canonical `build/compiler/import-context`
 // directory that `llvm/imports.sfn:_resolve_layout_manifest_path_for_slug`
 // scans. When `work_dir` is non-empty (`sfn build --work-dir <root>`),
-// the staging area moves under `<root>/native/import-context` so the
-// build can be redirected away from CWD-relative `build/` — the
-// driver-side equivalent of the prior `scripts/build.sh`'s
-// `IMPORT_CACHE` derivation (`SEED_CWD/build/native/import-context`;
-// the script itself was retired in Stage E PR7 / #383).
+// the staging area moves under `<root>/compiler/import-context` so the
+// build can be redirected away from CWD-relative `build/`.
+//
+// SFN-175: the canonical path moved from `build/native/import-context`
+// (a legacy Python-bootstrap-era layout). The current pinned seed still
+// stages to the old path during `make compile`; `imports.sfn` keeps a
+// one-release old-path read fallback and the Makefile copies the
+// seed-written tree old->new. Both retire at the next seed bump.
 fn _cr_import_context_root(work_dir: string) -> string {
-    if work_dir.length == 0 { return "build/native/import-context"; }
-    return work_dir + "/native/import-context";
+    if work_dir.length == 0 { return "build/compiler/import-context"; }
+    return work_dir + "/compiler/import-context";
 }
 
 // Validate a capsule.toml path segment is safe (no traversal).
@@ -898,7 +901,7 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
 // ---- Import-context staging ----
 // Emit .sfn-asm + .layout-manifest for a single capsule source. The
 // compiler's normal import resolver (llvm/imports.sfn:_resolve_layout_manifest_path_for_slug)
-// looks in build/native/import-context/<slug>.* so that's where we write.
+// looks in build/compiler/import-context/<slug>.* so that's where we write.
 //
 // Cache invalidation contract: a staged `.sfn-asm` + `.layout-manifest`
 // pair is a valid cache hit only when a `.srchash` sidecar written next to
@@ -3060,7 +3063,7 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
 
     // Slug-collision detection: two sources with the same slug but
     // different source paths would clobber each other under
-    // build/native/import-context/<slug>.* — surface the conflict so
+    // build/compiler/import-context/<slug>.* — surface the conflict so
     // the user can rename or restructure rather than silently picking
     // one.
     let mut deduped: CapsuleSource[] = [];

--- a/compiler/src/cli/commands/build.sfn
+++ b/compiler/src/cli/commands/build.sfn
@@ -288,7 +288,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
 
     // Resolve and compile any capsule deps declared in the project's
     // capsule.toml before compiling the main source. stage_capsule_imports
-    // writes .sfn-asm + .layout-manifest into <work_dir>/native/import-context/
+    // writes .sfn-asm + .layout-manifest into <work_dir>/compiler/import-context/
     // (or build/compiler/import-context/ when `--work-dir` is unset)
     // where the main module's lowering will find them.
     //

--- a/compiler/src/cli/commands/build.sfn
+++ b/compiler/src/cli/commands/build.sfn
@@ -289,7 +289,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     // Resolve and compile any capsule deps declared in the project's
     // capsule.toml before compiling the main source. stage_capsule_imports
     // writes .sfn-asm + .layout-manifest into <work_dir>/native/import-context/
-    // (or build/native/import-context/ when `--work-dir` is unset)
+    // (or build/compiler/import-context/ when `--work-dir` is unset)
     // where the main module's lowering will find them.
     //
     // Stage D PR3: the `-p` self-host (`walk_src`) explicitly

--- a/compiler/src/cli/commands/package.sfn
+++ b/compiler/src/cli/commands/package.sfn
@@ -404,8 +404,8 @@ fn _package_installer(target: string, out_dir: string, compiler_bin: string) -> 
     // saves a rebuild on first use. Same logic as the prelude
     // copy: presence is conditional, but once present a
     // failed `cp -R` is a bug, not a soft skip.
-    if fs.exists("build/native/import-context") {
-        let cp_import_ctx = process.run(["cp", "-R", "build/native/import-context", staging
+    if fs.exists("build/compiler/import-context") {
+        let cp_import_ctx = process.run(["cp", "-R", "build/compiler/import-context", staging
             + "/import-context"]);
         if cp_import_ctx != 0 {
             print("sfn package: failed to stage import-context (cp exit="

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -210,12 +210,16 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
 }
 
 fn _slug_alias_path_for_slug(slug: string) -> string {
-    return "build/native/import-context/" + slug + ".slugalias";
+    return "build/compiler/import-context/" + slug + ".slugalias";
 }
 
-fn _selfhost_slug_alias_path_for_slug(slug: string) -> string {
-    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug
-        + ".slugalias";
+// SFN-175: one-release old-path read fallback. The canonical import-context
+// tree moved to `build/compiler/import-context`, but the current pinned seed
+// still stages `build/native/import-context` during `make compile`. Reads try
+// the canonical path first and fall back here so transitional old-path trees
+// still resolve. Retires with the pre-stage + Makefile copy at the next seed bump.
+fn _compat_old_slug_alias_path_for_slug(slug: string) -> string {
+    return "build/native/import-context/" + slug + ".slugalias";
 }
 
 // #873: read the `.slugalias` sidecar the resolver drops at a capsule
@@ -225,7 +229,7 @@ fn _selfhost_slug_alias_path_for_slug(slug: string) -> string {
 fn _resolve_slug_alias(slug: string) -> string ![io] {
     let primary = _slug_alias_path_for_slug(slug);
     if fs.exists(primary) { return trim_text(fs.readFile(primary)); }
-    let fallback = _selfhost_slug_alias_path_for_slug(slug);
+    let fallback = _compat_old_slug_alias_path_for_slug(slug);
     if fs.exists(fallback) { return trim_text(fs.readFile(fallback)); }
     return "";
 }
@@ -394,7 +398,7 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
 
     // compiler/tests often import compiler sources via "../../src/<name>",
     // which resolves to "compiler/src/<name>". Our import-context artifacts
-    // are rooted at build/native/import-context/<name>.* (the compiler's own
+    // are rooted at build/compiler/import-context/<name>.* (the compiler's own
     // sources are staged with the `compiler/src/` prefix stripped, mirroring
     // `module_name_from_path`), so strip that prefix to keep imports and
     // artifact layout consistent.
@@ -414,27 +418,29 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
 }
 
 fn layout_manifest_path_for_slug(slug: string) -> string {
-    return "build/native/import-context/" + slug + ".layout-manifest";
+    return "build/compiler/import-context/" + slug + ".layout-manifest";
 }
 
 fn native_text_path_for_slug(slug: string) -> string {
+    return "build/compiler/import-context/" + slug + ".sfn-asm";
+}
+
+// SFN-175: one-release old-path read fallbacks (see
+// `_compat_old_slug_alias_path_for_slug`). Canonical reads target
+// `build/compiler/import-context`; these resolve transitional
+// `build/native/import-context` trees the current pinned seed still stages.
+fn _compat_old_layout_manifest_path_for_slug(slug: string) -> string {
+    return "build/native/import-context/" + slug + ".layout-manifest";
+}
+
+fn _compat_old_native_text_path_for_slug(slug: string) -> string {
     return "build/native/import-context/" + slug + ".sfn-asm";
-}
-
-fn _selfhost_layout_manifest_path_for_slug(slug: string) -> string {
-    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug
-        + ".layout-manifest";
-}
-
-fn _selfhost_native_text_path_for_slug(slug: string) -> string {
-    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug
-        + ".sfn-asm";
 }
 
 fn _resolve_layout_manifest_path_for_slug(slug: string) -> string ![io] {
     let primary = layout_manifest_path_for_slug(slug);
     if fs.exists(primary) { return primary; }
-    let fallback = _selfhost_layout_manifest_path_for_slug(slug);
+    let fallback = _compat_old_layout_manifest_path_for_slug(slug);
     if fs.exists(fallback) { return fallback; }
     return primary;
 }
@@ -442,7 +448,7 @@ fn _resolve_layout_manifest_path_for_slug(slug: string) -> string ![io] {
 fn _resolve_native_text_path_for_slug(slug: string) -> string ![io] {
     let primary = native_text_path_for_slug(slug);
     if fs.exists(primary) { return primary; }
-    let fallback = _selfhost_native_text_path_for_slug(slug);
+    let fallback = _compat_old_native_text_path_for_slug(slug);
     if fs.exists(fallback) { return fallback; }
     return primary;
 }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -395,7 +395,7 @@ fn _rh_descriptors_01(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
     });
     // Per-symbol fallback signature for libc `nanosleep`, called from
     // `runtime/sfn/clock.sfn::sfn_sleep`. In the common path the
-    // staged `build/native/import-context/runtime/sfn/platform/posix.sfn-asm`
+    // staged `build/compiler/import-context/runtime/sfn/platform/posix.sfn-asm`
     // artifact makes the imported function entry win at call resolution
     // (issue #633 — `core_call_resolution.sfn` prefers the function
     // entry over the descriptor and clears `result_helper`), and the
@@ -417,7 +417,7 @@ fn _rh_descriptors_01(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
     // from `runtime/sfn/clock.sfn::sfn_clock_monotonic_nanos` (#878).
     // Same fallback discipline as `nanosleep` directly above: in the
     // common path the staged
-    // `build/native/import-context/runtime/sfn/platform/posix.sfn-asm`
+    // `build/compiler/import-context/runtime/sfn/platform/posix.sfn-asm`
     // artifact makes the imported function entry win at call resolution
     // (#633) and `render_runtime_helper_declarations` skips this
     // descriptor via the `target == symbol` shadow check in

--- a/compiler/tests/e2e/capsule_build_test.sfn
+++ b/compiler/tests/e2e/capsule_build_test.sfn
@@ -117,7 +117,7 @@ test "capsule build: binary links and runs using capsule symbols" ![io] {
 
 // ---- Test 3: capsule import-context was staged ----
 // The import context for sfn/math lands at the CWD-relative
-// build/native/import-context/sfn/math/mod.sfn-asm (hardcoded in
+// build/compiler/import-context/sfn/math/mod.sfn-asm (hardcoded in
 // native_text_path_for_slug; always relative to the runner's CWD = repo root).
 test "capsule build: capsule import-context was staged" ![io] {
     _ensure_fixture();
@@ -129,7 +129,7 @@ test "capsule build: capsule import-context was staged" ![io] {
     let _e = process.capture_take_stderr();
     assert exit == 0;
 
-    assert fs.exists("build/native/import-context/sfn/math/mod.sfn-asm");
+    assert fs.exists("build/compiler/import-context/sfn/math/mod.sfn-asm");
 }
 
 // ---- Test 4: capsule .ll was produced under the per-capsule tree ----

--- a/compiler/tests/e2e/capsule_byname_import_link_test.sfn
+++ b/compiler/tests/e2e/capsule_byname_import_link_test.sfn
@@ -132,6 +132,6 @@ test "byname link: capsule staged + compiled under the spec slug (sfn/crypto/mod
     let _e = process.capture_take_stderr();
     assert exit == 0;
 
-    assert fs.exists("build/native/import-context/sfn/crypto/mod.sfn-asm");
+    assert fs.exists("build/compiler/import-context/sfn/crypto/mod.sfn-asm");
     assert fs.exists("build/capsules/sfn/crypto/ir/mod.ll");
 }

--- a/compiler/tests/e2e/check_cross_module_conformance_test.sfn
+++ b/compiler/tests/e2e/check_cross_module_conformance_test.sfn
@@ -105,13 +105,13 @@ test "check cross-module conformance: resolver staged import-context" ![io] {
     let _err = process.capture_take_stderr();
 
     // The staged .sfn-asm for shape.sfn lands at:
-    //   build/native/import-context/<root_without_leading_slash>/src/shape.sfn-asm
+    //   build/compiler/import-context/<root_without_leading_slash>/src/shape.sfn-asm
     // Strip the leading "/" from root to build the subdir path.
     let mut root_rel = root;
     if find(root, "/", 0) == 0 {
         root_rel = substring(root, 1, root.length);
     }
-    let shape_asm = "build/native/import-context/" + root_rel
+    let shape_asm = "build/compiler/import-context/" + root_rel
         + "/src/shape.sfn-asm";
     assert fs.exists(shape_asm);
 }

--- a/compiler/tests/e2e/cross_module_int_signature_ir_test.sfn
+++ b/compiler/tests/e2e/cross_module_int_signature_ir_test.sfn
@@ -16,7 +16,7 @@
 //   compiler/tests/e2e/cross_module_int_signature_test.sfn            (importer)
 //
 // The shared fixture's native ASM is staged under the default
-// `build/native/import-context/fixtures/` tree (CWD-relative, repo root)
+// `build/compiler/import-context/fixtures/` tree (CWD-relative, repo root)
 // so the importer's LLVM emit can resolve cross-module signatures.
 // Content is deterministic so concurrent parallel runs are safe.
 //
@@ -54,15 +54,15 @@ fn _importer_fixture() -> string {
 }
 
 // The shared fixture's .sfn-asm must live at
-// build/native/import-context/fixtures/<name>.sfn-asm so the default
+// build/compiler/import-context/fixtures/<name>.sfn-asm so the default
 // CWD-relative import-context lookup finds it when emitting the importer.
 // This is the same path `cd $SCRATCH && sfn emit native --module-name
-// fixtures/... -o $SCRATCH/build/native/import-context/fixtures/...` used
+// fixtures/... -o $SCRATCH/build/compiler/import-context/fixtures/...` used
 // in the original bash test, but here we write directly into the repo's
-// own build/native/import-context tree (deterministic content is safe
+// own build/compiler/import-context tree (deterministic content is safe
 // under concurrent runs).
 fn _staged_asm_path() -> string {
-    return "build/native/import-context/fixtures/cross_module_int_signature_shared.sfn-asm";
+    return "build/compiler/import-context/fixtures/cross_module_int_signature_shared.sfn-asm";
 }
 
 // Per-test LLVM IR output path (under SAILFIN_TEST_SCRATCH or /tmp).
@@ -72,13 +72,13 @@ fn _ll_path(tag: string) -> string ![io] {
     return base + "/sfn-xmod-int-sig-" + tag + ".ll";
 }
 
-// Stage the shared fixture's native ASM into build/native/import-context/fixtures/
+// Stage the shared fixture's native ASM into build/compiler/import-context/fixtures/
 // (CWD-relative). Emits only if not already present. Returns the asm path.
 fn _ensure_shared_asm_staged() -> string ![io] {
     let out = _staged_asm_path();
     if fs.exists(out) { return out; }
     // Ensure the directory exists.
-    fs.createDirectory("build/native/import-context/fixtures", true);
+    fs.createDirectory("build/compiler/import-context/fixtures", true);
     let exit = process.run_capture([_sfn_bin(), "emit", "--module-name", "fixtures/cross_module_int_signature_shared", "-o", out, "native", _shared_fixture()], _child_env());
     let _stdout = process.capture_take_stdout();
     let _stderr = process.capture_take_stderr();

--- a/compiler/tests/e2e/effect_gate_build_path_entry_test.sfn
+++ b/compiler/tests/e2e/effect_gate_build_path_entry_test.sfn
@@ -10,7 +10,7 @@
 // capsule and ran `sfn build -p .`; here we drive `sfn build -p <abs>`
 // from the runner's repo-root cwd. The per-module sidecar lands at the
 // repo-root-relative
-// `build/native/import-context/<fixture-abs-path>/src/util/sib.import-deps`
+// `build/compiler/import-context/<fixture-abs-path>/src/util/sib.import-deps`
 // (slug derived from the source's absolute path, which is unique per
 // test tag so concurrent runs in the parallel pool never collide).
 //
@@ -109,11 +109,11 @@ fn _build(root: string) -> BuildRun ![io] {
 }
 
 // The slug for the sibling sidecar is derived from the source's absolute
-// path: `build/native/import-context/<root-without-leading-slash>/src/util/sib.import-deps`.
+// path: `build/compiler/import-context/<root-without-leading-slash>/src/util/sib.import-deps`.
 fn _sidecar_path(root: string) -> string {
     // Strip the leading "/" from the absolute root.
     let rel = substring(root, 1, root.length);
-    return "build/native/import-context/" + rel + "/src/util/sib.import-deps";
+    return "build/compiler/import-context/" + rel + "/src/util/sib.import-deps";
 }
 
 // ---- Test 1: good sibling — its sidecar lists the entry's .sfn-asm ----

--- a/compiler/tests/e2e/http_capsule_serve_gate_test.sfn
+++ b/compiler/tests/e2e/http_capsule_serve_gate_test.sfn
@@ -49,7 +49,7 @@ fn _child_env() -> string[] ![io] {
 // discovery (`workspace.toml`) resolves the `sfn/http` dependency — a
 // system tmp dir would not. Repo-relative; the runner starts from the
 // repo root. This tree is unique per test, but the `sfn/http`
-// import-context it stages into (`build/native/import-context/sfn/http`)
+// import-context it stages into (`build/compiler/import-context/sfn/http`)
 // is a shared, fixed path — NOT the sole `sfn/http` consumer in the e2e
 // pool (see the #1789 note in the test body).
 fn _app_root() -> string { return "build/http-capsule-gate-e2e"; }
@@ -91,7 +91,7 @@ test "http serve gate: emit staging lowers imported serve to the capsule fn, not
     let main_path = _write_consumer();
 
     // #1789: this test previously force-COLD the emit with
-    // `rm -rf build/native/import-context/sfn/http`. That path is the
+    // `rm -rf build/compiler/import-context/sfn/http`. That path is the
     // shared, fixed import-context tree — routed only by `--work-dir`
     // (which `emit` does not expose), NOT by `SAILFIN_TEST_SCRATCH` — so
     // under the parallel `--jobs N` pool the delete raced concurrent

--- a/compiler/tests/e2e/runtime_sfn_sources_struct_import_test.sfn
+++ b/compiler/tests/e2e/runtime_sfn_sources_struct_import_test.sfn
@@ -14,7 +14,7 @@
 // (`<cache-dir>/rt-import-context/<slug>.sfn-asm`), writes per-module
 // `.import-deps` sidecars for sibling imports, and threads the root into
 // each child emit via `--import-context`, so sibling signatures resolve
-// without publishing into the shared cwd `build/native/import-context/`
+// without publishing into the shared cwd `build/compiler/import-context/`
 // tree (publishing there regresses the prelude's lowering).
 //
 // The test:

--- a/compiler/tests/e2e/runtime_sfn_sources_struct_import_test.sfn
+++ b/compiler/tests/e2e/runtime_sfn_sources_struct_import_test.sfn
@@ -215,9 +215,9 @@ test "runtime sfn-source struct import builds, stages context, and round-trips (
 
     // Nothing may leak into the SHARED cwd-relative import-context tree
     // (the prelude-regression vector). With --work-dir the shared tree
-    // would be `<build_dir>/native/import-context`; assert no runtime
+    // would be `<build_dir>/compiler/import-context`; assert no runtime
     // sfn-source asm leaked there.
-    let shared = build_dir + "/native/import-context/runtime/sfn";
+    let shared = build_dir + "/compiler/import-context/runtime/sfn";
     assert ! fs.exists(shared + "/structlib.sfn-asm");
     assert ! fs.exists(shared + "/structuse.sfn-asm");
 

--- a/compiler/tests/e2e/serve_loopback_test.sfn
+++ b/compiler/tests/e2e/serve_loopback_test.sfn
@@ -368,7 +368,7 @@ fn _write_fetch_client(port_str: string) -> string ![io] {
 //
 // #1789: deliberately NO `--work-dir` here. This is the sole
 // `sfn/http`-consumer build in its CI e2e shard (`e2e-d`), so there is no
-// sibling to isolate the shared `build/native/import-context/sfn/http`
+// sibling to isolate the shared `build/compiler/import-context/sfn/http`
 // from — a private `--work-dir` would buy no isolation and only force a
 // slower COLD build, adding CPU/memory pressure under the parallel pool
 // that can starve this test's spawned server and blow the readiness poll.

--- a/compiler/tests/e2e/work_dir_parity_test.sfn
+++ b/compiler/tests/e2e/work_dir_parity_test.sfn
@@ -17,7 +17,7 @@
 //      stays in `make check` (stage2-vs-stage3 IR comparison); the former
 //      standalone `--check-determinism` double-build is dropped from the
 //      e2e leg so it no longer times out under the parallel pool (#1576).
-//   2. The set of staged filenames under `<DIR>/native/import-context/`
+//   2. The set of staged filenames under `<DIR>/compiler/import-context/`
 //      is identical between two `--work-dir` roots (we compare the full
 //      recursive filename set — strictly stronger than `.ll`-only).
 //
@@ -127,7 +127,7 @@ fn _collect_files(root: string, rel: string, acc: string[]) -> string[] ![io] {
 }
 
 fn _ic_file_set(work_dir: string) -> string[] ![io] {
-    let ic = work_dir + "/native/import-context";
+    let ic = work_dir + "/compiler/import-context";
     let mut acc: string[] = [];
     if !fs.exists(ic) { return acc; }
     return _collect_files(ic, ".", acc);
@@ -200,7 +200,7 @@ test "work-dir-parity: two --work-dir builds produce byte-identical compilers" !
 
 // ---- Test 2: import-context filename sets are identical ----
 // Compares the full recursive filename set under
-// `<DIR>/native/import-context/` between two distinct work-dir roots.
+// `<DIR>/compiler/import-context/` between two distinct work-dir roots.
 // Module names and relative paths there don't depend on link-time UUIDs,
 // so the sets must be exactly equal.
 test "work-dir-parity: import-context filename set matches across roots" ![io] {

--- a/compiler/tests/integration/check_staging_equivalence_test.sfn
+++ b/compiler/tests/integration/check_staging_equivalence_test.sfn
@@ -28,7 +28,7 @@
 //     under a non-`sailfin` name is what forces the miss.
 //
 // Each run uses its own work directory (staging writes to
-// `<cwd>/build/native/import-context`), so the two staged trees can
+// `<cwd>/build/compiler/import-context`), so the two staged trees can
 // be `diff -r`'d whole: same file set, same bytes. Spawning the real
 // binary (rather than importing resolver entry points) matches
 // production exactly and avoids dragging the whole driver into the
@@ -37,7 +37,7 @@
 // Each spawned `check` clears `SAILFIN_TEST_SCRATCH` (`SAILFIN_TEST_SCRATCH=`
 // prefix): the parent test runner sets it per-file, and the compiler now
 // routes the import-context staging under it (#1333). This test asserts on
-// the CWD-relative default (`<cwd>/build/native/import-context`), so it
+// the CWD-relative default (`<cwd>/build/compiler/import-context`), so it
 // must opt out of that redirection to exercise the default path.
 extern fn sailfin_runtime_shell_capture(cmd: * u8) -> * u8;
 
@@ -99,18 +99,18 @@ test "check staging: subprocess path stages byte-identical artifacts to in-proce
     // staged at least one `.sfn-asm` (the fixture's relative import
     // guarantees a non-empty resolution).
     let staged_a = process.run(["sh", "-c", "find " + work_a
-        + "/build/native/import-context -name '*.sfn-asm' | grep -q ."]);
+        + "/build/compiler/import-context -name '*.sfn-asm' | grep -q ."]);
     assert staged_a == 0;
     let staged_b = process.run(["sh", "-c", "find " + work_b
-        + "/build/native/import-context -name '*.sfn-asm' | grep -q ."]);
+        + "/build/compiler/import-context -name '*.sfn-asm' | grep -q ."]);
     assert staged_b == 0;
 
     // The headline equivalence: identical file set, identical bytes
     // (`.sfn-asm`, `.layout-manifest`, and `.srchash` sidecars all
     // participate in the recursive diff).
     let rc_diff = process.run(["diff", "-r", work_a
-        + "/build/native/import-context", work_b
-        + "/build/native/import-context"]);
+        + "/build/compiler/import-context", work_b
+        + "/build/compiler/import-context"]);
     assert rc_diff == 0;
 
     process.run(["rm", "-rf", root]);
@@ -153,7 +153,7 @@ test "check staging: warm re-run is a cache hit (staged artifacts untouched)" ![
     // `_cr_write_capsule_slug_aliases` writes no `.slugalias` on
     // either run. A capsule fixture with a scoped slug would rewrite
     // the alias each run and flake the `-newer` half of this probe.
-    let ctx = work + "/build/native/import-context";
+    let ctx = work + "/build/compiler/import-context";
     let set_cmd = "cd " + ctx + " && find . -type f | sort";
     let set_before = _shell_capture(set_cmd);
     assert set_before.length > 0;

--- a/compiler/tests/unit/check_tool_test.sfn
+++ b/compiler/tests/unit/check_tool_test.sfn
@@ -276,7 +276,7 @@ test "check: location-only line includes file_path" {
 }
 
 test "check: location-only line works for arbitrary missing-artifact paths" {
-    let line = _local_render_location_only("build/native/import-context/sfn_prelude/mod.sfn-asm");
+    let line = _local_render_location_only("build/compiler/import-context/sfn_prelude/mod.sfn-asm");
     assert _contains(line, "import-context/sfn_prelude");
     assert _contains(line, ".sfn-asm");
 }

--- a/compiler/tests/unit/stage_capsule_imports_test.sfn
+++ b/compiler/tests/unit/stage_capsule_imports_test.sfn
@@ -4,7 +4,7 @@
 //
 // Before #514 the staging cache treated a present `.sfn-asm` + `.layout-manifest`
 // pair as an authoritative hit purely by existence, so the Makefile had to
-// wipe `build/native/import-context/*.sfn-asm` by hand on every rebuild. The
+// wipe `build/compiler/import-context/*.sfn-asm` by hand on every rebuild. The
 // fix records a `.srchash` sidecar holding the SHA-256 of the source; a hit
 // now requires that sidecar to match the source's current hash.
 //
@@ -77,8 +77,8 @@ fn _sct_stage(root: string, slug: string, src_path: string, asm_path: string, ma
 // Sidecar path shape
 // --------------------------------------------------------------
 test "stage cache: srchash sidecar is a sibling of the staged artifacts" {
-    assert _cr_srchash_path("build/native/import-context", "cli_main") == "build/native/import-context/cli_main.srchash";
-    assert _cr_srchash_path("build/native/import-context", "sfn/cli/mod") == "build/native/import-context/sfn/cli/mod.srchash";
+    assert _cr_srchash_path("build/compiler/import-context", "cli_main") == "build/compiler/import-context/cli_main.srchash";
+    assert _cr_srchash_path("build/compiler/import-context", "sfn/cli/mod") == "build/compiler/import-context/sfn/cli/mod.srchash";
 }
 
 // --------------------------------------------------------------

--- a/docs/proposals/0006-build-architecture.md
+++ b/docs/proposals/0006-build-architecture.md
@@ -292,7 +292,7 @@ single source file at a time.
   `compile_to_llvm_file_with_module(source, module_name, "build/sailfin/program.ll")`,
   then `clang`-links against the installed runtime bundle via
   `_clang_link`. It does **not** resolve imports itself; the compiler's
-  in-process import resolver reads from `build/native/import-context/` if
+  in-process import resolver reads from `build/compiler/import-context/` if
   present.
 - `sfn run <file>` — before compilation, calls `inline_imports_for_source`
   in `cli_commands.sfn`. That function performs *textual* import inlining:
@@ -827,7 +827,7 @@ build/capsules/sfn/compiler/
 ```
 
 The `.sfn-asm` + `.layout-manifest` pair replaces the current
-`build/native/import-context/` staging directory. Every consumer reads
+`build/compiler/import-context/` staging directory. Every consumer reads
 from `build/capsules/<dep>/ir/` for the dep's exported interface.
 
 ### 4.5 Resolver: one path for all imports
@@ -1651,7 +1651,7 @@ Raw CSV: `docs/baselines/compile-0.7.0-darwin-arm64.csv`.
 | Sum of isolated per-module emits | 566.73 s (serial; not the parallel build wall-time) |
 
 These are *isolated per-module* emit timings (each module emitted alone against
-`build/native/import-context`). Peak RSS of ~4.4 GB on a single module is under the
+`build/compiler/import-context`). Peak RSS of ~4.4 GB on a single module is under the
 8 GiB self-cap but is the standout regression candidate to watch — the heaviest
 emitters are the `llvm/expression_lowering/native/core*` family and the two CLI
 modules.

--- a/docs/proposals/0011-ci-test-speed.md
+++ b/docs/proposals/0011-ci-test-speed.md
@@ -164,7 +164,7 @@ the 1.5-3 min build. Two options:
   because shards run concurrently. The only cost is runner-minute
   consumption (4x build instead of 1x). Acceptable for Phase 1; ship it.
 - **1b (Phase 2, optimization):** split the build into its own job that
-  uploads `build/bin/sfn` + `build/native/import-context` +
+  uploads `build/bin/sfn` + `build/compiler/import-context` +
   `build/cache` as a workflow artifact (or `actions/cache` with a
   per-run key), and have each shard `needs:` that job and download
   instead of rebuilding. Saves the redundant build runner-minutes and

--- a/scripts/bench_compile.sh
+++ b/scripts/bench_compile.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 
 SEED="${SEED:-build/bin/sfn}"
 WORK_DIR="${WORK_DIR:-build/bench}"
-IMPORT_CONTEXT="${IMPORT_CONTEXT:-build/native/import-context}"
+IMPORT_CONTEXT="${IMPORT_CONTEXT:-build/compiler/import-context}"
 CSV_OUT=""
 TOP_N=0
 BUDGET_TIME=0        # seconds; 0 = no budget
@@ -137,11 +137,11 @@ bench_module() {
 
     # Prepare isolated working directory
     local module_cwd="$WORK_DIR/tmp/${name}/seed_cwd"
-    mkdir -p "$module_cwd/build/native" "$module_cwd/build/sailfin"
-    rm -rf "$module_cwd/build/native/import-context"
-    cp -a "$IMPORT_CONTEXT" "$module_cwd/build/native/import-context"
-    rm -f "$module_cwd/build/native/import-context/${slug}.sfn-asm" 2>/dev/null || true
-    rm -f "$module_cwd/build/native/import-context/${slug}.layout-manifest" 2>/dev/null || true
+    mkdir -p "$module_cwd/build/compiler" "$module_cwd/build/sailfin"
+    rm -rf "$module_cwd/build/compiler/import-context"
+    cp -a "$IMPORT_CONTEXT" "$module_cwd/build/compiler/import-context"
+    rm -f "$module_cwd/build/compiler/import-context/${slug}.sfn-asm" 2>/dev/null || true
+    rm -f "$module_cwd/build/compiler/import-context/${slug}.layout-manifest" 2>/dev/null || true
 
     local out_ll="$WORK_DIR/${name}.ll"
     local time_log="$WORK_DIR/${name}.time"

--- a/scripts/diag_determinism_sweep.sh
+++ b/scripts/diag_determinism_sweep.sh
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 OUT_DIR="/tmp/sailfin-diag-det/out"
-IMPORT_CACHE="$REPO_ROOT/build/native/import-context"
+IMPORT_CACHE="$REPO_ROOT/build/compiler/import-context"
 
 [[ -x "$SEED" ]]         || { echo "missing seed: $SEED" >&2; exit 2; }
 [[ -d "$IMPORT_CACHE" ]] || { echo "missing import-context (run make compile first)" >&2; exit 2; }
@@ -49,10 +49,10 @@ do_module() {
 
     local mod_cwd="/tmp/sailfin-diag-det/cwd/$safe"
     rm -rf "$mod_cwd"
-    mkdir -p "$mod_cwd/build/native"
-    cp -a "$IMPORT_CACHE" "$mod_cwd/build/native/import-context"
-    rm -f "$mod_cwd/build/native/import-context/${slug}.sfn-asm" \
-          "$mod_cwd/build/native/import-context/${slug}.layout-manifest"
+    mkdir -p "$mod_cwd/build/compiler"
+    cp -a "$IMPORT_CACHE" "$mod_cwd/build/compiler/import-context"
+    rm -f "$mod_cwd/build/compiler/import-context/${slug}.sfn-asm" \
+          "$mod_cwd/build/compiler/import-context/${slug}.layout-manifest"
 
     local hashes="" sizes="" nonascii_total=0
     for (( k=1; k<=ITERS; k++ )); do

--- a/scripts/test_arena.sh
+++ b/scripts/test_arena.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 SEED="${SEED:-build/bin/sfn}"
 WORK_DIR="${WORK_DIR:-build/arena-test}"
-IMPORT_CONTEXT="${IMPORT_CONTEXT:-build/native/import-context}"
+IMPORT_CONTEXT="${IMPORT_CONTEXT:-build/compiler/import-context}"
 
 # ---------------------------------------------------------------------------
 # Arg parsing
@@ -86,9 +86,9 @@ compile_once() {
     local out_ll="$4"
     local stderr_log="$5"
 
-    mkdir -p "$module_cwd/build/native" "$module_cwd/build/sailfin"
-    rm -rf "$module_cwd/build/native/import-context"
-    cp -a "$ABS_IC" "$module_cwd/build/native/import-context"
+    mkdir -p "$module_cwd/build/compiler" "$module_cwd/build/sailfin"
+    rm -rf "$module_cwd/build/compiler/import-context"
+    cp -a "$ABS_IC" "$module_cwd/build/compiler/import-context"
 
     local abs_src
     abs_src="$(cd "$REPO_ROOT" && realpath "$src")"


### PR DESCRIPTION
## Summary

Move the compiler's canonical import-context staging tree from the legacy `build/native/import-context` (a Python-bootstrap-era layout) to `build/compiler/import-context`, the natural sibling of the `build/bin/sfn` binary rename (SFN-173). Touches the capsule resolver (writer), the LLVM import loader (reader), the Makefile self-host flow, scripts, CI, the `package` command, and regression tests.

The migration is **one self-hosting PR — no seed cut**. The currently pinned seed still stages the old path during `make compile`, so the new compiler keeps a **one-release old-path read fallback** and `make rebuild` **copies** (not moves) the seed-written tree old→new after the binary is built. Both retire cleanly at the next seed bump.

Fixes SFN-175

## Changes

- **capsule_resolver.sfn** (writer): `_cr_import_context_root` stages `build/compiler/import-context` (no-work-dir default and the `<work_dir>/compiler/import-context` suffix, in lockstep). Every staging call site and the `.import-deps` sidecar paths derive from this one function.
- **llvm/imports.sfn** (reader): primary path builders (`layout_manifest_path_for_slug`, `native_text_path_for_slug`, `_slug_alias_path_for_slug`) emit the new path; the previously-dormant seed_cwd fallback tier is repurposed into `_compat_old_*` old-path read fallbacks wired into the existing `_resolve_*` new→old→primary tiering.
- **Makefile**: pre-stage of `runtime/sfn/platform/*` **stays** at the old path (it is emitted and read by the pinned seed during `build -p compiler`); `rebuild-impl` adds a `cp -a` old→new after the binary is finalized; post-stage platform/ownedbuf re-emit and every post-compile consumer (`bench`, `test-arena`, `ci-prepare-test-artifacts`) use the new path.
- **scripts** (`bench_compile.sh`, `test_arena.sh`, `diag_determinism_sweep.sh`): both the source-tree default and the per-module scratch-dest (the cwd-relative path the new compiler reads after `cd`) move to the new path.
- **driver/CLI**: `cli/commands/package.sfn` bundles the new path; comment-only updates in `cli/commands/build.sfn`, `llvm/runtime_helpers.sfn`, `build/runtime_objs.sfn`.
- **CI**: `ci.yml` shard-bundle path; `benchmark.yml` comment.
- **tests**: e2e/integration/unit assertions (they run the new compiler, so observe the new path).
- **docs**: active refs in `0006-build-architecture.md`, `0011-ci-test-speed.md`; historical seed_cwd/bash-collapse refs intentionally left.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file (17 files)
- [x] `sfn check` (fast static analysis) passes — `make check-fast`: 238 files ok
- [x] `make compile` — compiler self-hosts; fresh tree lands at `build/compiler/import-context` (216 `.sfn-asm`, platform + ownedbuf re-emitted there; old seed tree preserved as warm cache)
- [x] `make test-unit` — 206/206 passed
- [x] `make test-arena` — PASS (import-context copies cleanly into the new scratch-dest)
- [x] `make bench BENCH_ARGS="--top 1"` — all 202 modules within budget
- [x] Regression coverage: existing e2e/integration/unit path assertions updated to the new path
- [ ] `make check` — full triple-pass suite (not run; `make compile` + `make check-fast` + full `test-unit` cover the self-host and cross-module paths for a path-rename refactor)

## Map reconciliation

Advisory `## Files Affected` from the issue matched the tree; the resolver/import literals, Makefile staging, scripts, CI, packaging, and test surface were all where the issue's Evidence section pointed. No semantic scope change.

## Notes for reviewers

- **The one hard self-hosting constraint:** the Makefile pre-stage (`build/native/import-context/runtime/sfn/platform/*`) must stay on the old path — it is emitted by and read by the *pinned seed*. Moving it would break the cold build with the current seed. It retires with the `cp` shim and the reader fallback at the next seed bump.
- **Copy, not move:** `rebuild-impl` uses `cp -a` so the seed's srchash-keyed warm-build cache survives at the old path; a `mv` would force every module to re-emit its `.sfn-asm` on the next warm rebuild.
- Repo-wide `rg build/native/import-context` now leaves only: the seed-consumed Makefile pre-stage, the `cp` source + its comment, the `imports.sfn` compat-fallback literals, and historical docs.
- Non-blocking (pre-existing): the `_compat_old_*` fallback is cwd-relative with no `--work-dir` variant, matching the prior fallback tier; harmless because the new primary is always populated after `make compile`. Noted for the seed-bump cleanup.
- Follow-up at the next seed bump: delete the Makefile pre-stage's old-path lines, the `cp` shim, and the `imports.sfn` `_compat_old_*` tier together (cite SFN-175).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhSNQqgkNrd9F7ucxLC2eh)_