### PR TITLE
docs: document compiler runtime setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh |
 To pin a specific release:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | VERSION=<version> bash
+VERSION=0.8.0-alpha.5
+curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | VERSION="$VERSION" bash
 ```
 
 ### Windows PowerShell
@@ -152,8 +153,12 @@ throttled.
 
 ## Building From Source
 
-The compiler self-hosts from a released seed binary. `make compile` fetches
-the seed if needed and builds `build/bin/sfn`.
+The compiler self-hosts from the released seed pinned in
+[`bootstrap.toml`](bootstrap.toml). Source builds require `bash`, `make`, `jq`,
+LLVM tools 17+ or 18+, `clang`, and OpenSSL development libraries because the
+Sailfin-native runtime links TLS into every binary. See
+[`docs/development-setup.md`](docs/development-setup.md) for per-platform
+dependency installation and the supported build flags.
 
 ```sh
 make compile          # Build the self-hosted native compiler

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ documentation lives on the docs site.**
 ## Where to find things
 
 - **What runs today (feature matrix)** → `docs/status.md`
+- **Compiler/runtime development setup** → `docs/development-setup.md`
 - **Language specification** → [sailfin.dev/docs/reference/spec/](https://sailfin.dev/docs/reference/spec/)
   (source under `site/src/content/docs/docs/reference/spec/`, split by chapter)
 - **Grammar (EBNF)** → [sailfin.dev/docs/reference/grammar](https://sailfin.dev/docs/reference/grammar)

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -208,7 +208,7 @@ local source build unless you are changing the build driver itself.
 These are the build flags exposed by the compiler CLI:
 
 ```text
-sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)
+sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] [--skip-toolchain-check] (<file.sfn> | -p <capsule-path>)
 ```
 
 | Flag | Meaning |
@@ -221,14 +221,15 @@ sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] 
 | `--json` | Emit the structured build report. Used by CI and agent report tooling. |
 | `--work-dir DIR` | Use `DIR` for build scratch/output state. |
 | `--check-determinism` | Run the build determinism check. |
+| `--skip-toolchain-check` | Bypass the `[toolchain]` pin check for this invocation. |
 
 Related compiler commands expose their own flags:
 
 | Command | Supported flags |
 |---|---|
-| `sfn check` | `--quiet`, `--json`, `--allow-bare-assert` |
-| `sfn run` | `--no-cache`, `--clean`, `--cache-trace` |
-| `sfn test` | `--json`, `-k NAME`, `--tag TAG`, `--update-snapshots`, `--no-test-cache`, `--jobs N` |
+| `sfn check` | `--quiet`, `--json`, `--allow-bare-assert`, `--skip-toolchain-check` |
+| `sfn run` | `--no-cache`, `--clean`, `--cache-trace`, `--skip-toolchain-check` |
+| `sfn test` | `--json`, `-k NAME`, `--tag TAG`, `--update-snapshots`, `--no-test-cache`, `--jobs N`, `--shard I/N`, `--skip-toolchain-check` |
 | `sfn fmt` | `--check`, `--write` |
 | `sfn emit` | `--timing`, `-o OUTPUT`, `--module-name SLUG`, `--import-context DIR`, `--attempts N`, `--no-retry`, `--validate`, `--no-validate`, `--no-resolve-gate` |
 | `sfn package` | `--target T`, `--out DIR`, `--compiler-bin PATH`, `--installer`, `-p <capsule-path>` |

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -1,0 +1,305 @@
+# Compiler and runtime development setup
+
+This page is the source-oriented setup guide for people working on the Sailfin
+compiler (`compiler/src/`) and Sailfin-native runtime (`runtime/prelude.sfn`,
+`runtime/sfn/`). End users who only need a released `sfn` binary should use the
+install guide on the docs site.
+
+The compiler self-hosts from the exact released seed pinned in
+`bootstrap.toml [seed].version`. The build downloads that seed into
+`build/toolchains/seed/` and produces the local compiler at `build/bin/sfn`.
+
+## Supported hosts
+
+Linux and macOS are the primary development hosts for compiler/runtime work.
+Windows release artifacts are built through the cross-Windows target from
+Linux; for day-to-day compiler work on Windows, use WSL or a Linux/macOS
+machine unless you are specifically working on the Windows toolchain path.
+
+The current backend lowers Sailfin IR through LLVM and links with the platform
+toolchain. LLVM/clang independence is planned work, not the current build path.
+
+## Required tools
+
+Install these before running `make compile`:
+
+| Tool | Why it is needed |
+|---|---|
+| `git` | Clone and inspect the repository. |
+| `bash` | The Makefile intentionally runs recipes under bash. |
+| `make` | Top-level build and validation targets. |
+| `curl`, `tar`, `mktemp`, `uname` | Release installer and seed download plumbing. |
+| `jq` | GitHub release JSON parsing in `install.sh` / `make fetch-seed`. |
+| LLVM tools 17+ or 18+ | LLVM IR validation/linking tools such as `llvm-link` and `llvm-as`. |
+| `clang` | Assemble LLVM IR and link native executables. |
+| OpenSSL development libraries | The Sailfin-native runtime links TLS with `-lssl -lcrypto` for every binary. |
+| `shasum` or `sha256sum` | Seed/self-host hash checks. `shasum -a 256` is the portable default. |
+
+Optional tools:
+
+| Tool | Why it is useful |
+|---|---|
+| GNU `timeout` (`timeout` / `gtimeout`) | Bounds direct compiler invocations and some Makefile validation paths. |
+| `pkg-config` | Fallback OpenSSL discovery on non-standard macOS installs. |
+| `npm` | Required only for `make mcp-server`. |
+| `x86_64-w64-mingw32-gcc` | Required only for `make ci-cross-windows` from Linux. |
+
+## Install dependencies
+
+### Ubuntu / Debian
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  bash build-essential clang-18 curl git jq libssl-dev lld make \
+  tar llvm-18 pkg-config
+```
+
+If your distribution does not package LLVM 18, LLVM 17 is acceptable:
+
+```bash
+sudo apt-get install -y clang-17 llvm-17
+```
+
+Set `CLANG=clang-17` or `CLANG=clang-18` when you need to force a specific
+compiler binary.
+
+### Fedora / RHEL
+
+```bash
+sudo dnf install -y \
+  bash clang git jq llvm llvm-devel make openssl-devel pkg-config tar
+```
+
+Package names vary across Fedora/RHEL releases. The important checks are that
+`clang`, `llvm-link`, `llvm-as`, `jq`, and OpenSSL headers/libs are available on
+`PATH` or the system library search path.
+
+### macOS
+
+```bash
+xcode-select --install
+brew install jq llvm openssl@3 pkg-config
+```
+
+Add Homebrew LLVM tools to your shell path so `llvm-link` and `llvm-as` are
+available:
+
+```bash
+export PATH="$(brew --prefix llvm)/bin:$PATH"
+```
+
+The Makefile creates a local shim so the seed and built compiler use Apple's
+`/usr/bin/clang` by default on macOS. That avoids Homebrew clang trying to link
+against the macOS SDK with the wrong defaults. Override with
+`SAILFIN_CC=/path/to/clang` only when you know the replacement can link system
+libraries.
+
+OpenSSL is keg-only under Homebrew. The compiler probes the standard
+`openssl@3` keg locations and `brew --prefix openssl@3`; set
+`SAILFIN_OPENSSL_PREFIX=/path/to/openssl-prefix` when using a custom OpenSSL
+install. See `docs/runbooks/openssl-build-dependency.md` for the full link
+discovery contract.
+
+## Build and verify
+
+```bash
+git clone https://github.com/SailfinIO/sailfin.git
+cd sailfin
+
+# Download the exact seed pinned by bootstrap.toml, if it is not present.
+make fetch-seed
+
+# Build build/bin/sfn from the released seed.
+make compile
+
+# Fast parse/type/effect check over compiler + runtime sources.
+make check-fast
+
+# Run the full Sailfin-native test suite with the built compiler.
+make test
+
+# Full self-host validation gate. This is the authoritative pre-merge check.
+make check
+```
+
+`make compile` fetches the pinned seed automatically when needed, so running
+`make fetch-seed` first is optional. It is useful when validating network or
+GitHub token setup separately.
+
+After a successful build:
+
+```bash
+build/bin/sfn --version
+build/bin/sfn run examples/basics/hello-world.sfn
+build/bin/sfn fmt --check compiler/src runtime
+```
+
+Install the built compiler into `~/.local/bin`:
+
+```bash
+make install
+```
+
+Use `PREFIX=/some/prefix make install` or `BINDIR=/some/bin make install` to
+install somewhere else.
+
+## Common workflows
+
+| Task | Command |
+|---|---|
+| Fast compiler/runtime sanity check | `make check-fast` |
+| Rebuild after compiler/runtime edits | `make compile` |
+| Force rebuild from the seed | `make rebuild` |
+| Full validation before PR | `make check` |
+| CI-strict self-host fixed point | `make check-strict` or `make check SELFHOST_STRICT=1` |
+| Unit tests only | `make test-unit` |
+| Integration tests only | `make test-integration` |
+| End-to-end tests only | `make test-e2e` |
+| Capsule tests only | `make test-capsules` |
+| Format touched compiler/runtime files | `build/bin/sfn fmt --write <files>` then `build/bin/sfn fmt --check <files>` |
+| Package release artifacts | `make package` |
+| Build MCP server | `make mcp-server` |
+| Cross-compile Windows artifact from Linux | `make rebuild && make ci-cross-windows` |
+
+Before committing changes under `compiler/src/` or `runtime/`, run
+`make compile` before test-only validation so tests do not run against a stale
+compiler binary.
+
+## Supported Makefile overrides
+
+These are the supported knobs for source builds and local validation. Prefer
+command-line Make variables (`make test TEST_JOBS=4`) for one-off runs and
+environment variables for shell-wide behavior.
+
+| Override | Applies to | Default | Notes |
+|---|---|---|---|
+| `SEED_VERSION` | `make fetch-seed` | `bootstrap.toml [seed].version` | Fetch a different released seed intentionally. Normal development should use the checked-in pin. |
+| `SEED` | `make rebuild` | `build/toolchains/seed/bin/sfn` | Path or command name for the seed compiler. |
+| `SEED_NATIVE` | `make rebuild` | unset | One-off seed path override used by CI and seed-bisect work. Takes precedence over `SEED` inside `rebuild`. |
+| `BUILD_ARGS` | `make rebuild` | empty | Extra args passed to `sfn build -p compiler`, for example `BUILD_ARGS="--no-cache --cache-trace"`. |
+| `JSON=1` | agent-facing Make targets | off | Writes structured reports under `build/agent-report.*.json` and related JSONL files. |
+| `NATIVE_BIN` | test/bench/check targets | `build/bin/sfn` | Select which built compiler binary those targets run. |
+| `NATIVE_OUT` | `make rebuild` | `build/bin/sfn` | Destination path for the rebuilt compiler. |
+| `CLANG` | Makefile clang calls | `clang` | Clang executable for Makefile-owned compilation/link steps. On Linux CI this is often `clang-18`. |
+| `SAILFIN_CC` | macOS build recipes | `/usr/bin/clang` | Target of the macOS clang shim used by seed/built compiler subprocesses. |
+| `CLANG_LL_FLAGS` | LLVM IR compilation | empty | Extra flags when compiling `.ll`; use only for platform quirks such as opaque-pointer mode. |
+| `NATIVE_LL_TIMEOUT_SECONDS` | LLVM IR compilation | `600` | Wall-clock cap for individual clang jobs when `timeout` is available. |
+| `TEST_JOBS` | `make test*` | auto-detected | Parallel `sfn test --jobs N` children. Lower it on memory-constrained hosts. |
+| `CHECK_TEST_JOBS` | `make check` | `TEST_JOBS` | Parallelism for the full cold seedcheck suite. |
+| `CHECK_TEST_TIMEOUT` | `make check` | `1800` | Per-test timeout for the cold full-suite leg. |
+| `CHECK_FULL_PASS1=1` | `make check` | off | Restores the older full first-pass suite before seedcheck; useful for bisects. |
+| `SELFHOST_STRICT=1` | `make check` | off locally | Makes stage2/stage3 fixed-point mismatch fatal. `make check-strict` sets it. |
+| `TEST_BIN_CACHE_FLAGS` | `make test` | empty | Extra flags for `sfn test`; `make check` sets `--no-test-cache`. |
+| `PREFIX`, `BINDIR`, `INSTALL_NAME`, `DESTDIR` | `make install` | `~/.local`, `$(PREFIX)/bin`, `sfn`, empty | Installation path/name controls. |
+| `BENCH_ARGS` | `make bench` | empty | Extra args for compiler compile-time benchmarks. |
+| `BENCH_RUNTIME_ARGS` | `make bench-runtime` | empty | Extra args for runtime execution benchmarks. |
+| `ARENA_ARGS` | `make test-arena` | empty | Inputs/options for the arena IR identity harness. |
+| `KEEP_SEED=0` | `make clean-build` | keep seed | Also removes `build/toolchains/` during cleanup. |
+| `MINGW_CC` | `make ci-cross-windows` | `x86_64-w64-mingw32-gcc` | Windows cross-link compiler from Linux. |
+
+`BUILD_JOBS`, `NATIVE_OPT`, and `SELFHOST1_OPT` still exist in the Makefile for
+legacy/CI compatibility, but the normal self-host build now routes through
+`sfn build -p compiler`; do not rely on those as user-facing tuning knobs for a
+local source build unless you are changing the build driver itself.
+
+## Supported `sfn build` flags
+
+These are the build flags exposed by the compiler CLI:
+
+```text
+sfn build [-o OUTPUT] [-p PATH] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)
+```
+
+| Flag | Meaning |
+|---|---|
+| `-o OUTPUT` | Write the built executable to `OUTPUT`. |
+| `-p <capsule-path>` | Build a capsule by path instead of a single file. |
+| `--no-cache` | Bypass the build artifact cache for this invocation. |
+| `--clean` | Clean build outputs before compiling. |
+| `--cache-trace` | Print cache hit/miss diagnostics. |
+| `--json` | Emit the structured build report. Used by CI and agent report tooling. |
+| `--work-dir DIR` | Use `DIR` for build scratch/output state. |
+| `--check-determinism` | Run the build determinism check. |
+
+Related compiler commands expose their own flags:
+
+| Command | Supported flags |
+|---|---|
+| `sfn check` | `--quiet`, `--json`, `--allow-bare-assert` |
+| `sfn run` | `--no-cache`, `--clean`, `--cache-trace` |
+| `sfn test` | `--json`, `-k NAME`, `--tag TAG`, `--update-snapshots`, `--no-test-cache`, `--jobs N` |
+| `sfn fmt` | `--check`, `--write` |
+| `sfn emit` | `--timing`, `-o OUTPUT`, `--module-name SLUG`, `--import-context DIR`, `--attempts N`, `--no-retry`, `--validate`, `--no-validate`, `--no-resolve-gate` |
+| `sfn package` | `--target T`, `--out DIR`, `--compiler-bin PATH`, `--installer`, `-p <capsule-path>` |
+
+## Runtime and toolchain environment variables
+
+| Variable | Values | Notes |
+|---|---|---|
+| `SAILFIN_MEM_LIMIT` | bytes, `unlimited`, `off`, `0` | Linux compiler invocations self-apply an 8 GiB virtual-memory cap by default. This overrides or disables it. |
+| `SAILFIN_TRACE_MEM_LIMIT` | `1` | Trace memory-limit setup. |
+| `SAILFIN_OPENSSL_PREFIX` | path prefix | macOS OpenSSL link override; expects libraries under `$prefix/lib`. |
+| `SAILFIN_RUNTIME_ROOT` | path | Override where `sfn` resolves bundled runtime sources. Usually only for packaging/debugging. |
+| `SAILFIN_TOOLCHAIN` | `auto`, `local`, `<version>`, `off`, `0` | Toolchain pin dispatch policy for user capsules. Use `off` only for seed-transition work. |
+| `SAILFIN_SKIP_TOOLCHAIN_CHECK` | `1` | Downgrade a user capsule `[toolchain]` mismatch to a warning. |
+| `SAILFIN_BUILD_JOBS` | positive integer | Override compiler module scheduling inside `sfn build -p compiler`; use `1` for serial bisects or a small value on memory-constrained hosts. |
+| `SAILFIN_BUILD_CACHE_DIR` | path | Override the content-addressed build artifact cache root for user builds/tests. |
+| `SAILFIN_EFFECT_ENFORCE` | `error`, `warning`, `off` | Transitional effect checker severity; default is error. |
+| `SAILFIN_TRACE_LINK` | `1` | Print resolved clang/link command details. |
+| `SAILFIN_CACHE_TRACE` | `1` | Equivalent cache tracing path used by build/run internals. |
+| `SAILFIN_TEST_TIMEOUT` | seconds | Per-test timeout consumed by `sfn test`; `make check` sets this from `CHECK_TEST_TIMEOUT`. |
+| `SAILFIN_TEST_KEEP_SCRATCH` | `1` | Keep `sfn test` scratch directories for post-mortem debugging. |
+| `SAILFIN_TEST_SCRATCH` | path | Force the scratch root for tests/self-host isolation. |
+
+Debug and fault-injection variables under `SAILFIN_TRACE_*`,
+`SAILFIN_DEBUG_*`, and `SAILFIN_INJECT_*` are compiler-internal unless a doc or
+runbook explicitly marks them supported.
+
+## Troubleshooting
+
+### `Required command 'jq' is not installed`
+
+Install `jq`. The installer uses it for GitHub release selection, including
+repo-local seed downloads.
+
+### `llvm-link` or `llvm-as` is not found
+
+Install LLVM 17+ or 18+ and make sure its `bin` directory is on `PATH`. On
+macOS with Homebrew:
+
+```bash
+export PATH="$(brew --prefix llvm)/bin:$PATH"
+```
+
+### `ld: library 'ssl' not found` or `cannot find -lssl`
+
+Install OpenSSL development libraries. On Linux this is usually `libssl-dev` or
+`openssl-devel`. On macOS install `openssl@3` or set:
+
+```bash
+export SAILFIN_OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+```
+
+### `make compile` says the compiler is up to date
+
+`make compile` skips rebuilds when `build/bin/sfn` is newer than all
+`compiler/src/**/*.sfn` and `runtime/**/*.sfn` files. Use `make rebuild` to
+force a rebuild from the seed.
+
+### Source changes fail tests unexpectedly
+
+If you touched `compiler/src/` or `runtime/`, rebuild first:
+
+```bash
+make compile
+make test
+```
+
+For structural changes such as file splits, renamed exports, or module graph
+changes, start with a clean build:
+
+```bash
+make clean-build
+make compile
+```

--- a/site/src/content/docs/docs/contributing/guide.md
+++ b/site/src/content/docs/docs/contributing/guide.md
@@ -22,6 +22,10 @@ make compile   # Build the compiler from seed
 make test      # Verify everything works
 ```
 
+For host dependencies, OpenSSL/LLVM setup, and supported Makefile/CLI build
+flags, see the
+[compiler and runtime development setup](https://github.com/SailfinIO/sailfin/blob/main/docs/development-setup.md).
+
 3. Create a feature branch:
 
 ```bash

--- a/site/src/content/docs/docs/getting-started/install.md
+++ b/site/src/content/docs/docs/getting-started/install.md
@@ -23,17 +23,19 @@ Sailfin runs on the following platforms:
 WSL (Windows Subsystem for Linux) and Git Bash on Windows are also supported and
 use the Linux install path.
 
-### LLVM
+### Compiler and linker tools
 
-LLVM 17+ is required by the Sailfin compiler. **The installer and release binaries do not bundle LLVM/clang** — you must have them installed on your system even when installing via the script. If you are building the compiler from source, see the [Building from source](#building-from-source) section below for additional details.
+The installer only downloads and places the released `sfn` binary. To compile,
+run, or test Sailfin programs, the current backend still needs LLVM tools 17+
+or 18+ plus `clang` and the platform linker. Release binaries do not bundle
+LLVM/clang.
 
-### C toolchain / linker
+The installer script itself also requires `curl`, `tar`, `uname`, `mktemp`, and
+`jq` on Linux/macOS because it selects release assets through the GitHub API.
 
-To install Sailfin via the script or a prebuilt release binary, you do **not** need a C toolchain; the installer does not invoke `gcc` or `clang`.
-
-However, the Sailfin CLI uses a C toolchain (typically `clang` plus a system linker) to produce native executables. If you plan to compile, run, or test Sailfin programs on Linux or macOS, you must have a working `clang`/LLVM toolchain installed.
-
-A C linker is also required when building the Sailfin compiler itself from source. See [Building from source](#building-from-source) for details.
+If you are building Sailfin itself from source, you also need `bash`, `make`,
+OpenSSL development libraries, and the source-build dependencies listed in
+[Building from source](#building-from-source).
 
 ---
 
@@ -49,7 +51,7 @@ curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh |
 
 The script will:
 1. Detect your OS and architecture
-2. Download the latest stable release binary from GitHub Releases
+2. Download the latest matching release binary from GitHub Releases
 3. Install `sailfin` and `sfn` to `~/.local/bin`
 4. Print confirmation when complete
 
@@ -57,7 +59,7 @@ Example output:
 
 ```
 Detected: linux/x86_64
-Downloading sfn 0.5.1...
+Downloading sfn <version>...
 Installed sailfin -> /home/you/.local/bin/sailfin
 Installed sfn    -> /home/you/.local/bin/sfn
 Done. Run 'sfn --version' to verify.
@@ -79,7 +81,7 @@ Example output:
 
 ```
 Detected: windows/x86_64
-Downloading sfn 0.5.1...
+Downloading sfn <version>...
 Installed sailfin.exe -> C:\Users\you\AppData\Local\sailfin\bin\sailfin.exe
 Installed sfn.exe     -> C:\Users\you\AppData\Local\sailfin\bin\sfn.exe
 Added C:\Users\you\AppData\Local\sailfin\bin to user PATH.
@@ -102,7 +104,7 @@ sfn --version
 Expected output:
 
 ```
-sfn 0.5.1
+sfn <version>
 ```
 
 If the command is not found, see [Troubleshooting](#troubleshooting) below.
@@ -111,32 +113,42 @@ If the command is not found, see [Troubleshooting](#troubleshooting) below.
 
 ## Pinning a Version
 
-The pinned stable version for Sailfin development is **`v0.5.1`**.
-Releases past this point are pre-stabilization builds and may have known issues.
-Unless you have a specific reason to use a newer build, pin to the stable version.
+Sailfin is pre-1.0, so pin exact release versions in CI and reproducible setup
+scripts. Omit `VERSION` for the latest release asset that matches your platform.
+Compiler repository development uses the exact seed version in
+[`bootstrap.toml`](https://github.com/SailfinIO/sailfin/blob/main/bootstrap.toml),
+not a hard-coded docs-page version.
 
 ### Linux and macOS
 
+Replace the example version with the release you want to pin:
+
 ```bash
-VERSION=0.5.1 curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | bash
+VERSION=0.8.0-alpha.5
+curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | VERSION="$VERSION" bash
 ```
 
-Note the placement of `VERSION=...` before `curl`. This passes the variable into
-the curl subprocess's environment, which the install script reads.
+You can also pass the version as an install-script argument:
+
+```bash
+VERSION=0.8.0-alpha.5
+curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | bash -s -- --version "$VERSION"
+```
 
 ### Windows (PowerShell)
 
+Replace the example version with the release you want to pin:
+
 ```powershell
-$env:VERSION = "0.5.1"
+$env:VERSION = "0.8.0-alpha.5"
 irm https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.ps1 | iex
 ```
 
 Set `$env:VERSION` before invoking `iex` so the script reads it.
 
-> **Why pin?** The Sailfin project is marching toward a 1.0 release. Intermediate
-> alpha builds may include regressions as large parts of the compiler are rewritten.
-> `v0.5.1` is the version CI uses as its seed compiler and is the most
-> thoroughly validated build available.
+> **Why pin?** The Sailfin project is marching toward a 1.0 release. Alpha
+> builds may include regressions as large parts of the compiler and runtime are
+> rewritten. Pinning gives CI and onboarding scripts a reproducible toolchain.
 
 ---
 
@@ -161,7 +173,7 @@ You can override the install directory by setting `GLOBAL_BIN_DIR` before runnin
 the script:
 
 ```bash
-GLOBAL_BIN_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | GLOBAL_BIN_DIR=/usr/local/bin bash
 ```
 
 ### Confirming the binaries are on PATH
@@ -171,7 +183,7 @@ which sfn
 # /home/you/.local/bin/sfn
 
 sfn --version
-# sfn 0.5.1
+# sfn <version>
 ```
 
 On Windows:
@@ -194,7 +206,7 @@ every platform binary with direct download links.
 
 Go to the [Downloads](/dl) page or directly to
 [github.com/SailfinIO/sailfin/releases](https://github.com/SailfinIO/sailfin/releases)
-and locate the release for `v0.5.1`. Release assets follow this naming
+and locate the release you want to install. Release assets follow this naming
 convention:
 
 ```
@@ -205,18 +217,20 @@ Examples:
 
 | Asset name | Platform |
 |---|---|
-| `sailfin_0.5.1_linux_x86_64.tar.gz` | Linux x86_64 |
-| `sailfin_0.5.1_macos_arm64.tar.gz` | macOS Apple Silicon |
-| `sailfin_0.5.1_windows_x86_64.tar.gz` | Windows x86_64 |
+| `sailfin_${VERSION}_linux_x86_64.tar.gz` | Linux x86_64 |
+| `sailfin_${VERSION}_macos_arm64.tar.gz` | macOS Apple Silicon |
+| `sailfin_${VERSION}_windows_x86_64.tar.gz` | Windows x86_64 |
 
 ### Step 2: Extract and place the binary
 
 ```bash
+VERSION=0.8.0-alpha.5
+
 # Download (replace the filename with the one that matches your platform)
-curl -LO https://github.com/SailfinIO/sailfin/releases/download/v0.5.1/sailfin_0.5.1_linux_x86_64.tar.gz
+curl -LO "https://github.com/SailfinIO/sailfin/releases/download/v${VERSION}/sailfin_${VERSION}_linux_x86_64.tar.gz"
 
 # Extract
-tar -xzf sailfin_0.5.1_linux_x86_64.tar.gz
+tar -xzf "sailfin_${VERSION}_linux_x86_64.tar.gz"
 
 # The archive contains bin/sailfin and bin/sfn
 # Move them to a directory on your PATH
@@ -230,7 +244,7 @@ chmod +x ~/.local/bin/sailfin ~/.local/bin/sfn
 
 ```bash
 sfn --version
-# sfn 0.5.1
+# sfn <version>
 ```
 
 ---
@@ -244,10 +258,16 @@ Building from source is useful when:
 
 ### Prerequisites
 
-- `git`
-- LLVM 17+ (`llvm-17` or `llvm-18` packages on most Linux distributions; Homebrew `llvm` on macOS)
-- A C compiler: `gcc` or `clang`
-- `make`
+- `git`, `bash`, `make`
+- `curl`, `tar`, `mktemp`, `uname`, `jq`
+- LLVM tools 17+ or 18+ (`llvm-link`, `llvm-as`)
+- `clang` and the platform linker
+- OpenSSL development libraries (`libssl-dev`, `openssl-devel`, or Homebrew `openssl@3`)
+- `shasum -a 256` or `sha256sum`
+
+See the
+[compiler/runtime development setup](https://github.com/SailfinIO/sailfin/blob/main/docs/development-setup.md)
+for per-platform package commands and the complete supported build flag table.
 
 ### Steps
 
@@ -256,7 +276,7 @@ Building from source is useful when:
 git clone https://github.com/SailfinIO/sailfin.git
 cd sailfin
 
-# Build the native compiler by self-hosting from the released seed
+# Build the native compiler by self-hosting from the released seed pinned in bootstrap.toml
 make compile
 
 # Install to ~/.local/bin (or set PREFIX to override)
@@ -276,9 +296,9 @@ build/bin/sfn --version
 ```
 
 > **Note:** `make compile` routes through `<seed> build -p compiler` — the
-> Sailfin-native driver — and requires `bash`, `clang`, and LLVM tools
-> including `llvm-link`. `make fetch-seed` also requires `jq`. (The prior
-> `scripts/build.sh` orchestrator was retired in Stage E PR7 / #383.)
+> Sailfin-native driver — and requires `bash`, `clang`, LLVM tools, `jq`, and
+> OpenSSL development libraries. The prior `scripts/build.sh` orchestrator is
+> no longer in-tree.
 
 ---
 
@@ -292,7 +312,8 @@ existing binaries in-place:
 curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | bash
 
 # Linux / macOS: update to a specific version
-VERSION=0.5.1 curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | bash
+VERSION=0.8.0-alpha.5
+curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | VERSION="$VERSION" bash
 ```
 
 ```powershell
@@ -300,8 +321,8 @@ VERSION=0.5.1 curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/mai
 irm https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.ps1 | iex
 ```
 
-As with the initial install, pinning to a known stable version is recommended
-over updating to the absolute latest build.
+As with the initial install, pinning to a known release version is recommended
+for CI and reproducible environments.
 
 ---
 
@@ -361,29 +382,32 @@ The binary may not be marked executable. Fix it:
 chmod +x ~/.local/bin/sailfin ~/.local/bin/sfn
 ```
 
-### `LLVM not found` error
+### Missing LLVM, clang, or OpenSSL during a build
 
-This error only occurs when **building from source**. Install LLVM 17+:
+Install the source-build dependencies for your platform:
 
 ```bash
 # Ubuntu / Debian
-sudo apt-get install llvm-17 clang-17
+sudo apt-get install clang-18 llvm-18 libssl-dev jq
 
 # Fedora / RHEL
-sudo dnf install llvm17 clang17
+sudo dnf install clang llvm llvm-devel openssl-devel jq
 
 # macOS (Homebrew)
-brew install llvm
+brew install jq llvm openssl@3
 ```
 
-If LLVM is installed but not detected, set the path explicitly:
+If Homebrew LLVM is installed but `llvm-link` is not detected, put it on `PATH`:
 
 ```bash
-LLVM_PREFIX=/usr/lib/llvm-17 make compile
+export PATH="$(brew --prefix llvm)/bin:$PATH"
 ```
 
-Pre-built release binaries require LLVM 17+ to be installed on your system
-(see [LLVM](#llvm) above).
+If macOS cannot find OpenSSL at link time, set:
+
+```bash
+export SAILFIN_OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+```
 
 ### GitHub API rate limiting during install
 
@@ -391,11 +415,11 @@ The install script calls the GitHub Releases API to find the latest version. If
 you hit rate limits (common in CI environments), set a GitHub token:
 
 ```bash
-GITHUB_TOKEN=ghp_your_token_here curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/SailfinIO/sailfin/main/install.sh | GITHUB_TOKEN=ghp_your_token_here bash
 ```
 
-Alternatively, pin the version explicitly with `VERSION=0.5.1` — this
-skips the API call and downloads the asset directly.
+Alternatively, pin the version explicitly with `VERSION=<version>` — this
+constructs the asset name directly and can avoid the release-list lookup.
 
 ### Windows: script execution policy
 

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -316,10 +316,10 @@ sfn --version
 **Example output:**
 
 ```
-sfn 0.5.1
+sfn <version>
 ```
 
-The version string follows semantic versioning: `<major>.<minor>.<patch>` for stable releases, `<major>.<minor>.<patch>-alpha.<n>` for pre-releases. Local dev builds include a git hash suffix: `<version>+dev.<hash>` (e.g. `sfn 0.5.1+dev.abc1234`).
+The version string follows semantic versioning: `<major>.<minor>.<patch>` for stable releases, `<major>.<minor>.<patch>-alpha.<n>` for pre-releases. Local dev builds include a git hash suffix: `<version>+dev.<hash>`.
 
 The version is read from `compiler/capsule.toml` at runtime. For installed binaries where that file is not available, a baked-in fallback is used.
 
@@ -482,20 +482,30 @@ A project with no `[toolchain]` section is unaffected — the gate is a no-op.
 
 The repository Makefile provides higher-level build orchestration for the self-hosting workflow. These targets are for working on the Sailfin compiler itself; end users generally only need `sfn run` and `sfn test`.
 
+For host dependencies, OpenSSL setup, and the full source-build environment
+guide, see
+[`docs/development-setup.md`](https://github.com/SailfinIO/sailfin/blob/main/docs/development-setup.md).
+
 ### Complete target reference
 
 | Target | Description |
 |---|---|
 | `make compile` | Build the native compiler binary from a released seed, using the self-hosting pipeline. Skips rebuild if the binary is up to date. |
-| `make rebuild` | Force a rebuild from a released seed regardless of timestamps. Routes through `<seed> build -p compiler` (the self-hosting driver path); the prior `scripts/build.sh` orchestrator was retired in Stage E PR7 (#383) and is no longer in-tree. |
+| `make rebuild` | Force a rebuild from a released seed regardless of timestamps. Routes through `<seed> build -p compiler`. |
 | `make install` | Install the built compiler binary into `$(BINDIR)` (default: `~/.local/bin`). Requires `make compile` to have run first. |
 | `make check` | Compile (if needed), build a `sailfin-seedcheck` binary, verify it can run `hello-world.sfn`, then run the full test suite against it. This is the authoritative CI gate. |
-| `make test` | Run the full Sailfin-native test suite (unit + integration + e2e). Requires `make compile` first. |
+| `make check-strict` | Same as `make check`, but a stage2/stage3 fixed-point mismatch is fatal. |
+| `make check-fast` | Run `sfn check` over `compiler/src/` and `runtime/` without codegen or clang. |
+| `make test` | Run the full Sailfin-native test suite (unit + integration + e2e + capsule tests). Builds first if `build/bin/sfn` is missing. |
 | `make test-unit` | Run unit tests from `compiler/tests/unit/*_test.sfn`. |
 | `make test-integration` | Run integration tests from `compiler/tests/integration/*_test.sfn`. |
 | `make test-e2e` | Run end-to-end tests from `compiler/tests/e2e/*_test.sfn`. |
-| `make package` | Build and package native artifacts into `dist/`. Used for release artifacts. |
-| `make fetch-seed` | Download the pinned seed compiler (`bootstrap.toml [seed].version`, override with `SEED_VERSION`) from GitHub Releases into `build/toolchains/seed/`. Requires `GITHUB_TOKEN`. |
+| `make test-capsules` | Run per-capsule tests under `capsules/`. |
+| `make package` | Build and package native artifacts into `dist/`. |
+| `make fetch-seed` | Download the pinned seed compiler (`bootstrap.toml [seed].version`, override with `SEED_VERSION`) from GitHub Releases into `build/toolchains/seed/`. Set `GITHUB_TOKEN` to raise GitHub API rate limits. |
+| `make bench` | Benchmark compiler per-module compile time and memory. |
+| `make bench-runtime` | Benchmark compiled-program runtime execution. |
+| `make mcp-server` | Build the Sailfin MCP server under `tools/mcp-server/`. |
 | `make clean` | Remove `dist/` packaged artifacts. Does not remove build intermediates. |
 | `make clean-build` | Remove `build/` artifacts (keeps the seed toolchain under `build/toolchains/` by default). Pass `KEEP_SEED=0` to also remove `build/toolchains/`. |
 | `make clean-all` | Remove both `dist/` and `build/` artifacts completely. |
@@ -503,11 +513,18 @@ The repository Makefile provides higher-level build orchestration for the self-h
 
 ---
 
-### Parallelism
+### Parallelism and validation shape
 
-`<seed> build -p compiler` (the path `make rebuild` now routes through, as of Stage E PR2) runs `stage_capsule_imports` and `compile_capsule_modules` in parallel via the resolver's xargs fan-out (Stage E PR3 / #278). Cold builds measure **~2m27s** on a 4-core box with the parallel resolver — matching the historical ~2 min with `--jobs 4` that the prior (now retired) `bash scripts/build.sh` used to provide. Parallelism is controlled by `SAILFIN_BUILD_JOBS` (default: `nproc`, clamped to `[1, 8]`); `SAILFIN_BUILD_JOBS=1` keeps the pre-PR3 sequential path available as a regression-bisect escape hatch. The formerly-load-bearing `scripts/build.sh` was deleted in Stage E PR7 (#383); there is no longer a parallel-build escape hatch outside the driver.
+`make rebuild` routes through `<seed> build -p compiler`; the Sailfin-native
+driver owns compiler module scheduling. The driver reads
+`SAILFIN_BUILD_JOBS`; set it to a positive integer for build-parallelism
+bisects or memory-constrained hosts.
 
-The `~2 GB-per-job` divisor reflects the per-module peak RSS documented in `docs/proposals/0006-build-architecture.md` → Phase 6 (heaviest module ~1.76 GB after the `lowering_core.sfn` decomposition). With 2 jobs running the heaviest pair concurrently, peak concurrent memory is ~3.5 GB — fits the macOS 7 GB ceiling with OS + Actions agent overhead. Hosts with more RAM are still capped by `nproc` first.
+`make test` parallelism is controlled by `TEST_JOBS`, which is auto-detected
+from CPU and memory. `make check` uses `CHECK_TEST_JOBS` for its cold seedcheck
+suite and `CHECK_TEST_TIMEOUT` for the per-test timeout. Use
+`SELFHOST_STRICT=1` or `make check-strict` when a stage2/stage3 fixed-point
+mismatch must fail the run.
 
 ---
 
@@ -518,20 +535,35 @@ These environment variables influence the behavior of `sfn` and the Makefile bui
 | Variable | Scope | Description |
 |---|---|---|
 | `SAILFIN_RUNTIME_ROOT` | `sfn` binary | Override the directory where `sfn` looks for the bundled runtime. By default, the runtime is resolved relative to the executable. |
+| `SAILFIN_MEM_LIMIT` | `sfn` binary | Override the compiler's Linux self-applied 8 GiB virtual-memory cap. Use bytes, `unlimited`, `off`, or `0`. |
+| `SAILFIN_OPENSSL_PREFIX` | build/link | Override macOS OpenSSL discovery. The driver expects libraries under `$SAILFIN_OPENSSL_PREFIX/lib`. |
+| `SAILFIN_BUILD_JOBS` | `sfn build -p compiler` | Override compiler module scheduling inside the build driver. Use `1` for serial bisects or a small value on memory-constrained hosts. |
 | `SFN_REGISTRY` | `sfn add` / `sfn publish` | Override the package registry base URL for this shell. Takes precedence over `~/.sfn/config.toml`. See [`sfn config`](#sfn-config-getsetunsetlist-key-value). |
 | `SFN_TOKEN` | `sfn publish` | Bearer token used when uploading a capsule. Takes precedence over `~/.sfn/credentials` written by `sfn login`. |
 | `SAILFIN_SKIP_TOOLCHAIN_CHECK` | `sfn build`/`run`/`check`/`test` | Set to `1` to downgrade a `[toolchain]` pin mismatch from a hard error to a warning for every invocation in the shell/CI job. See [Toolchain Pinning Flags](#toolchain-pinning-flags). |
 | `SAILFIN_TOOLCHAIN` | `sfn build`/`run`/`check`/`test` | Controls the toolchain-pin mismatch response: `auto` (default) fetches + verifies + re-execs the pinned toolchain; `local` verifies only and errors on mismatch; `<version>` forces that dispatch target; `off` (or `0`) has the same effect as `SAILFIN_SKIP_TOOLCHAIN_CHECK=1`. See [Toolchain Pinning Flags](#toolchain-pinning-flags). |
 | `SAILFIN_TOOLCHAIN_DISPATCHED` | `sfn build`/`run`/`check`/`test` | Set automatically by `sfn` before re-exec'ing a dispatched toolchain (`=<version>`) as a re-entrancy guard; not intended to be set by hand. |
 | `PREFIX` | Makefile | Installation prefix. Defaults to `$HOME/.local`. The binary is installed to `$(PREFIX)/bin`. |
+| `BINDIR` | Makefile | Installation bin directory. Defaults to `$(PREFIX)/bin`. |
+| `INSTALL_NAME` | Makefile | Installed binary name. Defaults to `sfn`. |
+| `DESTDIR` | Makefile | Staging prefix for packaging-style installs. |
 | `GLOBAL_BIN_DIR` | Installer script | Override the installation bin directory directly (takes precedence over `PREFIX`). |
-| `GITHUB_TOKEN` | `make fetch-seed` | GitHub personal access token used to download seed releases from the `SailfinIO/sailfin` repository. Required for `make fetch-seed`. |
-| `BUILD_JOBS` | Makefile | Number of parallel compile jobs. Default: `1`. |
-| `BUILD_ARGS` | Makefile | Extra arguments passed through to the build orchestrator script. |
+| `GITHUB_TOKEN` | installer / `make fetch-seed` | GitHub token used to raise API rate limits and access release assets. |
+| `BUILD_ARGS` | Makefile | Extra arguments passed through to `sfn build -p compiler`, for example `--no-cache --cache-trace`. |
 | `SEED` | Makefile | Path to (or name of) the seed compiler used as the bootstrap. Defaults to the fetched repo-local seed alias, `build/toolchains/seed/bin/sfn` (`sfn.exe` on Windows). |
-| `SEED_VERSION` | Makefile | Version tag of the seed to fetch. Defaults to `latest`. |
-| `NATIVE_OPT` | Makefile | Optimization level passed to `clang` when compiling LLVM IR. Defaults to `-O2`. |
+| `SEED_VERSION` | Makefile | Version tag of the seed to fetch. Defaults to `bootstrap.toml [seed].version`. |
+| `SEED_NATIVE` | Makefile | One-off path to the seed used by `make rebuild`, taking precedence over `SEED`. |
+| `NATIVE_BIN` | Makefile | Compiler binary used by test, check, and bench targets. Defaults to `build/bin/sfn`. |
+| `NATIVE_OUT` | Makefile | Output path for `make rebuild`. Defaults to `build/bin/sfn`. |
 | `CLANG` | Makefile | `clang` executable to use. Defaults to `clang`. |
+| `SAILFIN_CC` | Makefile on macOS | Target of the local clang shim used by seed/built compiler subprocesses. Defaults to `/usr/bin/clang`. |
+| `CLANG_LL_FLAGS` | Makefile | Extra flags when compiling `.ll` files with clang. |
+| `TEST_JOBS` | Makefile | Parallel `sfn test --jobs N` children for `make test*`. Defaults to auto-detected CPU/memory budget. |
+| `CHECK_TEST_JOBS` | Makefile | Parallelism for `make check` test legs. Defaults to `TEST_JOBS`. |
+| `CHECK_TEST_TIMEOUT` | Makefile | Per-test timeout for `make check`'s cold full-suite leg. Defaults to `1800`. |
+| `CHECK_FULL_PASS1` | Makefile | Set to `1` to restore the older full first-pass suite before seedcheck. |
+| `SELFHOST_STRICT` | Makefile | Set to `1` to make stage2/stage3 fixed-point mismatch fatal. |
+| `JSON=1` | Makefile | Enable structured agent reports for agent-facing targets. |
 | `KEEP_SEED` | `make clean-build` | Set to `0` to also delete `build/toolchains/` during `make clean-build`. Defaults to `1` (the seed toolchain is preserved). |
 
 ### Debug and trace variables
@@ -540,11 +572,15 @@ These variables enable verbose runtime diagnostics. They are intended for compil
 
 | Variable | Description |
 |---|---|
-| `SAILFIN_TRACE_ARGV` | Print the argument vector received by `sailfin_cli_main` on startup (honored by the Sailfin entry point in `compiler/src/cli_main.sfn`). |
-| `SAILFIN_TRACE_CRASH` | Enable extended crash diagnostics. |
-| `SAILFIN_TRACE_ALLOC_STATS` | Print allocation statistics on exit. |
-| `SAILFIN_TRACE_LARGE_ARRAY_BACKTRACE` | Capture backtraces for unusually large array allocations. |
-| `SAILFIN_DEBUG_DUMP_BUDGET` | Control debug-dump output budget. |
+| `SAILFIN_TRACE_ARGV` | Print the argument vector received by the CLI entry point. |
+| `SAILFIN_TRACE_LINK` | Print resolved clang/link command details. |
+| `SAILFIN_CACHE_TRACE` | Print build cache hit/miss diagnostics; equivalent to `--cache-trace` on build/run paths. |
+| `SAILFIN_TEST_TIMEOUT` | Override the per-test timeout used by `sfn test`. |
+| `SAILFIN_TEST_KEEP_SCRATCH` | Keep `sfn test` scratch directories for post-mortem debugging. |
+| `SAILFIN_TRACE_LOWERING` | Enable LLVM lowering trace output for compiler debugging. |
+| `SAILFIN_DUMP_ARENA_STATS` | Print runtime arena statistics on exit. |
+| `SAILFIN_DEBUG_FORCE_PANIC` | Force an internal panic in a named compiler stage for ICE-path testing. |
+| `SAILFIN_INJECT_FAULT` | Inject transient emit failures for retry-path testing. |
 
 ---
 

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -63,7 +63,7 @@ Multiple path arguments group tests into named **suites** for reporting: each pa
 **Usage:**
 
 ```bash
-sfn test [--json] [path...]
+sfn test [--json] [-k NAME] [--tag TAG] [--update-snapshots] [--no-test-cache] [--jobs N] [--shard I/N] [--skip-toolchain-check] [path...]
 ```
 
 **Examples:**
@@ -79,6 +79,13 @@ sfn test compiler/tests/unit compiler/tests/integration capsules  # three suites
 
 | Flag | Description |
 |---|---|
+| `--json` | Emit a JSONL event stream. |
+| `-k NAME` | Only run tests whose name contains `NAME`. |
+| `--tag TAG` | Only run tests carrying `@tag("TAG")`. |
+| `--update-snapshots` | Re-baseline snapshot golden files. |
+| `--no-test-cache` | Bypass the per-test linked-binary cache. |
+| `--jobs N` | Run up to `N` per-file test children concurrently. |
+| `--shard I/N` | Run only the `I`-th of `N` file-count-balanced shards. |
 | `--skip-toolchain-check` | Bypass the `[toolchain]` pin check for this invocation — see [Toolchain Pinning Flags](#toolchain-pinning-flags) |
 
 > **Note:** `--filter` is not yet supported. To narrow test scope, pass a specific file or directory path.

--- a/site/src/pages/dl.astro
+++ b/site/src/pages/dl.astro
@@ -227,7 +227,7 @@ const featured = allAssets;
   <section class="dl-source">
     <div class="container">
       <h2>Build from Source</h2>
-      <p class="section-desc">Clone the repository and build the self-hosted compiler via LLVM. Requires LLVM 17+, clang, and make.</p>
+      <p class="section-desc">Clone the repository and build the self-hosted compiler via LLVM. Requires bash, make, jq, LLVM tools, clang, and OpenSSL development libraries.</p>
       <div class="code-block source-block">
         <code>git clone https://github.com/SailfinIO/sailfin.git && cd sailfin && make compile && make install</code>
       </div>


### PR DESCRIPTION
## Summary

- Add a canonical `docs/development-setup.md` for compiler/runtime contributors, covering supported hosts, required dependencies, per-platform install commands, setup flow, Makefile overrides, `sfn build` flags, and runtime/toolchain environment variables.
- Refresh install and CLI reference docs to remove stale `0.5.1` guidance, document the current seed/source-build model, OpenSSL dependency, curl-pipe env usage, and current Makefile/test knobs.
- Cross-link the setup guide from the README, docs index, contributor guide, and downloads page.

## Validation

- `git diff --check`
- `npm run build` from `site/` (passes; existing warnings remain for `ebnf` highlighting, missing `LINEAR_API_KEY`, and download-page capsule-manifest fallback)