### PR TITLE
fix(perf-history): seed-scope regression baseline + cap systemic floods (SFN-330)

### DIFF
--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -55,6 +55,11 @@ env:
   PERF_THRESHOLD_PCT: "10"
   BUILD_BUDGET_S: "300"
   DATA_BRANCH: "bench-data"
+  # Systemic-flood cap: if more than this many distinct modules regress in a
+  # single run — the signature of an environmental shift (seed bump, runner /
+  # toolchain change) rather than that many independent code regressions —
+  # file one aggregated issue instead of one-per-module (SFN-330).
+  PERF_SYSTEMIC_MODULES: "10"
 
 jobs:
   perf-history:
@@ -274,7 +279,54 @@ jobs:
             --force >/dev/null 2>&1 || true
 
           data_url="${{ github.server_url }}/${REPO}/tree/${DATA_BRANCH}"
-          cut -f1 regressions.tsv | sort -u | while IFS= read -r module; do
+
+          # Systemic-flood cap (SFN-330): count distinct regressing modules,
+          # excluding the <whole-build> budget pseudo-row (which always files
+          # its own issue). When more than PERF_SYSTEMIC_MODULES regress at
+          # once, that is an environmental shift, not that many independent
+          # code regressions — file ONE aggregated issue and drop the per-
+          # module fan-out. The seed-scoped baseline in perf_history.sh already
+          # suppresses the seed-bump case upstream; this is the backstop for
+          # any other broad shift (runner class, toolchain, a cross-cutting
+          # change).
+          modules_file="$(mktemp)"
+          cut -f1 regressions.tsv | grep -vFx '<whole-build>' | sort -u > "$modules_file" || true
+          module_count="$(grep -c . "$modules_file" || true)"
+          has_wholebuild="$(cut -f1 regressions.tsv | grep -cFx '<whole-build>' || true)"
+
+          remaining_file="$(mktemp)"
+          if [ "${module_count:-0}" -gt "${PERF_SYSTEMIC_MODULES}" ]; then
+            syn_title="perf regression: systemic — ${module_count} modules (${SHA:0:12})"
+            {
+              echo "# ${syn_title}"
+              echo ""
+              echo "Auto-filed by \`perf-history.yml\` (SFEP-0037 §3.3). **${module_count}** modules regressed beyond +${PERF_THRESHOLD_PCT}% vs the rolling median in a single nightly run. A broad simultaneous shift is almost always a shared environmental cause (seed bump, runner class, toolchain change) rather than ${module_count} independent code regressions, so this is filed as **one** aggregated issue instead of ${module_count} per-module issues (SFN-330). Investigate the shared cause first; see \`docs/perf/bench-history.md\` for how to read \`${DATA_BRANCH}\` and reproduce locally (\`make bench\`)."
+              echo ""
+              echo "**Run:** ${RUN_URL}"
+              echo "**Commit:** \`${SHA}\`"
+              echo "**Baseline:** rolling median of the last ${PERF_MIN_RUNS} same-seed runs on \`${DATA_BRANCH}\` (threshold +${PERF_THRESHOLD_PCT}%)"
+              echo "**Data:** ${data_url}"
+              echo ""
+              echo "## Regressed modules (${module_count})"
+              echo ""
+              awk -F'\t' '$1 != "<whole-build>" { printf "- **%s** / %s: current `%s` vs median `%s` (**+%s%%**)\n", $1, $2, $3, $4, $5 }' regressions.tsv
+            } > perf-systemic-body.md
+            new_number="$(gh issue create --repo "$REPO" \
+              --title "$syn_title" \
+              --label "type:perf" \
+              --label "perf-regression" \
+              --body-file perf-systemic-body.md \
+              | awk -F/ '/^https:/{print $NF}')"
+            echo "[perf-history] systemic regression: opened aggregated issue #${new_number} for ${module_count} modules"
+            # Only the whole-build budget breach (if any) still files below.
+            : > "$remaining_file"
+            [ "${has_wholebuild:-0}" -gt 0 ] && printf '%s\n' '<whole-build>' > "$remaining_file"
+          else
+            cp "$modules_file" "$remaining_file"
+            [ "${has_wholebuild:-0}" -gt 0 ] && printf '%s\n' '<whole-build>' >> "$remaining_file"
+          fi
+
+          while IFS= read -r module; do
             [ -n "$module" ] || continue
             title="perf regression: ${module}"
             metrics="$(awk -F'\t' -v m="$module" \
@@ -292,7 +344,7 @@ jobs:
             {
               echo "**Run:** ${RUN_URL}"
               echo "**Commit:** \`${SHA}\`"
-              echo "**Baseline:** rolling median of the last ${PERF_MIN_RUNS} runs on \`${DATA_BRANCH}\` (threshold +${PERF_THRESHOLD_PCT}%)"
+              echo "**Baseline:** rolling median of the last ${PERF_MIN_RUNS} same-seed runs on \`${DATA_BRANCH}\` (threshold +${PERF_THRESHOLD_PCT}%)"
               echo "**Data:** ${data_url}"
               echo ""
               echo "${metrics}"
@@ -322,7 +374,7 @@ jobs:
                 | awk -F/ '/^https:/{print $NF}')"
               echo "[perf-history] opened issue #${new_number} for ${module}"
             fi
-          done
+          done < "$remaining_file"
 
       - name: Upload run CSVs (artifact)
         if: always()

--- a/compiler/tests/e2e/perf_history_compare_test.sfn
+++ b/compiler/tests/e2e/perf_history_compare_test.sfn
@@ -1,0 +1,88 @@
+// compiler/tests/e2e/perf_history_compare_test.sfn
+//
+// Regression coverage for the seed-scoped baseline in
+// `scripts/perf_history.sh compare` (SFN-330). The nightly perf-history job
+// once filed one issue per module on a seed bump because the rolling-median
+// baseline mixed samples from different pinned seeds; a new seed rebuilds
+// every module with a different compiler binary, shifting all timings at once
+// and tripping the +10% gate tree-wide. The compare now windows each module
+// against same-seed samples only, so a seed change resets the baseline (a
+// module falls through the per-module cold-start skip until N same-seed runs
+// accrue) while a genuine same-seed regression is still caught.
+//
+// Drives the script as a subprocess (no bash e2e scripts — see
+// .claude/rules/no-bash-e2e.md) and asserts on captured stdout/stderr.
+import { contains } from "sfn/strings";
+
+// The compare path is pure shell/awk with no gh dependency, so bash plus the
+// coreutils it calls (cut/grep/awk/mktemp) is all the child needs — thread
+// PATH (and HOME/TMPDIR for good measure); run_capture's empty env is the
+// EMPTY environment, not "inherit".
+fn _child_env() -> string[] ![io] {
+    let mut e: string[] = [];
+    let path = env.get("PATH");
+    if path.length > 0 { e.push("PATH=" + path); }
+    let home = env.get("HOME");
+    if home.length > 0 { e.push("HOME=" + home); }
+    let tmpdir = env.get("TMPDIR");
+    if tmpdir.length > 0 { e.push("TMPDIR=" + tmpdir); }
+    return e;
+}
+
+fn _header() -> string {
+    return "run_sha,run_date,module,time_s,peak_kb,ir_lines,status,seed_version\n";
+}
+
+// Eight prior nightly runs (distinct shas = chronological order) at a stable
+// 1.0s / 10000kb for both foo and bar, all produced by `seed`.
+fn _prior_rows(seed: string) -> string {
+    let mut s = "";
+    let mut i = 1;
+    loop {
+        if i > 8 { break; }
+        let day = number_to_string(i);
+        s = s + "sha" + day + ",2026-07-01,foo,1.0,10000,500,OK," + seed + "\n";
+        s = s + "sha" + day + ",2026-07-01,bar,1.0,10000,500,OK," + seed + "\n";
+        i += 1;
+    }
+    return s;
+}
+
+fn _run_compare(dir: string) -> int ![io] {
+    return process.run_capture(["bash", "scripts/perf_history.sh", "compare", "--data-dir", dir, "--sha", "cur", "--min-runs", "7", "--threshold-pct", "10", "--out", dir
+        + "/out.tsv"], _child_env());
+}
+
+test "perf-history: a seed bump resets baselines and files no regressions" ![io] {
+    let dir = "build/perf-history-compare-test/seedbump";
+    fs.createDirectory(dir, true);
+    // Prior runs under 0.7.0; current run under the bumped 0.8.0 with every
+    // module 2x slower and 2x peak — a cross-seed comparison WOULD flag the
+    // whole tree, but same-seed windowing leaves the current run with zero
+    // baseline samples, so nothing is filed.
+    let csv = _header() + _prior_rows("0.7.0")
+        + "cur,2026-07-12,foo,2.0,20000,500,OK,0.8.0\n"
+        + "cur,2026-07-12,bar,2.0,20000,500,OK,0.8.0\n";
+    fs.writeFile(dir + "/compile.csv", csv);
+    let _exit = _run_compare(dir);
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    assert contains(out, "no regressions detected");
+    assert contains(err, "seed changed");
+}
+
+test "perf-history: a same-seed regression is still caught" ![io] {
+    let dir = "build/perf-history-compare-test/sameseed";
+    fs.createDirectory(dir, true);
+    // Same seed throughout; foo jumps 1.0 -> 1.5 (+50%) while bar and every
+    // peak_kb stay flat, so exactly one regression line (foo/time_s) is
+    // written.
+    let csv = _header() + _prior_rows("0.8.0")
+        + "cur,2026-07-12,foo,1.5,10000,500,OK,0.8.0\n"
+        + "cur,2026-07-12,bar,1.0,10000,500,OK,0.8.0\n";
+    fs.writeFile(dir + "/compile.csv", csv);
+    let _exit = _run_compare(dir);
+    let out = process.capture_take_stdout();
+    let _err = process.capture_take_stderr();
+    assert contains(out, "1 regression line(s) written");
+}

--- a/compiler/tests/e2e/perf_history_compare_test.sfn
+++ b/compiler/tests/e2e/perf_history_compare_test.sfn
@@ -64,9 +64,13 @@ test "perf-history: a seed bump resets baselines and files no regressions" ![io]
         + "cur,2026-07-12,foo,2.0,20000,500,OK,0.8.0\n"
         + "cur,2026-07-12,bar,2.0,20000,500,OK,0.8.0\n";
     fs.writeFile(dir + "/compile.csv", csv);
-    let _exit = _run_compare(dir);
+    let exit = _run_compare(dir);
     let out = process.capture_take_stdout();
     let err = process.capture_take_stderr();
+    // compare exits 0 on the no-regression path; a non-zero exit means the
+    // script itself broke (bad flag, missing tool) and must fail the test
+    // rather than be masked by a summary-text match.
+    assert exit == 0;
     assert contains(out, "no regressions detected");
     assert contains(err, "seed changed");
 }
@@ -81,8 +85,9 @@ test "perf-history: a same-seed regression is still caught" ![io] {
         + "cur,2026-07-12,foo,1.5,10000,500,OK,0.8.0\n"
         + "cur,2026-07-12,bar,1.0,10000,500,OK,0.8.0\n";
     fs.writeFile(dir + "/compile.csv", csv);
-    let _exit = _run_compare(dir);
+    let exit = _run_compare(dir);
     let out = process.capture_take_stdout();
     let _err = process.capture_take_stderr();
+    assert exit == 0;
     assert contains(out, "1 regression line(s) written");
 }

--- a/scripts/perf_history.sh
+++ b/scripts/perf_history.sh
@@ -168,11 +168,12 @@ cmd_compare() {
         NR == 1 { next }
         NF == 0 { next }
         {
-            sha = $1; module = $3; t = $4 + 0; p = $5 + 0; st = $7
+            sha = $1; module = $3; t = $4 + 0; p = $5 + 0; st = $7; sv = $8
             if (!(sha in seen)) { seen[sha] = 1; order[++n] = sha }
+            runseed[sha] = sv
             k = sha SUBSEP module
-            tval[k] = t; pval[k] = p; sval[k] = st
-            if (sha == CUR) curmods[module] = 1
+            tval[k] = t; pval[k] = p; sval[k] = st; svval[k] = sv
+            if (sha == CUR) { curmods[module] = 1; cur_seed = sv }
         }
         END {
             pc = 0
@@ -181,25 +182,40 @@ cmd_compare() {
                 printf("perf_history: cold start — %d prior run(s) < %d required; no comparison\n", pc, N) > "/dev/stderr"
                 exit 0
             }
-            wstart = pc - N + 1
+            # Seed-scoped baseline: a module is compared only against prior
+            # samples produced by the SAME pinned seed (compile.csv col 8,
+            # seed_version). A seed bump rebuilds every module with a different
+            # compiler binary, shifting all timings/RSS at once; comparing
+            # across that boundary flags the whole tree as regressed and floods
+            # triage (SFN-330). After a bump a module has < N same-seed samples
+            # and falls through the per-module cold-start skip below until N
+            # nightlies accrue under the new seed.
+            if (cur_seed != "" && runseed[prior[pc]] != "" && runseed[prior[pc]] != cur_seed) {
+                printf("perf_history: seed changed %s -> %s; per-module baselines reset (need %d same-seed runs before comparison resumes)\n", runseed[prior[pc]], cur_seed, N) > "/dev/stderr"
+            }
             for (module in curmods) {
                 ck = CUR SUBSEP module
                 if (!(ck in tval) || sval[ck] ~ /FAIL/) continue
-                tc = 0; mc = 0
-                for (i = wstart; i <= pc; i++) {
+                # Same-seed, non-FAIL prior samples for this module, in
+                # chronological (append) order; the rolling window is the last
+                # N of these.
+                tc = 0
+                for (i = 1; i <= pc; i++) {
                     bk = prior[i] SUBSEP module
-                    if ((bk in tval) && sval[bk] !~ /FAIL/) {
-                        tsamp[++tc] = tval[bk]; psamp[++mc] = pval[bk]
+                    if ((bk in tval) && sval[bk] !~ /FAIL/ && svval[bk] == cur_seed) {
+                        tsamp[++tc] = tval[bk]; psamp[tc] = pval[bk]
                     }
                 }
                 if (tc < N) { delete tsamp; delete psamp; continue }
-                mt = median(tsamp, tc); mp = median(psamp, mc)
+                w = 0
+                for (i = tc - N + 1; i <= tc; i++) { wt[++w] = tsamp[i]; wp[w] = psamp[i] }
+                mt = median(wt, N); mp = median(wp, N)
                 ct = tval[ck]; cp = pval[ck]
                 if (mt > 0 && ct > mt * (1 + TH / 100))
                     printf("%s\ttime_s\t%.4f\t%.4f\t%.1f\n", module, ct, mt, (ct / mt - 1) * 100)
                 if (mp > 0 && cp > mp * (1 + TH / 100))
                     printf("%s\tpeak_kb\t%.0f\t%.0f\t%.1f\n", module, cp, mp, (cp / mp - 1) * 100)
-                delete tsamp; delete psamp
+                delete tsamp; delete psamp; delete wt; delete wp
             }
         }
         ' "$compile_csv" >> "$out"


### PR DESCRIPTION
## Summary

The nightly `perf-history.yml` job auto-files one `perf regression: <module>` issue per module that drifts >10% above a rolling median. On 2026-07-12 it filed ~110 issues in a 3-minute window, flooding the Sailfin Triage queue. These were **not** real regressions: `scripts/perf_history.sh compare` computed each module's rolling-median baseline **without regard to which pinned seed produced each sample**. The seed bump to `0.8.0-alpha.5` (#2137) rebuilt every module with a different compiler binary, shifting all `time_s`/`peak_kb` at once, so the current (new-seed) run was compared against a median still full of old-seed samples — tripping the +10% gate tree-wide.

This touches the perf time-series tooling and the nightly workflow only — no compiler pass or runtime module.

Fixes SFN-330

## Changes

- **`scripts/perf_history.sh` (compare):** window each module's baseline against **same-seed** prior samples only (`compile.csv` col 8, `seed_version`). After a seed bump a module has `<N` same-seed samples and falls through the existing per-module cold-start skip until N nightlies accrue under the new seed; a genuine same-seed regression is still caught. Emits a `seed changed <old> -> <new>` note to stderr when the baseline resets.
- **`.github/workflows/perf-history.yml` (file-issues step):** systemic-flood cap — when more than `PERF_SYSTEMIC_MODULES` (default 10) distinct modules regress in one run, file **one aggregated issue** instead of one-per-module. This is the backstop for any other broad shift (runner class, toolchain) the seed guard doesn't cover; the `<whole-build>` wall-time budget breach still files its own issue.
- **tests:** `compiler/tests/e2e/perf_history_compare_test.sfn` — drives the compare script over fixture CSVs, asserting (a) a seed bump suppresses all regressions and (b) a real same-seed regression is still reported.

## Validation

- [x] `sfn fmt --check` clean on the new `.sfn` test (via the pinned `0.8.0-alpha.5` seed)
- [x] `sfn check` passes on the new test (only the expected W0210 bare-assert lint, idiomatic for `[io]` e2e tests)
- [x] New e2e test **run and passing** via the seed compiler (both cases green)
- [x] `bash -n` clean on `perf_history.sh`; workflow YAML parses; systemic-cap decision logic simulated across the 12-module / 3-module / whole-build-only cases
- [x] Regression coverage added under `compiler/tests/`
- [ ] `make compile` / `make check` — N/A, no `compiler/src/*.sfn` touched

## Notes for reviewers

- Defense-in-depth is intentional: the seed guard (script) suppresses the seed-bump class of flood *upstream* so it never reaches the file step; the systemic cap (workflow) is a backstop for other broad environmental shifts.
- The baseline window changed from a run-level last-N slice to a per-module last-N-same-seed slice — a slightly more robust median that also naturally implements the seed reset via the existing `tc < N` skip.
- Cleanup done alongside this PR (outside the diff): the ~126 already-filed false-positive issues were canceled as a seed-bump artifact, and 9 real hand-written issues buried under them were promoted out of Triage. SFN-330 is the standing record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeCKP7W8kttxrwxVnBS85

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKeCKP7W8kttxrwxVnBS85)_