### PR TITLE
feat(runtime): process.exec (execve) primitive for toolchain dispatch (SFN-199)

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -759,12 +759,18 @@ fn _rh_descriptors_05(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.run_capture", symbol: "sfn_process_run_capture", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_run_capture", c_abi_return_type: null
     });
-    // SFN-172 / SFEP-0046 §3.5: `process.exec(argv, env_flat)` — `execve(2)`
-    // process-image replacement for toolchain re-exec dispatch. Same 2-array
-    // shape as `process.run_capture` (argv + flat `KEY=VALUE` env). Only the
-    // freshly-built compiler emits this call (exclusively from the toolchain
-    // dispatcher), so — like `process.run_capture_cwd` above — no seed cut is
-    // required for the seed to build a compiler that uses it.
+    // SFN-199 / SFEP-0046 §3.5: `process.exec(argv, env_flat)` — `execve(2)`
+    // process-image replacement for toolchain re-exec dispatch (the SFN-172
+    // consumer). Same 2-array shape as `process.run_capture` (argv + flat
+    // `KEY=VALUE` env). Unlike `process.run_capture_cwd` below — which only
+    // `sfn/os` emits, and `sfn/os` is compiled by the freshly-built compiler —
+    // the dispatcher that will call `process.exec` lives in `compiler/src`,
+    // which the *pinned seed* compiles during `make compile`. So the seed's
+    // runtime-helper table must already contain this target before any
+    // `compiler/src` call site is added: this descriptor ships as a
+    // `seed-blocker` predecessor (no `compiler/src` caller yet, so it
+    // self-hosts now), and the SFN-172 consumer waits for a seed bump that
+    // carries it. See `.claude/rules/seed-dependency.md`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.exec", symbol: "sfn_process_exec", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_exec", c_abi_return_type: null
     });

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -759,6 +759,15 @@ fn _rh_descriptors_05(descriptors_in: RuntimeHelperDescriptor[]) -> RuntimeHelpe
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.run_capture", symbol: "sfn_process_run_capture", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_run_capture", c_abi_return_type: null
     });
+    // SFN-172 / SFEP-0046 §3.5: `process.exec(argv, env_flat)` — `execve(2)`
+    // process-image replacement for toolchain re-exec dispatch. Same 2-array
+    // shape as `process.run_capture` (argv + flat `KEY=VALUE` env). Only the
+    // freshly-built compiler emits this call (exclusively from the toolchain
+    // dispatcher), so — like `process.run_capture_cwd` above — no seed cut is
+    // required for the seed to build a compiler that uses it.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "process.exec", symbol: "sfn_process_exec", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_exec", c_abi_return_type: null
+    });
     // #1167: `process.run_capture_cwd` — `run_capture` plus a trailing
     // per-child `cwd` (`i8*`; empty/null = inherit). A SEPARATE target
     // from `process.run_capture` rather than a widened arity, because

--- a/compiler/tests/e2e/process_exec_test.sfn
+++ b/compiler/tests/e2e/process_exec_test.sfn
@@ -60,7 +60,7 @@ fn _build_fixture(src: string, binpath: string) -> int ![io] {
 
 test "process.exec: replaces the image with /bin/echo" ![io] {
     let root = _scratch_root() + "/sfn-process-exec-ok";
-    process.run(["mkdir", "-p", root]);
+    fs.createDirectory(root, true);
     let src = root + "/main.sfn";
     let bin = root + "/main";
     // On a successful exec, `execve` never returns: echo's stdout carries the
@@ -88,7 +88,7 @@ test "process.exec: replaces the image with /bin/echo" ![io] {
 
 test "process.exec: returns on a failed exec (image not replaced)" ![io] {
     let root = _scratch_root() + "/sfn-process-exec-fail";
-    process.run(["mkdir", "-p", root]);
+    fs.createDirectory(root, true);
     let src = root + "/main.sfn";
     let bin = root + "/main";
     // exec of a nonexistent path cannot replace the image, so `process.exec`

--- a/compiler/tests/e2e/process_exec_test.sfn
+++ b/compiler/tests/e2e/process_exec_test.sfn
@@ -1,0 +1,114 @@
+// compiler/tests/e2e/process_exec_test.sfn
+//
+// The `process.exec` (`execve(2)`) runtime primitive — the seed-blocker
+// predecessor for SFN-172 toolchain re-exec dispatch (SFEP-0046 §3.5).
+// `process.exec(argv, env_flat)` replaces the current process image, so the
+// dispatched pinned toolchain's exit code and signals pass through
+// transparently. These tests exercise it end-to-end (parse → typecheck →
+// effect → emit → lower → link → run) by building a fixture that calls it:
+//
+//   1. exec into `/bin/echo`: on success `execve` never returns, so the
+//      marker reaches stdout and the post-exec fallback line is unreachable,
+//      and the observed exit code is echo's (0), not the fixture's.
+//   2. exec of a nonexistent path: the image is NOT replaced, so
+//      `process.exec` returns and the fixture's fallback path runs.
+import { find } from "sfn/strings";
+
+// The compiler-under-test: $SAILFIN_BIN if set, else the self-hosted binary
+// relative to the repo root the runner starts from (mirrors sfn/test's own
+// `_resolve_sfn_bin`).
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/bin/sfn";
+}
+
+// Child env for the nested `sfn build`: `run_capture`'s empty env is the
+// EMPTY environment (not "inherit"), so a build-spawning test must thread
+// PATH (the nested build runs clang + its linker), HOME, TMPDIR, and
+// SAILFIN_TEST_SCRATCH (per-invocation build-cache isolation under the
+// parallel pool). Per `.claude/rules/no-bash-e2e.md`.
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+fn _scratch_root() -> string ![io] {
+    let s = env.get("SAILFIN_TEST_SCRATCH");
+    if s.length > 0 { return s; }
+    let t = env.get("TMPDIR");
+    if t.length > 0 { return t; }
+    return "/tmp";
+}
+
+// Build `src` to `binpath` with the compiler-under-test; returns the build
+// exit code. Threads the child env so the nested clang/link finds its tools.
+fn _build_fixture(src: string, binpath: string) -> int ![io] {
+    let exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, src], _child_env());
+    let _out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    return exit;
+}
+
+test "process.exec: replaces the image with /bin/echo" ![io] {
+    let root = _scratch_root() + "/sfn-process-exec-ok";
+    process.run(["mkdir", "-p", root]);
+    let src = root + "/main.sfn";
+    let bin = root + "/main";
+    // On a successful exec, `execve` never returns: echo's stdout carries the
+    // marker and SFN172_EXEC_FALLBACK is unreachable.
+    let program = "fn main() -> int ![io] {\n"
+        + "    let e: string[] = process.environ();\n"
+        + "    let _rc = process.exec([\"/bin/echo\", \"SFN172_EXEC_OK\"], e);\n"
+        + "    print.err(\"SFN172_EXEC_FALLBACK\");\n"
+        + "    return 42;\n"
+        + "}\n";
+    fs.writeFile(src, program);
+
+    let build_rc = _build_fixture(src, bin);
+    assert build_rc == 0;
+
+    let run_exit = process.run_capture([bin], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    // Image was replaced by echo: its exit code (0) is observed, its stdout
+    // carries the marker, and the fixture's post-exec fallback never ran.
+    assert run_exit == 0;
+    assert find(out, "SFN172_EXEC_OK", 0) >= 0;
+    assert find(out + err, "SFN172_EXEC_FALLBACK", 0) < 0;
+}
+
+test "process.exec: returns on a failed exec (image not replaced)" ![io] {
+    let root = _scratch_root() + "/sfn-process-exec-fail";
+    process.run(["mkdir", "-p", root]);
+    let src = root + "/main.sfn";
+    let bin = root + "/main";
+    // exec of a nonexistent path cannot replace the image, so `process.exec`
+    // returns and the fixture's fallback path runs to completion.
+    let program = "fn main() -> int ![io] {\n"
+        + "    let e: string[] = process.environ();\n"
+        + "    let _rc = process.exec([\"/nonexistent/sfn172/does-not-exist\"], e);\n"
+        + "    print.err(\"SFN172_EXEC_FALLBACK_REACHED\");\n"
+        + "    return 42;\n"
+        + "}\n";
+    fs.writeFile(src, program);
+
+    let build_rc = _build_fixture(src, bin);
+    assert build_rc == 0;
+
+    let run_exit = process.run_capture([bin], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    // The image was not replaced: the fixture continued past the failed exec,
+    // printed its marker, and returned its own exit code.
+    assert run_exit == 42;
+    assert find(out + err, "SFN172_EXEC_FALLBACK_REACHED", 0) >= 0;
+}

--- a/runtime/sfn/process.sfn
+++ b/runtime/sfn/process.sfn
@@ -94,6 +94,11 @@ extern fn posix_spawnp(pid: * i32, path: * u8, file_actions: * u8, attrp: * u8, 
 
 extern fn waitpid(pid: i32, status: * i32, options: i32) -> i32;
 
+// `execve(2)` — replace the current process image. Used by toolchain
+// dispatch (`sfn_process_exec`, SFEP-0046 §3.5); on success it never
+// returns.
+extern fn execve(path: * u8, argv: * * u8, envp: * * u8) -> i32;
+
 extern fn sfn_str_to_cstr(s_data: * u8, s_len: i64, arena_slot: * u8) -> * u8;
 
 // libc `environ` (`char **`) referenced directly via `extern var`
@@ -414,6 +419,42 @@ fn _process_build_cstr_argv(items: string[]) -> * u8 {
     let zero: i64 = 0;
     atomic_store(null_slot, zero);
     return buf;
+}
+
+// Replace the current process image with `argv[0]` via `execve(2)`,
+// passing `argv` and `env_flat` (flat `"KEY=VALUE"` entries) as the new
+// argv/envp. This is the re-exec used by toolchain dispatch (SFEP-0046
+// §3.5): because the image is replaced (not a child spawn), the pinned
+// toolchain's exit code and signals pass through transparently, so a
+// dispatched build is indistinguishable from running the pinned `sfn`
+// directly. On success `execve` never returns; any return means the exec
+// failed (e.g. the binary is missing or not executable), and this hands
+// back -1 so the caller can fall back to an actionable error. `env_flat`
+// is the child environment verbatim — an empty array is the empty
+// environment (the `_process_build_cstr_argv` contract), never "inherit",
+// so a dispatching caller threads the parent's `process.environ()` plus
+// the re-entrancy guard explicitly. `execve` does NOT search `PATH` (unlike
+// the `posix_spawnp` in `run_capture`), so `argv[0]` must be an absolute or
+// explicitly-relative path to the binary.
+fn sfn_process_exec(argv: string[], env_flat: string[]) -> int ![io] {
+    let argc: i64 = argv.length;
+    if argc <= 0 { return -1; }
+    let child_argv: * u8 = _process_build_cstr_argv(argv);
+    if child_argv as i64 == 0 { return -1; }
+    let child_envp: * u8 = _process_build_cstr_argv(env_flat);
+    if child_envp as i64 == 0 {
+        free(child_argv);
+        return -1;
+    }
+    let first: string = argv[0];
+    let path: * u8 = sfn_str_to_cstr(first as * u8, first.length, null);
+    let argv_pp: * * u8 = child_argv as * * u8;
+    let envp_pp: * * u8 = child_envp as * * u8;
+    execve(path, argv_pp, envp_pp);
+    // Only reached if execve failed; the image was not replaced.
+    free(child_argv);
+    free(child_envp);
+    return -1;
 }
 
 // Read one chunk (≤4096 bytes) from `fd` directly into the tail of


### PR DESCRIPTION
## Summary

Adds a `process.exec(argv, env_flat)` runtime builtin backed by `execve(2)` — the process-image-replacement primitive the SFN-172 toolchain re-exec dispatcher needs (SFEP-0046 §3.5). On success `execve` never returns, so a dispatched pinned toolchain's exit code and signals pass through transparently; on failure it returns so the caller can fall back to an actionable error. Touches the runtime (`runtime/sfn/process.sfn`) and the LLVM runtime-helper registry (`compiler/src/llvm/runtime_helpers.sfn`); no compiler pass changes.

This is the **seed-blocker predecessor** split out of SFN-172. A new namespaced runtime builtin used from `compiler/src` must be resolvable by the *pinned seed* that compiles it during `make compile` — the seed's baked-in runtime-helper table can't emit an unknown `process.exec`, which would break self-hosting. So the primitive lands **alone** here (nothing in `compiler/src` calls it yet → `make compile` self-hosts), rides the next cadence seed bump into `.seed-version`, and then SFN-172's dispatcher self-hosts against a seed that knows `process.exec`. See `.claude/rules/seed-dependency.md`.

Fixes SFN-199

## Changes

- **runtime** (`runtime/sfn/process.sfn`): `extern fn execve(path, argv, envp)` and `fn sfn_process_exec(argv: string[], env_flat: string[]) -> int [io]` — builds the NULL-terminated `char**` argv/envp via the existing `_process_build_cstr_argv` and materializes `argv[0]` via `sfn_str_to_cstr`, mirroring `_run_capture_impl`'s marshalling byte-for-byte. `execve` does not search `PATH`, so `argv[0]` must be an absolute/explicit path (documented on the fn). On a failed exec both buffers are freed and `-1` is returned.
- **llvm/runtime-helpers** (`compiler/src/llvm/runtime_helpers.sfn`): the `process.exec` descriptor — same 2-array shape as `process.run_capture` (`{ i8**, i64, i64 }*` × 2), `symbol`/`native_signature` `sfn_process_exec`, `return_type` `i64`, effect `io`.
- **tests** (`compiler/tests/e2e/process_exec_test.sfn`, new): builds a fixture calling `process.exec` and runs it — (1) exec into `/bin/echo` proves image replacement (marker on stdout, fallback unreachable, exit code = echo's); (2) exec of a nonexistent path proves the failed exec returns (fallback runs, fixture's own exit 42). Threads `PATH`/`HOME`/`TMPDIR`/`SAILFIN_TEST_SCRATCH` into the nested build per `.claude/rules/no-bash-e2e.md`.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `make compile` — compiler self-hosts (the primitive is additive; no `compiler/src` caller)
- [x] Regression coverage added under `compiler/tests/e2e/process_exec_test.sfn` (2/2 pass)
- [ ] `make check` — not run (additive runtime primitive with no compiler-side caller; `make compile` + the e2e test cover it)

## Stage1 readiness

- [x] Parses, type-checks, and effect-checks (`process.exec` callable from `[io]` code)
- [x] Emits valid IR and lowers/links (e2e build+run of a fixture calling it)
- [x] Enforced end-to-end — image replacement verified; a failed exec returns
- [ ] `docs/status.md` / spec — deferred to the SFN-172 consumer PR, which documents the user-facing `SAILFIN_TOOLCHAIN` dispatch surface (this primitive has no user-facing surface on its own)

## Notes for reviewers

- Reviewed by the Opus `code-reviewer`: FFI/ABI, memory management (on success `execve` never returns, so the two buffers are intentionally replaced with the image — not a leak), descriptor parity with `process.run_capture`, and the self-hosting invariant all check out.
- **Follow-up (SFN-172, Blocked on this + a seed bump):** the dispatcher (`toolchain_gate_or_dispatch`, the `SAILFIN_TOOLCHAIN` knob, the re-entrancy guard, `CliContext.orig_args`) is fully designed and recorded on SFN-172; it re-picks up after this merges and `/pin-seed` advances the seed.
- After merge this needs a cadence seed bump + `/pin-seed` before SFN-172 can proceed (queued, not a reactive cut).

---
_Generated by [Claude Code](https://claude.ai/code/session_017TAaFu1wUdVQQAf2MrnzEs)_