### PR TITLE
feat(bench): sailfin.bench/v1 JSON output + sailfin_bench MCP tool (SFN-64)

### DIFF
--- a/compiler/src/cli/commands/bench.sfn
+++ b/compiler/src/cli/commands/bench.sfn
@@ -38,6 +38,7 @@ import { number_to_string } from "../../num_format";
 import { char_code_at_text, index_of } from "../../string_utils";
 import { resolve_compiler_version } from "../../version";
 import { CliContext } from "../context";
+import { BenchJsonResult, render_bench_json_envelope } from "./bench_json";
 
 // The `sfn/cli` definition for `bench`, registered on the v2 root via
 // `with_subcommand`. Two modes share one command: the default runtime mode
@@ -60,6 +61,7 @@ fn command_def() -> Command {
     cmd = with_flag(cmd, flag_int("budget-time", "Fail (exit 2) if any workload/module exceeds this budget (runtime: median inner-ms; compiler: wall seconds)"));
     cmd = with_flag(cmd, flag_int("budget-mem", "Fail (exit 2) if any workload/module exceeds this peak RSS in KB"));
     cmd = with_flag(cmd, flag_value("work-dir", "Directory for staged sources + built binaries / emitted .ll (default build/bench-exec, or build/bench for --compiler)"));
+    cmd = with_flag(cmd, flag("json", "Emit results as a sailfin.bench/v1 JSON envelope on stdout, suppressing the human table (redirect to a file; pairs with --csv)"));
     cmd = with_arg(cmd, arg_variadic("path", "Runtime mode: one or more workload files or directories of *_bench.sfn (default: benchmarks/runtime)"));
     return cmd;
 }
@@ -169,6 +171,7 @@ fn _run_compiler_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
         budget_mem = get_int(matches, "budget-mem");
     }
     let modules = repeated(matches, "module");
+    let json = has_flag(matches, "json");
 
     if !fs.exists(import_ctx) {
         print.err("[bench] error: import-context not found at " + import_ctx);
@@ -178,16 +181,19 @@ fn _run_compiler_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
 
     let self_bin = _resolve_self_path(ctx.binary_dir);
     let version = resolve_compiler_version(ctx.binary_dir);
+    let platform = _bench_rt_platform();
 
     let all = _collect_sfn_files_cmd("compiler/src", 32);
     let mut sources: string[] = all;
     if modules.length > 0 { sources = _bench_filter_sources(all, modules); }
 
-    print("[bench] seed: " + self_bin + " (" + version + ")");
-    print("[bench] modules: " + number_to_string(sources.length));
-    print("");
-    print("  MODULE                                                     TIME      PEAK     IR LINES  STATUS");
-    print("  ------                                                     ----      ----     --------  ------");
+    if !json {
+        print("[bench] seed: " + self_bin + " (" + version + ")");
+        print("[bench] modules: " + number_to_string(sources.length));
+        print("");
+        print("  MODULE                                                     TIME      PEAK     IR LINES  STATUS");
+        print("  ------                                                     ----      ----     --------  ------");
+    }
 
     _ensure_dir(work_dir);
 
@@ -247,11 +253,14 @@ fn _run_compiler_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
         lines_list.push(ir_lines);
         status_list.push(status);
 
-        print("  " + name + "  " + _fmt_secs(wall_ms) + "s  " + number_to_string(peak_kb / 1024)
-            + "MB  "
-            + number_to_string(ir_lines)
-            + "  "
-            + status);
+        if !json {
+            print("  " + name + "  " + _fmt_secs(wall_ms) + "s  "
+                + number_to_string(peak_kb / 1024)
+                + "MB  "
+                + number_to_string(ir_lines)
+                + "  "
+                + status);
+        }
         i += 1;
     }
 
@@ -282,32 +291,36 @@ fn _run_compiler_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
         i += 1;
     }
 
-    print("");
-    print("==================================================================");
-    print("");
-    print("  SUMMARY");
-    print("  -------");
-    print("  Modules:       " + number_to_string(names.length));
-    print("  Total time:    " + _fmt_secs(total_ms) + "s");
-    print("  Slowest:       " + _fmt_secs(max_ms) + "s  (" + max_ms_name + ")");
-    print("  Peak memory:   " + number_to_string(max_kb / 1024) + "MB  ("
-        + max_kb_name
-        + ")");
-    if fail_count > 0 {
-        print("  FAILURES:      " + number_to_string(fail_count));
+    if !json {
+        print("");
+        print("==================================================================");
+        print("");
+        print("  SUMMARY");
+        print("  -------");
+        print("  Modules:       " + number_to_string(names.length));
+        print("  Total time:    " + _fmt_secs(total_ms) + "s");
+        print("  Slowest:       " + _fmt_secs(max_ms) + "s  (" + max_ms_name
+            + ")");
+        print("  Peak memory:   " + number_to_string(max_kb / 1024) + "MB  ("
+            + max_kb_name
+            + ")");
+        if fail_count > 0 {
+            print("  FAILURES:      " + number_to_string(fail_count));
+        }
+        if budget_time > 0 {
+            print("  Over budget:   " + number_to_string(slow_count)
+                + " modules > "
+                + number_to_string(budget_time)
+                + "s");
+        }
+        if budget_mem > 0 {
+            print("  Over memory:   " + number_to_string(highmem_count)
+                + " modules > "
+                + number_to_string(budget_mem / 1024)
+                + "MB");
+        }
+        print("");
     }
-    if budget_time > 0 {
-        print("  Over budget:   " + number_to_string(slow_count) + " modules > "
-            + number_to_string(budget_time)
-            + "s");
-    }
-    if budget_mem > 0 {
-        print("  Over memory:   " + number_to_string(highmem_count)
-            + " modules > "
-            + number_to_string(budget_mem / 1024)
-            + "MB");
-    }
-    print("");
 
     if csv_out.length > 0 {
         let csv_dir_slash = index_of(csv_out, "/");
@@ -340,10 +353,10 @@ fn _run_compiler_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
             i += 1;
         }
         fs.writeFile(csv_out, csv_content);
-        print("[bench] wrote " + csv_out);
+        if !json { print("[bench] wrote " + csv_out); }
     }
 
-    if top_n > 0 && names.length > top_n {
+    if !json && top_n > 0 && names.length > top_n {
         print("  TOP " + number_to_string(top_n) + " BY COMPILE TIME");
         print("  -------------------------");
         let mut order: int[] = [];
@@ -378,6 +391,28 @@ fn _run_compiler_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
             t += 1;
         }
         print("");
+    }
+
+    let mut exit_code = 0;
+    if fail_count > 0 { exit_code = 1; } else if slow_count > 0 || highmem_count > 0 {
+        exit_code = 2;
+    }
+
+    if json {
+        // Compiler mode measures one emit per module, so the spread collapses
+        // to a single wall-clock sample (min = median = max, stddev = 0) and
+        // there is no op count. config mirrors that: one iteration, no warm-up.
+        let mut jresults: BenchJsonResult[] = [];
+        let mut ji = 0;
+        loop {
+            if ji >= names.length { break; }
+            jresults.push(BenchJsonResult {
+                name: names[ji], ops: 0, time_min: wall_ms_list[ji], time_median: wall_ms_list[ji], time_max: wall_ms_list[ji], time_stddev: 0, peak_rss_kb: peak_kb_list[ji], status: status_list[ji]
+            });
+            ji += 1;
+        }
+        print(render_bench_json_envelope("compiler", version, platform, 1, 0, exit_code, jresults));
+        return exit_code;
     }
 
     if fail_count > 0 {
@@ -603,6 +638,57 @@ fn _bench_rt_min(xs: int[]) -> int {
     return m;
 }
 
+fn _bench_rt_max(xs: int[]) -> int {
+    if xs.length == 0 { return 0; }
+    let mut m = xs[0];
+    let mut i = 1;
+    loop {
+        if i >= xs.length { break; }
+        if xs[i] > m { m = xs[i]; }
+        i += 1;
+    }
+    return m;
+}
+
+// Floor integer square root via binary search — no float dependency, so the
+// stddev column stays int-only like the rest of the bench math.
+fn _bench_rt_isqrt(n: int) -> int {
+    if n <= 0 { return 0; }
+    let mut lo = 1;
+    let mut hi = n;
+    loop {
+        if lo >= hi { break; }
+        let mid = (lo + hi + 1) / 2;
+        if mid <= n / mid { lo = mid; } else { hi = mid - 1; }
+    }
+    return lo;
+}
+
+// Population standard deviation (floor, ms) of the timing samples, for the
+// JSON `time_ms.stddev` field. Integer mean and variance keep the value in
+// the same millisecond units as the other timing columns.
+fn _bench_rt_stddev(xs: int[]) -> int {
+    let n = xs.length;
+    if n == 0 { return 0; }
+    let mut sum = 0;
+    let mut i = 0;
+    loop {
+        if i >= n { break; }
+        sum += xs[i];
+        i += 1;
+    }
+    let mean = sum / n;
+    let mut acc = 0;
+    i = 0;
+    loop {
+        if i >= n { break; }
+        let d = xs[i] - mean;
+        acc += d * d;
+        i += 1;
+    }
+    return _bench_rt_isqrt(acc / n);
+}
+
 // Median of `xs` (insertion sort over a copy); even length averages the two
 // middle samples, matching the former `bench_runtime.sh`'s integer median.
 fn _bench_rt_median(xs: int[]) -> int {
@@ -690,6 +776,8 @@ struct RtResult {
     name: string;
     inner_min: int;
     inner_median: int;
+    inner_max: int;
+    inner_stddev: int;
     peak_kb: int;
     ops: int;
     ops_per_ms: string;
@@ -727,6 +815,8 @@ fn _bench_rt_one(self_bin: string, src: string, work_dir: string, child_env: str
             name: name,
             inner_min: 0,
             inner_median: 0,
+            inner_max: 0,
+            inner_stddev: 0,
             peak_kb: 0,
             ops: 0,
             ops_per_ms: "0.0",
@@ -778,6 +868,8 @@ fn _bench_rt_one(self_bin: string, src: string, work_dir: string, child_env: str
             name: name,
             inner_min: 0,
             inner_median: 0,
+            inner_max: 0,
+            inner_stddev: 0,
             peak_kb: peak_kb,
             ops: 0,
             ops_per_ms: "0.0",
@@ -787,6 +879,8 @@ fn _bench_rt_one(self_bin: string, src: string, work_dir: string, child_env: str
 
     let inner_min = _bench_rt_min(samples);
     let inner_median = _bench_rt_median(samples);
+    let inner_max = _bench_rt_max(samples);
+    let inner_stddev = _bench_rt_stddev(samples);
     let mut status = "ok";
     if runfail { status = "RUNFAIL"; }
     if budget_time > 0 && inner_median > budget_time {
@@ -803,6 +897,8 @@ fn _bench_rt_one(self_bin: string, src: string, work_dir: string, child_env: str
         name: name,
         inner_min: inner_min,
         inner_median: inner_median,
+        inner_max: inner_max,
+        inner_stddev: inner_stddev,
         peak_kb: peak_kb,
         ops: ops,
         ops_per_ms: _bench_rt_ops_per_ms(ops, inner_median),
@@ -839,6 +935,7 @@ fn _run_runtime_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
     if has(matches, "budget-mem") {
         budget_mem = get_int(matches, "budget-mem");
     }
+    let json = has_flag(matches, "json");
 
     let mut sources = _bench_rt_discover(paths);
     if filter.length > 0 { sources = _bench_rt_filter(sources, filter); }
@@ -851,26 +948,28 @@ fn _run_runtime_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
     let version = resolve_compiler_version(ctx.binary_dir);
     let platform = _bench_rt_platform();
 
-    print("[bench] runner: " + self_bin + " (" + version + ")");
-    print("[bench] platform: " + platform);
-    print("[bench] workloads: " + number_to_string(sources.length));
-    print("[bench] timed runs per workload: " + number_to_string(iterations)
-        + " (+"
-        + number_to_string(warmup)
-        + " warm-up)");
-    print("");
-    print("  " + _bench_rt_pad("WORKLOAD", 31) + " " + _bench_rt_pad("MEDIAN", 10)
-        + "  "
-        + _bench_rt_pad("PEAK", 8)
-        + "  "
-        + _bench_rt_pad("OPS/MS", 10)
-        + "  STATUS");
-    print("  " + _bench_rt_pad("--------", 31) + " " + _bench_rt_pad("------", 10)
-        + "  "
-        + _bench_rt_pad("----", 8)
-        + "  "
-        + _bench_rt_pad("------", 10)
-        + "  ------");
+    if !json {
+        print("[bench] runner: " + self_bin + " (" + version + ")");
+        print("[bench] platform: " + platform);
+        print("[bench] workloads: " + number_to_string(sources.length));
+        print("[bench] timed runs per workload: " + number_to_string(iterations)
+            + " (+"
+            + number_to_string(warmup)
+            + " warm-up)");
+        print("");
+        print("  " + _bench_rt_pad("WORKLOAD", 31) + " " + _bench_rt_pad("MEDIAN", 10)
+            + "  "
+            + _bench_rt_pad("PEAK", 8)
+            + "  "
+            + _bench_rt_pad("OPS/MS", 10)
+            + "  STATUS");
+        print("  " + _bench_rt_pad("--------", 31) + " " + _bench_rt_pad("------", 10)
+            + "  "
+            + _bench_rt_pad("----", 8)
+            + "  "
+            + _bench_rt_pad("------", 10)
+            + "  ------");
+    }
 
     _ensure_dir(work_dir);
     let child_env = process.environ();
@@ -880,15 +979,17 @@ fn _run_runtime_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
     loop {
         if i >= sources.length { break; }
         let r = _bench_rt_one(self_bin, sources[i], work_dir, child_env, iterations, warmup, budget_time, budget_mem);
-        print("  " + _bench_rt_pad(r.name, 31) + " " + _bench_rt_pad(number_to_string(r.inner_median)
-            + "ms", 10)
-            + "  "
-            + _bench_rt_pad(number_to_string(r.peak_kb / 1024)
-            + "MB", 8)
-            + "  "
-            + _bench_rt_pad(r.ops_per_ms, 10)
-            + "  "
-            + r.status);
+        if !json {
+            print("  " + _bench_rt_pad(r.name, 31) + " " + _bench_rt_pad(number_to_string(r.inner_median)
+                + "ms", 10)
+                + "  "
+                + _bench_rt_pad(number_to_string(r.peak_kb / 1024)
+                + "MB", 8)
+                + "  "
+                + _bench_rt_pad(r.ops_per_ms, 10)
+                + "  "
+                + r.status);
+        }
         results.push(r);
         i += 1;
     }
@@ -921,35 +1022,38 @@ fn _run_runtime_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
         i += 1;
     }
 
-    print("");
-    print("==================================================================");
-    print("");
-    print("  SUMMARY");
-    print("  -------");
-    print("  Workloads:     " + number_to_string(results.length));
-    print("  Slowest:       " + number_to_string(slowest) + "ms  ("
-        + slowest_name
-        + ")");
-    print("  Peak memory:   " + number_to_string(max_mem / 1024) + "MB  ("
-        + max_mem_name
-        + ")");
-    if buildfail > 0 {
-        print("  BUILD FAILS:   " + number_to_string(buildfail));
+    if !json {
+        print("");
+        print("==================================================================");
+        print("");
+        print("  SUMMARY");
+        print("  -------");
+        print("  Workloads:     " + number_to_string(results.length));
+        print("  Slowest:       " + number_to_string(slowest) + "ms  ("
+            + slowest_name
+            + ")");
+        print("  Peak memory:   " + number_to_string(max_mem / 1024) + "MB  ("
+            + max_mem_name
+            + ")");
+        if buildfail > 0 {
+            print("  BUILD FAILS:   " + number_to_string(buildfail));
+        }
+        if runfail > 0 {
+            print("  RUN FAILS:     " + number_to_string(runfail));
+        }
+        if budget_time > 0 {
+            print("  Over budget:   " + number_to_string(slow) + " workloads > "
+                + number_to_string(budget_time)
+                + "ms");
+        }
+        if budget_mem > 0 {
+            print("  Over memory:   " + number_to_string(highmem)
+                + " workloads > "
+                + number_to_string(budget_mem / 1024)
+                + "MB");
+        }
+        print("");
     }
-    if runfail > 0 {
-        print("  RUN FAILS:     " + number_to_string(runfail));
-    }
-    if budget_time > 0 {
-        print("  Over budget:   " + number_to_string(slow) + " workloads > "
-            + number_to_string(budget_time)
-            + "ms");
-    }
-    if budget_mem > 0 {
-        print("  Over memory:   " + number_to_string(highmem) + " workloads > "
-            + number_to_string(budget_mem / 1024)
-            + "MB");
-    }
-    print("");
 
     if csv_out.length > 0 {
         _bench_rt_ensure_parent(csv_out);
@@ -976,10 +1080,10 @@ fn _run_runtime_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
             i += 1;
         }
         fs.writeFile(csv_out, csv);
-        print("[bench] wrote " + csv_out);
+        if !json { print("[bench] wrote " + csv_out); }
     }
 
-    if top_n > 0 && results.length > top_n {
+    if !json && top_n > 0 && results.length > top_n {
         print("  TOP " + number_to_string(top_n) + " BY MEDIAN INNER TIME");
         print("  ------------------------------");
         let mut order: int[] = [];
@@ -1015,6 +1119,25 @@ fn _run_runtime_mode(matches: Matches, ctx: CliContext) -> int ![clock, io] {
             t += 1;
         }
         print("");
+    }
+
+    let mut exit_code = 0;
+    if buildfail > 0 || runfail > 0 { exit_code = 1; } else if slow > 0
+        || highmem > 0 { exit_code = 2; }
+
+    if json {
+        let mut jresults: BenchJsonResult[] = [];
+        let mut ji = 0;
+        loop {
+            if ji >= results.length { break; }
+            let r = results[ji];
+            jresults.push(BenchJsonResult {
+                name: r.name, ops: r.ops, time_min: r.inner_min, time_median: r.inner_median, time_max: r.inner_max, time_stddev: r.inner_stddev, peak_rss_kb: r.peak_kb, status: r.status
+            });
+            ji += 1;
+        }
+        print(render_bench_json_envelope("runtime", version, platform, iterations, warmup, exit_code, jresults));
+        return exit_code;
     }
 
     if buildfail > 0 || runfail > 0 {

--- a/compiler/src/cli/commands/bench_json.sfn
+++ b/compiler/src/cli/commands/bench_json.sfn
@@ -25,7 +25,7 @@ struct BenchJsonResult {
     status: string;
 }
 
-// JSON string escaping: the six RFC 8259 escapes the rest of the compiler's
+// JSON string escaping: the five RFC 8259 escapes the rest of the compiler's
 // encoders emit (`\"`, `\\`, `\n`, `\r`, `\t`) with literal passthrough for
 // everything else. Bench names are module/workload slugs and platform/version
 // strings — ASCII-clean — but escaping keeps the envelope well-formed if a
@@ -62,8 +62,11 @@ fn _bj_number_field(name: string, value: int) -> string {
     return _bj_field(name, _bj_number_to_string(value));
 }
 
-// Local copy of `number_to_string` (see preamble) so the module stays
-// self-contained and avoids the seed-compiler import-cycle limitation.
+// Local integer formatter (self-contained per the preamble, avoiding the
+// seed-compiler import-cycle limitation). O(digits) via `/` and `%` — every
+// bench number (ms timing, peak RSS KiB, op count, exit code) is non-negative,
+// so the `0 - working` negation path is unreachable for real input and cannot
+// hit the i64-min overflow edge.
 fn _bj_number_to_string(value: int) -> string {
     if value == 0 { return "0"; }
     let mut working: int = value;
@@ -73,20 +76,12 @@ fn _bj_number_to_string(value: int) -> string {
         working = 0 - working;
     }
     let digits = "0123456789";
-    let mut remaining: int = working;
     let mut output: string = "";
     loop {
-        if remaining <= 0 { break; }
-        let mut temp: int = remaining;
-        let mut quotient: int = 0;
-        loop {
-            if temp < 10 { break; }
-            temp -= 10;
-            quotient += 1;
-        }
-        let ch = substring(digits, temp, temp + 1);
-        output = ch + output;
-        remaining = quotient;
+        if working <= 0 { break; }
+        let d = working % 10;
+        output = substring(digits, d, d + 1) + output;
+        working = working / 10;
     }
     if negative { output = "-" + output; }
     return output;

--- a/compiler/src/cli/commands/bench_json.sfn
+++ b/compiler/src/cli/commands/bench_json.sfn
@@ -1,0 +1,225 @@
+// compiler/src/cli/commands/bench_json.sfn
+//
+// `sailfin.bench/v1` JSON envelope for `sfn bench --json` (SFN-64, epic
+// #1503). A pure, I/O-free encoder: both bench modes normalize their
+// per-module / per-workload results into `BenchJsonResult` records and hand
+// them here to render the versioned envelope documented at
+// `docs/reference/bench-json-schema.md`. The JSON primitive helpers are
+// duplicated locally rather than imported from `diagnostics_json.sfn` — the
+// same seed-compiler import-cycle constraint that module documents — so this
+// file stays self-contained for its unit tests.
+// A single benchmarked unit, normalized across both bench domains. For the
+// compiler domain each module contributes one emit sample, so `time_min`,
+// `time_median`, and `time_max` collapse to the same wall-clock value and
+// `time_stddev` is 0; `ops` is 0 (module emit has no op count). For the
+// runtime domain the fields carry the workload's inner-loop timing spread and
+// op count.
+struct BenchJsonResult {
+    name: string;
+    ops: int;
+    time_min: int;
+    time_median: int;
+    time_max: int;
+    time_stddev: int;
+    peak_rss_kb: int;
+    status: string;
+}
+
+// JSON string escaping: the six RFC 8259 escapes the rest of the compiler's
+// encoders emit (`\"`, `\\`, `\n`, `\r`, `\t`) with literal passthrough for
+// everything else. Bench names are module/workload slugs and platform/version
+// strings — ASCII-clean — but escaping keeps the envelope well-formed if a
+// path ever carries a quote.
+fn _bj_escape_string(s: string) -> string {
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
+            out = out + "\\\\";
+        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
+            out = out + "\\r";
+        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+fn _bj_quote(s: string) -> string {
+    return "\"" + _bj_escape_string(s) + "\"";
+}
+
+fn _bj_field(name: string, value: string) -> string {
+    return _bj_quote(name) + ":" + value;
+}
+
+fn _bj_string_field(name: string, value: string) -> string {
+    return _bj_field(name, _bj_quote(value));
+}
+
+fn _bj_number_field(name: string, value: int) -> string {
+    return _bj_field(name, _bj_number_to_string(value));
+}
+
+// Local copy of `number_to_string` (see preamble) so the module stays
+// self-contained and avoids the seed-compiler import-cycle limitation.
+fn _bj_number_to_string(value: int) -> string {
+    if value == 0 { return "0"; }
+    let mut working: int = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: int = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: int = remaining;
+        let mut quotient: int = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}
+
+// Join already-built JSON fragments with `sep`.
+fn _bj_join(parts: string[], sep: string) -> string {
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= parts.length { break; }
+        if i > 0 { out = out + sep; }
+        out = out + parts[i];
+        i += 1;
+    }
+    return out;
+}
+
+// Substring presence test (no dependency on string_utils::index_of, keeping
+// the encoder self-contained per the module preamble).
+fn _bj_has(hay: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if needle.length > hay.length { return false; }
+    let last = hay.length - needle.length;
+    let mut i: int = 0;
+    loop {
+        if i > last { break; }
+        if substring(hay, i, i + needle.length) == needle { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// Collapse one raw status token to the documented enum. The bench modes emit
+// `ok` / `FAIL` / `BUILDFAIL` / `RUNFAIL` / `SLOW` / `HIGHMEM`; every failure
+// token maps to `fail`, and `slow` / `highmem` lowercase. An unrecognized
+// token passes through unchanged so a future status shows up rather than
+// silently vanishing.
+fn _bj_map_token(t: string) -> string {
+    if t == "ok" { return "ok"; }
+    if _bj_has(t, "FAIL") { return "fail"; }
+    if t == "SLOW" { return "slow"; }
+    if t == "HIGHMEM" { return "highmem"; }
+    return t;
+}
+
+fn _bj_append_status(acc: string, tok: string) -> string {
+    if tok.length == 0 { return acc; }
+    if acc.length == 0 { return tok; }
+    return acc + "+" + tok;
+}
+
+// Normalize a mode's raw status (possibly `+`-joined, e.g. `SLOW+HIGHMEM`) to
+// the documented `ok` / `fail` / `slow` / `highmem` enum, preserving `+`
+// combinations. Empty input normalizes to `ok`.
+fn _bj_normalize_status(raw: string) -> string {
+    let mut out: string = "";
+    let mut token: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= raw.length { break; }
+        let ch = substring(raw, i, i + 1);
+        if ch == "+" {
+            out = _bj_append_status(out, _bj_map_token(token));
+            token = "";
+        } else { token = token + ch; }
+        i += 1;
+    }
+    out = _bj_append_status(out, _bj_map_token(token));
+    if out.length == 0 { return "ok"; }
+    return out;
+}
+
+fn _bj_render_tool(version: string, platform: string) -> string {
+    let mut p: string[] = [];
+    p.push(_bj_string_field("version", version));
+    p.push(_bj_string_field("platform", platform));
+    return "{" + _bj_join(p, ",") + "}";
+}
+
+fn _bj_render_config(iterations: int, warmup: int) -> string {
+    let mut p: string[] = [];
+    p.push(_bj_number_field("iterations", iterations));
+    p.push(_bj_number_field("warmup", warmup));
+    return "{" + _bj_join(p, ",") + "}";
+}
+
+fn _bj_render_time_ms(min: int, median: int, max: int, stddev: int) -> string {
+    let mut p: string[] = [];
+    p.push(_bj_number_field("min", min));
+    p.push(_bj_number_field("median", median));
+    p.push(_bj_number_field("max", max));
+    p.push(_bj_number_field("stddev", stddev));
+    return "{" + _bj_join(p, ",") + "}";
+}
+
+// `unit` labels the `time_ms` block, which is always milliseconds; it is a
+// fixed `"ms"` today and reserved for a finer-grained unit under a schema
+// bump.
+fn _bj_render_result(r: BenchJsonResult) -> string {
+    let mut p: string[] = [];
+    p.push(_bj_string_field("name", r.name));
+    p.push(_bj_number_field("ops", r.ops));
+    p.push(_bj_string_field("unit", "ms"));
+    p.push(_bj_field("time_ms", _bj_render_time_ms(r.time_min, r.time_median, r.time_max, r.time_stddev)));
+    p.push(_bj_number_field("peak_rss_kb", r.peak_rss_kb));
+    p.push(_bj_string_field("status", _bj_normalize_status(r.status)));
+    return "{" + _bj_join(p, ",") + "}";
+}
+
+fn _bj_render_results(results: BenchJsonResult[]) -> string {
+    let mut items: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= results.length { break; }
+        items.push(_bj_render_result(results[i]));
+        i += 1;
+    }
+    return "[" + _bj_join(items, ",") + "]";
+}
+
+// Render the full `sailfin.bench/v1` envelope. `domain` is `compiler` or
+// `runtime`; `exit_code` mirrors the process exit (0 ok, 1 build/run/emit
+// failure, 2 budget violation). Trailing newline matches the other `--json`
+// surfaces.
+fn render_bench_json_envelope(domain: string, version: string, platform: string, iterations: int, warmup: int, exit_code: int, results: BenchJsonResult[]) -> string {
+    let mut parts: string[] = [];
+    parts.push(_bj_string_field("schema", "sailfin.bench/v1"));
+    parts.push(_bj_string_field("command", "sfn bench"));
+    parts.push(_bj_string_field("domain", domain));
+    parts.push(_bj_number_field("exit_code", exit_code));
+    parts.push(_bj_field("tool", _bj_render_tool(version, platform)));
+    parts.push(_bj_field("config", _bj_render_config(iterations, warmup)));
+    parts.push(_bj_field("results", _bj_render_results(results)));
+    return "{" + _bj_join(parts, ",") + "}\n";
+}

--- a/compiler/tests/e2e/bench_json_schema_test.sfn
+++ b/compiler/tests/e2e/bench_json_schema_test.sfn
@@ -1,0 +1,115 @@
+// End-to-end schema-lock test for `sfn bench --json` (SFN-64), locking the
+// `sailfin.bench/v1` envelope across both compiler mode and runtime mode.
+// Drives the compiler binary as a subprocess and asserts on documented field
+// presence via `sfn/strings`, per .claude/rules/no-bash-e2e.md (the `sfn/test`
+// `expect_*` matchers are `![pure]` and unusable from an `![io]` subprocess
+// test). Skips when the import-context tree is not staged (compiler-mode
+// bench requires `make compile` to have produced it), matching
+// bench_compiler_test.sfn.
+import { find } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/bin/sfn";
+}
+
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { e.push("SAILFIN_TEST_SCRATCH=" + scratch); }
+    return e;
+}
+
+test "bench json: --compiler emits sailfin.bench/v1 envelope" ![io] {
+    if !fs.exists("build/compiler/import-context") {
+        assert true;
+        return;
+    }
+    let exit = process.run_capture([_sfn_bin(), "bench", "--compiler", "--module", "num_format", "--json"], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    assert exit == 0;
+    assert find(out, "\"schema\":\"sailfin.bench/v1\"", 0) >= 0;
+    assert find(out, "\"command\":\"sfn bench\"", 0) >= 0;
+    assert find(out, "\"domain\":\"compiler\"", 0) >= 0;
+    assert find(out, "\"exit_code\":", 0) >= 0;
+    assert find(out, "\"tool\":", 0) >= 0;
+    assert find(out, "\"version\":", 0) >= 0;
+    assert find(out, "\"platform\":", 0) >= 0;
+    assert find(out, "\"config\":", 0) >= 0;
+    assert find(out, "\"iterations\":", 0) >= 0;
+    assert find(out, "\"warmup\":", 0) >= 0;
+    assert find(out, "\"results\":", 0) >= 0;
+    assert find(out, "\"name\":", 0) >= 0;
+    assert find(out, "\"ops\":", 0) >= 0;
+    assert find(out, "\"unit\":\"ms\"", 0) >= 0;
+    assert find(out, "\"time_ms\":", 0) >= 0;
+    assert find(out, "\"min\":", 0) >= 0;
+    assert find(out, "\"median\":", 0) >= 0;
+    assert find(out, "\"max\":", 0) >= 0;
+    assert find(out, "\"stddev\":", 0) >= 0;
+    assert find(out, "\"peak_rss_kb\":", 0) >= 0;
+    assert find(out, "\"status\":", 0) >= 0;
+    // Compiler-domain invariants: single fixed iteration, no warmup, ops
+    // is not a meaningful concept for a compile pass.
+    assert find(out, "\"config\":{\"iterations\":1,\"warmup\":0}", 0) >= 0;
+    assert find(out, "\"ops\":0", 0) >= 0;
+    assert err.length == 0;
+}
+
+test "bench json: runtime mode emits sailfin.bench/v1 envelope" ![io, clock] {
+    if !fs.exists("build/compiler/import-context") {
+        assert true;
+        return;
+    }
+    let workload = "benchmarks/runtime/arena_alloc_bench.sfn";
+    if !fs.exists(workload) {
+        assert true;
+        return;
+    }
+    let exit = process.run_capture([_sfn_bin(), "bench", workload, "--iterations", "2", "--json"], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    assert exit == 0;
+    assert find(out, "\"schema\":\"sailfin.bench/v1\"", 0) >= 0;
+    assert find(out, "\"command\":\"sfn bench\"", 0) >= 0;
+    assert find(out, "\"domain\":\"runtime\"", 0) >= 0;
+    assert find(out, "\"exit_code\":", 0) >= 0;
+    assert find(out, "\"tool\":", 0) >= 0;
+    assert find(out, "\"version\":", 0) >= 0;
+    assert find(out, "\"platform\":", 0) >= 0;
+    assert find(out, "\"config\":{\"iterations\":2,", 0) >= 0;
+    assert find(out, "\"results\":", 0) >= 0;
+    assert find(out, "\"name\":", 0) >= 0;
+    assert find(out, "\"ops\":", 0) >= 0;
+    assert find(out, "\"unit\":\"ms\"", 0) >= 0;
+    assert find(out, "\"time_ms\":", 0) >= 0;
+    assert find(out, "\"min\":", 0) >= 0;
+    assert find(out, "\"median\":", 0) >= 0;
+    assert find(out, "\"max\":", 0) >= 0;
+    assert find(out, "\"stddev\":", 0) >= 0;
+    assert find(out, "\"peak_rss_kb\":", 0) >= 0;
+    assert find(out, "\"status\":", 0) >= 0;
+    assert err.length == 0;
+}
+
+test "bench json: stdout is a single JSON object, no human table" ![io] {
+    if !fs.exists("build/compiler/import-context") {
+        assert true;
+        return;
+    }
+    let exit = process.run_capture([_sfn_bin(), "bench", "--compiler", "--module", "num_format", "--json"], _child_env());
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    assert exit == 0;
+    assert find(out, "SUMMARY", 0) < 0;
+    assert find(out, "MODULE ", 0) < 0;
+    assert find(out, "{", 0) == 0;
+}

--- a/compiler/tests/unit/bench_json_test.sfn
+++ b/compiler/tests/unit/bench_json_test.sfn
@@ -1,0 +1,132 @@
+// Unit tests for `compiler/src/cli/commands/bench_json.sfn` —
+// `sfn bench --json`'s pure encoder. Boundary tests for the schema
+// (`sailfin.bench/v1`, documented at `docs/reference/bench-json-schema.md`)
+// and for the status normalization / empty-array / escaping paths that the
+// e2e schema-lock test (`compiler/tests/e2e/bench_json_schema_test.sfn`)
+// exercises only for the happy path.
+//
+// The `_bj_*` helpers are module-private, so these drive the public
+// `render_bench_json_envelope` with crafted `BenchJsonResult` inputs — the
+// same boundary-through-the-public-entry approach as
+// `diagnostics_json_test.sfn`.
+import { BenchJsonResult, render_bench_json_envelope } from "../../src/cli/commands/bench_json";
+import { index_of } from "../../src/string_utils";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+fn _result(name: string, status: string) -> BenchJsonResult {
+    return BenchJsonResult {
+        name: name,
+        ops: 0,
+        time_min: 10,
+        time_median: 12,
+        time_max: 15,
+        time_stddev: 2,
+        peak_rss_kb: 2048,
+        status: status
+    };
+}
+
+fn _empty_results() -> BenchJsonResult[] {
+    let results: BenchJsonResult[] = [];
+    return results;
+}
+
+fn _one(status: string) -> BenchJsonResult[] {
+    let mut results: BenchJsonResult[] = [];
+    results.push(_result("arena_alloc", status));
+    return results;
+}
+
+// -------------------------------------------------------------------
+// Envelope shape
+// -------------------------------------------------------------------
+test "bench json: empty results renders as []" {
+    let out = render_bench_json_envelope("compiler", "0.0.0", "Linux x86_64", 1, 0, 0, _empty_results());
+    assert _contains(out, "sailfin.bench/v1");
+    assert _contains(out, "sfn bench");
+    assert _contains(out, "\"results\":[]");
+}
+
+test "bench json: top-level fields present" {
+    let out = render_bench_json_envelope("runtime", "0.8.0", "Linux x86_64", 5, 1, 0, _one("ok"));
+    assert _contains(out, "\"schema\":\"sailfin.bench/v1\"");
+    assert _contains(out, "\"command\":\"sfn bench\"");
+    assert _contains(out, "\"domain\":\"runtime\"");
+    assert _contains(out, "\"exit_code\":0");
+    assert _contains(out, "\"tool\":");
+    assert _contains(out, "\"version\":\"0.8.0\"");
+    assert _contains(out, "\"platform\":\"Linux x86_64\"");
+    assert _contains(out, "\"config\":");
+    assert _contains(out, "\"iterations\":5");
+    assert _contains(out, "\"warmup\":1");
+}
+
+test "bench json: result carries all documented fields" {
+    let out = render_bench_json_envelope("runtime", "0.8.0", "Linux x86_64", 5, 1, 0, _one("ok"));
+    assert _contains(out, "\"name\":\"arena_alloc\"");
+    assert _contains(out, "\"ops\":0");
+    assert _contains(out, "\"unit\":\"ms\"");
+    assert _contains(out, "\"time_ms\":");
+    assert _contains(out, "\"min\":10");
+    assert _contains(out, "\"median\":12");
+    assert _contains(out, "\"max\":15");
+    assert _contains(out, "\"stddev\":2");
+    assert _contains(out, "\"peak_rss_kb\":2048");
+}
+
+test "bench json: ends with trailing newline" {
+    let out = render_bench_json_envelope("compiler", "0.0.0", "Linux x86_64", 1, 0, 0, _empty_results());
+    assert out.length > 0;
+    assert _contains(out, "\n");
+}
+
+test "bench json: exit_code is encoded" {
+    let out = render_bench_json_envelope("runtime", "0.0.0", "Linux x86_64", 2, 1, 2, _one("highmem"));
+    assert _contains(out, "\"exit_code\":2");
+}
+
+// -------------------------------------------------------------------
+// Status normalization
+// -------------------------------------------------------------------
+test "bench json: ok status passes through" {
+    let out = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 0, _one("ok"));
+    assert _contains(out, "\"status\":\"ok\"");
+}
+
+test "bench json: FAIL normalizes to fail" {
+    let out = render_bench_json_envelope("compiler", "0.0.0", "p", 1, 0, 1, _one("FAIL"));
+    assert _contains(out, "\"status\":\"fail\"");
+}
+
+test "bench json: BUILDFAIL and RUNFAIL normalize to fail" {
+    let build = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 1, _one("BUILDFAIL"));
+    assert _contains(build, "\"status\":\"fail\"");
+    let run = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 1, _one("RUNFAIL"));
+    assert _contains(run, "\"status\":\"fail\"");
+}
+
+test "bench json: SLOW and HIGHMEM lowercase" {
+    let slow = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 2, _one("SLOW"));
+    assert _contains(slow, "\"status\":\"slow\"");
+    let mem = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 2, _one("HIGHMEM"));
+    assert _contains(mem, "\"status\":\"highmem\"");
+}
+
+test "bench json: combined status preserves the + join" {
+    let out = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 2, _one("SLOW+HIGHMEM"));
+    assert _contains(out, "\"status\":\"slow+highmem\"");
+}
+
+// -------------------------------------------------------------------
+// String escaping
+// -------------------------------------------------------------------
+test "bench json: a quote in a name is escaped" {
+    // A workload named with an embedded quote must not break the envelope.
+    let mut results: BenchJsonResult[] = [];
+    results.push(_result("a\"b", "ok"));
+    let escaped = render_bench_json_envelope("runtime", "0.0.0", "p", 5, 1, 0, results);
+    assert _contains(escaped, "a\\\"b");
+}

--- a/compiler/tests/unit/bench_json_test.sfn
+++ b/compiler/tests/unit/bench_json_test.sfn
@@ -80,7 +80,9 @@ test "bench json: result carries all documented fields" {
 test "bench json: ends with trailing newline" {
     let out = render_bench_json_envelope("compiler", "0.0.0", "Linux x86_64", 1, 0, 0, _empty_results());
     assert out.length > 0;
-    assert _contains(out, "\n");
+    // Assert the FINAL byte is the newline, not merely that one appears
+    // somewhere — a value carrying an escaped "\n" must not satisfy this.
+    assert substring(out, out.length - 1, out.length) == "\n";
 }
 
 test "bench json: exit_code is encoded" {

--- a/docs/reference/bench-json-schema.md
+++ b/docs/reference/bench-json-schema.md
@@ -1,0 +1,248 @@
+# `sfn bench --json` Schema (`sailfin.bench/v1`)
+
+Status: Shipped in SFN-64 (epic #1503). Locked at `sailfin.bench/v1`.
+2026-07-11.
+
+`sfn bench --json` is a boolean flag, the same shape as `sfn check --json`:
+it suppresses the human-readable table and prints a single UTF-8 JSON
+document to stdout. There is no `--json=PATH` form — write to a file with a
+shell redirect (`sfn bench --compiler --json > out.json`). It works in both
+bench modes:
+
+- `sfn bench --compiler --json` — compiler domain (per-module emit timing).
+- `sfn bench [<path>...] --json` — runtime domain (per-workload timing).
+
+Exit codes mirror the human renderer: `0` clean, `1` build/emit/run failure,
+`2` budget violation (`--budget-time` / `--budget-mem` exceeded). The same
+value is echoed as the `exit_code` field in the envelope.
+
+**Pre-flight config errors emit no envelope.** Two setup failures are detected
+before any benchmark runs and are reported as a plain-text message on stderr
+with exit `1` and **empty stdout** — not as a JSON envelope: compiler mode when
+the import-context is missing (`build/compiler/import-context` absent — run
+`make compile` first), and runtime mode when no workloads resolve from the
+given paths. A `--json` consumer must therefore treat empty/non-JSON stdout
+with a non-zero exit as a setup error rather than assuming every invocation
+yields an envelope. Every failure that occurs *after* benchmarking starts
+(build/emit/run failure, budget violation) is reported inside the envelope via
+`exit_code` and per-result `status`.
+
+## Versioning
+
+The first field of every envelope is `schema`. Today it is the literal string
+`"sailfin.bench/v1"`. Breaking changes bump this string (e.g.
+`"sailfin.bench/v2"`). Consumers MUST hard-fail on unknown versions rather
+than guess at unfamiliar field shapes.
+
+Additive changes (new optional fields) keep the same version string.
+Consumers must tolerate unknown fields. Two tests guard the field set so a
+silent leak fails CI before it lands: the e2e schema-lock test
+(`compiler/tests/e2e/bench_json_schema_test.sfn`) runs both modes end-to-end,
+and the encoder unit test (`compiler/tests/unit/bench_json_test.sfn`) locks the
+envelope shape, status normalization, and escaping at the
+`render_bench_json_envelope` boundary.
+
+## Envelope shape
+
+```jsonc
+{
+  "schema": "sailfin.bench/v1",
+  "command": "sfn bench",
+  "domain": "compiler",
+  "exit_code": 0,
+  "tool": {
+    "version": "0.8.0-alpha.5",
+    "platform": "Linux x86_64"
+  },
+  "config": {
+    "iterations": 1,
+    "warmup": 0
+  },
+  "results": [
+    {
+      "name": "lexer",
+      "ops": 0,
+      "unit": "ms",
+      "time_ms": {
+        "min": 455,
+        "median": 455,
+        "max": 455,
+        "stddev": 0
+      },
+      "peak_rss_kb": 118580,
+      "status": "ok"
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema` | string | Always first. `"sailfin.bench/N"` — consumers must hard-fail on unknown N. |
+| `command` | string | Always `"sfn bench"`. |
+| `domain` | string | `"compiler"` (per-module emit timing, `sfn bench --compiler`) or `"runtime"` (per-workload timing, `sfn bench [<path>...]`). |
+| `exit_code` | number | Mirrors the process exit code: `0` clean, `1` build/emit/run failure, `2` budget violation (`--budget-time` / `--budget-mem`). |
+| `tool` | object | `{ "version", "platform" }` — see below. |
+| `config` | object | `{ "iterations", "warmup" }` — see below. |
+| `results` | array | One object per benchmarked module (compiler domain) or workload (runtime domain). |
+
+## `tool`
+
+| Field | Type | Notes |
+|---|---|---|
+| `version` | string | The running compiler's version string, e.g. `"0.8.0-alpha.5"`. |
+| `platform` | string | `"<uname -s> <uname -m>"`, e.g. `"Linux x86_64"`. |
+
+## `config`
+
+| Field | Type | Notes |
+|---|---|---|
+| `iterations` | number | Compiler domain always reports `1` — it measures one emit per module, no repeat runs. Runtime domain reports the effective `--iterations` value (default 5). |
+| `warmup` | number | Compiler domain always reports `0` — there is no warm-up concept for a single emit. Runtime domain reports the effective `--warmup` value (default 1). |
+
+## `results[]`
+
+Each result is a JSON object with a fixed field set, shared by both domains.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Compiler domain: the module label (e.g. `lexer`, `parser__mod` — path slashes flattened to `__`). Runtime domain: the workload label (the `_bench.sfn` fixture's stem, e.g. `arena_alloc`). |
+| `ops` | number | Runtime domain: the workload's reported operation count. Compiler domain: always `0` — module emit has no op concept. |
+| `unit` | string | Labels the `time_ms` measurements. Currently always `"ms"`; reserved for a finer-grained unit under a future schema bump. `time_ms` values are **always milliseconds** regardless of `unit`. |
+| `time_ms` | object | `{ "min", "median", "max", "stddev" }`, all integer milliseconds — see below. |
+| `peak_rss_kb` | number | Peak resident set size in KiB, sampled from the metered subprocess. **Platform caveat**: this is a Linux/WSL-oriented measurement (KiB, as reported by the kernel); Darwin normalization is deferred, so both this column and `--budget-mem` are most meaningful on Linux today. |
+| `status` | string | Normalized status — see below. |
+
+### `time_ms`
+
+| Field | Type | Notes |
+|---|---|---|
+| `min` | number | Minimum wall-clock time across the timed samples, in milliseconds. |
+| `median` | number | Median wall-clock time, in milliseconds. |
+| `max` | number | Maximum wall-clock time, in milliseconds. |
+| `stddev` | number | Population standard deviation across the timed samples, floored to an integer, in milliseconds. |
+
+Runtime domain computes all four across the timed (post-warmup) iterations.
+Compiler domain has a single emit sample per module, so `min == median ==
+max` and `stddev == 0` always.
+
+### `status`
+
+Normalized to one of `ok` | `fail` | `slow` | `highmem`, with `+`-joined
+combinations (e.g. `"slow+highmem"`). The two bench modes internally track a
+richer set of tokens — `ok` / `FAIL` / `BUILDFAIL` / `RUNFAIL` / `SLOW` /
+`HIGHMEM` — which the JSON encoder maps down to the documented enum before
+emitting:
+
+| Internal token(s) | Normalized `status` |
+|---|---|
+| `ok` | `ok` |
+| `FAIL`, `BUILDFAIL`, `RUNFAIL` | `fail` |
+| `SLOW` | `slow` |
+| `HIGHMEM` | `highmem` |
+
+`+`-joined internal combinations (e.g. `SLOW+HIGHMEM`) normalize token-by-token,
+preserving the combination (e.g. `"slow+highmem"`).
+
+## Examples
+
+### Compiler-domain clean run
+
+```jsonc
+{
+  "schema": "sailfin.bench/v1",
+  "command": "sfn bench",
+  "domain": "compiler",
+  "exit_code": 0,
+  "tool": { "version": "0.8.0-alpha.5", "platform": "Linux x86_64" },
+  "config": { "iterations": 1, "warmup": 0 },
+  "results": [
+    {
+      "name": "lexer",
+      "ops": 0,
+      "unit": "ms",
+      "time_ms": { "min": 455, "median": 455, "max": 455, "stddev": 0 },
+      "peak_rss_kb": 118580,
+      "status": "ok"
+    },
+    {
+      "name": "num_format",
+      "ops": 0,
+      "unit": "ms",
+      "time_ms": { "min": 151, "median": 151, "max": 151, "stddev": 0 },
+      "peak_rss_kb": 66440,
+      "status": "ok"
+    }
+  ]
+}
+```
+
+### Runtime-domain clean run
+
+```jsonc
+{
+  "schema": "sailfin.bench/v1",
+  "command": "sfn bench",
+  "domain": "runtime",
+  "exit_code": 0,
+  "tool": { "version": "0.8.0-alpha.5", "platform": "Linux x86_64" },
+  "config": { "iterations": 3, "warmup": 1 },
+  "results": [
+    {
+      "name": "arena_alloc",
+      "ops": 30000,
+      "unit": "ms",
+      "time_ms": { "min": 551, "median": 552, "max": 577, "stddev": 12 },
+      "peak_rss_kb": 6740,
+      "status": "ok"
+    }
+  ]
+}
+```
+
+### Runtime-domain budget violation (`exit_code: 2`)
+
+```jsonc
+{
+  "schema": "sailfin.bench/v1",
+  "command": "sfn bench",
+  "domain": "runtime",
+  "exit_code": 2,
+  "tool": { "version": "0.8.0-alpha.5", "platform": "Linux x86_64" },
+  "config": { "iterations": 2, "warmup": 1 },
+  "results": [
+    {
+      "name": "arena_alloc",
+      "ops": 30000,
+      "unit": "ms",
+      "time_ms": { "min": 537, "median": 550, "max": 564, "stddev": 13 },
+      "peak_rss_kb": 6708,
+      "status": "highmem"
+    }
+  ]
+}
+```
+
+## Consumers
+
+- **MCP server** (`tools/mcp-server/`): exposes `sailfin_bench`, which shells
+  `sfn bench --json` and returns the parsed envelope as `structuredContent`
+  for agentic/programmatic clients.
+- **CI scrapers / interactive use**: `jq` is the canonical reader. Examples:
+  ```bash
+  sfn bench --compiler --json | jq '.results | sort_by(.time_ms.median) | reverse | .[0:5]'  # 5 slowest modules
+  sfn bench --json | jq '[.results[] | select(.status != "ok")]'                             # failing/slow/highmem only
+  sfn bench --json | jq -r '.results[] | "\(.name): \(.time_ms.median)ms (\(.status))"'       # one-line-per-result summary
+  ```
+
+## Stability contract
+
+- Field names and types in `sailfin.bench/v1` are frozen.
+- New optional fields will land *with the same schema string* — consumers
+  must tolerate unknown fields.
+- Field renames or type changes bump to `sailfin.bench/v2`.
+- The schema-lock test at `compiler/tests/e2e/bench_json_schema_test.sfn`
+  exercises both bench domains and asserts the field set matches this
+  document.

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -17,12 +17,13 @@ Part of the "AI agents are users" strategy described in [`CLAUDE.md`](../../CLAU
 | `sailfin_fmt_write` | `sfn fmt --write <path>` | Reformat a file or directory in place (canonical). Run before committing to satisfy the CI `fmt --check` gate. |
 | `sailfin_build` | `sfn build <file>` / `-p <capsule>` | Build a single `.sfn` file or a capsule to a native binary. **Not** the compiler self-host (see below). |
 | `sailfin_test` | `sfn test <path> [-k <name>] [--jobs N] [--json]` | Run a targeted suite directory or a single `_test.sfn` file. `path` required. |
+| `sailfin_bench` | `sfn bench [--compiler] [<path>] --json` | Benchmark compiler per-module build (compiler mode) or runtime workloads, returning the `sailfin.bench/v1` JSON envelope. |
 
 **Design rule:** every tool is a *pure passthrough* to one `sailfin` subcommand — no build/test orchestration lives in the server. In particular, `sailfin_build` does **not** self-host the compiler: that build needs seed resolution and extern pre-staging (`make rebuild`), and the tool deliberately does not replicate it. Use `make compile` for the self-host build until that orchestration folds into the driver.
 
 `sailfin_test` requires a `path` on purpose — agents target one file or one suite (e.g. `compiler/tests/unit`) rather than the full serial suite, which can take ~45 min and is intentionally not exposed as a single call. The broad `compiler/tests/integration` and `compiler/tests/e2e` directories can still take several minutes.
 
-Timeouts: `sailfin_build` and `sailfin_test` run under a 10-minute budget, `sailfin_fmt_write` under 2 minutes, and the analysis/emit tools under 60 seconds. The compiler self-applies its 8 GiB memory budget on Linux (see the [`compiler-safety` rule](../../.claude/rules/compiler-safety.md)); paths that resolve outside the workspace root are refused.
+Timeouts: `sailfin_build`, `sailfin_test`, and `sailfin_bench` run under a 10-minute budget, `sailfin_fmt_write` under 2 minutes, and the analysis/emit tools under 60 seconds. The compiler self-applies its 8 GiB memory budget on Linux (see the [`compiler-safety` rule](../../.claude/rules/compiler-safety.md)); paths that resolve outside the workspace root are refused.
 
 ## Build
 
@@ -64,4 +65,4 @@ Future tools to consider as the compiler grows:
 - `sailfin_run` — capability-gated program execution. Requires the capability-manifest plumbing to ship first; executing a `.sfn` must honor its declared effect manifest, so this is a security surface, not a convenience wrapper.
 - A native `sfn mcp` subcommand — bundle this server into the compiler binary so `sfn mcp` Just Works after install, replacing the standalone Node wrapper.
 
-Shipped since the first cut: `sailfin_diagnostics` (`--json` envelope), `sailfin_fmt_write`, `sailfin_build`, and `sailfin_test` (targeted suites + `-k` single-test filter).
+Shipped since the first cut: `sailfin_diagnostics` (`--json` envelope), `sailfin_fmt_write`, `sailfin_build`, `sailfin_test` (targeted suites + `-k` single-test filter), and `sailfin_bench`.

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -12,6 +12,7 @@
 //   - sailfin_fmt_write       — reformat in place (canonical)
 //   - sailfin_build           — build a .sfn file / capsule to a binary
 //   - sailfin_test            — run a targeted suite or single test
+//   - sailfin_bench           — benchmark compiler build or runtime workloads
 //
 // Every tool goes through runSailfin(), which enforces the timeout
 // and keeps invocations inside the workspace.
@@ -159,6 +160,53 @@ const fmtWritePathSchema = z
     "Path to a .sfn file or directory to reformat in place, relative to the workspace root.",
   );
 
+const benchCompilerSchema = z
+  .boolean()
+  .optional()
+  .describe(
+    "Benchmark compiler-mode: per-module compile time + memory across the compiler source tree (--compiler). When omitted/false, benchmarks runtime workloads instead. Ignores `path` when true.",
+  );
+
+const benchPathSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Runtime mode only: a workload file or directory, relative to the workspace root. Ignored when `compiler` is true. Defaults to the compiler's built-in runtime workload set (benchmarks/runtime) when omitted.",
+  );
+
+const benchTopSchema = z
+  .number()
+  .int()
+  .min(1)
+  .optional()
+  .describe("Only report the top N results by time (maps to --top N).");
+
+const benchFilterSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Runtime mode: only run workloads whose name matches this glob (maps to --filter GLOB).",
+  );
+
+const benchModuleSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Compiler mode: only report modules whose path contains this substring (maps to --module SUBSTR).",
+  );
+
+const benchIterationsSchema = z
+  .number()
+  .int()
+  .min(1)
+  .optional()
+  .describe(
+    "Runtime mode: number of timed iterations per workload (maps to --iterations K).",
+  );
+
 // Cold builds (especially macOS) and broad test suites take minutes, not
 // seconds — give them headroom over runSailfin's 60s default. Both block
 // the MCP channel for their duration, which is why sailfin_test requires a
@@ -166,6 +214,7 @@ const fmtWritePathSchema = z
 const BUILD_TIMEOUT_MS = 600_000; // 10 min
 const TEST_TIMEOUT_MS = 600_000; // 10 min
 const FMT_WRITE_TIMEOUT_MS = 120_000; // 2 min — dir-wide fmt touches many files
+const BENCH_TIMEOUT_MS = 600_000; // 10 min — compiler-mode walks the whole compiler/src tree
 
 server.registerTool(
   "sailfin_version",
@@ -392,6 +441,103 @@ server.registerTool(
       }
       const result = await runSailfin(args, { timeoutMs: TEST_TIMEOUT_MS });
       return formatResult("sailfin test", result);
+    });
+    return out as ToolResult;
+  },
+);
+
+// Machine-readable counterpart used for benchmarking. Returns the
+// `sailfin.bench/v1` envelope (documented at
+// `docs/reference/bench-json-schema.md`) parsed into
+// `structuredContent`, mirroring `sailfin_diagnostics`. Falls back to
+// surfacing the raw stdout on parse failure — that path also signals
+// isError since bench setup errors (missing import-context, no
+// workloads) exit 1 with a plain-text stderr message and no JSON.
+server.registerTool(
+  "sailfin_bench",
+  {
+    title: "Benchmark compiler build or runtime workloads",
+    description:
+      "Run `sailfin bench --json` and return the sailfin.bench/v1 JSON envelope. Pass `compiler: true` to benchmark per-module compile time and memory across the compiler source tree (--compiler); omit it to benchmark runtime workloads (optionally scoped with `path`, `filter`, `iterations`). Use `top` to limit results and `module` (compiler mode) to filter by path substring. Schema documented at docs/reference/bench-json-schema.md. Runs under a 10-minute timeout.",
+    inputSchema: {
+      compiler: benchCompilerSchema,
+      path: benchPathSchema,
+      top: benchTopSchema,
+      filter: benchFilterSchema,
+      module: benchModuleSchema,
+      iterations: benchIterationsSchema,
+    },
+  },
+  async ({ compiler, path: userPath, top, filter, module, iterations }) => {
+    const isCompilerMode = compiler === true;
+    const hasPath = typeof userPath === "string" && userPath.length > 0;
+
+    async function runBench(resolvedPath: string | null): Promise<ToolResult> {
+      const args = ["bench"];
+      if (isCompilerMode) {
+        args.push("--compiler");
+      } else if (resolvedPath !== null) {
+        args.push(resolvedPath);
+      }
+      if (typeof top === "number") {
+        args.push("--top", String(top));
+      }
+      if (!isCompilerMode && typeof filter === "string" && filter.length > 0) {
+        args.push("--filter", filter);
+      }
+      if (isCompilerMode && typeof module === "string" && module.length > 0) {
+        args.push("--module", module);
+      }
+      if (!isCompilerMode && typeof iterations === "number") {
+        args.push("--iterations", String(iterations));
+      }
+      args.push("--json");
+
+      const result = await runSailfin(args, { timeoutMs: BENCH_TIMEOUT_MS });
+      // sfn bench exits 0 (clean), 1 (build/emit failure — still emits a
+      // valid envelope in most cases), or 2 (budget violation — still a
+      // valid envelope). Only a failure to parse the envelope is a tool
+      // error.
+      let envelope: Record<string, unknown> | null = null;
+      let parseError: string | null = null;
+      try {
+        envelope = JSON.parse(result.stdout) as Record<string, unknown>;
+      } catch (err) {
+        parseError = err instanceof Error ? err.message : String(err);
+      }
+      const ok = envelope !== null;
+      const header = ok
+        ? `sailfin bench: ok (exit=${result.exit}, ${result.durationMs}ms)`
+        : `sailfin bench: FAIL (envelope did not parse as JSON: ${parseError})`;
+      const body = [
+        header,
+        ok ? "" : `--- raw stdout ---\n${result.stdout}`,
+        result.stderr.length > 0 ? `--- stderr ---\n${result.stderr}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+      const structured: Record<string, unknown> =
+        ok && envelope !== null
+          ? envelope
+          : {
+              exit: result.exit,
+              duration_ms: result.durationMs,
+              parse_error: parseError ?? "",
+              raw_stdout: result.stdout,
+              raw_stderr: result.stderr,
+            };
+      return {
+        isError: !ok,
+        content: [{ type: "text", text: body }],
+        structuredContent: structured,
+      } satisfies ToolResult;
+    }
+
+    if (isCompilerMode || !hasPath) {
+      return await runBench(null);
+    }
+    const out = await withResolvedPath(userPath as string, async (abs) => {
+      return await runBench(abs);
     });
     return out as ToolResult;
   },

--- a/tools/mcp-server/test/smoke.test.ts
+++ b/tools/mcp-server/test/smoke.test.ts
@@ -136,13 +136,14 @@ async function withServer<T>(
   }
 }
 
-test("tools/list exposes all nine tools with correct names", async () => {
+test("tools/list exposes all ten tools with correct names", async () => {
   const workspace = makeStubWorkspace();
   await withServer(workspace, async (client) => {
     const resp = await client.request("tools/list");
     const result = resp.result as { tools: Array<{ name: string }> };
     const names = result.tools.map((t) => t.name).sort();
     assert.deepEqual(names, [
+      "sailfin_bench",
       "sailfin_build",
       "sailfin_check",
       "sailfin_diagnostics",
@@ -390,6 +391,66 @@ test("sailfin_diagnostics flags isError when envelope does not parse", async () 
       result.structuredContent!.raw_stdout,
       "this is not JSON at all",
     );
+  });
+});
+
+test("sailfin_bench parses the envelope into structuredContent", async () => {
+  // Stub `sfn bench --json` output that mirrors the real
+  // sailfin.bench/v1 envelope. The MCP server parses it and surfaces
+  // the parsed object as structuredContent so MCP clients can act on
+  // benchmark results programmatically.
+  const envelope = JSON.stringify({
+    schema: "sailfin.bench/v1",
+    command: "sfn bench",
+    domain: "runtime",
+    exit_code: 0,
+    tool: { version: "0.0.0-stub", platform: "Linux x86_64" },
+    config: { iterations: 5, warmup: 1 },
+    results: [
+      {
+        name: "arena_alloc",
+        ops: 1000,
+        unit: "ms",
+        time_ms: { min: 10, median: 12, max: 15, stddev: 2 },
+        peak_rss_kb: 2048,
+        status: "ok",
+      },
+    ],
+  });
+  const workspace = makeStubWorkspace({
+    exitCode: 0,
+    stdoutBody: envelope,
+    stderrBody: "",
+  });
+  await withServer(workspace, async (client) => {
+    const resp = await client.request("tools/call", {
+      name: "sailfin_bench",
+      arguments: { compiler: true },
+    });
+    const result = resp.result as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent?: Record<string, unknown>;
+    };
+    assert.notEqual(
+      result.isError,
+      true,
+      "clean envelope parse should NOT be flagged as a tool error",
+    );
+    assert.ok(
+      result.structuredContent,
+      "structuredContent must carry the parsed envelope",
+    );
+    assert.equal(result.structuredContent!.schema, "sailfin.bench/v1");
+    assert.equal(result.structuredContent!.domain, "runtime");
+    const results = result.structuredContent!.results as Array<{
+      name: string;
+      time_ms: { median: number };
+      status: string;
+    }>;
+    assert.equal(results[0].name, "arena_alloc");
+    assert.equal(results[0].time_ms.median, 12);
+    assert.equal(results[0].status, "ok");
   });
 });
 

--- a/tools/mcp-server/test/smoke.test.ts
+++ b/tools/mcp-server/test/smoke.test.ts
@@ -424,8 +424,11 @@ test("sailfin_bench parses the envelope into structuredContent", async () => {
   });
   await withServer(workspace, async (client) => {
     const resp = await client.request("tools/call", {
+      // Runtime mode with no path: exercises the runBench(null) branch (no
+      // workspace-path resolution) and matches the runtime-domain stub
+      // envelope below.
       name: "sailfin_bench",
-      arguments: { compiler: true },
+      arguments: {},
     });
     const result = resp.result as {
       content: Array<{ type: string; text: string }>;


### PR DESCRIPTION
## Summary

Give `sfn bench` a stable, versioned JSON output so agents can benchmark the
compiler and runtime workloads without scraping the human table, and expose it
as an MCP passthrough. Touches the `bench` CLI command (`compiler/src/cli/commands/`),
a new pure JSON encoder module, the MCP server (`tools/mcp-server/`), and docs.

Builds on the two now-merged bench runners: SFN-61 (`sfn bench --compiler`) and
SFN-63 (`sfn bench <path>`).

Fixes SFN-64

## Changes

- **driver / cli:** new `--json` boolean flag on `sfn bench` (both `--compiler`
  and `<path>` modes). In `--json` mode all human stdout is suppressed and a
  single `sailfin.bench/v1` envelope is printed — mirroring `sfn check --json`.
- **new module `compiler/src/cli/commands/bench_json.sfn`:** pure, I/O-free
  encoder (`render_bench_json_envelope` + self-contained JSON primitives, per the
  `diagnostics_json.sfn` import-cycle precedent) + status normalization to
  `ok|fail|slow|highmem` (+ combinations).
- **runtime mode:** `RtResult` extended with `inner_max` / `inner_stddev`
  (integer-isqrt population stddev) so `time_ms` carries `{min,median,max,stddev}`.
  Compiler mode has one emit sample → `min=median=max`, `stddev=0`, `ops=0`,
  `config {iterations:1, warmup:0}`. `exit_code` (0/1/2) is echoed in the envelope
  and matches the human path.
- **MCP (`tools/mcp-server/`):** `sailfin_bench` tool — passthrough to
  `sfn bench --json`, parses the envelope into `structuredContent` like
  `sailfin_diagnostics`, 10-min timeout; README table + roadmap updated.
- **docs:** `docs/reference/bench-json-schema.md` — versioning/bump rule,
  per-domain field semantics, status normalization, examples.
- **tests:** e2e schema-lock (`compiler/tests/e2e/bench_json_schema_test.sfn`,
  both modes) + encoder unit test (`compiler/tests/unit/bench_json_test.sfn`,
  empty-array / status combos / escaping at the encoder boundary).

## Acceptance Criteria

- [x] `sfn bench --compiler --json` and `sfn bench <path> --json` emit
  schema-valid `sailfin.bench/v1` (verified against the built compiler).
- [x] The schema is documented and versioned with a bump rule
  (`docs/reference/bench-json-schema.md`).
- [x] `sailfin_bench` MCP tool returns the envelope; documented in
  `tools/mcp-server/README.md`.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Map reconciliation

The issue's `In:` describes the flag as `--json[=PATH]` (optional inline path).
The `sfn/cli` parser has **no optional-value flag kind** — a value-taking flag
given bare (`--json` with nothing after) errors with `missing_value`, and a
boolean flag given `--json=PATH` errors with `unexpected_value`. Supporting the
literal `[=PATH]` form would mean adding a new flag kind to the shared
`capsules/sfn/cli` parser — a new public CLI surface **and** a seed-dependency
(the compiler's `bench` command imports `sfn/cli`, so the new kind would have to
be in the pinned seed first).

Instead, `--json` is a **boolean → stdout**, identical to every other `--json`
in the toolchain (`check`, `build`, `test`); file output is a shell redirect
(`sfn bench --compiler --json > out.json`). This honors the Goal ("stable,
versioned JSON output") and both acceptance-criteria invocations, matches the
`sfn check --json` shape the issue asked to mirror, and avoids touching the
shared parser. The reduction of `[=PATH]` is a convention-matching
reconciliation, not a dropped acceptance criterion.

Advisory `## Files Affected` named `cli_commands.sfn`; the bench command actually
lives at `compiler/src/cli/commands/bench.sfn` (post-CLI-v2 layout) — followed the
current tree.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` passes
- [x] `make compile` — compiler self-hosts
- [x] `make test` — unit 211/211, integration 45/45, e2e 213/213, capsules 45/45
- [x] Regression coverage added (e2e schema-lock + encoder unit test)
- [x] MCP: `npm run build` + `npm test` green (14/14 smoke tests)

Real captured envelope (compiler mode):
```json
{"schema":"sailfin.bench/v1","command":"sfn bench","domain":"compiler","exit_code":0,"tool":{"version":"0.8.0-alpha.5","platform":"Linux x86_64"},"config":{"iterations":1,"warmup":0},"results":[{"name":"lexer","ops":0,"unit":"ms","time_ms":{"min":455,"median":455,"max":455,"stddev":0},"peak_rss_kb":118580,"status":"ok"}]}
```

## Notes for reviewers

- Opus `code-reviewer` approved the core diff; the two highest-risk invariants —
  stdout purity in `--json` mode (no `print` leakage; only the envelope reaches
  stdout) and `exit_code` fidelity vs the human path — were traced clean in both
  modes.
- Two **pre-flight** config errors (compiler mode missing import-context; runtime
  mode no workloads resolved) exit `1` with a stderr message and **no envelope**;
  documented in the schema reference. Everything after benchmarking starts is
  reported inside the envelope.
- Darwin peak-RSS normalization stays deferred (epic #1503) — the `peak_rss_kb`
  column and `--budget-mem` are Linux-oriented, matching the existing modes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScFk8VZeDzYME7Jn9sdY8G)_