### PR TITLE
fix(parser): parse turbofish type arguments on a call (SFN-329)

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -69,7 +69,15 @@ enum Expression {
     Call {
         callee: Expression,
         arguments: Expression[],
-        span: SourceSpan?
+        span: SourceSpan?,
+        // Explicit turbofish type arguments `f<T1, T2>(args)` (SFN-329).
+        // Empty for an ordinary or inference-resolved call; the field is
+        // appended last so the seed compiler's positional-GEP field
+        // indexing for the existing fields stays stable. Carried on the
+        // node for faithful parsing; the monomorphizer still resolves the
+        // repro forms by unifying argument types, so these are inert until
+        // the return-only-position turbofish gap (SFEP-0038) is closed.
+        type_arguments: TypeAnnotation[]
     },
     Index { sequence: Expression, index: Expression },
     Array { elements: Expression[] },

--- a/compiler/src/emit_native_desugar_try.sfn
+++ b/compiler/src/emit_native_desugar_try.sfn
@@ -318,7 +318,8 @@ fn replace_first_try(expression: Expression, bind_name: string) -> TryReplace {
                 expression: Expression.Call {
                     callee: callee.expression,
                     arguments: expression.arguments,
-                    span: expression.span
+                    span: expression.span,
+                    type_arguments: expression.type_arguments
                 },
                 operand: callee.operand,
                 found: true
@@ -330,7 +331,8 @@ fn replace_first_try(expression: Expression, bind_name: string) -> TryReplace {
                 expression: Expression.Call {
                     callee: expression.callee,
                     arguments: args.items,
-                    span: expression.span
+                    span: expression.span,
+                    type_arguments: expression.type_arguments
                 },
                 operand: args.operand,
                 found: true

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -754,7 +754,8 @@ fn _rewrite_expression(ctx: LiftContext, expression: Expression) -> ExpressionRe
             expression: Expression.Call {
                 callee: renamed_callee,
                 arguments: new_args,
-                span: expression.span
+                span: expression.span,
+                type_arguments: expression.type_arguments
             }
         };
     }

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -1290,9 +1290,29 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             current_expression = Expression.Call {
                 callee: current_expression,
                 arguments: call_result.arguments,
-                span: null
+                span: null,
+                type_arguments: []
             };
             continue;
+        }
+        // Turbofish call `f<T1, T2>(args)` (SFN-329). A bare `<` in postfix
+        // position is ambiguous with the less-than comparison operator, so we
+        // speculatively scan a balanced `< ... >` type-argument list and
+        // COMMIT to a generic call only when `(` immediately follows the
+        // closing `>`. A `<` that does not fit that shape is left unconsumed
+        // and breaks the chain, so the precedence climb parses it as a
+        // comparison (`x < y > z` is unchanged). Gated to an `Identifier`
+        // callee — member turbofish (`x.f<T>()`) is out of scope (SFN-329).
+        if strings_equal(sym, "<") {
+            if current_expression.variant == "Identifier" {
+                let turbofish = parse_turbofish_call(current_state, current_expression);
+                if turbofish.success {
+                    current_state = turbofish.state;
+                    current_expression = turbofish.expression;
+                    continue;
+                }
+            }
+            break;
         }
         if strings_equal(sym, "[") {
             let index_state = expression_tokens_advance(current_state);
@@ -1359,6 +1379,120 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
     return ExpressionParseResult {
         state: current_state,
         expression: current_expression,
+        success: true
+    };
+}
+
+// ============================================================================
+// Turbofish Call Disambiguation (SFN-329)
+// ============================================================================
+// `state` is positioned at the `<` that follows a turbofish-eligible callee.
+// Speculatively scan a balanced `< ... >` type-argument list and, only when
+// `(` immediately follows the closing `>`, parse the call arguments and return
+// a `Call` carrying the explicit `type_arguments`. Any shape that is not
+// `<types>(` — an unbalanced list, an empty `<>`, or a `>` not followed by `(`
+// — returns `success:false` with the ORIGINAL `state` untouched, so the caller
+// leaves the `<` for the precedence climb to parse as a comparison. Nested
+// generic arguments (`f<Map<int, string>>(x)`) are supported via `>>`-degluing,
+// mirroring `read_cast_target`. The loop is input-driven, so it is bounded by a
+// guard counter.
+fn parse_turbofish_call(state: ExpressionTokens, callee: Expression) -> ExpressionParseResult {
+    // Consume the opening `<` (the caller confirmed it).
+    let mut cursor = expression_tokens_advance(state);
+    let mut type_arguments: TypeAnnotation[] = [];
+    let mut current_text: string = "";
+    let mut angle_depth: int = 1;
+    let mut guard: int = 0;
+
+    loop {
+        guard += 1;
+        if guard > 100000 { return expression_parse_failure(state); }
+        if expression_tokens_is_at_end(cursor) {
+            return expression_parse_failure(state);
+        }
+        let tok = expression_tokens_peek(cursor);
+        if tok.kind.variant != "Symbol" {
+            current_text = _cast_target_append(current_text, tok.lexeme);
+            cursor = expression_tokens_advance(cursor);
+            continue;
+        }
+        let lx = tok.lexeme;
+        if strings_equal(lx, "<") {
+            angle_depth += 1;
+            current_text = _cast_target_append(current_text, "<");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, ">>") {
+            // A `>>` closes two levels at once. It ends the outer list only
+            // when exactly two are open (the inner generic plus this list);
+            // the inner close becomes part of the current argument's text.
+            if angle_depth == 2 {
+                current_text = _cast_target_append(current_text, ">");
+                cursor = expression_tokens_advance(cursor);
+                angle_depth = 0;
+                break;
+            }
+            if angle_depth > 2 {
+                angle_depth -= 2;
+                current_text = _cast_target_append(current_text, ">>");
+                cursor = expression_tokens_advance(cursor);
+            } else {
+                // `angle_depth == 1`: a stray second `>` — not a turbofish.
+                return expression_parse_failure(state);
+            }
+        } else if strings_equal(lx, ">") {
+            angle_depth -= 1;
+            if angle_depth == 0 {
+                cursor = expression_tokens_advance(cursor);
+                break;
+            }
+            current_text = _cast_target_append(current_text, ">");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, ",") {
+            if angle_depth == 1 {
+                type_arguments.push(TypeAnnotation { text: current_text });
+                current_text = "";
+                cursor = expression_tokens_advance(cursor);
+            } else {
+                current_text = _cast_target_append(current_text, ",");
+                cursor = expression_tokens_advance(cursor);
+            }
+        } else {
+            current_text = _cast_target_append(current_text, lx);
+            cursor = expression_tokens_advance(cursor);
+        }
+    }
+
+    // Flush the final argument. An empty final slot is ignored, so a trailing
+    // comma (`<int,>`) is tolerated; a fully empty list (`<>`) yields no type
+    // arguments and is not a turbofish — fall back to comparison parsing.
+    if current_text.length > 0 {
+        type_arguments.push(TypeAnnotation { text: current_text });
+    }
+    if type_arguments.length == 0 { return expression_parse_failure(state); }
+
+    // Commit only when `(` immediately follows the type-argument list.
+    if expression_tokens_is_at_end(cursor) {
+        return expression_parse_failure(state);
+    }
+    let paren = expression_tokens_peek(cursor);
+    if paren.kind.variant != "Symbol" {
+        return expression_parse_failure(state);
+    }
+    if !strings_equal(paren.lexeme, "(") {
+        return expression_parse_failure(state);
+    }
+
+    let call_result = parse_call_arguments(cursor);
+    if !call_result.success { return expression_parse_failure(state); }
+
+    return ExpressionParseResult {
+        state: call_result.state,
+        expression: Expression.Call {
+            callee: callee,
+            arguments: call_result.arguments,
+            span: null,
+            type_arguments: type_arguments
+        },
         success: true
     };
 }

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -1402,6 +1402,13 @@ fn parse_turbofish_call(state: ExpressionTokens, callee: Expression) -> Expressi
     let mut type_arguments: TypeAnnotation[] = [];
     let mut current_text: string = "";
     let mut angle_depth: int = 1;
+    // Non-angle delimiter depths so a comma nested inside a function-pointer
+    // (`fn(int, int) -> int`), tuple, array, or object type argument is not
+    // mistaken for a top-level type-argument separator (mirrors
+    // `split_token_slices_by_comma` in parser/token_utils.sfn).
+    let mut paren_depth: int = 0;
+    let mut brace_depth: int = 0;
+    let mut bracket_depth: int = 0;
     let mut guard: int = 0;
 
     loop {
@@ -1417,7 +1424,31 @@ fn parse_turbofish_call(state: ExpressionTokens, callee: Expression) -> Expressi
             continue;
         }
         let lx = tok.lexeme;
-        if strings_equal(lx, "<") {
+        if strings_equal(lx, "(") {
+            paren_depth += 1;
+            current_text = _cast_target_append(current_text, "(");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, ")") {
+            if paren_depth > 0 { paren_depth -= 1; }
+            current_text = _cast_target_append(current_text, ")");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, "{") {
+            brace_depth += 1;
+            current_text = _cast_target_append(current_text, "{");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, "}") {
+            if brace_depth > 0 { brace_depth -= 1; }
+            current_text = _cast_target_append(current_text, "}");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, "[") {
+            bracket_depth += 1;
+            current_text = _cast_target_append(current_text, "[");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, "]") {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+            current_text = _cast_target_append(current_text, "]");
+            cursor = expression_tokens_advance(cursor);
+        } else if strings_equal(lx, "<") {
             angle_depth += 1;
             current_text = _cast_target_append(current_text, "<");
             cursor = expression_tokens_advance(cursor);
@@ -1448,7 +1479,9 @@ fn parse_turbofish_call(state: ExpressionTokens, callee: Expression) -> Expressi
             current_text = _cast_target_append(current_text, ">");
             cursor = expression_tokens_advance(cursor);
         } else if strings_equal(lx, ",") {
-            if angle_depth == 1 {
+            let top_level = angle_depth == 1 && paren_depth == 0 && brace_depth == 0
+                && bracket_depth == 0;
+            if top_level {
                 type_arguments.push(TypeAnnotation { text: current_text });
                 current_text = "";
                 cursor = expression_tokens_advance(cursor);

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -1423,7 +1423,8 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
         }, Expression.NumberLiteral {
             value: _assert_int_to_string(assert_col)
         }, Expression.StringLiteral { value: "assertion failed" }],
-        span: null
+        span: null,
+        type_arguments: []
     };
     let fail_statement = Statement.ExpressionStatement {
         expression: fail_call,

--- a/compiler/tests/e2e/fixtures/turbofish_call.sfn
+++ b/compiler/tests/e2e/fixtures/turbofish_call.sfn
@@ -1,0 +1,16 @@
+// Fixture for the turbofish end-to-end test (SFN-329). Exercises an
+// explicit type-argument call in both the single-argument form
+// (`id<int>(41)`) and the comma form (`pick<int>(4, 9)`). The declared type
+// parameter is inferable from the value arguments, so the existing
+// argument-unification monomorphizer resolves both instantiations; the
+// turbofish syntax must parse, typecheck, build, and run. Exit code 45
+// (41 + 4) is the observable acceptance signal.
+fn id<T>(x: T) -> T { return x; }
+
+fn pick<T>(a: T, b: T) -> T { return a; }
+
+fn main() -> int ![io] {
+    let a = id < int > (41);
+    let b = pick < int > (4, 9);
+    return a + b;
+}

--- a/compiler/tests/e2e/turbofish_call_run_test.sfn
+++ b/compiler/tests/e2e/turbofish_call_run_test.sfn
@@ -1,0 +1,55 @@
+// End-to-end coverage for turbofish calls (SFN-329). Drives the production
+// `sfn check` / `sfn build` paths as subprocesses to pin the acceptance
+// criteria: an explicit type-argument call `f<int>(args)` parses,
+// typechecks, builds, and runs — in both the single-argument and comma
+// forms. The type parameter is inferable from the value arguments, so the
+// existing argument-unification monomorphizer resolves the instantiation.
+//
+// Matchers note: the `sfn/test` `expect_*` matchers are `![pure]` and cannot
+// be called from an `![io]` test; assert on captured output / exit codes
+// instead (#842). Build isolation follows `.claude/rules/no-bash-e2e.md`:
+// the full parent environment is threaded (PATH for clang/ld,
+// SAILFIN_TEST_SCRATCH for per-invocation build-cache isolation under the
+// parallel pool).
+import { contains } from "sfn/strings";
+
+fn _sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/bin/sfn";
+}
+
+fn _child_env() -> string[] ![io] { return process.environ(); }
+
+fn _scratch_dir() -> string ![io] {
+    let mut dir = env.get("SAILFIN_TEST_SCRATCH");
+    if dir.length == 0 { dir = "/tmp"; }
+    fs.createDirectory(dir, true);
+    return dir;
+}
+
+test "turbofish e2e: explicit type-argument call typechecks clean" ![io] {
+    let exit = process.run_capture([_sfn_bin(), "check", "compiler/tests/e2e/fixtures/turbofish_call.sfn"], _child_env());
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    // The pre-fix misparse surfaced as E0808 (function-as-value); it must be
+    // gone now that `id<int>(...)` parses as a call.
+    assert ! contains(out + err, "E0808");
+    assert exit == 0;
+}
+
+test "turbofish e2e: single and comma forms build and run" ![io] {
+    let dir = _scratch_dir();
+    let bin = dir + "/sfn-turbofish-bin";
+    if fs.exists(bin) { fs.deleteFile(bin); }
+    let build_exit = process.run_capture([_sfn_bin(), "build", "-o", bin, "compiler/tests/e2e/fixtures/turbofish_call.sfn"], _child_env());
+    let _bo = process.capture_take_stdout();
+    let _be = process.capture_take_stderr();
+    assert build_exit == 0;
+    let run_exit = process.run_capture([bin], _child_env());
+    let _ro = process.capture_take_stdout();
+    let _re = process.capture_take_stderr();
+    if fs.exists(bin) { fs.deleteFile(bin); }
+    // 41 (id<int>) + 4 (pick<int>) = 45.
+    assert run_exit == 45;
+}

--- a/compiler/tests/unit/parser_turbofish_call_test.sfn
+++ b/compiler/tests/unit/parser_turbofish_call_test.sfn
@@ -1,0 +1,101 @@
+// Unit tests for turbofish call parsing (SFN-329).
+//
+// Before the fix, an explicit type-argument call `f<int>(x)` misparsed at
+// expression position: the postfix chain had no `<` arm, so the precedence
+// climb consumed `<`/`>` as comparison operators and produced the chained
+// comparison `(f < int) > (x)` (which then tripped E0808 / E0818). The fix
+// adds a turbofish arm to `parse_postfix_chain` that speculatively scans a
+// balanced `< ... >` type-argument list and commits to a `Call` — carrying
+// the explicit `type_arguments` — only when `(` immediately follows the
+// closing `>`. A `<` that does not fit that shape stays a comparison.
+import { Expression } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+// Initializer of the first top-level `let` in `source`.
+fn first_initializer(source: string) -> Expression ![io] {
+    let program = parse_program(source);
+    let stmt = program.statements[0];
+    assert stmt.variant == "VariableDeclaration";
+    let init = stmt.initializer;
+    assert init != null;
+    return init;
+}
+
+// -------------------------------------------------------------------
+// A single type argument: `id<int>(41)` is a `Call` carrying one explicit
+// type argument and the one value argument.
+// -------------------------------------------------------------------
+test "turbofish: single type argument parses as a call" ![io] {
+    let init = first_initializer("let x = id<int>(41);");
+    assert init.variant == "Call";
+    assert init.type_arguments.length == 1;
+    assert init.type_arguments[0].text == "int";
+    assert init.arguments.length == 1;
+    assert init.arguments[0].variant == "NumberLiteral";
+}
+
+// -------------------------------------------------------------------
+// The comma form `apply<int>(3, g)` no longer degrades to `Raw`: it is a
+// `Call` with both value arguments intact.
+// -------------------------------------------------------------------
+test "turbofish: call with comma arguments does not degrade to Raw" ![io] {
+    let init = first_initializer("let x = apply<int>(3, g);");
+    assert init.variant == "Call";
+    assert init.type_arguments.length == 1;
+    assert init.type_arguments[0].text == "int";
+    assert init.arguments.length == 2;
+}
+
+// -------------------------------------------------------------------
+// Multiple type arguments: `pair<int, string>(a, b)` splits the list into
+// two type arguments at the top-level comma.
+// -------------------------------------------------------------------
+test "turbofish: multiple type arguments split at the top-level comma" ![io] {
+    let init = first_initializer("let x = pair<int, string>(a, b);");
+    assert init.variant == "Call";
+    assert init.type_arguments.length == 2;
+    assert init.type_arguments[0].text == "int";
+    assert init.type_arguments[1].text == "string";
+    assert init.arguments.length == 2;
+}
+
+// -------------------------------------------------------------------
+// A nested generic type argument closes with `>>`: `wrap<Box<int>>(v)`
+// deglues the double-close into one inner `>` (kept in the argument text)
+// plus the list terminator, yielding a single type argument.
+// -------------------------------------------------------------------
+test "turbofish: nested generic type argument deglues the double close" ![io] {
+    let init = first_initializer("let x = wrap<Box<int>>(v);");
+    assert init.variant == "Call";
+    assert init.type_arguments.length == 1;
+    assert init.arguments.length == 1;
+}
+
+// -------------------------------------------------------------------
+// No regression: a genuine comparison chain `a < b > c` (no callee/`(`
+// shape) still parses as a comparison, not a turbofish call.
+// -------------------------------------------------------------------
+test "turbofish: comparison chain without a following paren stays a comparison" ![io] {
+    let init = first_initializer("let x = a < b > c;");
+    assert init.variant == "Binary";
+    assert init.operator == ">";
+}
+
+// -------------------------------------------------------------------
+// No regression: a single comparison `a < b` is unaffected.
+// -------------------------------------------------------------------
+test "turbofish: a bare less-than is still a comparison" ![io] {
+    let init = first_initializer("let x = a < b;");
+    assert init.variant == "Binary";
+    assert init.operator == "<";
+}
+
+// -------------------------------------------------------------------
+// No regression: an ordinary call carries no explicit type arguments.
+// -------------------------------------------------------------------
+test "turbofish: ordinary call has an empty type-argument list" ![io] {
+    let init = first_initializer("let x = id(41);");
+    assert init.variant == "Call";
+    assert init.type_arguments.length == 0;
+    assert init.arguments.length == 1;
+}

--- a/compiler/tests/unit/parser_turbofish_call_test.sfn
+++ b/compiler/tests/unit/parser_turbofish_call_test.sfn
@@ -60,6 +60,18 @@ test "turbofish: multiple type arguments split at the top-level comma" ![io] {
 }
 
 // -------------------------------------------------------------------
+// A comma nested inside a function-pointer type argument does not split
+// the type-argument list: `apply<fn(int, int) -> int>(f)` is one type
+// argument, not two (only top-level commas separate type arguments).
+// -------------------------------------------------------------------
+test "turbofish: comma inside a fn-pointer type argument does not split the list" ![io] {
+    let init = first_initializer("let x = apply<fn(int, int) -> int>(f);");
+    assert init.variant == "Call";
+    assert init.type_arguments.length == 1;
+    assert init.arguments.length == 1;
+}
+
+// -------------------------------------------------------------------
 // A nested generic type argument closes with `>>`: `wrap<Box<int>>(v)`
 // deglues the double-close into one inner `>` (kept in the argument text)
 // plus the list terminator, yielding a single type argument.


### PR DESCRIPTION
## Summary

An explicit type-argument call `f<int>(x)` (turbofish) misparsed at expression
position. `parse_postfix_chain` had no `<` arm, so the precedence climb consumed
`<`/`>` as comparison operators and produced the chained comparison
`(f < int) > (x)` — tripping `E0808` (function-as-value) for the single-arg form
and degrading the comma form `apply<int>(3, g)` to `Raw` (`E0818`). Generic
*declarations* (`fn id<T>`) already parsed; the gap was type *arguments* at a call
site.

The fix adds a turbofish arm to the postfix chain (parser only) that
speculatively scans a balanced `< ... >` type-argument list and commits to a
`Call` — carrying explicit type arguments — only when `(` immediately follows the
closing `>`; any other shape leaves `<` for the comparison path unchanged. The
existing argument-unification monomorphizer resolves the instantiation for the
repro forms, so explicit type arguments are carried on the node but not yet
threaded to `.sfn-asm` (the return-only-position gap is SFEP-0038 and out of
scope).

Fixes SFN-329

## Changes

- **ast** — `Expression.Call` gains a trailing `type_arguments: TypeAnnotation[]`
  field (appended last for positional-GEP layout stability; empty for ordinary /
  inference-resolved calls).
- **parser** (`parser/expressions.sfn`) — new `parse_turbofish_call` helper +
  a `<` arm in `parse_postfix_chain`, gated to an `Identifier` callee. Commits to
  a generic call only when `>` is immediately followed by `(`; balanced-angle scan
  with `>>`-degluing (mirrors `read_cast_target`), top-level-comma split, and an
  input-driven-loop guard. Member turbofish (`x.f<T>()`) stays out of scope.
- **parser/emitter threading** — the ordinary-call and assert-desugar sites
  construct `type_arguments: []`; the two try-desugar reconstructions
  (`emit_native_desugar_try.sfn`) and the lambda-lowering reconstruction
  (`lambda_lowering.sfn`) preserve the source node's `type_arguments`.
- **tests** — `parser_turbofish_call_test.sfn` (single arg, comma form,
  multi-arg split, nested `>>` deglue, `a < b > c` / `a < b` comparison
  preservation, ordinary-call empty list) and `turbofish_call_run_test.sfn` +
  `fixtures/turbofish_call.sfn` (drives `sfn check` / `build` / run; asserts
  `E0808` is gone and the program exits 45).

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes
- [x] `make compile` — compiler self-hosts (parser + AST change)
- [ ] `make check` — full suite + seedcheck (ran the targeted parser, generics,
  effect/concurrency, and new turbofish suites green; did not run the full
  ~15–20 min gate)
- [x] Regression coverage added under `compiler/tests/`

## Notes for reviewers

- **Ambiguity resolution:** bare-`<>` turbofish inherently cannot distinguish
  `id<int>(41)` from a `a < b > (c)` chained comparison, so the parser commits to
  a call whenever a balanced `< ... >` is immediately followed by `(` (the rule
  named in the issue's root-cause hypothesis). The hard acceptance criterion —
  `x < y > z` with no trailing paren stays a comparison — holds, and is tested.
- **Explicit args are carried, not yet lowered:** the monomorphizer resolves the
  repro forms by unifying argument types; threading explicit type arguments to
  `.sfn-asm` (needed for return-only-position `T`) is the SFEP-0038 gap and stays
  out of scope. The field is inert until then.
- Reviewed by the Opus `code-reviewer` (approve, conditional on confirming the
  ~14 untouched `Expression.Call {…}` test sites still compile with the new
  trailing field — verified green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY9snXqzvDTY3fP1mqNso6)_