### PR TITLE
perf(test): cap macOS TEST_JOBS at 2 to bound e2e-pool OOM margin (SFN-87)

### DIFF
--- a/scripts/detect_test_jobs.sh
+++ b/scripts/detect_test_jobs.sh
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 # detect_test_jobs.sh — Pick a sensible TEST_JOBS default for the current host.
 #
-# Heuristic: min(cores, mem_mb / 384), floor 1, cap 16.
+# Heuristic: min(cores, mem_mb / 384), floor 1, cap 16; macOS caps at 2.
 #
-# The 384 MB-per-job budget is sized for test-runner child processes, not
-# compiler-module builds. Measured child-process peak at the time of #1998:
+# The 384 MB-per-job budget is sized for the common test-runner child
+# process, not compiler-module builds. Measured child-process peak at the
+# time of #1998:
 #   * typical unit/integration test child   : ~50–80 MB RSS
-#   * e2e test that spawns a nested compiler : ~150 MB RSS (heaviest class)
-# The 384 MB budget gives ~2.5× headroom over the heaviest class to
-# absorb e2e tests that fork nested compiler+clang trees without
-# overcommitting the runner.
+# The 384 MB budget gives ample headroom over that common class.
 #
 # This deliberately differs from detect_build_jobs.sh's ~2 GB-per-job budget,
 # which is sized for per-module emit (heaviest module: ~1.76 GB peak RSS).
-# Using BUILD_JOBS' budget for test children would under-report parallelism
-# by ~5×: a 7 GB macOS runner that allows BUILD_JOBS=2 allows TEST_JOBS≈18,
-# bounded further by core count.
+# Using BUILD_JOBS' budget for every test child would under-report
+# parallelism by ~5× for the light majority.
 #
-# No macOS-specific ceiling: the 2-job cap in detect_build_jobs.sh exists
-# because two concurrent 1.6 GB module builds overcommit a 7 GB runner.
-# Test children are ~10× lighter, so the memory budget alone protects
-# the macOS CI runner (7168 / 384 ≈ 18 → naturally bounded by the 3-4
-# core count and the global cap of 16 anyway).
+# macOS additionally caps at 2 jobs, mirroring detect_build_jobs.sh. The
+# 384 MB budget is right for the light majority but wrong for the
+# build-and-run e2e class: an e2e test that spawns a nested cold
+# `sfn build`/`sfn run`/`sfn emit` peaks ~1.3–1.8 GB RSS while that nested
+# compile runs — the same weight class as a module build, not the ~150 MB
+# once assumed here. On the memory-constrained macOS runner (~7 GB) the
+# memory budget alone lets enough of those heavy children coincide to tip
+# the pool into OOM: the macOS-arm64 nightly self-host check kept aborting
+# with exit 134 / SIGABRT in the e2e phase, the victim test roaming run to
+# run (SFN-87). A flat 2-job cap bounds the concurrent-heavy-compile peak
+# the same way BUILD_JOBS=2 does; Linux is unaffected and an explicit
+# TEST_JOBS=N still wins.
 #
 # Cap 16: the runner's --jobs parameter accepts [1, 256] but the
 # sliding-window pool has diminishing returns past core count; 16 matches
@@ -67,8 +71,13 @@ by_mem=$((mem_mb / 384))
 jobs=$cores
 [ "$by_mem" -lt "$jobs" ] && jobs=$by_mem
 
-# Windows: xargs -P parallelism is unreliable under MSYS/Cygwin/Git Bash.
+# macOS caps at 2 (see header: bounds the concurrent build-and-run e2e
+# peak on the ~7 GB runner, SFN-87). Windows: xargs -P parallelism is
+# unreliable under MSYS/Cygwin/Git Bash.
 case "$uname_s" in
+    Darwin*)
+        [ "$jobs" -gt 2 ] && jobs=2
+        ;;
     MINGW*|MSYS*|CYGWIN*)
         jobs=1
         ;;


### PR DESCRIPTION
## Summary

The macOS-arm64 nightly self-host check (run #87, and most nights before it) aborts with **exit 134 / SIGABRT** in the e2e phase. The victim test *roams* run to run — #87's was `compiler/tests/e2e/capsule_artifact_sidecar_test.sfn:276` (a build-and-run test whose freshly-built binary ran but produced no output), exactly the "fourth victim" SFN-87 predicts. Linux stays green; the failing leg alternates platforms across nights, the signature of **margin-dependent OOM under concurrent cold compiles**, not a per-test bug.

Root cause is in the pool-sizing heuristic, not the compiler: `scripts/detect_test_jobs.sh` budgets **384 MB/job** on the assumption that a nested-compiler e2e child peaks ~150 MB. Per SFN-87's measurements the **build-and-run e2e class actually peaks ~1.3–1.8 GB** while its nested cold `sfn build`/`run`/`emit` runs — the same weight class as a module build. On the ~7 GB macOS runner the memory budget alone lets enough heavy children coincide to tip the pool into OOM.

This mirrors the existing macOS 2-job cap in `scripts/detect_build_jobs.sh` (same runner, same concurrent-heavy-compile problem) onto the test-jobs heuristic. It's SFN-87's preferred "option 2" (a macOS-aware nested-compile concurrency cap) realized at the jobs-detection layer that post-dates the issue. Bash-only change — no compiler source, no `.sfn` touched.

Ref SFN-87

<!-- Link-only, not Fixes: SFN-87's acceptance criterion is 2–3 consecutive green
     macOS nightly runs, which a single merge cannot satisfy. Leave it open for the soak. -->

## Changes

- `scripts/detect_test_jobs.sh`:
  - Add a `Darwin*` branch capping `jobs` at 2 (mirrors `detect_build_jobs.sh`).
  - Correct the stale header comment that under-stated the heaviest e2e class at ~150 MB; document the ~1.3–1.8 GB build-and-run peak and the SFN-87 OOM signature.

Strictly reduces peak RSS. Linux/Windows detection is unchanged; an explicit `TEST_JOBS=N` (or the sharded-CI `SAILFIN_TEST_JOBS` path in `test_shards.sh`) still wins.

## Validation

- [x] N/A — config/script-only change (no `.sfn` touched, so no `sfn fmt`/`sfn check`/`make compile` gate applies)
- [x] `bash -n scripts/detect_test_jobs.sh` clean; native Linux run unchanged (4 on a 4-core host); simulated Darwin path caps at 2 across cores∈{3,4,8} × by_mem∈{4,18}
- Durable signal is the macOS-arm64 nightly self-host soak (per SFN-87 AC) — local Linux runs cannot reproduce the macOS OOM.

## Notes for reviewers

- **Margin-reduction step, not a claimed closure.** SFN-87 requires a 2–3 night green macOS streak to verify; this bounds the concurrent-heavy-compile peak but the soak is the proof. Left as `Ref` so the issue stays open.
- **Wall-clock tradeoff is bounded.** macOS `make check` currently runs ~2h of a 180-min job budget; cutting the e2e pool 3→2 slows only the parallel test phases (each separately capped at `CHECK_TEST_TIMEOUT=1800s`), with ample headroom. Reducing parallelism cannot worsen the OOM axis.
- Deliberately does **not** patch the roaming victim (`capsule_artifact_sidecar_test.sfn`) — SFN-87 warns a per-test patch just moves the failure to a fifth test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6HsfkmZyJGEXgyLdpZNzW)_