### PR TITLE
ci(release): automate cadence train cuts

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -9,6 +9,13 @@ Sailfin uses a manually-triggered release workflow instead of auto-releasing on
 every merge.  The canonical version lives in `compiler/capsule.toml` and is
 mirrored in `compiler/src/version.sfn`.
 
+The public minor-alpha train is automated separately by
+`.github/workflows/release-train.yml`: on the 2-week Monday cadence, a scheduled
+train run dispatches `release.yml` with `channel=alpha bump=minor` when the
+latest nightly self-host check on `main` is green. Manual `/release` remains the
+path for routine alpha prereleases, hotfix/off-cadence cuts, and stable
+promotion.
+
 The workflow accepts two inputs:
 - **channel**: `alpha` | `beta` | `rc` | `stable`
 - **bump**: `prerelease` | `patch` | `minor` | `major`
@@ -166,10 +173,9 @@ After the dispatch summary, suggest running `/pin-seed` as a follow-up
 when **any** of these is true:
 
 - The cut is `bump=patch` (almost always implies a hotfix-pin).
-- A `seed-blocker` issue closed since the current `.seed-version` was
-  set:
+- A `seed-blocker` issue closed since the current seed pin was set:
   ```bash
-  last_pin_at="$(git log -1 --format=%cI .seed-version)"
+  last_pin_at="$(git log -1 --format=%cI bootstrap.toml)"
   ```
   ```
   mcp__github__search_issues query='repo:SailfinIO/sailfin is:issue is:closed label:seed-blocker closed:>=<last_pin_at>'

--- a/.github/workflows/cadence-seed-pin.yml
+++ b/.github/workflows/cadence-seed-pin.yml
@@ -1,0 +1,212 @@
+name: Cadence Seed Pin
+
+# After the release train cuts a new minor alpha, open a draft PR that adopts
+# that just-published toolchain as the compiler checkout seed. The canonical pin
+# is `bootstrap.toml [seed].version` (SFEP-0047); `.seed-version` is updated only
+# while it exists during the migration window, so SFN-214 can delete it without
+# redesigning this workflow.
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Released cadence alpha tag to pin, e.g. v0.9.0-alpha.1"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cadence-seed-pin
+  cancel-in-progress: false
+
+jobs:
+  open-pin-pr:
+    name: Open seed-pin PR
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+      SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Resolve released version
+        id: version
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG:-}" ]; then
+            tag="$INPUT_TAG"
+            version="${tag#v}"
+          else
+            version="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml)"
+            tag="v${version}"
+          fi
+          if [ -z "$version" ]; then
+            echo "::error::Could not resolve compiler version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR for cadence seed bump
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          post_slack() {
+            if [ -z "${SLACK_RELEASE_WEBHOOK_URL:-}" ]; then
+              return 0
+            fi
+            SLACK_TEXT="$1" python3 - <<'PY' > /tmp/slack-payload.json
+          import json
+          import os
+          print(json.dumps({"text": os.environ["SLACK_TEXT"]}))
+          PY
+            curl -fsS -X POST \
+              -H 'Content-type: application/json' \
+              --data @/tmp/slack-payload.json \
+              "$SLACK_RELEASE_WEBHOOK_URL" >/dev/null || true
+          }
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.0-alpha\.1$ ]]; then
+            echo "[seed-pin] $VERSION is not a cadence minor alpha (*.0-alpha.1); skipping automatic seed-pin PR."
+            exit 0
+          fi
+
+          source_version="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml)"
+          if [ "$source_version" != "$VERSION" ]; then
+            echo "::error::compiler/capsule.toml is at $source_version, not $VERSION; refusing to pin a seed ahead of the source version."
+            exit 1
+          fi
+
+          if ! gh release view "$TAG" --json assets --jq '.assets | length' >/tmp/asset-count; then
+            echo "::error::Release $TAG is not visible yet"
+            exit 1
+          fi
+          assets="$(cat /tmp/asset-count)"
+          if [ "$assets" -eq 0 ]; then
+            echo "::error::Release $TAG has no uploaded assets yet; retry after release-tag completes."
+            exit 1
+          fi
+
+          current="$(awk '
+            /^\[[^]]+\]/ { section=$0 }
+            section == "[seed]" && /^version[[:space:]]*=/ {
+              gsub(/"/, "", $3); print $3; exit
+            }
+          ' bootstrap.toml)"
+          if [ "$current" = "$VERSION" ]; then
+            echo "[seed-pin] bootstrap.toml already pins $VERSION; nothing to do."
+            exit 0
+          fi
+
+          branch="bot/cadence-seed-pin-v${VERSION}"
+          if [ "$(gh pr list --head "$branch" --state open --json number --jq 'length')" != "0" ]; then
+            echo "[seed-pin] an open PR already exists for $branch; skipping."
+            exit 0
+          fi
+
+          git config user.name "Sailfin Release Bot"
+          git config user.email "releases@sailfin.io"
+          git checkout -b "$branch"
+
+          tmp="$(mktemp)"
+          awk -v v="$VERSION" '
+            /^\[[^]]+\]/ { section=$0 }
+            section == "[seed]" && /^version[[:space:]]*=/ {
+              sub(/"[^"]*"/, "\"" v "\"")
+            }
+            { print }
+          ' bootstrap.toml > "$tmp"
+          mv "$tmp" bootstrap.toml
+
+          tmp="$(mktemp)"
+          awk -v v="$VERSION" '
+            /^\[[^]]+\]/ { section=$0 }
+            section == "[toolchain]" && /^sfn[[:space:]]*=/ {
+              sub(/"[^"]*"/, "\"" v "\"")
+            }
+            { print }
+          ' compiler/capsule.toml > "$tmp"
+          mv "$tmp" compiler/capsule.toml
+
+          if [ -f .seed-version ]; then
+            printf '%s\n' "$VERSION" > .seed-version
+          fi
+
+          git add bootstrap.toml compiler/capsule.toml
+          if [ -f .seed-version ]; then
+            git add .seed-version
+          fi
+          if git diff --cached --quiet; then
+            echo "[seed-pin] no changes after rewrite; skipping."
+            exit 0
+          fi
+
+          git commit -m "chore(seed): pin cadence seed to ${VERSION}"
+          git push -u origin "$branch"
+
+          body="$(mktemp)"
+          cat > "$body" <<EOF
+          ## Summary
+
+          Pins the compiler checkout seed from \`${current}\` to \`${VERSION}\` after the cadence alpha \`${TAG}\` published release assets.
+
+          ## Notes
+
+          - Updates \`bootstrap.toml [seed].version\`, the canonical compiler-checkout seed policy.
+          - Updates \`compiler/capsule.toml [toolchain].sfn\` so the public toolchain floor tracks the adopted seed.
+          - Updates \`.seed-version\` only if that transitional file still exists; SFN-214 can remove it without changing this workflow.
+
+          ## Verification
+
+          - \`gh release view ${TAG} --json assets\` returned ${assets} asset(s).
+          EOF
+
+          pr_url="$(gh pr create \
+            --draft \
+            --base main \
+            --head "$branch" \
+            --title "chore(seed): pin cadence seed to ${VERSION}" \
+            --body-file "$body")"
+          echo "$pr_url"
+          post_slack ":seedling: Sailfin cadence seed-pin PR opened for ${VERSION}.\nPR: ${pr_url}\nRelease: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+
+      - name: Notify Slack on seed-pin failure
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_RELEASE_WEBHOOK_URL:-}" ]; then
+            exit 0
+          fi
+          python3 - <<'PY' > /tmp/slack-payload.json
+          import json
+          import os
+          tag = os.environ.get("TAG", "unknown")
+          run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          print(json.dumps({
+              "text": f":warning: Sailfin cadence seed-pin workflow failed for {tag}.\\nRun: {run_url}"
+          }))
+          PY
+          curl -fsS -X POST \
+            -H 'Content-type: application/json' \
+            --data @/tmp/slack-payload.json \
+            "$SLACK_RELEASE_WEBHOOK_URL" >/dev/null || true
+        env:
+          TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -212,7 +212,7 @@ jobs:
           # hit skips the mirror; on a miss, download is bounded + retried.
           DEB_DIR="$HOME/.cache/mingw-debs"
           mkdir -p "$DEB_DIR"
-          if ! ls "$DEB_DIR"/*.deb >/dev/null 2>&1; then
+          if ! find "$DEB_DIR" -maxdepth 1 -type f -name '*.deb' -print -quit | grep -q .; then
             for attempt in 1 2 3; do
               echo "[mingw] download attempt ${attempt}/3"
               if sudo timeout 300 apt-get update \
@@ -232,7 +232,8 @@ jobs:
             sudo rm -rf "$DEB_DIR/partial"
             sudo chown -R "$(id -u):$(id -g)" "$DEB_DIR"
           else
-            echo "[mingw] cache hit: $(ls "$DEB_DIR"/*.deb | wc -l) package(s)"
+            deb_count="$(find "$DEB_DIR" -maxdepth 1 -type f -name '*.deb' | wc -l | tr -d ' ')"
+            echo "[mingw] cache hit: ${deb_count} package(s)"
           fi
           sudo dpkg -i "$DEB_DIR"/*.deb \
             || sudo apt-get install -y --no-install-recommends -f
@@ -309,7 +310,7 @@ jobs:
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          for payload in $(find dist -maxdepth 1 -type f -name 'installer-*.tar.gz'); do
+          while IFS= read -r -d '' payload; do
             label="$(basename "$payload" .tar.gz)"
             case "$label" in
               *linux-x86_64*)
@@ -336,7 +337,7 @@ jobs:
             else
               shasum -a 256 "dist/${installer_name}" > "dist/${installer_name}.sha256"
             fi
-          done
+          done < <(find dist -maxdepth 1 -type f -name 'installer-*.tar.gz' -print0)
 
       # Supply-chain root: publish a signed SHA256SUMS manifest over the release
       # assets so `sfn` can verify a fetched toolchain against the public key
@@ -382,3 +383,32 @@ jobs:
             dist/SHA256SUMS.sig
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+  notify-slack-failure:
+    name: Notify Slack on release asset failure
+    needs: [build, upload]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Slack notification
+        shell: bash
+        env:
+          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_RELEASE_WEBHOOK_URL:-}" ]; then
+            exit 0
+          fi
+          python3 - <<'PY' > /tmp/slack-payload.json
+          import json
+          import os
+          tag = os.environ["RELEASE_TAG"]
+          run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          print(json.dumps({
+              "text": f":x: Sailfin release asset build/upload failed for {tag}.\\nRun: {run_url}"
+          }))
+          PY
+          curl -fsS -X POST \
+            -H 'Content-type: application/json' \
+            --data @/tmp/slack-payload.json \
+            "$SLACK_RELEASE_WEBHOOK_URL" >/dev/null || true

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -389,6 +389,7 @@ jobs:
     needs: [build, upload]
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Post Slack notification
         shell: bash

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -12,19 +12,18 @@ name: Release Train (cadence)
 #      self-host check), NOT the open scope. Whatever scoped work is not done
 #      ROLLS FORWARD to the next train: open `release:next-minor` items are
 #      surfaced for visibility but NEVER block the train (time-box semantics).
-#   3. Surfaces "ready to cut" on the tracker. It does **not** auto-dispatch
-#      the curated minor cut: the actual `release.yml` dispatch stays
-#      **human-confirmable**. A maintainer re-runs this workflow with
-#      `confirm_dispatch=true` to fire the cut once the cadence comment looks
-#      right (mirroring how `seed-cut-advisor.yml` only flags, never cuts).
+#   3. Dispatches the curated minor alpha automatically on scheduled cadence
+#      runs when the cut gate is green. Manual runs stay human-confirmable:
+#      re-run this workflow with `confirm_dispatch=true` to fire an off-clock
+#      or repair cut once the cadence comment looks right.
 #
 # It is a PLAIN, deterministic Actions workflow in the spirit of
 # `seed-cut-advisor.yml` — NOT a gh-aw `.md` source. No compiled `.lock.yml`,
 # no LLM engine, no ANTHROPIC_API_KEY. A single pinned `actions/github-script`
 # step does the version math / tracker upsert / gate evaluation / optional
-# dispatch. The routine daily alpha (`channel=alpha bump=prerelease`) is
-# unaffected — this is the curated minor train on the cadence, and its alpha
-# cut doubles as the scheduled seed bump (SFEP-0026 §3.3).
+# dispatch. Routine alpha prerelease bumps remain manual/off-cadence — this is
+# the curated minor train on the cadence, and its alpha cut doubles as the
+# scheduled seed bump (SFEP-0026 §3.3).
 #
 # See `.github/AGENTS.md`, `docs/conventions/issue-naming.md` "Release
 # tracking" / "Seed pinning", and `.claude/commands/release-plan.md` (which
@@ -45,7 +44,7 @@ on:
         type: boolean
         default: false
       confirm_dispatch:
-        description: "Actually dispatch release.yml for the cadence minor cut (requires a clear cut gate)"
+        description: "Manual confirmation: dispatch release.yml for the cadence minor cut (requires a clear cut gate)"
         required: false
         type: boolean
         default: false
@@ -81,6 +80,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           CONFIRM_DISPATCH: ${{ inputs.confirm_dispatch }}
           FORCE: ${{ inputs.force }}
+          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
         with:
           github-token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           script: |
@@ -92,6 +92,22 @@ jobs:
             const isSchedule = context.eventName === 'schedule';
             const summary = [];
             const note = (s) => { core.info(s); summary.push(s); };
+            async function postSlack(text) {
+              const url = process.env.SLACK_RELEASE_WEBHOOK_URL || '';
+              if (!url) return;
+              try {
+                const res = await fetch(url, {
+                  method: 'POST',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ text }),
+                });
+                if (!res.ok) {
+                  core.warning(`Slack notification failed (${res.status}): ${await res.text()}`);
+                }
+              } catch (e) {
+                core.warning(`Slack notification failed: ${e.message}`);
+              }
+            }
 
             // --- 0. Bi-weekly cadence gate (scheduled runs only) --------------
             // ISO-8601 week number; even week == cadence week. Deterministic and
@@ -160,8 +176,11 @@ jobs:
                 + openNextMinor.map(i => '#' + i.number).join(', '));
 
             // --- 4. Open or update the tracker --------------------------------
+            // Trackers are looked up by exact title first. The `tracking` label
+            // is still applied for compatibility with older advisor tooling, but
+            // a missing label must not make the train miss an existing tracker.
             const existing = (await github.paginate(github.rest.issues.listForRepo, {
-              owner, repo, state: 'open', labels: 'tracking', per_page: 100,
+              owner, repo, state: 'open', per_page: 100,
             })).filter(i => !i.pull_request && i.title.trim() === trackerTitle);
             let tracker = existing[0] || null;
             if (existing.length > 1) {
@@ -182,9 +201,9 @@ jobs:
                   '_Auto-opened by the cadence release train. Run `/release-plan '
                     + target + '` to enrich the must-close / seed-blocker sub-issues and the seed-bump section._', '',
                   '## Cut gate', '',
-                  'This is a curated cadence cut. The train surfaces readiness; the actual '
-                    + '`release.yml` dispatch stays human-confirmable (re-run **Release Train** with '
-                    + '`confirm_dispatch=true`). Open scope rolls forward — it never blocks the train.', '',
+                  'This is a curated cadence cut. Scheduled train runs dispatch `release.yml` '
+                    + 'automatically when the nightly self-host gate is green; manual runs require '
+                    + '`confirm_dispatch=true`. Open scope rolls forward — it never blocks the train.', '',
                   '## Cross-references', '',
                   '- Cadence train: `.github/workflows/release-train.yml`',
                   '- Convention: `docs/conventions/issue-naming.md` "Release tracking" / "Seed pinning"',
@@ -199,6 +218,19 @@ jobs:
               }
             } else {
               note(`Tracker "${trackerTitle}" already open as #${tracker.number}.`);
+            }
+            if (tracker) {
+              const hasTracking = (tracker.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'tracking');
+              if (!hasTracking) {
+                if (dryRun) {
+                  note(`[dry-run] would ADD missing \`tracking\` label to tracker #${tracker.number}.`);
+                } else {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: tracker.number, labels: ['tracking'],
+                  });
+                  note(`Added missing \`tracking\` label to tracker #${tracker.number}.`);
+                }
+              }
             }
 
             // --- 5. Idempotent cadence comment --------------------------------
@@ -215,14 +247,17 @@ jobs:
               const gateLine = cutGateClear
                 ? `✅ Cut gate clear — latest nightly self-host on \`${defaultBranch}\` is green.`
                 : `⛔ Cut gate NOT clear — ${nightly ? 'nightly self-host is ' + nightly.conclusion : 'no nightly run found'}; hold the cut until main is green.`;
+              const dispatchLine = cutGateClear
+                ? (isSchedule
+                    ? `**Auto-dispatching.** This scheduled cadence run will dispatch the curated minor (\`channel=alpha bump=minor\` → \`${maj}.${min + 1}.0-alpha.1\`).`
+                    : `**Ready to cut.** To dispatch the curated minor (\`channel=alpha bump=minor\` → \`${maj}.${min + 1}.0-alpha.1\`), re-run the **Release Train** workflow with \`confirm_dispatch=true\`.`)
+                : `**Not cutting.** The train rolls forward; it will re-evaluate next cadence boundary once main is green.`;
               const cadenceBody = [
                 `${cadenceMarker}`, '',
                 `Cadence train boundary reached for **${target}**.`, '',
                 gateLine, '',
                 `Rolling forward (not blocking): ${rollFwd}`, '',
-                cutGateClear
-                  ? `**Ready to cut.** To dispatch the curated minor (\`channel=alpha bump=minor\` → \`${maj}.${min + 1}.0-alpha.1\`, which is also this cadence's seed bump), re-run the **Release Train** workflow with \`confirm_dispatch=true\`.`
-                  : `**Not cutting.** The train rolls forward; it will re-evaluate next cadence boundary once main is green.`,
+                dispatchLine,
               ].join('\n');
               if (dryRun) {
                 note(`[dry-run] would ${already ? 'SKIP (already posted)' : 'POST'} the cadence comment on #${tracker.number}.`);
@@ -234,23 +269,39 @@ jobs:
               }
             }
 
-            // --- 6. Human-confirmable dispatch of release.yml -----------------
-            // Scheduled runs NEVER dispatch — they only surface readiness.
-            // A maintainer confirms by re-running with confirm_dispatch=true.
-            if (confirmDispatch && !isSchedule) {
+            // --- 6. Dispatch release.yml --------------------------------------
+            // Scheduled cadence runs are the public release train: if the gate is
+            // green, they dispatch automatically. Manual runs require explicit
+            // confirmation so repair/off-clock cuts stay deliberate.
+            const releaseTag = `v${maj}.${min + 1}.0-alpha.1`;
+            async function tagExists(tag) {
+              try {
+                await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
+                return true;
+              } catch (e) {
+                if (e.status === 404) return false;
+                throw e;
+              }
+            }
+            const shouldDispatch = isSchedule || confirmDispatch;
+            if (shouldDispatch) {
               if (dryRun) {
-                note('[dry-run] confirm_dispatch set but dry-run — not dispatching release.yml.');
+                note(`[dry-run] would ${isSchedule ? 'auto-dispatch' : 'dispatch'} release.yml (channel=alpha bump=minor) for ${releaseTag}.`);
               } else if (!cutGateClear) {
-                note('confirm_dispatch set but cut gate NOT clear — refusing to dispatch release.yml on a red main.');
+                note(`${isSchedule ? 'Scheduled train' : 'confirm_dispatch'} requested a cut, but cut gate is NOT clear — refusing to dispatch release.yml on a red main.`);
+                await postSlack(`:warning: Sailfin release train blocked for ${target}. Latest nightly self-host is ${nightly ? nightly.conclusion : 'missing'}.\nTracker: ${tracker ? tracker.html_url : trackerTitle}\nRun: https://github.com/${owner}/${repo}/actions/runs/${context.runId}`);
+              } else if (await tagExists(releaseTag)) {
+                note(`Release tag ${releaseTag} already exists — skipping dispatch.`);
               } else {
                 await github.rest.actions.createWorkflowDispatch({
                   owner, repo, workflow_id: 'release.yml', ref: defaultBranch,
                   inputs: { channel: 'alpha', bump: 'minor', dry_run: 'false' },
                 });
-                note(`Dispatched release.yml (channel=alpha bump=minor) → ${maj}.${min + 1}.0-alpha.1.`);
+                note(`Dispatched release.yml (channel=alpha bump=minor) → ${releaseTag}.`);
+                await postSlack(`:rocket: Sailfin release train dispatched ${releaseTag} (channel=alpha bump=minor).\nTracker: ${tracker ? tracker.html_url : trackerTitle}\nRun: https://github.com/${owner}/${repo}/actions/runs/${context.runId}`);
               }
-            } else if (confirmDispatch && isSchedule) {
-              note('confirm_dispatch is ignored on scheduled runs — dispatch is human-confirmable (re-run manually).');
+            } else {
+              note('Manual run without confirm_dispatch — surfaced readiness only.');
             }
 
             core.summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,6 +360,7 @@ jobs:
     needs: release
     if: failure()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Post Slack notification
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,42 +305,44 @@ jobs:
           PREV_TAG: ${{ steps.bump.outputs.prev_tag }}
         run: |
           set -euo pipefail
-          PRERELEASE_FLAG=""
+          prerelease_args=()
           if [ "$CHANNEL" != "stable" ]; then
-            PRERELEASE_FLAG="--prerelease"
+            prerelease_args=(--prerelease)
           fi
 
-          LATEST_FLAG=""
+          latest_args=()
           if [ "$CHANNEL" = "stable" ]; then
-            LATEST_FLAG="--latest"
+            latest_args=(--latest)
           fi
 
           # Only pass --notes-start-tag if the previous tag actually exists
-          NOTES_START=""
+          notes_start_args=()
           if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
-            NOTES_START="--notes-start-tag $PREV_TAG"
+            notes_start_args=(--notes-start-tag "$PREV_TAG")
           fi
 
           gh release create "$TAG" \
             --title "Sailfin $VERSION" \
             --generate-notes \
-            $NOTES_START \
-            $PRERELEASE_FLAG \
-            $LATEST_FLAG
+            "${notes_start_args[@]}" \
+            "${prerelease_args[@]}" \
+            "${latest_args[@]}"
 
       - name: Dry run summary
         if: inputs.dry_run == true
         run: |
-          echo "## Dry Run Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Current | ${{ steps.bump.outputs.prev_tag }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Next | ${{ steps.bump.outputs.tag }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Channel | ${{ inputs.channel }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Bump | ${{ inputs.bump }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "No changes were made (dry run)." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Dry Run Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Current | ${{ steps.bump.outputs.prev_tag }} |"
+            echo "| Next | ${{ steps.bump.outputs.tag }} |"
+            echo "| Channel | ${{ inputs.channel }} |"
+            echo "| Bump | ${{ inputs.bump }} |"
+            echo ""
+            echo "No changes were made (dry run)."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build-assets:
     name: Build release assets
@@ -352,3 +354,35 @@ jobs:
     with:
       tag: ${{ needs.release.outputs.tag }}
     secrets: inherit
+
+  notify-slack-failure:
+    name: Notify Slack on release workflow failure
+    needs: release
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Slack notification
+        shell: bash
+        env:
+          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          CHANNEL: ${{ inputs.channel }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_RELEASE_WEBHOOK_URL:-}" ]; then
+            exit 0
+          fi
+          python3 - <<'PY' > /tmp/slack-payload.json
+          import json
+          import os
+          channel = os.environ.get("CHANNEL", "unknown")
+          bump = os.environ.get("BUMP", "unknown")
+          run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          print(json.dumps({
+              "text": f":x: Sailfin release workflow failed before asset build (channel={channel}, bump={bump}).\\nRun: {run_url}"
+          }))
+          PY
+          curl -fsS -X POST \
+            -H 'Content-type: application/json' \
+            --data @/tmp/slack-payload.json \
+            "$SLACK_RELEASE_WEBHOOK_URL" >/dev/null || true

--- a/.github/workflows/seed-cut-advisor.yml
+++ b/.github/workflows/seed-cut-advisor.yml
@@ -149,10 +149,11 @@ jobs:
               core.info('No release-critical marker — advisory queues for the next cadence bump.');
             }
 
-            // 4. Resolve the ACTIVE release tracker dynamically: open, labeled
-            //    `tracking`, title `Release: vX.Y.Z`. Never hardcoded.
+            // 4. Resolve the ACTIVE release tracker dynamically: open issue,
+            //    title `Release: vX.Y.Z`. The `tracking` label is restored if
+            //    missing, but label drift must not hide the tracker.
             const trackers = (await github.paginate(github.rest.issues.listForRepo, {
-              owner, repo, state: 'open', labels: 'tracking', per_page: 100,
+              owner, repo, state: 'open', per_page: 100,
             })).filter(i => !i.pull_request && /^Release:\s*v\d+\.\d+\.\d+\b/.test(i.title));
             if (trackers.length === 0) {
               core.info('No open semver Release tracker (Release: vX.Y.Z) — logging and exiting 0 without posting.');
@@ -169,6 +170,17 @@ jobs:
             const tracker = trackers[0]; // nearest (lowest) unreleased version
             if (trackers.length > 1) {
               core.info(`Multiple open trackers; using nearest ${tracker.title} (#${tracker.number}).`);
+            }
+            const trackerHasTracking = (tracker.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'tracking');
+            if (!trackerHasTracking) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: tracker.number, labels: ['tracking'],
+                });
+                core.info(`Added missing tracking label to #${tracker.number}.`);
+              } catch (e) {
+                core.warning(`Could not add tracking label to #${tracker.number}: ${e.message}`);
+              }
             }
 
             // 5. Idempotency: skip if an advisory for THIS PR already exists.

--- a/.github/workflows/stable-promotion-advisor.yml
+++ b/.github/workflows/stable-promotion-advisor.yml
@@ -1,0 +1,142 @@
+name: Stable Promotion Advisor
+
+# Stable promotion is intentionally human-confirmed, but the eligibility signal
+# should not depend on someone remembering the calendar. This daily advisor
+# watches the current prerelease line and comments once when the stable gate is
+# clear: no open release:stable issues plus seven consecutive green scheduled
+# nightly self-host runs on main.
+
+on:
+  schedule:
+    # Runs after nightly-selfhost.yml (07:00 UTC) has normally completed.
+    - cron: "30 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: stable-promotion-advisor
+  cancel-in-progress: false
+
+jobs:
+  advise:
+    name: Check stable promotion gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Evaluate stable gate
+        uses: actions/github-script@v9.0.0
+        env:
+          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+        with:
+          github-token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const summary = [];
+            const note = (s) => { core.info(s); summary.push(s); };
+            async function postSlack(text) {
+              const url = process.env.SLACK_RELEASE_WEBHOOK_URL || '';
+              if (!url) return;
+              try {
+                const res = await fetch(url, {
+                  method: 'POST',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ text }),
+                });
+                if (!res.ok) {
+                  core.warning(`Slack notification failed (${res.status}): ${await res.text()}`);
+                }
+              } catch (e) {
+                core.warning(`Slack notification failed: ${e.message}`);
+              }
+            }
+
+            const capsule = fs.readFileSync('compiler/capsule.toml', 'utf8');
+            const vm = capsule.match(/^version\s*=\s*"([^"]+)"/m);
+            if (!vm) { core.setFailed('Could not read version from compiler/capsule.toml'); return; }
+            const m = vm[1].match(/^(\d+)\.(\d+)\.(\d+)(-.+)?$/);
+            if (!m) { core.setFailed(`Cannot parse version '${vm[1]}'`); return; }
+            if (!m[4]) {
+              note(`Current version ${vm[1]} is already stable; no promotion advice needed.`);
+              core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();
+              return;
+            }
+
+            const target = `v${m[1]}.${m[2]}.${m[3]}`;
+            const trackerTitle = `Release: ${target}`;
+            note(`Current ${vm[1]} -> stable target ${target}.`);
+
+            const openStable = (await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'release:stable', per_page: 100,
+            })).filter(i => !i.pull_request);
+            if (openStable.length > 0) {
+              note(`${openStable.length} open release:stable issue(s): ${openStable.map(i => '#' + i.number).join(', ')}.`);
+            } else {
+              note('No open release:stable issues.');
+            }
+
+            const defaultBranch = context.payload.repository?.default_branch || 'main';
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner, repo, workflow_id: 'nightly-selfhost.yml', branch: defaultBranch,
+              event: 'schedule', status: 'completed', per_page: 20,
+            });
+            const recent = runs.slice(0, 7);
+            const sevenGreen = recent.length === 7 && recent.every(r => r.conclusion === 'success');
+            note(recent.length < 7
+              ? `Only ${recent.length}/7 scheduled nightly self-host runs found.`
+              : `Last 7 scheduled nightly self-host conclusions: ${recent.map(r => r.conclusion).join(', ')}.`);
+
+            if (openStable.length > 0 || !sevenGreen) {
+              note('Stable promotion gate is not clear.');
+              core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();
+              return;
+            }
+
+            const trackers = (await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', per_page: 100,
+            })).filter(i => !i.pull_request && i.title.trim() === trackerTitle);
+            if (trackers.length === 0) {
+              note(`Stable gate is clear, but no open tracker titled "${trackerTitle}" exists.`);
+              core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();
+              return;
+            }
+            const tracker = trackers.sort((a, b) => a.number - b.number)[0];
+            const hasTracking = (tracker.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'tracking');
+            if (!hasTracking) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: tracker.number, labels: ['tracking'],
+              });
+              note(`Added missing tracking label to tracker #${tracker.number}.`);
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: tracker.number, per_page: 100,
+            });
+            const marker = `Stable-promotion-advisor: ${target} eligible`;
+            if (comments.some(c => (c.body || '').includes(marker))) {
+              note(`Eligibility comment already exists on #${tracker.number}.`);
+            } else {
+              const body = [
+                marker, '',
+                `Stable promotion gate is clear for **${target}**:`,
+                '- no open `release:stable` issues',
+                '- seven consecutive scheduled `nightly-selfhost.yml` runs on `main` are green', '',
+                'Promotion remains human-confirmed. Run `release.yml` with `channel=stable` and `bump=prerelease` when ready.',
+              ].join('\n');
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: tracker.number, body,
+              });
+              note(`Posted stable-promotion eligibility comment on #${tracker.number}.`);
+              await postSlack(`:white_check_mark: Sailfin ${target} is eligible for stable promotion.\nTracker: ${tracker.html_url}\nRun release.yml with channel=stable, bump=prerelease when ready.`);
+            }
+
+            core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();

--- a/.github/workflows/stable-promotion-advisor.yml
+++ b/.github/workflows/stable-promotion-advisor.yml
@@ -1,10 +1,11 @@
 name: Stable Promotion Advisor
 
-# Stable promotion is intentionally human-confirmed, but the eligibility signal
+# Stable promotion is intentionally human-confirmed, but the review prompt
 # should not depend on someone remembering the calendar. This daily advisor
-# watches the current prerelease line and comments once when the stable gate is
-# clear: no open release:stable issues plus seven consecutive green scheduled
-# nightly self-host runs on main.
+# watches the current prerelease line and comments once when automated
+# preconditions are satisfied: no open release:stable issues plus seven
+# consecutive green scheduled nightly self-host runs on main. Maintainers still
+# review the release tracker before promotion.
 
 on:
   schedule:
@@ -23,7 +24,7 @@ concurrency:
 
 jobs:
   advise:
-    name: Check stable promotion gate
+    name: Check stable promotion preconditions
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,7 +33,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Evaluate stable gate
+      - name: Evaluate stable preconditions
         uses: actions/github-script@v9.0.0
         env:
           SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
@@ -85,10 +86,11 @@ jobs:
             }
 
             const defaultBranch = context.payload.repository?.default_branch || 'main';
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            const runsResponse = await github.rest.actions.listWorkflowRuns({
               owner, repo, workflow_id: 'nightly-selfhost.yml', branch: defaultBranch,
               event: 'schedule', status: 'completed', per_page: 20,
             });
+            const runs = runsResponse.data.workflow_runs;
             const recent = runs.slice(0, 7);
             const sevenGreen = recent.length === 7 && recent.every(r => r.conclusion === 'success');
             note(recent.length < 7
@@ -96,7 +98,7 @@ jobs:
               : `Last 7 scheduled nightly self-host conclusions: ${recent.map(r => r.conclusion).join(', ')}.`);
 
             if (openStable.length > 0 || !sevenGreen) {
-              note('Stable promotion gate is not clear.');
+              note('Stable promotion automated preconditions are not satisfied.');
               core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();
               return;
             }
@@ -105,7 +107,7 @@ jobs:
               owner, repo, state: 'open', per_page: 100,
             })).filter(i => !i.pull_request && i.title.trim() === trackerTitle);
             if (trackers.length === 0) {
-              note(`Stable gate is clear, but no open tracker titled "${trackerTitle}" exists.`);
+              note(`Stable promotion automated preconditions are satisfied, but no open tracker titled "${trackerTitle}" exists.`);
               core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();
               return;
             }
@@ -121,22 +123,22 @@ jobs:
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: tracker.number, per_page: 100,
             });
-            const marker = `Stable-promotion-advisor: ${target} eligible`;
+            const marker = `Stable-promotion-advisor: ${target} ready for human review`;
             if (comments.some(c => (c.body || '').includes(marker))) {
-              note(`Eligibility comment already exists on #${tracker.number}.`);
+              note(`Stable promotion review comment already exists on #${tracker.number}.`);
             } else {
               const body = [
                 marker, '',
-                `Stable promotion gate is clear for **${target}**:`,
+                `Stable promotion automated preconditions are satisfied for **${target}**:`,
                 '- no open `release:stable` issues',
                 '- seven consecutive scheduled `nightly-selfhost.yml` runs on `main` are green', '',
-                'Promotion remains human-confirmed. Run `release.yml` with `channel=stable` and `bump=prerelease` when ready.',
+                'Promotion remains human-confirmed. Review the release tracker for unresolved scope, then run `release.yml` with `channel=stable` and `bump=prerelease` when ready.',
               ].join('\n');
               await github.rest.issues.createComment({
                 owner, repo, issue_number: tracker.number, body,
               });
-              note(`Posted stable-promotion eligibility comment on #${tracker.number}.`);
-              await postSlack(`:white_check_mark: Sailfin ${target} is eligible for stable promotion.\nTracker: ${tracker.html_url}\nRun release.yml with channel=stable, bump=prerelease when ready.`);
+              note(`Posted stable-promotion review comment on #${tracker.number}.`);
+              await postSlack(`:white_check_mark: Sailfin ${target} passed automated stable-promotion checks.\nTracker: ${tracker.html_url}\nReview the tracker, then run release.yml with channel=stable, bump=prerelease when ready.`);
             }
 
             core.summary.addRaw('## Stable Promotion Advisor\n\n' + summary.map(s => '- ' + s).join('\n')).write();

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -448,7 +448,7 @@ Release workflows post high-signal notifications to Slack when
 `SLACK_RELEASE_WEBHOOK_URL` is configured in GitHub Actions secrets. The
 intended channel is `#sailfin-notifications`; notifications are limited to
 cadence dispatch/block events, cadence seed-pin PRs or failures, stable
-promotion eligibility, and release workflow/asset failures.
+promotion review prompts, and release workflow/asset failures.
 
 ### Labels
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -421,6 +421,35 @@ For curated cuts `/release` lists the open items under the matching
 confirmation before dispatching. The gate is advisory — the human always
 has the final call.
 
+### Release cadence
+
+The public compiler train is a **2-week Monday cadence**. The scheduled
+`release-train.yml` workflow runs every Monday at 09:00 UTC and enforces the
+2-week boundary with ISO-week parity. On the cadence week, if the latest
+`nightly-selfhost.yml` run on `main` is green, the train automatically
+dispatches `release.yml` with `channel=alpha bump=minor`, producing the next
+minor alpha (`vX.Y.0-alpha.1`). Open release scope rolls forward; it is
+reported on the tracker but does not block the train.
+
+Manual cadence workflow runs do **not** dispatch by default. Use
+`confirm_dispatch=true` only for a deliberate repair or off-clock cut, and only
+when the same nightly self-host gate is clear.
+
+Routine alphas (`channel=alpha bump=prerelease`) remain manual/off-cadence.
+They are for urgent fixes, release-critical seed needs, or maintainer-curated
+snapshots between trains; they are not the public cadence contract.
+
+Stable promotion is **not** on a timer. Promote to `channel=stable` only when
+both conditions hold: the target release tracker is clear and `main` has seven
+consecutive green nightly self-host runs. The stable dispatch stays
+human-confirmed.
+
+Release workflows post high-signal notifications to Slack when
+`SLACK_RELEASE_WEBHOOK_URL` is configured in GitHub Actions secrets. The
+intended channel is `#sailfin-notifications`; notifications are limited to
+cadence dispatch/block events, cadence seed-pin PRs or failures, stable
+promotion eligibility, and release workflow/asset failures.
+
 ### Labels
 
 | Label | Hard gate at | Soft signal at |
@@ -459,13 +488,12 @@ curation, not the issue.
 
 ## Seed pinning
 
-The Sailfin compiler self-hosts from a released seed binary. The pin
-lives at `.seed-version` (single-line file at repo root) and is read by
-`make fetch-seed`, `ci.yml`, `nightly-selfhost.yml`, and
-`release-branches.yml`. **Bumping the pin is a separate concern from
-cutting a release** — `release.yml` deliberately doesn't touch
-`.seed-version` because the new binary doesn't exist at tag-creation
-time and most alpha releases shouldn't be pinned.
+The Sailfin compiler self-hosts from a released seed binary. The canonical
+pin lives in `bootstrap.toml` as `[seed].version`; during the SFEP-0047
+migration it is mirrored to `.seed-version` for older bootstrap paths.
+**Bumping the pin is a separate concern from cutting a release** —
+`release.yml` deliberately doesn't touch the seed pin because the new binary
+doesn't exist at tag-creation time and most alpha releases shouldn't be pinned.
 
 **Seeds advance on the cadence, batched.** Per SFEP-0026 WS-C, the pin is
 **not** chased reactively per-need (the `0.7.0-alpha.49` treadmill). Routine
@@ -496,10 +524,13 @@ the need clears the release-critical bar.
 
 Mid-flight seed needs — a `needs-seed-cut` flag from the advisor, or a
 `seed-blocker` issue closing — **queue against the next scheduled cadence
-seed bump** by default. `/pin-seed` runs **once per cadence** against that
-cycle's alpha cut; it is not run reactively for each individual need. This
-is the SFEP-0026 §3.3 batching policy: trade a small latency on
-non-critical seed needs for a large reduction in cut/`pin-seed` overhead.
+seed bump** by default. After the cadence alpha assets publish, the
+`cadence-seed-pin.yml` workflow opens a draft PR that advances
+`bootstrap.toml [seed].version` (and the transitional mirror only while it
+exists). The pin advances **once per cadence**; it is not run reactively for
+each individual need. This is the SFEP-0026 §3.3 batching policy: trade a
+small latency on non-critical seed needs for a large reduction in seed-pin
+overhead.
 
 **The release-critical bar (the only thing that breaks the batch).** A
 mid-flight seed need may force an **off-cadence** seed cut only if **all
@@ -584,9 +615,9 @@ escalate to **"off-cadence seed cut may be warranted"** (it clears the
 release-critical bar above).
 
 It is idempotent (one advisory per PR per tracker) and **only flags** —
-it never dispatches `release.yml` or bumps `.seed-version`, and it never
-applies `release-critical-seed` (that marker is human/grooming-applied; the
-advisor only reads it). `/release-plan` consumes the `needs-seed-cut` label,
+it never dispatches `release.yml` or bumps the seed pin, and it never applies
+`release-critical-seed` (that marker is human/grooming-applied; the advisor
+only reads it). `/release-plan` consumes the `needs-seed-cut` label,
 surfacing a "Seed cut required" checklist section on the per-cycle tracking
 issue. A queued flag clears when the cadence `/pin-seed` lands; a
 release-critical flag clears when its off-cadence `/pin-seed` lands. Remove
@@ -628,7 +659,7 @@ When a current-seed bug breaks downstream work:
 
 The pin PR lives off `main` (never `claude/*`), is reviewed even though
 it's one line, and is never auto-merged — it cascades through every
-workflow that reads `.seed-version`.
+workflow that reads the compiler checkout seed pin.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary

Automates the public minor-alpha release train while keeping stable promotion human-confirmed:

- scheduled cadence runs in `release-train.yml` now dispatch `release.yml` automatically when the latest nightly self-host gate is green
- tracker lookup is self-healing: release trackers are found by exact title and the `tracking` label is restored if it drifted
- adds `cadence-seed-pin.yml` to open a draft seed-pin PR after a cadence `*.0-alpha.1` release publishes assets
- adds `stable-promotion-advisor.yml` to comment when the stable gate is clear: no open `release:stable` issues plus seven green scheduled nightly self-host runs
- adds optional Slack notifications through `SLACK_RELEASE_WEBHOOK_URL` for cadence dispatch/block, seed-pin PR/failure, stable eligibility, and release workflow/asset failures
- documents the public contract in the release conventions and `/release` guidance

## SFN-214 compatibility

The seed-pin automation treats `bootstrap.toml [seed].version` as canonical and updates `.seed-version` only if that transitional file still exists. That keeps this compatible with the planned SFN-214 migration to remove `.seed-version` later.

## Slack behavior

Slack posting is best-effort and no-ops when `SLACK_RELEASE_WEBHOOK_URL` is unset. A Slack outage or malformed webhook response will warn in the workflow logs but will not fail release automation.

## Verification

- `actionlint .github/workflows/release.yml .github/workflows/release-tag.yml .github/workflows/release-train.yml .github/workflows/cadence-seed-pin.yml .github/workflows/stable-promotion-advisor.yml .github/workflows/seed-cut-advisor.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "yaml ok #{f}" }' .github/workflows/release.yml .github/workflows/release-tag.yml .github/workflows/release-train.yml .github/workflows/cadence-seed-pin.yml .github/workflows/stable-promotion-advisor.yml .github/workflows/seed-cut-advisor.yml`
- `bash -n` on embedded shell steps in `release.yml`, `release-tag.yml`, and `cadence-seed-pin.yml`
- `git diff --check`