### PR TITLE
refactor(cli): read login token via io.read_line, retire head -1 shellout (SFN-178)

### DIFF
--- a/compiler/src/cli/commands/login.sfn
+++ b/compiler/src/cli/commands/login.sfn
@@ -82,9 +82,10 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     } else {
         print("enter your registry token:");
         // Read a single line from fd 0. `io.read_line(0) -> string?` returns
-        // `null` only on immediate EOF (no input at all); a blank line is
-        // `Some("")`, which falls through to the "empty token" guard below —
-        // matching the legacy `head -1` behaviour without the mktemp/rm shellout.
+        // `null` on immediate EOF (no input at all) or an allocation failure;
+        // a blank line is `Some("")`, which falls through to the "empty token"
+        // guard below — matching the legacy `head -1` behaviour without the
+        // mktemp/rm shellout.
         let line = io.read_line(0);
         if line != null { token = _toml_trim_cmd(line); } else {
             print("error: failed to read token");

--- a/compiler/src/cli/commands/login.sfn
+++ b/compiler/src/cli/commands/login.sfn
@@ -9,8 +9,10 @@
 // `login` takes a single optional positional `[token]`. When present it is
 // the registry token; when absent, `run` prompts and reads the token from
 // stdin exactly as the legacy handler did. The credential store
-// (`~/.sfn/credentials`), the `chmod 700/600` handling, the write-back
-// verification, and every exit code / message are reproduced byte-for-byte:
+// (`~/.sfn/credentials`), the `chmod 700/600` handling, and the write-back
+// verification are preserved, as are the exit codes below. Messages match
+// the legacy handler except that immediate stdin EOF now reports "failed to
+// read token" (SFN-154 made EOF distinguishable from a blank line):
 //   - 0 — credentials written and verified.
 //   - 1 — empty token, no home directory, or a failed write.
 // The usage error (2) for extra positionals is enforced by the v2 dispatch
@@ -43,7 +45,7 @@ import {
     with_arg
 } from "sfn/cli";
 
-import { _ensure_dir_recursive_cmd, _shell_read_cmd, _toml_trim_cmd } from "../../build/fs";
+import { _ensure_dir_recursive_cmd, _toml_trim_cmd } from "../../build/fs";
 import { _get_home_cmd } from "../../build_flags";
 import { CliContext } from "../context";
 
@@ -66,8 +68,10 @@ fn command_def() -> Command {
 
 // Save a registry token to `~/.sfn/credentials`. With a `token` positional
 // the value is used directly; without one, prompt and read a single line
-// from stdin. `ctx` is part of the per-command contract but unused here.
-// Byte-identical to the legacy `login` command-handler body.
+// from stdin via `io.read_line(0)` (SFN-154), replacing the legacy `head -1`
+// shellout. `ctx` is part of the per-command contract but unused here. Exit
+// codes and side effects match the legacy handler; the only message change
+// is the immediate-EOF path (see the header note).
 fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     let token_arg = get(matches, "token");
     let mut token: string = "";
@@ -77,19 +81,15 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
         token = _toml_trim_cmd(token_arg);
     } else {
         print("enter your registry token:");
-        let tmp = _shell_read_cmd("mktemp /tmp/.sfn_login_XXXXXX");
-        if tmp.length == 0 {
-            print("error: failed to create secure temp file");
-            return 1;
-        }
-        let read_rc = process.run(["sh", "-c", "head -1 > " + tmp]);
-        if read_rc != 0 {
-            process.run(["rm", "-f", tmp]);
+        // Read a single line from fd 0. `io.read_line(0) -> string?` returns
+        // `null` only on immediate EOF (no input at all); a blank line is
+        // `Some("")`, which falls through to the "empty token" guard below —
+        // matching the legacy `head -1` behaviour without the mktemp/rm shellout.
+        let line = io.read_line(0);
+        if line != null { token = _toml_trim_cmd(line); } else {
             print("error: failed to read token");
             return 1;
         }
-        if fs.exists(tmp) { token = _toml_trim_cmd(fs.readFile(tmp)); }
-        process.run(["rm", "-f", tmp]);
     }
 
     if token.length == 0 {

--- a/compiler/tests/e2e/login_test.sfn
+++ b/compiler/tests/e2e/login_test.sfn
@@ -145,3 +145,20 @@ test "login: sets restrictive permissions" ![io] {
     assert fs.get_perms(home + "/.sfn") == 448;
     assert fs.get_perms(home + "/.sfn/credentials") == 384;
 }
+
+// ---- Test 9: login on immediate stdin EOF fails cleanly ----
+// Close the child's stdin with nothing written: `io.read_line(0)` sees an
+// immediate EOF and returns null, so `login` reports a read error, exits 1,
+// and writes no credentials (SFN-154 EOF-null path; `login` is its first
+// production consumer).
+test "login: immediate stdin EOF fails cleanly" ![io] {
+    let home = _home("eof");
+    let id = process.spawn_with_env([_sfn_bin(), "login"], _env(home));
+    assert id != 0;
+    process.handle_close_stdin(id);
+    let _out = process.handle_read_stdout(id);
+    let _err = process.handle_read_stderr(id);
+    let exit = process.handle_wait(id);
+    assert exit == 1;
+    assert ! fs.exists(home + "/.sfn/credentials");
+}


### PR DESCRIPTION
## Summary

Retires the interactive token-read hack in `sfn login`
(`compiler/src/cli/commands/login.sfn`): the `mktemp` →
`process.run(["sh","-c","head -1 > tmp"])` → `fs.readFile` → `rm -f` shellout is
replaced with a direct `io.read_line(0) -> string?`, null-checking for immediate
EOF. `io.read_line` (SFN-154 / #1579) is a typed stdin builtin already present in
the pinned seed (`v0.8.0-alpha.3`), so this compiler-source consumer self-hosts.

Fixes SFN-178

## Changes

- **driver / cli** (`compiler/src/cli/commands/login.sfn`): interactive branch now
  reads one line via `io.read_line(0)` instead of the mktemp/`head -1`/rm
  sequence; `_shell_read_cmd` import dropped (no remaining use). Updated the
  module-header comments that claimed the body was "byte-identical" to the legacy
  handler, since the immediate-EOF message intentionally changes.
- **tests** (`compiler/tests/e2e/login_test.sfn`): added Test 9 — `login` on
  immediate stdin EOF exits 1 and writes no credentials (locks in the SFN-154
  EOF-null path; `login` is its first production consumer).

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts
- [ ] `make check` — not run; ran `make test` (full suite) instead
- [x] Regression coverage added or updated under `compiler/tests/`

`make test`: unit 207/207, integration 45/45, capsules 42/42; e2e 204/205 — the
lone e2e miss is `work_dir_parity_test.sfn` timing out (`make` Error 124) under
the loaded parallel pool. It **passes 2/2 in isolation** and is unrelated to this
change (login.sfn has no `work_dir` surface). `login_test.sfn` passes 9/9.

Manual behaviour check with a private `HOME`:
- Piped token (`printf 'tok\n' | sfn login`) → saved, exit 0.
- Immediate EOF (`sfn login < /dev/null`) → `error: failed to read token`, exit 1, no credentials.
- Blank line (`printf '\n' | sfn login`) → `error: empty token`, exit 1 (unchanged from legacy).

## Behavioural fidelity

Exit codes and side effects match the legacy handler. The only observable
difference is the message on **immediate stdin EOF**: `failed to read token`
(was `empty token`). This is intentional — SFN-154 makes EOF distinguishable
from a blank line, and a blank line still routes to the existing empty-token
guard.

## Notes for reviewers

- Nullable narrowing (`if line != null { token = _toml_trim_cmd(line) }`) is the
  established `string?` → `string` flow-narrowing pattern; confirmed by `sfn check`
  + self-host.
- `## Map reconciliation`: none — the advisory `Files affected` (login.sfn) matched
  the tree; login_test.sfn extension is in-scope per the issue's Verification note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtffyuUpShugH88jiexnMp)_