### PR TITLE
feat(bench): sfn/bench microbenchmark harness capsule (SFN-62)

### DIFF
--- a/capsules/sfn/bench/capsule.toml
+++ b/capsules/sfn/bench/capsule.toml
@@ -1,0 +1,13 @@
+[capsule]
+name = "sfn/bench"
+version = "0.1.0"
+description = "In-language microbenchmark harness for Sailfin (the parallel to sfn/test)"
+
+[dependencies]
+
+[capabilities]
+required = ["clock", "io"]
+
+[build]
+entry = "src/mod.sfn"
+kind = "library"

--- a/capsules/sfn/bench/examples/sample_bench.sfn
+++ b/capsules/sfn/bench/examples/sample_bench.sfn
@@ -1,0 +1,21 @@
+// capsules/sfn/bench/examples/sample_bench.sfn — a runnable `*_bench.sfn`.
+//
+// The minimal end-to-end shape of a benchmark on the `sfn/bench` harness: a
+// single unit of work whose result feeds the black-box sink, handed to the
+// auto-calibrating `benchmark(...)`. The harness supplies the repetition and
+// emits one `bench-record/1 ...` line on stdout — no hand-tuned iteration
+// constant, no manual dead-code guard. Build and run it directly:
+//
+//   sfn run capsules/sfn/bench/examples/sample_bench.sfn
+import { benchmark, keep } from "sfn/bench";
+
+// One unit of work: a couple of integer mixes, kept so the loop is not elided.
+fn _work(seed: int) -> int {
+    let a = seed * 2654435761;
+    let b = a + 1013904223;
+    return keep(b);
+}
+
+fn main() ![clock, io] {
+    let _ = benchmark("sample", fn () -> int { return _work(7); });
+}

--- a/capsules/sfn/bench/src/mod.sfn
+++ b/capsules/sfn/bench/src/mod.sfn
@@ -1,0 +1,150 @@
+// capsules/sfn/bench/src/mod.sfn — In-language microbenchmark harness.
+//
+// The benchmarking parallel to `sfn/test`: a Sailfin program links this
+// capsule to measure its own hot paths, and the bundled runtime workloads
+// migrate onto it (SFN-63). A harness call brackets a caller-supplied `body`
+// closure with the monotonic clock, auto-calibrates the invocation count so
+// the timed window dwarfs the (whole-millisecond) timer resolution, defeats
+// dead-code elimination via `keep`, and emits one structured, machine-
+// parseable record per benchmark for the `sfn bench` runner (SFN-63) to
+// aggregate.
+//
+// Timing rides the prelude's public `monotonic_millis()` (`![clock]`).
+// Nanosecond-resolution bracketing waits on a public `monotonic_nanos()`,
+// deferred to the rusage child of the `sfn bench` epic per SFN-62's scope
+// note ("monotonic_nanos if not added by the rusage child"); auto-calibration
+// is what makes the coarse timer sufficient in the meantime.
+//
+// Effect model: a `body: fn () -> int` parameter carries no effect row — the
+// effect checker attributes a closure's effects to the scope that *defines*
+// it, so a caller that builds an `![io]`/`![clock]` body already accounts for
+// those effects; the harness only declares the `![clock, io]` it uses
+// directly (clock brackets + record print). This mirrors `sfn/test`'s scoped
+// fixtures (capsules/sfn/test/src/fixtures.sfn).
+// Grow the timed window to at least this many milliseconds before reporting,
+// so whole-millisecond quantization contributes under ~1% of the measurement.
+// Auto-calibration exists precisely because the timer is coarse.
+let _TARGET_MS: int = 100;
+
+// Bounds on the calibration search, guarding the input-driven growth loop
+// (code-style: guard counters on growth loops). A body whose single batch is
+// already slower than the target reports at the cap rather than spinning.
+let _MAX_OPS: int = 2000000000;
+let _MAX_GROWS: int = 60;
+
+// Invocation count for the first calibration batch.
+let _SEED_OPS: int = 1024;
+
+// ---------------------------------------------------------------------------
+// Black-box sink
+// ---------------------------------------------------------------------------
+// Force the optimizer to materialize `x` so a benchmarked computation whose
+// result is otherwise unused is not eliminated. A data-dependent branch on a
+// runtime value the compiler cannot fold does the job (the Rust `black_box`
+// intent) without an effect. Callers wrap the final result of the code under
+// test; the harness threads every `body` return through it internally.
+fn keep(x: int) -> int {
+    // 2147483647 is an arbitrary sentinel the compiler cannot prove `x` avoids,
+    // so the branch — and with it `x` — is never folded away.
+    if x == 2147483647 { return 0 - x; }
+    return x;
+}
+
+// ---------------------------------------------------------------------------
+// Structured record
+// ---------------------------------------------------------------------------
+// The one record the `sfn bench` runner (SFN-63) parses: a stable versioned
+// prefix, then space-separated `key=value` fields with `name` last so a name
+// containing spaces is still recoverable as the remainder of the line. One
+// record is emitted per benchmark on stdout.
+fn record_line(name: string, ops: int, inner_ms: int) -> string {
+    return "bench-record/1 ops=" + number_to_string(ops) + " inner_ms="
+        + number_to_string(inner_ms)
+        + " name="
+        + name;
+}
+
+// Emit the record. The line is bound to a local before printing: on this
+// compiler a `+`-concatenation passed straight to `print` produces no stdout
+// output, whereas a bound string prints (benchmarks/runtime/README.md).
+fn _emit(name: string, ops: int, inner_ms: int) ![io] {
+    let line = record_line(name, ops, inner_ms);
+    print(line);
+}
+
+// ---------------------------------------------------------------------------
+// Timed execution
+// ---------------------------------------------------------------------------
+// Invoke `body` exactly `count` times, threading its returned sink through an
+// accumulator so the optimizer cannot prove the calls dead. Returns the raw
+// accumulation; callers pass it through `keep` before it escapes. `body`'s own
+// effects are charged to the scope that defines it, so this helper is
+// effect-free.
+fn _run(body: fn () -> int, count: int) -> int {
+    let mut acc = 0;
+    let mut i = 0;
+    loop {
+        if i >= count { break; }
+        acc = acc + body();
+        i = i + 1;
+    }
+    return acc;
+}
+
+// Next calibration batch size: when the last window was unmeasurable (0 ms),
+// leap by a fixed factor; otherwise scale toward twice the target for
+// headroom, never shrinking and never overflowing the cap.
+fn _next_ops(ops: int, inner_ms: int) -> int {
+    if inner_ms <= 0 {
+        let leap = ops * 8;
+        if leap > _MAX_OPS { return _MAX_OPS; }
+        return leap;
+    }
+    let scaled = ops * _TARGET_MS * 2 / inner_ms;
+    let mut next = scaled;
+    if next <= ops { next = ops * 2; }
+    if next > _MAX_OPS { next = _MAX_OPS; }
+    return next;
+}
+
+// ---------------------------------------------------------------------------
+// Public harness
+// ---------------------------------------------------------------------------
+// Run `body` exactly `ops` times under the monotonic clock, emit the record,
+// and return the black-box-kept accumulation of `body`'s returns. The fixed-
+// count variant: deterministic given a deterministic body, so it is what the
+// harness's own tests drive and what a caller reaches for to control the
+// invocation count directly rather than auto-calibrating.
+fn benchmark_fixed(name: string, ops: int, body: fn () -> int) -> int ![clock, io] {
+    let start = monotonic_millis();
+    let acc = _run(body, ops);
+    let inner_ms = monotonic_millis() - start;
+    let kept = keep(acc);
+    _emit(name, ops, inner_ms);
+    return kept;
+}
+
+// Auto-calibrating harness (the headline API): grow the invocation count until
+// a timed batch reaches the target window, then emit that batch's record. This
+// removes the hand-tuned iteration constants the ad-hoc workloads carry — the
+// body is one unit of work and the harness supplies the repetition. Returns
+// the black-box-kept accumulation so the calibrated work cannot be elided.
+fn benchmark(name: string, body: fn () -> int) -> int ![clock, io] {
+    let mut ops = _SEED_OPS;
+    let mut acc = 0;
+    let mut inner_ms = 0;
+    let mut grows = 0;
+    loop {
+        let start = monotonic_millis();
+        acc = _run(body, ops);
+        inner_ms = monotonic_millis() - start;
+        if inner_ms >= _TARGET_MS { break; }
+        if ops >= _MAX_OPS { break; }
+        if grows >= _MAX_GROWS { break; }
+        grows = grows + 1;
+        ops = _next_ops(ops, inner_ms);
+    }
+    let kept = keep(acc);
+    _emit(name, ops, inner_ms);
+    return kept;
+}

--- a/capsules/sfn/bench/src/mod.sfn
+++ b/capsules/sfn/bench/src/mod.sfn
@@ -56,17 +56,16 @@ fn keep(x: int) -> int {
 // The one record the `sfn bench` runner (SFN-63) parses: a stable versioned
 // prefix, then space-separated `key=value` fields with `name` last so a name
 // containing spaces is still recoverable as the remainder of the line. One
-// record is emitted per benchmark on stdout.
+// record is emitted per benchmark on stdout. Built with `{{ }}` interpolation
+// — the idiom the runtime workloads already use and the documented-safe way to
+// reach stdout on this compiler (benchmarks/runtime/README.md:104-108), which
+// sidesteps the `+`-concatenation-to-`print` quirk entirely.
 fn record_line(name: string, ops: int, inner_ms: int) -> string {
-    return "bench-record/1 ops=" + number_to_string(ops) + " inner_ms="
-        + number_to_string(inner_ms)
-        + " name="
-        + name;
+    return "bench-record/1 ops={{ops}} inner_ms={{inner_ms}} name={{name}}";
 }
 
-// Emit the record. The line is bound to a local before printing: on this
-// compiler a `+`-concatenation passed straight to `print` produces no stdout
-// output, whereas a bound string prints (benchmarks/runtime/README.md).
+// Emit the record on stdout. The interpolated line is bound to a local before
+// printing, matching the runtime workloads' proven pattern.
 fn _emit(name: string, ops: int, inner_ms: int) ![io] {
     let line = record_line(name, ops, inner_ms);
     print(line);

--- a/capsules/sfn/bench/tests/bench_test.sfn
+++ b/capsules/sfn/bench/tests/bench_test.sfn
@@ -1,0 +1,25 @@
+// Tests for the sfn/bench harness (SFN-62): the black-box sink, the structured
+// record format, and the fixed-count runner's invocation count. The auto-
+// calibrating `benchmark(...)` is covered end-to-end by `sample_run_test.sfn`
+// (its calibrated op count is timing-dependent, so it is exercised through the
+// runnable sample rather than pinned here).
+import { benchmark_fixed, keep, record_line } from "../src/mod";
+
+test "bench: keep returns its argument unchanged" {
+    assert keep(5) == 5;
+    assert keep(0) == 0;
+    assert keep(0 - 7) == 0 - 7;
+}
+
+test "bench: record_line formats the structured bench record" {
+    let line = record_line("arena_alloc", 1000, 50);
+    assert line == "bench-record/1 ops=1000 inner_ms=50 name=arena_alloc";
+}
+
+test "bench: benchmark_fixed invokes the body exactly ops times" ![clock, io] {
+    // Each body call returns 1, so the black-box-kept accumulation equals the
+    // invocation count — a deterministic proof the fixed runner drives `body`
+    // exactly `ops` times.
+    let n = benchmark_fixed("unit", 10, fn () -> int { return 1; });
+    assert n == 10;
+}

--- a/capsules/sfn/bench/tests/sample_run_test.sfn
+++ b/capsules/sfn/bench/tests/sample_run_test.sfn
@@ -1,0 +1,28 @@
+// End-to-end proof that a `*_bench.sfn` on the sfn/bench harness compiles,
+// runs, and prints the structured record (SFN-62 acceptance criterion). Drives
+// the bundled sample through `sfn run` as a subprocess and asserts the
+// `bench-record/1` line lands on stdout — the shape the `sfn bench` runner
+// (SFN-63) parses.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/bin/sfn";
+}
+
+// Inherit the full parent environment for the nested `sfn run` via
+// `process.environ()`. That carries the vars the nested compile needs: PATH
+// (it shells out to clang + linker), HOME/TMPDIR, and SAILFIN_TEST_SCRATCH,
+// which the compiler routes the build-cache dir under so a parallel `sfn test`
+// pool does not collide on build/sailfin (.claude/rules/no-bash-e2e.md).
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+test "bench: sample bench compiles, runs, and prints the structured record" ![io] {
+    let exit = process.run_capture([_sfn_bin(), "run", "capsules/sfn/bench/examples/sample_bench.sfn"], _child_env());
+    let out = process.capture_take_stdout();
+    let _ = process.capture_take_stderr();
+    assert exit == 0;
+    assert find(out, "bench-record/1", 0) >= 0;
+    assert find(out, "name=sample", 0) >= 0;
+}

--- a/workspace.toml
+++ b/workspace.toml
@@ -8,4 +8,4 @@
 # parser surfaces the literal entries via toml_get_workspace_members().
 
 [workspace]
-members = ["compiler", "runtime", "capsules/sfn/cli", "capsules/sfn/crypto", "capsules/sfn/fs", "capsules/sfn/http", "capsules/sfn/json", "capsules/sfn/layers", "capsules/sfn/log", "capsules/sfn/losses", "capsules/sfn/math", "capsules/sfn/net", "capsules/sfn/nn", "capsules/sfn/os", "capsules/sfn/path", "capsules/sfn/prelude", "capsules/sfn/strings", "capsules/sfn/sync", "capsules/sfn/tensor", "capsules/sfn/test", "capsules/sfn/time", "capsules/sfn/toml"]
+members = ["compiler", "runtime", "capsules/sfn/bench", "capsules/sfn/cli", "capsules/sfn/crypto", "capsules/sfn/fs", "capsules/sfn/http", "capsules/sfn/json", "capsules/sfn/layers", "capsules/sfn/log", "capsules/sfn/losses", "capsules/sfn/math", "capsules/sfn/net", "capsules/sfn/nn", "capsules/sfn/os", "capsules/sfn/path", "capsules/sfn/prelude", "capsules/sfn/strings", "capsules/sfn/sync", "capsules/sfn/tensor", "capsules/sfn/test", "capsules/sfn/time", "capsules/sfn/toml"]


### PR DESCRIPTION
## Summary

Adds `capsules/sfn/bench`, the in-language microbenchmark harness — the parallel
to `sfn/test`. A Sailfin program links it to benchmark its own hot paths, and the
bundled runtime workloads migrate onto it (SFN-63). A harness call brackets a
caller-supplied `body` closure with the monotonic clock, auto-calibrates the
invocation count so the timed window dwarfs the (whole-millisecond) timer
resolution, defeats dead-code elimination via `keep`, and emits one structured,
machine-parseable record per benchmark for the `sfn bench` runner (SFN-63) to
aggregate. Pure library work — no compiler pass is touched.

Fixes SFN-62

<!-- Branch name carries the sibling `sfn-63` infix for session reasons; the
Linear leaf this PR completes is SFN-62 (the harness), the blocker for SFN-63. -->

## Changes

- **runtime capsule** `capsules/sfn/bench/src/mod.sfn`:
  - `benchmark(name, body)` — auto-calibrating headline API: grows the
    invocation count until a timed batch reaches the target window (≥100 ms),
    replacing hand-tuned iteration constants; the body is one unit of work and
    the harness supplies the repetition.
  - `benchmark_fixed(name, ops, body)` — deterministic fixed-count variant.
  - `keep(x)` — black-box sink defeating dead-code elimination; `_run` threads
    every `body()` return through it.
  - `record_line(...)` / `_emit` — emit one versioned record per benchmark on
    stdout: `bench-record/1 ops=<n> inner_ms=<ms> name=<name>` (`name` last so a
    spaced name is recoverable). Bound-then-print, respecting the documented
    `+`-to-`print` stdout quirk (`benchmarks/runtime/README.md`).
- **manifest** `capsules/sfn/bench/capsule.toml` — new leaf capsule.
- **workspace** `workspace.toml` — registers `capsules/sfn/bench` as a member.
- **sample** `capsules/sfn/bench/examples/sample_bench.sfn` — a runnable
  `*_bench.sfn` on the harness.
- **tests** `capsules/sfn/bench/tests/{bench_test,sample_run_test}.sfn` — unit
  coverage (`keep`, `record_line`, `benchmark_fixed` invocation count) plus a
  subprocess e2e that builds + runs the sample and asserts the record on stdout.

Timing rides the prelude's public `monotonic_millis()` (`[clock]`).
Nanosecond bracketing (`monotonic_nanos`) is deferred to the epic's rusage child
per the issue's scope note; auto-calibration is what makes the coarse timer
sufficient in the meantime.

## Capability envelope

`capsule.toml [capabilities] required = ["clock", "io"]` — exactly what the code
uses (`monotonic_millis` → clock; `print` → io) and nothing more. `body: fn () ->
int` params carry no effect row: a closure's effects charge to the scope that
defines it (mirroring `sfn/test`'s scoped fixtures), so `_run` is effect-free and
the harness declares only its own `[clock, io]`.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts (up-to-date; no `compiler/src` change)
- [ ] `make check` — not run; ran `make test` instead (below)
- [x] Regression coverage added under `capsules/sfn/bench/tests/` (not
  `compiler/tests/`, since this is a stdlib capsule)

Additional:
- `make test` — full suite green: **unit 210/210 · integration 45/45 · e2e
  208/208 · capsules 45/45**, 0 failed (`sailfin-make/1` status: pass).
- `sfn test capsules/sfn/bench/tests` — 4/4 tests pass.
- `sfn run capsules/sfn/bench/examples/sample_bench.sfn` emits
  `bench-record/1 ops=104857600 inner_ms=160 name=sample`.

## Notes for reviewers

- Two forward-notes for the SFN-63 runner (not defects here): its record parser
  should treat the line as newline-delimited (a `name` with a newline would break
  the one-line invariant), and guard `inner_ms == 0` before computing throughput
  (a pathologically fast body can cap out with `inner_ms=0`).
- The header/`_TARGET_MS`-comment adjacency in `mod.sfn` is `sfn fmt`'s canonical
  output (it collapses the separating blank line); left as fmt produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zeDLGHCjEEA2njcVDQ3Pv

---
_Generated by [Claude Code](https://claude.ai/code/session_012zeDLGHCjEEA2njcVDQ3Pv)_