### PR TITLE
fix(resolver): stage cached capsules for manifest-less bare builds (SFN-216)

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -80,6 +80,7 @@ import {
 import { RuntimeCapsuleArtifacts, enumerate_runtime_capsule_artifacts } from "./runtime_capsule_resolver";
 import {
     SemVer,
+    semver_compare,
     semver_is_valid,
     semver_parse,
     semver_satisfies_floor
@@ -852,6 +853,59 @@ fn _cr_locate_capsule_src(project_root: string, spec: string, version: string) -
         + "/src";
     if fs.exists(cached) { return cached; }
     return "";
+}
+
+// Locate the src/ dir for a scoped capsule in the user cache
+// (~/.sfn/cache/capsules/<scope>/<name>/<version>/src), choosing the
+// highest semver version present. Used by the manifest-less, workspace-
+// less bare-build path (SFN-216): a bare `sfn build main.sfn` has no
+// capsule.toml or capsule.lock to pin a version, so the newest cached
+// version is selected. Returns "" if the capsule is not cached or no
+// cached version has a src/ dir.
+fn _cr_locate_cached_capsule_src_latest(spec: string) -> string ![io] {
+    let slash = _cr_find_char(spec, "/", 0);
+    if slash <= 0 { return ""; }
+    let slash2 = _cr_find_char(substring(spec, slash + 1, spec.length), "/", 0);
+    if slash2 >= 0 { return ""; }
+    let scope = substring(spec, 0, slash);
+    let name = substring(spec, slash + 1, spec.length);
+    if !_cr_is_safe_segment(scope) { return ""; }
+    if !_cr_is_safe_segment(name) { return ""; }
+    let home = _cr_get_home();
+    if home.length == 0 { return ""; }
+    let base = home + "/.sfn/cache/capsules/" + scope + "/" + name;
+    if !fs.exists(base) { return ""; }
+    let entries = fs.listDirectory(base);
+    let mut best_version: string = "";
+    let mut has_best: boolean = false;
+    // `best_parsed` is only read when `has_best` is true; the placeholder
+    // seed keeps the type inferred as SemVer without importing the name.
+    let mut best_parsed = semver_parse("0.0.0");
+    let guard: int = 4096;
+    let mut i: int = 0;
+    loop {
+        if i >= entries.length { break; }
+        if i >= guard { break; }
+        let ver = entries[i];
+        i += 1;
+        if ver.length == 0 { continue; }
+        if ver[0] == "." { continue; }
+        if !_cr_is_safe_version(ver) { continue; }
+        let parsed = semver_parse(ver);
+        if !semver_is_valid(parsed) { continue; }
+        let src = base + "/" + ver + "/src";
+        if !fs.exists(src) { continue; }
+        if !has_best {
+            has_best = true;
+            best_parsed = parsed;
+            best_version = ver;
+        } else if semver_compare(parsed, best_parsed) > 0 {
+            best_parsed = parsed;
+            best_version = ver;
+        }
+    }
+    if !has_best { return ""; }
+    return base + "/" + best_version + "/src";
 }
 
 // Walk a capsule src/ dir iteratively (BFS) and collect every .sfn file,
@@ -3019,6 +3073,67 @@ fn enumerate_workspace_implicit_sources(entry_path: string, members: WorkspaceMe
     return out;
 }
 
+// Resolve scoped imports of a bare-build entry file against the user
+// cache (~/.sfn/cache), the manifest-less + workspace-less analogue of
+// `enumerate_workspace_implicit_sources` (SFN-216). A bare `sfn build
+// main.sfn` with neither a capsule.toml nor a workspace.toml still needs
+// an imported capsule (`sfn/strings`, `sfn/http`) that the user `sfn
+// add`ed into the cache to be staged + compiled as its own unit, so its
+// entry-module functions mangle under the canonical `<scope>/<name>/mod`
+// slug and both the frontend signature lookup and the final link resolve.
+// Without this, the import is unstaged: the call site can't find the
+// callee's signature (lowering [fatal]) or, once resolved, the symbol is
+// undefined at link.
+//
+// BFS-walks each staged capsule's own scoped imports so an import of
+// sfn/http that internally imports sfn/strings pulls both in (each must
+// itself be cached). Version selection picks the newest cached version —
+// there is no lockfile to pin one in the manifest-less path.
+fn enumerate_cache_implicit_sources(entry_path: string) -> CapsuleSource[] ![io] {
+    let mut out: CapsuleSource[] = [];
+    if entry_path.length == 0 { return out; }
+    let mut covered: string[] = [];
+    let mut paths_to_scan: string[] = [entry_path];
+    let mut head: int = 0;
+    let max_iterations: int = 1024;
+    let mut iterations: int = 0;
+    loop {
+        if head >= paths_to_scan.length { break; }
+        if iterations >= max_iterations { break; }
+        iterations += 1;
+        let path = paths_to_scan[head];
+        head += 1;
+        if !fs.exists(path) { continue; }
+        let source = fs.readFile(path);
+        let specs = collect_scoped_import_specs(source);
+        let mut i: int = 0;
+        loop {
+            if i >= specs.length { break; }
+            let spec = specs[i];
+            i += 1;
+            // Canonicalise to "scope/name" (drop any submodule suffix).
+            let first = _cr_find_char(spec, "/", 0);
+            if first <= 0 { continue; }
+            let second = _cr_find_char(spec, "/", first + 1);
+            let mut canonical = spec;
+            if second > 0 { canonical = substring(spec, 0, second); }
+            if _cr_string_array_contains(covered, canonical) { continue; }
+            let src_dir = _cr_locate_cached_capsule_src_latest(canonical);
+            if src_dir.length == 0 { continue; }
+            covered.push(canonical);
+            let found = _cr_collect_capsule_sources(src_dir, canonical);
+            let mut j: int = 0;
+            loop {
+                if j >= found.length { break; }
+                out.push(found[j]);
+                paths_to_scan.push(found[j].source_path);
+                j += 1;
+            }
+        }
+    }
+    return out;
+}
+
 // ---- Top-level orchestrator ----
 // Parse the dep keys (e.g. "sfn/cli", "sfn/http") from the
 // `name=version\n` text returned by toml_get_dependencies. Used to seed the
@@ -3310,6 +3425,33 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
                 wi += 1;
             }
             wi_entry += 1;
+        }
+    }
+
+    // (4) Cache-implicit imports (SFN-216): a bare `sfn build main.sfn`
+    // with neither a capsule.toml (no project_root) nor a workspace.toml
+    // (no workspace_root) resolves scoped imports the user `sfn add`ed
+    // into ~/.sfn/cache. Gated on BOTH roots being absent so it never
+    // double-stages a spec the manifest or workspace legs already
+    // supplied — two sources with the same canonical slug but different
+    // source paths (member src vs cache src) would trip the slug-collision
+    // detector below. When a manifest or workspace is present, those legs
+    // own scoped resolution (declared deps fall back to the cache via
+    // `_cr_locate_capsule_src`).
+    if project_root.length == 0 {
+        if workspace_root.length == 0 {
+            let mut ci_entry: int = 0;
+            loop {
+                if ci_entry >= entry_paths.length { break; }
+                let cached = enumerate_cache_implicit_sources(entry_paths[ci_entry]);
+                let mut cci: int = 0;
+                loop {
+                    if cci >= cached.length { break; }
+                    sources.push(cached[cci]);
+                    cci += 1;
+                }
+                ci_entry += 1;
+            }
         }
     }
 

--- a/compiler/tests/e2e/cli_bare_file_cached_capsule_import_test.sfn
+++ b/compiler/tests/e2e/cli_bare_file_cached_capsule_import_test.sfn
@@ -1,0 +1,124 @@
+// End-to-end regression for SFN-216: a bare `sfn build main.sfn` — no
+// sibling `capsule.toml` and no ancestor `workspace.toml` — that imports
+// and calls a function defined directly in a cached capsule's entry
+// module (`mod.sfn`) must link and run.
+//
+// Before the fix, the manifest-less + workspace-less path staged nothing
+// for a scoped import: the resolver's relative-walk leg only handles
+// `./`-imports, the manifest leg is `capsule.toml`-gated, and the
+// workspace-implicit leg is `workspace.toml`-gated. With none present,
+// the imported capsule was never compiled as its own unit, so the entry-
+// module callee's signature was unknown to LLVM lowering (a `[fatal]`) —
+// and, once resolved, its symbol was undefined at link
+// (`undefined symbol: greet__demo__greeter__mod`). `sfn/http` `fetch`/`get`
+// and `sfn/strings` `int_to_string` are the real-world cases. CI never
+// exercised the manifest-less path — every other e2e fixture writes a
+// `capsule.toml` — so this guards the newly-added
+// `enumerate_cache_implicit_sources` leg (capsule_resolver.sfn).
+//
+// Hermetic by construction: a synthetic `demo/greeter` capsule is written
+// into a throwaway `HOME`'s cache (~/.sfn/cache/capsules/demo/greeter/
+// 0.1.0/src/mod.sfn) and the child build runs with `HOME` pointed at it,
+// so the test touches no real user cache and does not depend on any
+// shipped capsule's evolving source. The entry file lives under
+// `fs.mkdtemp`'s `/tmp` dir — deliberately outside the repo — so no
+// `workspace.toml` ancestor is discoverable and the cache path (not the
+// workspace-implicit path) is the one under test.
+import { find } from "sfn/strings";
+import { with_tmp_dir } from "sfn/test";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/bin/sfn";
+}
+
+// Child environment for the spawned `sfn build`, with `HOME` overridden
+// to the throwaway cache root. Start from the parent snapshot (PATH plus
+// the macOS SDK/toolchain vars the nested clang/ld need, and
+// SAILFIN_TEST_SCRATCH for parallel build-cache isolation, #1333), drop
+// any inherited `HOME`, then append the override so the resolver's
+// `_cr_get_home()` (`$HOME`) finds the synthetic capsule.
+fn _child_env_with_home(home: string) -> string[] ![io] {
+    let parent = process.environ();
+    let mut e: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= parent.length { break; }
+        let entry = parent[i];
+        i += 1;
+        if find(entry, "HOME=", 0) == 0 { continue; }
+        e.push(entry);
+    }
+    e.push("HOME=" + home);
+    return e;
+}
+
+// A fresh marker-file path under the runner's scratch dir (or `/tmp`),
+// stale value removed, living outside the `with_tmp_dir` tree so it
+// survives teardown.
+fn _marker(name: string) -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-216-cached-" + name + ".out";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+// Write the synthetic `demo/greeter` capsule into `<home>`'s cache and a
+// bare `main.sfn` (no capsule.toml) that imports its entry-module `greet`,
+// build, then run. Stashes the run's stdout to `out_marker`; returns the
+// run's exit code, or `-100` if the build itself failed.
+//
+// Two cached versions are written — 0.1.0 (`greet` → "hello …") and 0.2.0
+// (`greet` → "hi …") — so the run's output ("hi …" vs "hello …") also
+// pins the version-selection policy: with no lockfile to pin one, the
+// newest cached version must win (`_cr_locate_cached_capsule_src_latest`).
+fn _build_and_run(out_marker: string) -> int ![io] {
+    return with_tmp_dir(fn (dir: string) -> int {
+        let cache_base = dir + "/.sfn/cache/capsules/demo/greeter";
+        let older_src = cache_base + "/0.1.0/src";
+        fs.createDirectory(older_src, true);
+        fs.writeFile(older_src + "/mod.sfn", "fn greet(name: string) -> string {\n"
+            + "    return \"hello \" + name;\n"
+            + "}\n");
+        let newer_src = cache_base + "/0.2.0/src";
+        fs.createDirectory(newer_src, true);
+        fs.writeFile(newer_src + "/mod.sfn", "fn greet(name: string) -> string {\n"
+            + "    return \"hi \" + name;\n"
+            + "}\n");
+
+        let srcpath = dir + "/main.sfn";
+        fs.writeFile(srcpath, "import { greet } from \"demo/greeter\";\n\n"
+            + "fn main() ![io] {\n"
+            + "    print.info(greet(\"sfn216\"));\n"
+            + "}\n");
+
+        let binpath = dir + "/main";
+        let build_exit = process.run_capture([_sfn_bin(), "build", "-o", binpath, srcpath], _child_env_with_home(dir));
+        let _bo = process.capture_take_stdout();
+        let _be = process.capture_take_stderr();
+        if build_exit != 0 { return -100; }
+
+        let run_exit = process.run_capture([binpath], []);
+        let out = process.capture_take_stdout();
+        let _re = process.capture_take_stderr();
+        fs.writeFile(out_marker, out);
+        return run_exit;
+    });
+}
+
+test "bare-file: cached capsule's entry-module fn links and runs (no manifest, no workspace)" ![io] {
+    let marker = _marker("greet");
+    let exit = _build_and_run(marker);
+    // Assert build+run succeeded (`-100` == build failure) before touching
+    // the marker: on a build failure the marker is never written.
+    assert exit == 0;
+    let out = fs.readFile(marker);
+    if fs.exists(marker) { fs.deleteFile(marker); }
+    // The newest cached version (0.2.0 → "hi …") must be selected, not the
+    // older 0.1.0 ("hello …") — pins the version-selection policy.
+    assert find(out, "hi sfn216", 0) >= 0;
+    assert find(out, "hello sfn216", 0) < 0;
+}


### PR DESCRIPTION
## Summary

A bare `sfn build main.sfn` with **no** sibling `capsule.toml` and **no** ancestor `workspace.toml` could not link an imported capsule's entry-module functions. The resolver has three enumeration legs — relative-walk (`./` only), manifest-declared (`capsule.toml`-gated), and workspace-implicit (`workspace.toml`-gated) — so a scoped import the user `sfn add`ed into `~/.sfn/cache` was staged by **none** of them. The imported capsule was never compiled as its own unit, so its entry-module callee's signature was unknown to LLVM lowering (a fatal), and once resolved its symbol was undefined at link (e.g. `undefined symbol: int_to_string__sfn__strings__mod`). Re-exported submodule symbols linked fine (they route through a re-export shim in the defining module), which is why only directly-defined entry-module functions were exposed.

This touches only the build driver's capsule resolver (`compiler/src/capsule_resolver.sfn`) — no change to lowering or mangling; the fix makes the cached capsule get staged + compiled under its canonical slug, so the existing mangling resolves.

Fixes SFN-216

## Changes

- **driver / resolver:** add `enumerate_cache_implicit_sources` — the manifest-less + workspace-less analogue of `enumerate_workspace_implicit_sources` — which BFS-walks the entry file's scoped imports and stages each from `~/.sfn/cache` under its canonical `<scope>/<name>/<stem>` slug (transitive: a cached `sfn/http` importing `sfn/strings` pulls both in, each of which must itself be cached).
- **driver / resolver:** add `_cr_locate_cached_capsule_src_latest`, which scans `~/.sfn/cache/capsules/<scope>/<name>/` and selects the highest valid semver version dir that has a `src/` — the version-selection policy for a path with no lockfile to pin one. Path segments and the version pass `_cr_is_safe_segment` / `_cr_is_safe_version` before any filesystem path is built.
- **driver / resolver:** wire the new leg into `_cr_resolve_and_dedupe`, gated on `project_root == "" && workspace_root == ""` — the only case the other three legs don't cover — so it never double-stages a spec the manifest or workspace legs already supply (which would trip the slug-collision detector).
- **tests:** add `compiler/tests/e2e/cli_bare_file_cached_capsule_import_test.sfn`, a hermetic e2e (synthetic `demo/greeter` capsule in a throwaway `HOME`'s cache; entry file under `fs.mkdtemp`'s `/tmp`, outside the repo, so no manifest/workspace ancestor is discoverable) asserting a cached capsule's entry-module function links and runs, and that the newest of two cached versions is the one selected. This is the first CI coverage of the manifest-less build path.

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts (`status: pass`)
- [ ] `make check` — full triple-pass not run; `make test` (full unit/integration/e2e/capsules suite) is running and will be confirmed on this PR
- [x] Regression coverage added under `compiler/tests/e2e/`

Manual end-to-end verification against the freshly self-hosted binary:
- Manifest-less + no-workspace build importing a cached `demo/greeter` entry-module `greet` — **builds and runs** (was: frontend fatal / link undefined-symbol).
- Same for cached `sfn/strings` `int_to_string` (the issue's real case) — prints `42`.
- No-regression: manifest-less build at the workspace root, and the declared-dep transitive-link e2e (`capsule_transitive_dep_link_test.sfn`), bare-dispatch, and main-entry e2e all still pass.

## Notes for reviewers

- Capability envelope: unchanged — the new functions are `[io]` (filesystem + `$HOME`), the same effect the resolver already uses; the manifest-less consumer has no `[capabilities]` list, so the effect cross-check is skipped as before.
- Version selection deliberately picks the newest cached version because the manifest-less path has no `capsule.toml`/`capsule.lock` to pin one; when a manifest or workspace **is** present, those legs own resolution (and declared deps already fall back to the cache via `_cr_locate_capsule_src`).
- Follow-up filed: SFN-218 — `_cr_collect_capsule_sources`'s `max_depth` bound is mis-named (it counts directories visited, not tree depth) and truncates silently; pre-existing and shared with the workspace-implicit leg, surfaced during review here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwWrY1oqunWnfdyhMMFu9p)_