### PR TITLE
feat(dx): surface clang/llvm-link failures as Sailfin diagnostics (SFN-34)

### DIFF
--- a/compiler/src/cli/commands/build.sfn
+++ b/compiler/src/cli/commands/build.sfn
@@ -60,11 +60,8 @@ import {
     parse_scope_name
 } from "../../capsule_artifact";
 import { ResolverConsumer, prepare_project_capsules, toolchain_gate } from "../../capsule_resolver";
-import {
-    compile_to_llvm_file_with_module,
-    module_name_from_path,
-    number_to_string
-} from "../../main";
+import { format_backend_failure_banner } from "../../ice";
+import { compile_to_llvm_file_with_module, module_name_from_path } from "../../main";
 import { runtime_capsule_from_root } from "../../runtime_capsule_resolver";
 import { CliContext } from "../context";
 
@@ -353,8 +350,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
         let rc_obj = backend.assemble(ll_path, out_path, "-O2", no_includes);
         if rc_obj != 0 {
             if !json_flag {
-                print("library build failed (clang exit=" + number_to_string(rc_obj)
-                    + ")");
+                print.err(format_backend_failure_banner(binary_dir, "clang -c", ll_path, rc_obj));
             }
             return rc_obj;
         }
@@ -412,7 +408,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
     let rc = link_result.rc;
     if rc != 0 {
         if !json_flag {
-            print("link failed (clang exit=" + number_to_string(rc) + ")");
+            print.err(format_backend_failure_banner(binary_dir, "clang link", ll_path, rc));
         }
         return rc;
     }

--- a/compiler/src/cli/commands/run.sfn
+++ b/compiler/src/cli/commands/run.sfn
@@ -45,11 +45,8 @@ import { _ends_with, _ensure_dir } from "../../build/paths";
 import { _runtime_bundle_exists } from "../../build/runtime_objs";
 import { cache_root, merge_cache_stats, resolve_build_cache_config } from "../../build_cache";
 import { empty_resolver_consumer, prepare_project_capsules, toolchain_gate } from "../../capsule_resolver";
-import {
-    compile_to_llvm_file_with_module,
-    module_name_from_path,
-    number_to_string
-} from "../../main";
+import { format_backend_failure_banner } from "../../ice";
+import { compile_to_llvm_file_with_module, module_name_from_path } from "../../main";
 import { runtime_capsule_from_root } from "../../runtime_capsule_resolver";
 import { CliContext } from "../context";
 
@@ -169,7 +166,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io] {
         // (the prior `process.run(["sfn", "run", input_path])` "seed
         // fallback" recursed into itself forever on a persistent failure,
         // #969).
-        print("link failed (clang exit=" + number_to_string(link_rc) + ")");
+        print.err(format_backend_failure_banner(binary_dir, "clang link", ll_path, link_rc));
         return link_rc;
     }
 

--- a/compiler/src/cli/commands/test.sfn
+++ b/compiler/src/cli/commands/test.sfn
@@ -89,6 +89,7 @@ import {
     toolchain_gate
 } from "../../capsule_resolver";
 import { ImportSymbolTable, empty_import_symbols } from "../../effect_imports";
+import { format_backend_failure_banner } from "../../ice";
 import { compile_tests_to_llvm_file_with_module_imports, module_name_from_path } from "../../main";
 import { LayoutManifest } from "../../native_ir";
 import { number_to_string } from "../../num_format";
@@ -1272,8 +1273,7 @@ fn run(matches: Matches, ctx: CliContext) -> int ![io, clock] {
             if trace_runner { print.err("test runner: link start"); }
             let link_rc = _clang_link_test_cmd_with_deps(ll_path, exe_path, runtime_root, groups[group_idx].dep_ll_paths, scratch_root, binary_dir);
             if link_rc != 0 {
-                print.err("link failed (clang exit=" + number_to_string(link_rc)
-                    + ")");
+                print.err(format_backend_failure_banner(binary_dir, "clang link", ll_path, link_rc));
                 if json_output {
                     let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "link failed (clang exit="
                         + number_to_string(link_rc)

--- a/compiler/src/ice.sfn
+++ b/compiler/src/ice.sfn
@@ -24,6 +24,7 @@
 // the formatter when a panic fires. `binary_dir` is stashed (not the resolved
 // version) so the version's filesystem read is paid lazily, only on an actual
 // panic, not on every CLI invocation.
+import { number_to_string } from "./num_format";
 import { resolve_compiler_version } from "./version";
 
 // New-issue URL prefilled with the ICE template. Kept grep-stable: /triage
@@ -94,6 +95,29 @@ fn format_ice_banner(version: string, stage: string, source: string, message: st
     if stage_line.length == 0 { stage_line = "<unknown>"; }
     banner = banner + "note: stage: " + stage_line + "\n";
     if source.length > 0 { banner = banner + "note: source: " + source + "\n"; }
+    banner = banner + "note: file a report: " + ICE_ISSUE_URL + "\n";
+    return banner;
+}
+
+// Format a backend (clang / llvm-link) failure as a Sailfin-branded ICE
+// banner (SFN-34). A nonzero backend exit means driver-emitted IR was rejected
+// downstream — a compiler bug, not user error — so the failure is framed as an
+// internal compiler error naming the failing IR path and a bug-report pointer,
+// replacing the bare `clang exit=N` line. Printed (not thrown) by the CLI link
+// sites so the clang exit code still propagates as the process exit code: the
+// forward-only stage/source caveat in this file's header is exactly why link
+// orchestration must not `throw` a banner.
+fn format_backend_failure_banner(binary_dir: string, tool: string, ir_path: string, rc: int) -> string ![io] {
+    let version = resolve_compiler_version(binary_dir);
+    let mut banner: string = "error: internal compiler error (ICE): backend "
+        + tool
+        + " failed (exit "
+        + number_to_string(rc)
+        + ")\n";
+    banner = banner
+        + "note: the backend rejected compiler-emitted IR — this is a compiler bug, not an error in your code\n";
+    banner = banner + "note: version: " + version + "\n";
+    banner = banner + "note: failing IR: " + ir_path + "\n";
     banner = banner + "note: file a report: " + ICE_ISSUE_URL + "\n";
     return banner;
 }

--- a/compiler/tests/unit/backend_failure_banner_test.sfn
+++ b/compiler/tests/unit/backend_failure_banner_test.sfn
@@ -1,0 +1,20 @@
+// compiler/tests/unit/backend_failure_banner_test.sfn
+//
+// Regression for SFN-34: a backend (clang / llvm-link) failure must reach the
+// user as a Sailfin-branded internal-compiler-error banner naming the failing
+// IR path and a bug-report URL — not a bare `clang exit=N` line. Asserts on the
+// formatter directly (deterministic: binary_dir="" resolves the version
+// fallback) rather than reproducing a real link failure, mirroring how
+// version_resolution_test.sfn exercises resolve_compiler_version("").
+import { find } from "sfn/strings";
+
+import { format_backend_failure_banner } from "../../src/ice";
+
+test "backend banner: frames link failure as a Sailfin ICE with IR path and bug URL" ![io] {
+    let banner = format_backend_failure_banner("", "clang link", "build/sailfin/program.ll", 1);
+    assert find(banner, "internal compiler error (ICE)", 0) >= 0;
+    assert find(banner, "clang link", 0) >= 0;
+    assert find(banner, "build/sailfin/program.ll", 0) >= 0;
+    assert find(banner, "https://github.com/SailfinIO/sailfin/issues/new", 0) >= 0;
+    assert find(banner, "link failed (clang exit=", 0) < 0;
+}


### PR DESCRIPTION
## Summary

A nonzero clang/llvm-link exit reached the user as a bare `link failed (clang exit=1)` line with no framing — unmappable to the compiler bug it actually is (#1386 class). This adds `format_backend_failure_banner` to the driver's ICE facility (`ice.sfn`, reusing `ICE_ISSUE_URL`) and prints it at the four build/run/test link + assemble failure sites: a Sailfin-branded **internal compiler error** naming the failing IR path and the bug-report URL.

The banner is **printed, not thrown** — each site keeps returning the clang exit code, preserving exit-code fidelity (run.sfn #969 fail-closed, test.sfn `overall_rc`) and avoiding the forward-only stage/source caveat documented in `ice.sfn`'s header that makes throwing a banner from link orchestration wrong. Driver stays pure orchestration; no IR fixups (`.claude/rules/selfhost-invariant.md`).

Fixes SFN-34

## Changes

- **driver / `ice.sfn`** — add `format_backend_failure_banner(binary_dir, tool, ir_path, rc)`; imports `number_to_string` from the prelude-only `./num_format` leaf (no import cycle).
- **driver / `cli/commands/build.sfn`** — reframe both the `clang -c` library-assemble and the link failure sites; drop the now-dead `number_to_string` import.
- **driver / `cli/commands/run.sfn`** — reframe the link failure site; drop the now-dead `number_to_string` import.
- **driver / `cli/commands/test.sfn`** — reframe the human-facing link failure line; the `--json` synthetic-assert event and `[test] FAIL` banner are unchanged (internal correlation strings).
- **tests** — new `compiler/tests/unit/backend_failure_banner_test.sfn` pins the banner shape (branded ICE, failing IR path, bug URL, and absence of the bare `clang exit=` phrasing) deterministically via the version fallback.

## Map reconciliation

The issue's advisory `## Files Affected` named `cli_main.sfn` / `capsule_resolver.sfn`. After the CLI driver's folder split, the actual link/assemble failure sites live in `cli/commands/{build,run,test}.sfn`, and the Sailfin-framed error facility is `ice.sfn` — same semantic unit (the build driver's link-step error reporting). Cosmetic drift, reconciled and in-scope; no new acceptance criterion or public surface.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts
- [x] Full suite: unit 208/208, integration 45/45, capsules 43/43, e2e 206/206 (one initial e2e crash was a confirmed parallel-pool flake — green on isolated re-run; the new code path is inert on any successful build)
- [x] Regression coverage added under `compiler/tests/unit/`

## Acceptance Criteria

- [x] A backend link failure prints a Sailfin-branded error with the failing IR path and a bug-report hint, not bare `clang exit=1`.
- [x] Driver remains pure orchestration (no IR fixups) per `.claude/rules/selfhost-invariant.md`.
- [x] `make compile` / `make test` pass.

## Notes for reviewers

Per the issue's `Out:` scope, per-error source-mapping of arbitrary LLVM diagnostics is not attempted — clang's own text still prints (inherited stdio); the driver now adds the Sailfin ICE frame around the failure summary. Minor cross-site asymmetry (intentional, not new): `build.sfn` suppresses the banner under `--json` while `test.sfn` prints it — both are safe because the banner goes to stderr and the JSON document is on stdout.

---
_Generated by [Claude Code](https://claude.ai/code/session_011uvusoVYhJn56c96S2yXKD)_