### PR TITLE
feat(crypto): native crypto primitive layer for OpenSSL removal (SFEP draft-native-crypto Phase A)

### DIFF
--- a/capsules/sfn/crypto/src/bits.sfn
+++ b/capsules/sfn/crypto/src/bits.sfn
@@ -1,0 +1,82 @@
+// capsules/sfn/crypto/src/bits.sfn
+//
+// Constant-time / masking helper module for the sfn/crypto capsule
+// (SFEP draft-native-crypto.md §3.3-3.4). Centralizes the mandated
+// safe-integer idioms — 32-bit masking, rotates, constant-time byte
+// comparison, and big/little-endian word (de)serialization — so the
+// other Phase A primitives (sha1, sha384, chacha20, poly1305) call a
+// single tested source instead of re-inlining these expressions.
+// The 0xffffffff 32-bit mask as a decimal constant.
+fn mask32() -> int { return 4294967295; }
+
+// Rotate a 32-bit word left by n bits (0 <= n < 32). Result masked to 32
+// bits. `x` must already be a masked 32-bit value so `>>` (LLVM `ashr`)
+// behaves as a logical shift.
+fn rotl32(x: int, n: int) -> int {
+    return ((x << n) | (x >> (32 - n))) & 4294967295;
+}
+
+// Rotate a 32-bit word right by n bits (0 <= n < 32). Result masked to 32
+// bits. `x` must already be a masked 32-bit value so `>>` (LLVM `ashr`)
+// behaves as a logical shift.
+fn rotr32(x: int, n: int) -> int {
+    return ((x >> n) | (x << (32 - n))) & 4294967295;
+}
+
+// Constant-time byte-array equality. Returns false immediately on a length
+// mismatch (length is public), otherwise accumulates the OR of per-byte XOR
+// differences with no data-dependent branch or early return.
+fn ct_eq_bytes(a: int[], b: int[]) -> bool {
+    if a.length != b.length { return false; }
+
+    let mut diff: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= a.length { break; }
+        diff = diff | ((a[i] & 255) ^ (b[i] & 255));
+        i += 1;
+    }
+    return diff == 0;
+}
+
+// Read a big-endian 32-bit word from bytes[off..off+4]. Caller guarantees
+// off+4 <= bytes.length. Result in [0, 2^32).
+fn load_u32_be(bytes: int[], off: int) -> int {
+    return ((bytes[off] << 24) | (bytes[off + 1] << 16) | (bytes[off + 2] << 8) | bytes[off
+        + 3]) & 4294967295;
+}
+
+// Append the 4 big-endian bytes of the 32-bit word x to out (via out.push).
+fn store_u32_be(out: int[], x: int) -> void {
+    out.push((x >> 24) & 255);
+    out.push((x >> 16) & 255);
+    out.push((x >> 8) & 255);
+    out.push(x & 255);
+}
+
+// Read a little-endian 32-bit word from bytes[off..off+4]. Caller guarantees
+// off+4 <= bytes.length. Result in [0, 2^32).
+fn load_u32_le(bytes: int[], off: int) -> int {
+    return (bytes[off] | (bytes[off + 1] << 8) | (bytes[off + 2] << 16) | (bytes[off
+        + 3] << 24)) & 4294967295;
+}
+
+// Append the 4 little-endian bytes of the 32-bit word x to out (via
+// out.push).
+fn store_u32_le(out: int[], x: int) -> void {
+    out.push(x & 255);
+    out.push((x >> 8) & 255);
+    out.push((x >> 16) & 255);
+    out.push((x >> 24) & 255);
+}
+
+export {
+    mask32,
+    rotl32,
+    rotr32,
+    ct_eq_bytes,
+    load_u32_be,
+    store_u32_be,
+    load_u32_le,
+    store_u32_le
+};

--- a/capsules/sfn/crypto/src/bits.sfn
+++ b/capsules/sfn/crypto/src/bits.sfn
@@ -1,7 +1,7 @@
 // capsules/sfn/crypto/src/bits.sfn
 //
 // Constant-time / masking helper module for the sfn/crypto capsule
-// (SFEP draft-native-crypto.md §3.3-3.4). Centralizes the mandated
+// (SFEP-0048 §3.3-3.4). Centralizes the mandated
 // safe-integer idioms — 32-bit masking, rotates, constant-time byte
 // comparison, and big/little-endian word (de)serialization — so the
 // other Phase A primitives (sha1, sha384, chacha20, poly1305) call a
@@ -42,8 +42,9 @@ fn ct_eq_bytes(a: int[], b: int[]) -> bool {
 // Read a big-endian 32-bit word from bytes[off..off+4]. Caller guarantees
 // off+4 <= bytes.length. Result in [0, 2^32).
 fn load_u32_be(bytes: int[], off: int) -> int {
-    return ((bytes[off] << 24) | (bytes[off + 1] << 16) | (bytes[off + 2] << 8) | bytes[off
-        + 3]) & 4294967295;
+    return (((bytes[off] & 255) << 24) | ((bytes[off + 1] & 255) << 16) | ((bytes[off
+        + 2] & 255) << 8) | (bytes[off
+        + 3] & 255)) & 4294967295;
 }
 
 // Append the 4 big-endian bytes of the 32-bit word x to out (via out.push).
@@ -57,8 +58,8 @@ fn store_u32_be(out: int[], x: int) -> void {
 // Read a little-endian 32-bit word from bytes[off..off+4]. Caller guarantees
 // off+4 <= bytes.length. Result in [0, 2^32).
 fn load_u32_le(bytes: int[], off: int) -> int {
-    return (bytes[off] | (bytes[off + 1] << 8) | (bytes[off + 2] << 16) | (bytes[off
-        + 3] << 24)) & 4294967295;
+    return ((bytes[off] & 255) | ((bytes[off + 1] & 255) << 8) | ((bytes[off + 2] & 255) << 16) | ((bytes[off
+        + 3] & 255) << 24)) & 4294967295;
 }
 
 // Append the 4 little-endian bytes of the 32-bit word x to out (via

--- a/capsules/sfn/crypto/src/chacha20.sfn
+++ b/capsules/sfn/crypto/src/chacha20.sfn
@@ -1,0 +1,98 @@
+// capsules/sfn/crypto/src/chacha20.sfn
+//
+// ChaCha20 stream cipher (RFC 8439 §2.3-2.4), pure 32-bit ARX. Phase B
+// consumer: the ChaCha20-Poly1305 AEAD (with `poly1305`). Uses the RFC 8439
+// profile: a 32-bit block counter (word 12) and a 96-bit nonce (words 13-15).
+import { rotl32, load_u32_le, store_u32_le } from "./bits";
+
+// The 4 ChaCha20 constant words ("expand 32-byte k").
+fn _chacha20_c0() -> int { return 1634760805; }
+
+fn _chacha20_c1() -> int { return 857760878; }
+
+fn _chacha20_c2() -> int { return 2036477234; }
+
+fn _chacha20_c3() -> int { return 1797285236; }
+
+// Apply the ChaCha quarter-round to state words s[a], s[b], s[c], s[d]
+// in place.
+fn _chacha20_quarter_round(s: int[], a: int, b: int, c: int, d: int) -> void {
+    let mask: int = 4294967295;
+    s[a] = (s[a] + s[b]) & mask;
+    s[d] = rotl32((s[d] ^ s[a]) & mask, 16);
+    s[c] = (s[c] + s[d]) & mask;
+    s[b] = rotl32((s[b] ^ s[c]) & mask, 12);
+    s[a] = (s[a] + s[b]) & mask;
+    s[d] = rotl32((s[d] ^ s[a]) & mask, 8);
+    s[c] = (s[c] + s[d]) & mask;
+    s[b] = rotl32((s[b] ^ s[c]) & mask, 7);
+}
+
+// Produce one 64-byte ChaCha20 keystream block. `key` is 32 bytes, `nonce` is
+// 12 bytes (RFC 8439 96-bit nonce), `counter` is the 32-bit block counter.
+// Returns 64 keystream bytes as an int[]. Returns [] if key.length != 32 or
+// nonce.length != 12 (fail-closed).
+fn chacha20_block(key: int[], counter: int, nonce: int[]) -> int[] {
+    let empty: int[] = [];
+    if key.length != 32 { return empty; }
+    if nonce.length != 12 { return empty; }
+
+    let mask: int = 4294967295;
+    let mut s: int[] = [_chacha20_c0(), _chacha20_c1(), _chacha20_c2(), _chacha20_c3(), load_u32_le(key, 0), load_u32_le(key, 4), load_u32_le(key, 8), load_u32_le(key, 12), load_u32_le(key, 16), load_u32_le(key, 20), load_u32_le(key, 24), load_u32_le(key, 28), counter & mask, load_u32_le(nonce, 0), load_u32_le(nonce, 4), load_u32_le(nonce, 8),];
+
+    let mut w: int[] = [s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8], s[9], s[10], s[11], s[12], s[13], s[14], s[15],];
+
+    let mut round: int = 0;
+    loop {
+        if round >= 10 { break; }
+        _chacha20_quarter_round(w, 0, 4, 8, 12);
+        _chacha20_quarter_round(w, 1, 5, 9, 13);
+        _chacha20_quarter_round(w, 2, 6, 10, 14);
+        _chacha20_quarter_round(w, 3, 7, 11, 15);
+        _chacha20_quarter_round(w, 0, 5, 10, 15);
+        _chacha20_quarter_round(w, 1, 6, 11, 12);
+        _chacha20_quarter_round(w, 2, 7, 8, 13);
+        _chacha20_quarter_round(w, 3, 4, 9, 14);
+        round += 1;
+    }
+
+    let mut out: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= 16 { break; }
+        store_u32_le(out, (w[i] + s[i]) & mask);
+        i += 1;
+    }
+    return out;
+}
+
+// XOR `data` with the ChaCha20 keystream starting at `initial_counter`,
+// producing ciphertext (or, applied again, plaintext). key=32 bytes,
+// nonce=12 bytes. Returns an int[] of the same length as data. Returns [] on a
+// bad key/nonce length. This is the RFC 8439 §2.4 chacha20_encrypt.
+fn chacha20_xor(key: int[], initial_counter: int, nonce: int[], data: int[]) -> int[] {
+    let empty: int[] = [];
+    if key.length != 32 { return empty; }
+    if nonce.length != 12 { return empty; }
+
+    let mask: int = 4294967295;
+    let mut counter: int = initial_counter & mask;
+    let mut out: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= data.length { break; }
+        let ks: int[] = chacha20_block(key, counter, nonce);
+        let mut j: int = 0;
+        loop {
+            if j >= 64 { break; }
+            if i + j >= data.length { break; }
+            out.push((data[i + j] ^ ks[j]) & 255);
+            j += 1;
+        }
+        i += 64;
+        counter = (counter + 1) & mask;
+    }
+    return out;
+}
+
+export { chacha20_block, chacha20_xor };

--- a/capsules/sfn/crypto/src/hkdf.sfn
+++ b/capsules/sfn/crypto/src/hkdf.sfn
@@ -1,7 +1,7 @@
 // capsules/sfn/crypto/src/hkdf.sfn
 //
 // HKDF-SHA-256 (RFC 5869) for the sfn/crypto capsule — the TLS 1.3 key
-// schedule's key-derivation primitive (SFEP draft-native-crypto.md, Phase B).
+// schedule's key-derivation primitive (SFEP-0048, Phase B).
 // Operates end-to-end on `int[]` byte arrays (never `string`) because PRK
 // and expand-output blocks are arbitrary binary that routinely contain 0x00
 // bytes, which a Sailfin `string` cannot represent. Ships its own pure
@@ -214,12 +214,15 @@ fn hkdf_sha256_extract(salt: int[], ikm: int[]) -> int[] {
     return hmac_sha256_bytes(s, ikm);
 }
 
-// HKDF-Expand (RFC 5869 §2.3). prk is a >=32-byte int[]; info is an int[]
-// (may be empty); length is the desired output length in bytes (1..=8160 =
-// 255*32). Returns `length` output bytes as an int[]. Returns [] (empty) if
-// length is out of range (fail-closed).
+// HKDF-Expand (RFC 5869 §2.3). prk is a >=32-byte int[] (HashLen for
+// SHA-256); info is an int[] (may be empty); length is the desired output
+// length in bytes (1..=8160 = 255*32). Returns `length` output bytes as an
+// int[]. Returns [] (empty) if length is out of range or prk is shorter than
+// HashLen (fail-closed — a too-short PRK would silently yield a non-standard
+// derivation).
 fn hkdf_sha256_expand(prk: int[], info: int[], length: int) -> int[] {
     if length < 1 || length > 8160 { return []; }
+    if prk.length < 32 { return []; }
 
     let n: int = (length + 31) / 32;
     let mut t: int[] = [];

--- a/capsules/sfn/crypto/src/hkdf.sfn
+++ b/capsules/sfn/crypto/src/hkdf.sfn
@@ -1,0 +1,265 @@
+// capsules/sfn/crypto/src/hkdf.sfn
+//
+// HKDF-SHA-256 (RFC 5869) for the sfn/crypto capsule — the TLS 1.3 key
+// schedule's key-derivation primitive (SFEP draft-native-crypto.md, Phase B).
+// Operates end-to-end on `int[]` byte arrays (never `string`) because PRK
+// and expand-output blocks are arbitrary binary that routinely contain 0x00
+// bytes, which a Sailfin `string` cannot represent. Ships its own pure
+// `int[]`-based SHA-256/HMAC-SHA-256 rather than the shipped string-based,
+// OpenSSL-backed `hmac_sha256` (`mod.sfn`).
+import { rotr32, store_u32_be } from "./bits";
+
+// FIPS 180-4 SHA-256 round constants K[0..63].
+fn _sha256_k() -> int[] {
+    return [1116352408, 1899447441, 3049323471, 3921009573, 961987163, 1508970993, 2453635748, 2870763221, 3624381080, 310598401, 607225278, 1426881987, 1925078388, 2162078206, 2614888103, 3248222580, 3835390401, 4022224774, 264347078, 604807628, 770255983, 1249150122, 1555081692, 1996064986, 2554220882, 2821834349, 2952996808, 3210313671, 3336571891, 3584528711, 113926993, 338241895, 666307205, 773529912, 1294757372, 1396182291, 1695183700, 1986661051, 2177026350, 2456956037, 2730485921, 2820302411, 3259730800, 3345764771, 3516065817, 3600352804, 4094571909, 275423344, 430227734, 506948616, 659060556, 883997877, 958139571, 1322822218, 1537002063, 1747873779, 1955562222, 2024104815, 2227730452, 2361852424, 2428436474, 2756734187, 3204031479, 3329325298,];
+}
+
+// Compute the SHA-256 digest of a byte array, returning the 32 digest bytes
+// as an int[]. Mechanical transcription of the shipped `sha256_hex`
+// (mod.sfn): input is already an int[] (no string decode), and the digest is
+// pushed as big-endian bytes (via `bits::store_u32_be`) instead of hex.
+fn _sha256_bytes(msg: int[]) -> int[] {
+    let mask: int = 4294967295;
+
+    let mut bytes: int[] = [];
+    let mut bi: int = 0;
+    loop {
+        if bi >= msg.length { break; }
+        bytes.push(msg[bi] & 255);
+        bi += 1;
+    }
+    let bit_len: int = bytes.length * 8;
+
+    bytes.push(128);
+    loop {
+        if (bytes.length % 64) == 56 { break; }
+        bytes.push(0);
+    }
+    let hi: int = (bit_len >> 32) & mask;
+    let lo: int = bit_len & mask;
+    bytes.push((hi >> 24) & 255);
+    bytes.push((hi >> 16) & 255);
+    bytes.push((hi >> 8) & 255);
+    bytes.push(hi & 255);
+    bytes.push((lo >> 24) & 255);
+    bytes.push((lo >> 16) & 255);
+    bytes.push((lo >> 8) & 255);
+    bytes.push(lo & 255);
+
+    let k: int[] = _sha256_k();
+
+    let mut h0: int = 1779033703;
+    let mut h1: int = 3144134277;
+    let mut h2: int = 1013904242;
+    let mut h3: int = 2773480762;
+    let mut h4: int = 1359893119;
+    let mut h5: int = 2600822924;
+    let mut h6: int = 528734635;
+    let mut h7: int = 1541459225;
+
+    let num_blocks: int = bytes.length / 64;
+    let mut block: int = 0;
+    loop {
+        if block >= num_blocks { break; }
+        let base: int = block * 64;
+
+        let mut w: int[] = [];
+        let mut t: int = 0;
+        loop {
+            if t >= 16 { break; }
+            let j: int = base + t * 4;
+            let word: int = ((bytes[j] << 24) | (bytes[j + 1] << 16) | (bytes[j
+                + 2] << 8) | bytes[j
+                + 3]) & mask;
+            w.push(word);
+            t += 1;
+        }
+        t = 16;
+        loop {
+            if t >= 64 { break; }
+            let w15: int = w[t - 15];
+            let w2: int = w[t - 2];
+            let s0: int = (rotr32(w15, 7) ^ rotr32(w15, 18) ^ ((w15 >> 3) & mask)) & mask;
+            let s1: int = (rotr32(w2, 17) ^ rotr32(w2, 19) ^ ((w2 >> 10) & mask)) & mask;
+            w.push((w[t - 16] + s0 + w[t - 7] + s1) & mask);
+            t += 1;
+        }
+
+        let mut a: int = h0;
+        let mut b: int = h1;
+        let mut c: int = h2;
+        let mut d: int = h3;
+        let mut e: int = h4;
+        let mut f: int = h5;
+        let mut g: int = h6;
+        let mut h: int = h7;
+
+        let mut r: int = 0;
+        loop {
+            if r >= 64 { break; }
+            let big_s1: int = (rotr32(e, 6) ^ rotr32(e, 11) ^ rotr32(e, 25)) & mask;
+            let ch: int = ((e & f) ^ ((mask ^ e) & g)) & mask;
+            let temp1: int = (h + big_s1 + ch + k[r] + w[r]) & mask;
+            let big_s0: int = (rotr32(a, 2) ^ rotr32(a, 13) ^ rotr32(a, 22)) & mask;
+            let maj: int = ((a & b) ^ (a & c) ^ (b & c)) & mask;
+            let temp2: int = (big_s0 + maj) & mask;
+            h = g;
+            g = f;
+            f = e;
+            e = (d + temp1) & mask;
+            d = c;
+            c = b;
+            b = a;
+            a = (temp1 + temp2) & mask;
+            r += 1;
+        }
+
+        h0 = (h0 + a) & mask;
+        h1 = (h1 + b) & mask;
+        h2 = (h2 + c) & mask;
+        h3 = (h3 + d) & mask;
+        h4 = (h4 + e) & mask;
+        h5 = (h5 + f) & mask;
+        h6 = (h6 + g) & mask;
+        h7 = (h7 + h) & mask;
+        block += 1;
+    }
+
+    let mut out: int[] = [];
+    store_u32_be(out, h0);
+    store_u32_be(out, h1);
+    store_u32_be(out, h2);
+    store_u32_be(out, h3);
+    store_u32_be(out, h4);
+    store_u32_be(out, h5);
+    store_u32_be(out, h6);
+    store_u32_be(out, h7);
+    return out;
+}
+
+// Pure HMAC-SHA-256 over byte arrays. key and data are int[] byte arrays
+// (values 0-255); returns the 32-byte MAC as an int[]. RFC 2104.
+fn hmac_sha256_bytes(key: int[], data: int[]) -> int[] {
+    let mut k: int[] = key;
+    if k.length > 64 { k = _sha256_bytes(k); }
+
+    let mut k_pad: int[] = [];
+    let mut ki: int = 0;
+    loop {
+        if ki >= k.length { break; }
+        k_pad.push(k[ki] & 255);
+        ki += 1;
+    }
+    loop {
+        if k_pad.length >= 64 { break; }
+        k_pad.push(0);
+    }
+
+    let mut ipad: int[] = [];
+    let mut opad: int[] = [];
+    let mut pi: int = 0;
+    loop {
+        if pi >= 64 { break; }
+        ipad.push((k_pad[pi] ^ 54) & 255);
+        opad.push((k_pad[pi] ^ 92) & 255);
+        pi += 1;
+    }
+
+    let mut inner_msg: int[] = [];
+    let mut ii: int = 0;
+    loop {
+        if ii >= ipad.length { break; }
+        inner_msg.push(ipad[ii]);
+        ii += 1;
+    }
+    let mut di: int = 0;
+    loop {
+        if di >= data.length { break; }
+        inner_msg.push(data[di] & 255);
+        di += 1;
+    }
+    let inner: int[] = _sha256_bytes(inner_msg);
+
+    let mut outer_msg: int[] = [];
+    let mut oi: int = 0;
+    loop {
+        if oi >= opad.length { break; }
+        outer_msg.push(opad[oi]);
+        oi += 1;
+    }
+    let mut ni: int = 0;
+    loop {
+        if ni >= inner.length { break; }
+        outer_msg.push(inner[ni]);
+        ni += 1;
+    }
+    return _sha256_bytes(outer_msg);
+}
+
+// HKDF-Extract (RFC 5869 §2.2). salt and ikm are int[] byte arrays; salt may
+// be empty (treated as HashLen=32 zero bytes per the RFC). Returns the
+// 32-byte PRK.
+fn hkdf_sha256_extract(salt: int[], ikm: int[]) -> int[] {
+    let mut s: int[] = salt;
+    if s.length == 0 {
+        let mut zeros: int[] = [];
+        let mut zi: int = 0;
+        loop {
+            if zi >= 32 { break; }
+            zeros.push(0);
+            zi += 1;
+        }
+        s = zeros;
+    }
+    return hmac_sha256_bytes(s, ikm);
+}
+
+// HKDF-Expand (RFC 5869 §2.3). prk is a >=32-byte int[]; info is an int[]
+// (may be empty); length is the desired output length in bytes (1..=8160 =
+// 255*32). Returns `length` output bytes as an int[]. Returns [] (empty) if
+// length is out of range (fail-closed).
+fn hkdf_sha256_expand(prk: int[], info: int[], length: int) -> int[] {
+    if length < 1 || length > 8160 { return []; }
+
+    let n: int = (length + 31) / 32;
+    let mut t: int[] = [];
+    let mut okm: int[] = [];
+    let mut i: int = 1;
+    loop {
+        if i > n { break; }
+
+        let mut msg: int[] = [];
+        let mut ti: int = 0;
+        loop {
+            if ti >= t.length { break; }
+            msg.push(t[ti]);
+            ti += 1;
+        }
+        let mut fi: int = 0;
+        loop {
+            if fi >= info.length { break; }
+            msg.push(info[fi] & 255);
+            fi += 1;
+        }
+        msg.push(i & 255);
+
+        t = hmac_sha256_bytes(prk, msg);
+
+        let mut tj: int = 0;
+        loop {
+            if tj >= t.length { break; }
+            okm.push(t[tj]);
+            tj += 1;
+        }
+        i += 1;
+    }
+
+    let mut result: int[] = [];
+    let mut ri: int = 0;
+    loop {
+        if ri >= length { break; }
+        result.push(okm[ri]);
+        ri += 1;
+    }
+    return result;
+}

--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -5,6 +5,29 @@
 // verification (RFC 8032). No effects required — pure computation.
 export { ed25519_verify, ed25519_verify_utf8 } from "./ed25519";
 
+export { sha1_hex } from "./sha1";
+
+export { sha384_hex } from "./sha384";
+
+export { hmac_sha256_bytes, hkdf_sha256_extract, hkdf_sha256_expand } from "./hkdf";
+
+export { poly1305_mac } from "./poly1305";
+
+// Constant-time / masking helpers shared by the Phase A hash and cipher
+// primitives (SFEP draft-native-crypto.md §3.3-3.4).
+export {
+    mask32,
+    rotl32,
+    rotr32,
+    ct_eq_bytes,
+    load_u32_be,
+    store_u32_be,
+    load_u32_le,
+    store_u32_le
+} from "./bits";
+
+export { chacha20_block, chacha20_xor } from "./chacha20";
+
 // ── OpenSSL HMAC-SHA256 surface (libcrypto) ──────────────────────
 // OpenSSL is already linked for the native TLS runtime (`-lcrypto`). The
 // externs carry no effect surface; `hmac_sha256` is deterministic pure

--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -14,7 +14,7 @@ export { hmac_sha256_bytes, hkdf_sha256_extract, hkdf_sha256_expand } from "./hk
 export { poly1305_mac } from "./poly1305";
 
 // Constant-time / masking helpers shared by the Phase A hash and cipher
-// primitives (SFEP draft-native-crypto.md §3.3-3.4).
+// primitives (SFEP-0048 §3.3-3.4).
 export {
     mask32,
     rotl32,

--- a/capsules/sfn/crypto/src/poly1305.sfn
+++ b/capsules/sfn/crypto/src/poly1305.sfn
@@ -1,7 +1,7 @@
 // capsules/sfn/crypto/src/poly1305.sfn
 //
 // Poly1305 one-time message authentication code (RFC 8439 §2.5), the AEAD
-// tag primitive paired with ChaCha20 (SFEP draft-native-crypto.md §3.3 item
+// tag primitive paired with ChaCha20 (SFEP-0048 §3.3 item
 // 5). Implemented with the 5x26-bit limb schedule ("poly1305-donna 32") so
 // every intermediate product stays inside signed i64 without a native
 // unsigned 64-bit carry chain.

--- a/capsules/sfn/crypto/src/poly1305.sfn
+++ b/capsules/sfn/crypto/src/poly1305.sfn
@@ -1,0 +1,227 @@
+// capsules/sfn/crypto/src/poly1305.sfn
+//
+// Poly1305 one-time message authentication code (RFC 8439 §2.5), the AEAD
+// tag primitive paired with ChaCha20 (SFEP draft-native-crypto.md §3.3 item
+// 5). Implemented with the 5x26-bit limb schedule ("poly1305-donna 32") so
+// every intermediate product stays inside signed i64 without a native
+// unsigned 64-bit carry chain.
+import { load_u32_le, store_u32_le } from "./bits";
+
+// The 26-bit limb mask, 2^26 - 1.
+fn _limb_mask() -> int { return 67108863; }
+
+// Extract five 26-bit limbs from four little-endian 32-bit words, matching
+// the interleaved bit layout r0..r4 in the spec (bits 0..129 across w0..w3).
+fn _extract_limbs(w0: int, w1: int, w2: int, w3: int) -> int[] {
+    let mask: int = _limb_mask();
+    let n0: int = w0 & mask;
+    let n1: int = ((w0 >> 26) | (w1 << 6)) & mask;
+    let n2: int = ((w1 >> 20) | (w2 << 12)) & mask;
+    let n3: int = ((w2 >> 14) | (w3 << 18)) & mask;
+    let n4: int = (w3 >> 8) & mask;
+    return [n0, n1, n2, n3, n4];
+}
+
+// Compute the 16-byte Poly1305 MAC of `msg` under the 32-byte one-time `key`
+// (RFC 8439 §2.5). key[0..15] is r (clamped internally), key[16..31] is s.
+// Returns the 16-byte tag as an int[]. Returns [] if key.length != 32
+// (fail-closed).
+fn poly1305_mac(msg: int[], key: int[]) -> int[] {
+    if key.length != 32 { return []; }
+
+    let mask: int = _limb_mask();
+
+    // Clamp r: mask the raw little-endian words per RFC 8439 §2.5.1, then
+    // derive the five 26-bit limbs from the already-clamped words.
+    let mut t0: int = load_u32_le(key, 0);
+    let mut t1: int = load_u32_le(key, 4);
+    let mut t2: int = load_u32_le(key, 8);
+    let mut t3: int = load_u32_le(key, 12);
+    t0 = t0 & 268435455;  // 0x0fffffff
+    t1 = t1 & 268435452;  // 0x0ffffffc
+    t2 = t2 & 268435452;  // 0x0ffffffc
+    t3 = t3 & 268435452;  // 0x0ffffffc
+
+    let r_limbs: int[] = _extract_limbs(t0, t1, t2, t3);
+    let r0: int = r_limbs[0];
+    let r1: int = r_limbs[1];
+    let r2: int = r_limbs[2];
+    let r3: int = r_limbs[3];
+    let r4: int = r_limbs[4];
+
+    // Precompute the x5 wraparound multipliers used by the reduction below.
+    let s1: int = r1 * 5;
+    let s2: int = r2 * 5;
+    let s3: int = r3 * 5;
+    let s4: int = r4 * 5;
+
+    let mut h0: int = 0;
+    let mut h1: int = 0;
+    let mut h2: int = 0;
+    let mut h3: int = 0;
+    let mut h4: int = 0;
+
+    let mut i: int = 0;
+    loop {
+        if i >= msg.length { break; }
+        let blen: int = _min_int(16, msg.length - i);
+
+        // Zero-pad the block into a 16-byte buffer before limb extraction.
+        let mut b: int[] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let mut j: int = 0;
+        loop {
+            if j >= blen { break; }
+            b[j] = msg[i + j];
+            j += 1;
+        }
+
+        let w0: int = load_u32_le(b, 0);
+        let w1: int = load_u32_le(b, 4);
+        let w2: int = load_u32_le(b, 8);
+        let w3: int = load_u32_le(b, 12);
+        let n: int[] = _extract_limbs(w0, w1, w2, w3);
+        let mut n0: int = n[0];
+        let mut n1: int = n[1];
+        let mut n2: int = n[2];
+        let mut n3: int = n[3];
+        let mut n4: int = n[4];
+
+        // Set the high bit at bit position 8*blen (2^24 lands in limb 4 for
+        // a full 16-byte block, matching the "n4 + 2^24" special case).
+        let bit_pos: int = 8 * blen;
+        let lb: int = bit_pos / 26;
+        let bb: int = bit_pos % 26;
+        let bit_value: int = 1 << bb;
+        if lb == 0 { n0 = n0 + bit_value; }
+        if lb == 1 { n1 = n1 + bit_value; }
+        if lb == 2 { n2 = n2 + bit_value; }
+        if lb == 3 { n3 = n3 + bit_value; }
+        if lb == 4 { n4 = n4 + bit_value; }
+
+        h0 += n0;
+        h1 += n1;
+        h2 += n2;
+        h3 += n3;
+        h4 += n4;
+
+        // Multiply the accumulator by r mod 2^130-5 with the x5 wraparound
+        // reduction; every column stays comfortably below 2^63 (spec Feasibility).
+        let mut d0: int = h0 * r0 + h1 * s4 + h2 * s3 + h3 * s2 + h4 * s1;
+        let mut d1: int = h0 * r1 + h1 * r0 + h2 * s4 + h3 * s3 + h4 * s2;
+        let mut d2: int = h0 * r2 + h1 * r1 + h2 * r0 + h3 * s4 + h4 * s3;
+        let mut d3: int = h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * s4;
+        let mut d4: int = h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+
+        // Carry-propagate d0..d4 back into 26-bit limbs.
+        let mut c: int = d0 >> 26;
+        h0 = d0 & mask;
+        d1 = d1 + c;
+        c = d1 >> 26;
+        h1 = d1 & mask;
+        d2 = d2 + c;
+        c = d2 >> 26;
+        h2 = d2 & mask;
+        d3 = d3 + c;
+        c = d3 >> 26;
+        h3 = d3 & mask;
+        d4 = d4 + c;
+        c = d4 >> 26;
+        h4 = d4 & mask;
+        h0 = h0 + c * 5;  // top carry x5 (2^130 == 5 mod 2^130-5)
+        c = h0 >> 26;
+        h0 = h0 & mask;
+        h1 = h1 + c;
+
+        i += 16;
+    }
+
+    // Fully carry h0..h4 before the final reduction (spec Finalize step 1,
+    // matching the poly1305-donna finish). At loop exit h1 may hold an
+    // unmasked bit 26; without this pass the keep-h branch below would
+    // serialize that dirty limb and drop the carry at bit 52.
+    let mut fc: int = h1 >> 26;
+    h1 = h1 & mask;
+    h2 = h2 + fc;
+    fc = h2 >> 26;
+    h2 = h2 & mask;
+    h3 = h3 + fc;
+    fc = h3 >> 26;
+    h3 = h3 & mask;
+    h4 = h4 + fc;
+    fc = h4 >> 26;
+    h4 = h4 & mask;
+    h0 = h0 + fc * 5;
+    fc = h0 >> 26;
+    h0 = h0 & mask;
+    h1 = h1 + fc;
+
+    // Final reduction: h - (2^130-5) via a borrow chain, keeping g only if
+    // it did not borrow past bit 130. The tag is public output (not a
+    // secret comparison), so a plain branch on the sign of g4 is acceptable
+    // here per the spec's constant-time scoping note.
+    let g0_raw: int = h0 + 5;
+    let mut c2: int = g0_raw >> 26;
+    let g0: int = g0_raw & mask;
+    let g1_raw: int = h1 + c2;
+    c2 = g1_raw >> 26;
+    let g1: int = g1_raw & mask;
+    let g2_raw: int = h2 + c2;
+    c2 = g2_raw >> 26;
+    let g2: int = g2_raw & mask;
+    let g3_raw: int = h3 + c2;
+    c2 = g3_raw >> 26;
+    let g3: int = g3_raw & mask;
+    let g4: int = h4 + c2 - 67108864;
+
+    let mut fh0: int = h0;
+    let mut fh1: int = h1;
+    let mut fh2: int = h2;
+    let mut fh3: int = h3;
+    let mut fh4: int = h4;
+    if g4 >= 0 {
+        fh0 = g0;
+        fh1 = g1;
+        fh2 = g2;
+        fh3 = g3;
+        fh4 = g4;
+    }
+
+    // Recombine the five 26-bit limbs into four 32-bit words, then add s.
+    let word_mask: int = 4294967295;
+    let mut f0: int = (fh0 | (fh1 << 26)) & word_mask;
+    let mut f1: int = ((fh1 >> 6) | (fh2 << 20)) & word_mask;
+    let mut f2: int = ((fh2 >> 12) | (fh3 << 14)) & word_mask;
+    let mut f3: int = ((fh3 >> 18) | (fh4 << 8)) & word_mask;
+
+    let sv0: int = load_u32_le(key, 16);
+    let sv1: int = load_u32_le(key, 20);
+    let sv2: int = load_u32_le(key, 24);
+    let sv3: int = load_u32_le(key, 28);
+
+    let mut acc: int = f0 + sv0;
+    f0 = acc & word_mask;
+    let mut carry: int = (acc >> 32) & 1;
+    acc = f1 + sv1 + carry;
+    f1 = acc & word_mask;
+    carry = (acc >> 32) & 1;
+    acc = f2 + sv2 + carry;
+    f2 = acc & word_mask;
+    carry = (acc >> 32) & 1;
+    acc = f3 + sv3 + carry;
+    f3 = acc & word_mask;
+
+    let mut tag: int[] = [];
+    store_u32_le(tag, f0);
+    store_u32_le(tag, f1);
+    store_u32_le(tag, f2);
+    store_u32_le(tag, f3);
+    return tag;
+}
+
+// Smaller of two ints.
+fn _min_int(a: int, b: int) -> int {
+    if a < b { return a; }
+    return b;
+}
+
+export { poly1305_mac };

--- a/capsules/sfn/crypto/src/sha1.sfn
+++ b/capsules/sfn/crypto/src/sha1.sfn
@@ -1,0 +1,132 @@
+// capsules/sfn/crypto/src/sha1.sfn
+//
+// SHA-1 (RFC 3174 / RFC 6234 §5) implemented in pure Sailfin. Same 32-bit-word
+// ARX shape as the shipped SHA-256 (SFEP draft-native-crypto.md): all
+// arithmetic is masked to 32 bits after every operation, rotates go through
+// `bits::rotl32`. Used to compute the RFC 6455 WebSocket
+// `Sec-WebSocket-Accept` value (Phase D consumer).
+import { rotl32, load_u32_be, store_u32_be } from "./bits";
+
+// Render a 32-bit word as 8 lowercase hex characters.
+fn sha1_word_hex(x: int) -> string {
+    let digits: string[] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f",];
+    let mut out: string = "";
+    let mut shift: int = 28;
+    loop {
+        if shift < 0 { break; }
+        out = out + digits[(x >> shift) & 15];
+        shift -= 4;
+    }
+    return out;
+}
+
+fn sha1_hex(data: string) -> string {
+    // Compute the SHA-1 digest of `data` and return the bare 40-character
+    // lowercase hex string.
+    //
+    // Usage:
+    //   let h = sha1_hex("abc");
+    //   // h == "a9993e364706816aba3e25717850c26c9cd0d89d"
+    let mask: int = 4294967295;
+
+    // 1. Decode the input into a byte sequence (byte-oriented, matches
+    //    `sha1sum` for arbitrary content, not just ASCII).
+    let mut bytes: int[] = [];
+    let mut bi: int = 0;
+    loop {
+        if bi >= data.length { break; }
+        bytes.push(char_code(data[bi]) & 255);
+        bi += 1;
+    }
+    let bit_len: int = bytes.length * 8;
+
+    // 2. Pad: append 0x80, then zeros until length ≡ 56 (mod 64), then the
+    //    64-bit big-endian message length in bits.
+    bytes.push(128);
+    loop {
+        if (bytes.length % 64) == 56 { break; }
+        bytes.push(0);
+    }
+    let hi: int = (bit_len >> 32) & mask;
+    let lo: int = bit_len & mask;
+    store_u32_be(bytes, hi);
+    store_u32_be(bytes, lo);
+
+    // Initial hash state H[0..4].
+    let mut h0: int = 1732584193;
+    let mut h1: int = 4023233417;
+    let mut h2: int = 2562383102;
+    let mut h3: int = 271733878;
+    let mut h4: int = 3285377520;
+
+    // 3. Process each 64-byte block.
+    let num_blocks: int = bytes.length / 64;
+    let mut block: int = 0;
+    loop {
+        if block >= num_blocks { break; }
+        let base: int = block * 64;
+
+        // Build the 80-word message schedule.
+        let mut w: int[] = [];
+        let mut t: int = 0;
+        loop {
+            if t >= 16 { break; }
+            w.push(load_u32_be(bytes, base + t * 4));
+            t += 1;
+        }
+        t = 16;
+        loop {
+            if t >= 80 { break; }
+            w.push(rotl32((w[t - 3] ^ w[t - 8] ^ w[t - 14] ^ w[t - 16]) & mask, 1));
+            t += 1;
+        }
+
+        let mut a: int = h0;
+        let mut b: int = h1;
+        let mut c: int = h2;
+        let mut d: int = h3;
+        let mut e: int = h4;
+
+        let mut r: int = 0;
+        loop {
+            if r >= 80 { break; }
+            let mut f: int = 0;
+            let mut k: int = 0;
+            if r < 20 {
+                let notb: int = b ^ mask;
+                f = ((b & c) | (notb & d)) & mask;
+                k = 1518500249;
+            } else if r < 40 {
+                f = (b ^ c ^ d) & mask;
+                k = 1859775393;
+            } else if r < 60 {
+                f = ((b & c) | (b & d) | (c & d)) & mask;
+                k = 2400959708;
+            } else {
+                f = (b ^ c ^ d) & mask;
+                k = 3395469782;
+            }
+
+            let temp: int = (rotl32(a, 5) + f + e + k + w[r]) & mask;
+            e = d;
+            d = c;
+            c = rotl32(b, 30);
+            b = a;
+            a = temp;
+            r += 1;
+        }
+
+        h0 = (h0 + a) & mask;
+        h1 = (h1 + b) & mask;
+        h2 = (h2 + c) & mask;
+        h3 = (h3 + d) & mask;
+        h4 = (h4 + e) & mask;
+        block += 1;
+    }
+
+    return sha1_word_hex(h0) + sha1_word_hex(h1) + sha1_word_hex(h2)
+        + sha1_word_hex(h3)
+        + sha1_word_hex(h4);
+}
+
+export { sha1_hex };

--- a/capsules/sfn/crypto/src/sha1.sfn
+++ b/capsules/sfn/crypto/src/sha1.sfn
@@ -1,7 +1,7 @@
 // capsules/sfn/crypto/src/sha1.sfn
 //
 // SHA-1 (RFC 3174 / RFC 6234 §5) implemented in pure Sailfin. Same 32-bit-word
-// ARX shape as the shipped SHA-256 (SFEP draft-native-crypto.md): all
+// ARX shape as the shipped SHA-256 (SFEP-0048): all
 // arithmetic is masked to 32 bits after every operation, rotates go through
 // `bits::rotl32`. Used to compute the RFC 6455 WebSocket
 // `Sec-WebSocket-Accept` value (Phase D consumer).

--- a/capsules/sfn/crypto/src/sha384.sfn
+++ b/capsules/sfn/crypto/src/sha384.sfn
@@ -1,0 +1,206 @@
+// capsules/sfn/crypto/src/sha384.sfn
+//
+// SHA-384 (FIPS 180-4) implemented in pure Sailfin as SHA-512 truncated to
+// 384 bits with a different initial state. SHA-512 is a 64-bit-word hash,
+// and under Sailfin's signed-i64 `int` a naive single-`int` 64-bit word
+// would corrupt `>>` (LLVM `ashr` sign-extends once bit 63 is set). Every
+// 64-bit word is therefore held as a `[hi, lo]` pair of 32-bit limbs (each
+// masked to `[0, 2^32)`), and every 64-bit rotate/shift/xor/add is
+// implemented limb-wise with explicit carry (SFEP draft-native-crypto.md
+// §3.3 item 4).
+import { load_u32_be, store_u32_be } from "./bits";
+
+// 64-bit XOR: componentwise.
+fn xor64(a: int[], b: int[]) -> int[] {
+    return [(a[0] ^ b[0]) & 4294967295, (a[1] ^ b[1]) & 4294967295];
+}
+
+// 64-bit AND: componentwise.
+fn and64(a: int[], b: int[]) -> int[] {
+    return [(a[0] & b[0]) & 4294967295, (a[1] & b[1]) & 4294967295];
+}
+
+// 64-bit NOT within 64 bits.
+fn not64(a: int[]) -> int[] {
+    return [(a[0] ^ 4294967295) & 4294967295, (a[1] ^ 4294967295) & 4294967295];
+}
+
+// 64-bit modular add with carry from lo into hi. `a[1] + b[1] < 2^33` fits
+// comfortably in i64, so the carry is bit 32 of that sum; likewise
+// `a[0] + b[0] + carry < 2^33`. No i64 overflow.
+fn add64(a: int[], b: int[]) -> int[] {
+    let lo: int = (a[1] + b[1]) & 4294967295;
+    let carry: int = ((a[1] + b[1]) >> 32) & 1;
+    let hi: int = (a[0] + b[0] + carry) & 4294967295;
+    return [hi, lo];
+}
+
+// 64-bit logical right shift by n (0 < n < 64). Zero-fill — this is the
+// point of the limb split, since a naive `>>` on a single int would ashr.
+fn shr64(a: int[], n: int) -> int[] {
+    if n == 0 { return [a[0], a[1]]; }
+    if n < 32 {
+        let lo: int = ((a[1] >> n) | (a[0] << (32 - n))) & 4294967295;
+        let hi: int = (a[0] >> n) & 4294967295;
+        return [hi, lo];
+    }
+    let lo: int = (a[0] >> (n - 32)) & 4294967295;
+    return [0, lo];
+}
+
+// 64-bit logical left shift by n (0 < n < 64) — needed only inside rotr64.
+fn shl64(a: int[], n: int) -> int[] {
+    if n == 0 { return [a[0], a[1]]; }
+    if n < 32 {
+        let hi: int = ((a[0] << n) | (a[1] >> (32 - n))) & 4294967295;
+        let lo: int = (a[1] << n) & 4294967295;
+        return [hi, lo];
+    }
+    let hi: int = (a[1] << (n - 32)) & 4294967295;
+    return [hi, 0];
+}
+
+// 64-bit rotate right by n (0 < n < 64): ROTR(x,n) = (x >> n) | (x << (64 - n)).
+fn rotr64(a: int[], n: int) -> int[] {
+    let right: int[] = shr64(a, n);
+    let left: int[] = shl64(a, 64 - n);
+    return [(right[0] | left[0]) & 4294967295, (right[1] | left[1]) & 4294967295];
+}
+
+// Render a 64-bit `[hi, lo]` word as 16 lowercase hex characters.
+fn sha384_word_hex(hi: int, lo: int) -> string {
+    let digits: string[] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f",];
+    let mut out: string = "";
+    let mut shift: int = 28;
+    loop {
+        if shift < 0 { break; }
+        out = out + digits[(hi >> shift) & 15];
+        shift -= 4;
+    }
+    shift = 28;
+    loop {
+        if shift < 0 { break; }
+        out = out + digits[(lo >> shift) & 15];
+        shift -= 4;
+    }
+    return out;
+}
+
+// The 80 SHA-512 round constants (FIPS 180-4 §4.2.3), each as a `[hi, lo]`
+// decimal pair (hex literals unavailable). Verified against the SHA-384
+// known-answer vectors in sha384_test.sfn — a single wrong entry fails them.
+fn sha384_round_constants() -> int[][] {
+    return [[1116352408, 3609767458], [1899447441, 602891725], [3049323471, 3964484399], [3921009573, 2173295548], [961987163, 4081628472], [1508970993, 3053834265], [2453635748, 2937671579], [2870763221, 3664609560], [3624381080, 2734883394], [310598401, 1164996542], [607225278, 1323610764], [1426881987, 3590304994], [1925078388, 4068182383], [2162078206, 991336113], [2614888103, 633803317], [3248222580, 3479774868], [3835390401, 2666613458], [4022224774, 944711139], [264347078, 2341262773], [604807628, 2007800933], [770255983, 1495990901], [1249150122, 1856431235], [1555081692, 3175218132], [1996064986, 2198950837], [2554220882, 3999719339], [2821834349, 766784016], [2952996808, 2566594879], [3210313671, 3203337956], [3336571891, 1034457026], [3584528711, 2466948901], [113926993, 3758326383], [338241895, 168717936], [666307205, 1188179964], [773529912, 1546045734], [1294757372, 1522805485], [1396182291, 2643833823], [1695183700, 2343527390], [1986661051, 1014477480], [2177026350, 1206759142], [2456956037, 344077627], [2730485921, 1290863460], [2820302411, 3158454273], [3259730800, 3505952657], [3345764771, 106217008], [3516065817, 3606008344], [3600352804, 1432725776], [4094571909, 1467031594], [275423344, 851169720], [430227734, 3100823752], [506948616, 1363258195], [659060556, 3750685593], [883997877, 3785050280], [958139571, 3318307427], [1322822218, 3812723403], [1537002063, 2003034995], [1747873779, 3602036899], [1955562222, 1575990012], [2024104815, 1125592928], [2227730452, 2716904306], [2361852424, 442776044], [2428436474, 593698344], [2756734187, 3733110249], [3204031479, 2999351573], [3329325298, 3815920427], [3391569614, 3928383900], [3515267271, 566280711], [3940187606, 3454069534], [4118630271, 4000239992], [116418474, 1914138554], [174292421, 2731055270], [289380356, 3203993006], [460393269, 320620315], [685471733, 587496836], [852142971, 1086792851], [1017036298, 365543100], [1126000580, 2618297676], [1288033470, 3409855158], [1501505948, 4234509866], [1607167915, 987167468], [1816402316, 1246189591],];
+}
+
+fn sha384_hex(data: string) -> string {
+    // Compute the SHA-384 digest of `data` (byte-oriented over raw UTF-8
+    // bytes, matching `sha384sum`) and return the bare 96-character
+    // lowercase hex string.
+    let mut bytes: int[] = [];
+    let mut bi: int = 0;
+    loop {
+        if bi >= data.length { break; }
+        bytes.push(char_code(data[bi]) & 255);
+        bi += 1;
+    }
+    let bit_len: int = bytes.length * 8;
+
+    // Pad: 0x80, zeros until length % 128 == 112, then the 128-bit
+    // big-endian message length in bits. `bit_len` fits in 64 bits, so the
+    // high 64 bits of the 128-bit length are all zero.
+    bytes.push(128);
+    loop {
+        if (bytes.length % 128) == 112 { break; }
+        bytes.push(0);
+    }
+    let mut zi: int = 0;
+    loop {
+        if zi >= 8 { break; }
+        bytes.push(0);
+        zi += 1;
+    }
+    let len_hi: int = (bit_len >> 32) & 4294967295;
+    let len_lo: int = bit_len & 4294967295;
+    store_u32_be(bytes, len_hi);
+    store_u32_be(bytes, len_lo);
+
+    // Initial state H[0..7] (SHA-384 IV).
+    let mut h: int[][] = [[3418070365, 3238371032], [1654270250, 914150663], [2438529370, 812702999], [355462360, 4144912697], [1731405415, 4290775857], [2394180231, 1750603025], [3675008525, 1694076839], [1203062813, 3204075428],];
+
+    let k: int[][] = sha384_round_constants();
+
+    let num_blocks: int = bytes.length / 128;
+    let mut block: int = 0;
+    loop {
+        if block >= num_blocks { break; }
+        let base: int = block * 128;
+
+        let mut w: int[][] = [];
+        let mut t: int = 0;
+        loop {
+            if t >= 16 { break; }
+            let j: int = base + t * 8;
+            w.push([load_u32_be(bytes, j), load_u32_be(bytes, j + 4)]);
+            t += 1;
+        }
+        t = 16;
+        loop {
+            if t >= 80 { break; }
+            let w15: int[] = w[t - 15];
+            let w2: int[] = w[t - 2];
+            let s0: int[] = xor64(xor64(rotr64(w15, 1), rotr64(w15, 8)), shr64(w15, 7));
+            let s1: int[] = xor64(xor64(rotr64(w2, 19), rotr64(w2, 61)), shr64(w2, 6));
+            w.push(add64(add64(add64(w[t - 16], s0), w[t - 7]), s1));
+            t += 1;
+        }
+
+        let mut a: int[] = h[0];
+        let mut b: int[] = h[1];
+        let mut c: int[] = h[2];
+        let mut d: int[] = h[3];
+        let mut e: int[] = h[4];
+        let mut f: int[] = h[5];
+        let mut g: int[] = h[6];
+        let mut hh: int[] = h[7];
+
+        let mut r: int = 0;
+        loop {
+            if r >= 80 { break; }
+            let big_s1: int[] = xor64(xor64(rotr64(e, 14), rotr64(e, 18)), rotr64(e, 41));
+            let ch: int[] = xor64(and64(e, f), and64(not64(e), g));
+            let t1: int[] = add64(add64(add64(add64(hh, big_s1), ch), k[r]), w[r]);
+            let big_s0: int[] = xor64(xor64(rotr64(a, 28), rotr64(a, 34)), rotr64(a, 39));
+            let maj: int[] = xor64(xor64(and64(a, b), and64(a, c)), and64(b, c));
+            let t2: int[] = add64(big_s0, maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = add64(d, t1);
+            d = c;
+            c = b;
+            b = a;
+            a = add64(t1, t2);
+            r += 1;
+        }
+
+        h[0] = add64(h[0], a);
+        h[1] = add64(h[1], b);
+        h[2] = add64(h[2], c);
+        h[3] = add64(h[3], d);
+        h[4] = add64(h[4], e);
+        h[5] = add64(h[5], f);
+        h[6] = add64(h[6], g);
+        h[7] = add64(h[7], hh);
+        block += 1;
+    }
+
+    // SHA-384 truncates to the first 6 of the 8 state words.
+    return sha384_word_hex(h[0][0], h[0][1]) + sha384_word_hex(h[1][0], h[1][1])
+        + sha384_word_hex(h[2][0], h[2][1])
+        + sha384_word_hex(h[3][0], h[3][1])
+        + sha384_word_hex(h[4][0], h[4][1])
+        + sha384_word_hex(h[5][0], h[5][1]);
+}
+
+export { sha384_hex };

--- a/capsules/sfn/crypto/src/sha384.sfn
+++ b/capsules/sfn/crypto/src/sha384.sfn
@@ -6,7 +6,7 @@
 // would corrupt `>>` (LLVM `ashr` sign-extends once bit 63 is set). Every
 // 64-bit word is therefore held as a `[hi, lo]` pair of 32-bit limbs (each
 // masked to `[0, 2^32)`), and every 64-bit rotate/shift/xor/add is
-// implemented limb-wise with explicit carry (SFEP draft-native-crypto.md
+// implemented limb-wise with explicit carry (SFEP-0048
 // §3.3 item 4).
 import { load_u32_be, store_u32_be } from "./bits";
 

--- a/capsules/sfn/crypto/tests/bits_test.sfn
+++ b/capsules/sfn/crypto/tests/bits_test.sfn
@@ -1,0 +1,79 @@
+// capsules/sfn/crypto/tests/bits_test.sfn
+//
+// Regression coverage for the sfn/crypto bits module: masking, rotates,
+// constant-time byte comparison, and big/little-endian word codecs.
+import {
+    mask32,
+    rotl32,
+    rotr32,
+    ct_eq_bytes,
+    load_u32_be,
+    store_u32_be,
+    load_u32_le,
+    store_u32_le
+} from "../src/bits";
+
+test "bits: mask32 is 0xffffffff" { assert mask32() == 4294967295; }
+
+test "bits: rotl32 of 1 by 1 is 2" { assert rotl32(1, 1) == 2; }
+
+test "bits: rotl32 wraps the top bit" {
+    // 0x80000000 rotated left by 1 == 0x00000001
+    assert rotl32(2147483648, 1) == 1;
+}
+
+test "bits: rotr32 of 1 by 1 wraps to top bit" {
+    // 0x00000001 rotated right by 1 == 0x80000000
+    assert rotr32(1, 1) == 2147483648;
+}
+
+test "bits: rotl32 then rotr32 is identity" {
+    assert rotr32(rotl32(305419896, 7), 7) == 305419896;  // 0x12345678
+}
+
+test "bits: ct_eq_bytes equal" {
+    assert ct_eq_bytes([1, 2, 3], [1, 2, 3]) == true;
+}
+
+test "bits: ct_eq_bytes differ" {
+    assert ct_eq_bytes([1, 2, 3], [1, 2, 4]) == false;
+}
+
+test "bits: ct_eq_bytes length mismatch" {
+    assert ct_eq_bytes([1, 2], [1, 2, 3]) == false;
+}
+
+test "bits: ct_eq_bytes empty" {
+    let a: int[] = [];
+    let b: int[] = [];
+    assert ct_eq_bytes(a, b) == true;
+}
+
+test "bits: load_u32_be" {
+    // 0x12345678
+    assert load_u32_be([18, 52, 86, 120], 0) == 305419896;
+}
+
+test "bits: store_u32_be round-trips" {
+    let mut out: int[] = [];
+    store_u32_be(out, 305419896);  // 0x12345678
+    assert out.length == 4;
+    assert out[0] == 18;
+    assert out[1] == 52;
+    assert out[2] == 86;
+    assert out[3] == 120;
+    assert load_u32_be(out, 0) == 305419896;
+}
+
+test "bits: load_u32_le" {
+    // bytes 78 56 34 12 little-endian == 0x12345678
+    assert load_u32_le([120, 86, 52, 18], 0) == 305419896;
+}
+
+test "bits: store_u32_le round-trips" {
+    let mut out: int[] = [];
+    store_u32_le(out, 305419896);
+    assert out.length == 4;
+    assert out[0] == 120;
+    assert load_u32_le(out, 0) == 305419896;
+}

--- a/capsules/sfn/crypto/tests/chacha20_test.sfn
+++ b/capsules/sfn/crypto/tests/chacha20_test.sfn
@@ -1,0 +1,75 @@
+// capsules/sfn/crypto/tests/chacha20_test.sfn
+//
+// Known-answer coverage for sfn/crypto ChaCha20 (RFC 8439 §2.3.2 block
+// function, §2.4.2 encryption) plus a fail-closed bad-key-length check.
+import { chacha20_block, chacha20_xor } from "../src/chacha20";
+
+// Map a single hex digit character to its 0-15 value, or -1 if not hex.
+fn _hexval(c: string) -> int {
+    let code: int = char_code(c) & 255;
+    if code >= 48 && code <= 57 {
+        return code - 48;
+    }  // '0'..'9'
+    if code >= 97 && code <= 102 {
+        return code - 97 + 10;
+    }  // 'a'..'f'
+    if code >= 65 && code <= 70 {
+        return code - 65 + 10;
+    }  // 'A'..'F'
+    return -1;
+}
+
+// Decode a lowercase/uppercase hex string into an int[] of bytes.
+fn hexb(s: string) -> int[] {
+    let mut out: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i + 1 >= s.length { break; }
+        let hi: int = _hexval(s[i]);
+        let lo: int = _hexval(s[i + 1]);
+        out.push(((hi << 4) | lo) & 255);
+        i += 2;
+    }
+    return out;
+}
+
+// Plain (non-constant-time) byte-array equality for test assertions.
+fn eq_bytes(a: int[], b: int[]) -> bool {
+    if a.length != b.length { return false; }
+    let mut i: int = 0;
+    loop {
+        if i >= a.length { break; }
+        if a[i] != b[i] { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+test "chacha20_block: RFC 8439 §2.3.2 keystream block" {
+    // key = 00 01 02 ... 1f, counter = 1, nonce = 00 00 00 09 00 00 00 4a 00 00 00 00
+    let key: int[] = hexb("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    let nonce: int[] = hexb("000000090000004a00000000");
+    let ks: int[] = chacha20_block(key, 1, nonce);
+    assert ks.length == 64;
+    assert eq_bytes(ks, hexb("10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4ed2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e"));
+}
+
+test "chacha20_xor: RFC 8439 §2.4.2 encryption" {
+    let key: int[] = hexb("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    let nonce: int[] = hexb("000000000000004a00000000");
+    // plaintext: "Ladies and Gentlemen of the class of '99: If I could offer
+    // you only one tip for the future, sunscreen would be it." (114 bytes)
+    let pt: int[] = hexb("4c616469657320616e642047656e746c656d656e206f662074686520636c617373206f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73637265656e20776f756c642062652069742e");
+    let ct: int[] = chacha20_xor(key, 1, nonce, pt);
+    assert eq_bytes(ct, hexb("6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d807ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42874d"));
+    // Round-trip: XOR again recovers the plaintext.
+    let back: int[] = chacha20_xor(key, 1, nonce, ct);
+    assert eq_bytes(back, pt);
+}
+
+test "chacha20_block: rejects bad key length" {
+    let bad: int[] = [1, 2, 3];
+    let nonce: int[] = hexb("000000090000004a00000000");
+    let ks: int[] = chacha20_block(bad, 1, nonce);
+    assert ks.length == 0;
+}

--- a/capsules/sfn/crypto/tests/hkdf_test.sfn
+++ b/capsules/sfn/crypto/tests/hkdf_test.sfn
@@ -1,0 +1,83 @@
+// capsules/sfn/crypto/tests/hkdf_test.sfn
+//
+// Regression coverage for HKDF-SHA-256 (RFC 5869) and its internal pure
+// HMAC-SHA-256: RFC 4231 test case 1 cross-checks the HMAC, and RFC 5869
+// test cases 1 and 3 cover extract/expand, including empty salt/info and
+// out-of-range length rejection.
+import { hmac_sha256_bytes, hkdf_sha256_extract, hkdf_sha256_expand } from "../src/hkdf";
+
+// Parse an even-length lowercase hex string into an int[] of bytes.
+fn hexb(s: string) -> int[] {
+    let digits: string = "0123456789abcdef";
+    let mut out: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= s.length { break; }
+        let hi: int = _hexval(s[i]);
+        let lo: int = _hexval(s[i + 1]);
+        out.push(((hi << 4) | lo) & 255);
+        i += 2;
+    }
+    return out;
+}
+
+fn _hexval(c: string) -> int {
+    let code: int = char_code(c) & 255;
+    if code >= 48 && code <= 57 {
+        return code - 48;
+    }  // '0'-'9'
+    if code >= 97 && code <= 102 {
+        return code - 97 + 10;
+    }  // 'a'-'f'
+    return 0;
+}
+
+fn eq_bytes(a: int[], b: int[]) -> bool {
+    if a.length != b.length { return false; }
+    let mut i: int = 0;
+    loop {
+        if i >= a.length { break; }
+        if a[i] != b[i] { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+// RFC 4231 test case 1 cross-checks the internal pure HMAC-SHA-256.
+test "hmac_sha256_bytes: RFC 4231 test case 1" {
+    let key: int[] = hexb("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");  // 20 x 0x0b
+    let data: int[] = [72, 105, 32, 84, 104, 101, 114, 101];  // "Hi There"
+    let mac: int[] = hmac_sha256_bytes(key, data);
+    assert eq_bytes(mac, hexb("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"));
+}
+
+test "hkdf: RFC 5869 test case 1 extract" {
+    let ikm: int[] = hexb("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");  // 22 x 0x0b
+    let salt: int[] = hexb("000102030405060708090a0b0c");
+    let prk: int[] = hkdf_sha256_extract(salt, ikm);
+    assert eq_bytes(prk, hexb("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"));
+}
+
+test "hkdf: RFC 5869 test case 1 expand (L=42)" {
+    let prk: int[] = hexb("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+    let info: int[] = hexb("f0f1f2f3f4f5f6f7f8f9");
+    let okm: int[] = hkdf_sha256_expand(prk, info, 42);
+    assert eq_bytes(okm, hexb("3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"));
+}
+
+test "hkdf: RFC 5869 test case 3 (empty salt and info)" {
+    let ikm: int[] = hexb("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");  // 22 x 0x0b
+    let salt: int[] = [];
+    let prk: int[] = hkdf_sha256_extract(salt, ikm);
+    assert eq_bytes(prk, hexb("19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04"));
+    let info: int[] = [];
+    let okm: int[] = hkdf_sha256_expand(prk, info, 42);
+    assert eq_bytes(okm, hexb("8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"));
+}
+
+test "hkdf: expand rejects out-of-range length" {
+    let prk: int[] = hexb("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+    let info: int[] = [];
+    let empty: int[] = hkdf_sha256_expand(prk, info, 0);
+    assert empty.length == 0;
+}

--- a/capsules/sfn/crypto/tests/hkdf_test.sfn
+++ b/capsules/sfn/crypto/tests/hkdf_test.sfn
@@ -81,3 +81,10 @@ test "hkdf: expand rejects out-of-range length" {
     let empty: int[] = hkdf_sha256_expand(prk, info, 0);
     assert empty.length == 0;
 }
+
+test "hkdf: expand rejects a PRK shorter than HashLen" {
+    let short_prk: int[] = hexb("077709362c2e32df0ddc3f0dc47bba63");  // 16 bytes < 32
+    let info: int[] = [];
+    let empty: int[] = hkdf_sha256_expand(short_prk, info, 42);
+    assert empty.length == 0;
+}

--- a/capsules/sfn/crypto/tests/poly1305_test.sfn
+++ b/capsules/sfn/crypto/tests/poly1305_test.sfn
@@ -1,0 +1,78 @@
+// capsules/sfn/crypto/tests/poly1305_test.sfn
+//
+// Regression coverage for the sfn/crypto poly1305 module: RFC 8439 §2.5.2
+// test vector, a full-carry finalize vector for the keep-h reduction branch,
+// the empty-message edge case, and bad-key-length rejection.
+import { poly1305_mac } from "../src/poly1305";
+
+fn hexb(s: string) -> int[] {
+    let mut out: int[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= s.length { break; }
+        let hi: int = _hexval(s[i]);
+        let lo: int = _hexval(s[i + 1]);
+        out.push(((hi << 4) | lo) & 255);
+        i += 2;
+    }
+    return out;
+}
+
+fn _hexval(c: string) -> int {
+    let code: int = char_code(c) & 255;
+    if code >= 48 && code <= 57 {
+        return code - 48;
+    }  // '0'-'9'
+    if code >= 97 && code <= 102 {
+        return code - 97 + 10;
+    }  // 'a'-'f'
+    return 0;
+}
+
+fn eq_bytes(a: int[], b: int[]) -> bool {
+    if a.length != b.length { return false; }
+    let mut i: int = 0;
+    loop {
+        if i >= a.length { break; }
+        if a[i] != b[i] { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+test "poly1305_mac: RFC 8439 §2.5.2" {
+    let key: int[] = hexb("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b");
+    // msg = "Cryptographic Forum Research Group" (34 bytes)
+    let msg: int[] = hexb("43727970746f6772617068696320466f72756d2052657365617263682047726f7570");
+    let tag: int[] = poly1305_mac(msg, key);
+    assert tag.length == 16;
+    assert eq_bytes(tag, hexb("a8061dc1305136c6c22b8baf0c0127a9"));
+}
+
+test "poly1305_mac: empty message" {
+    // Empty message → tag is s mod 2^128 = key[16..31] little-endian unchanged.
+    let key: int[] = hexb("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b");
+    let msg: int[] = [];
+    let tag: int[] = poly1305_mac(msg, key);
+    assert eq_bytes(tag, hexb("0103808afb0db2fd4abff6af4149f51b"));
+}
+
+test "poly1305_mac: full-carry finalize (h-branch with dirty h1 limb)" {
+    // Adversarially constructed known-answer vector (verified against the
+    // RFC 8439 big-integer reference): clamp-maximal r, s = 0, and a third
+    // block chosen so the per-block loop exits with bit 26 of h1 set while
+    // the final select keeps h. Without the full-carry pass in finalize the
+    // serialized tag drops that carry (byte 6 reads 70 instead of 80).
+    let key: int[] = hexb("ffffffffffffffffffffffffffffffff00000000000000000000000000000000");
+    let msg: int[] = hexb("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdbb15c00ffffffffffffffffffffffff");
+    let tag: int[] = poly1305_mac(msg, key);
+    assert tag.length == 16;
+    assert eq_bytes(tag, hexb("6b881517000080fb2980e3234b802893"));
+}
+
+test "poly1305_mac: rejects bad key length" {
+    let key: int[] = [1, 2, 3];
+    let msg: int[] = [4, 5, 6];
+    let tag: int[] = poly1305_mac(msg, key);
+    assert tag.length == 0;
+}

--- a/capsules/sfn/crypto/tests/sha1_test.sfn
+++ b/capsules/sfn/crypto/tests/sha1_test.sfn
@@ -1,0 +1,29 @@
+// capsules/sfn/crypto/tests/sha1_test.sfn
+//
+// Regression tests for the pure-Sailfin SHA-1 implementation (RFC 3174).
+// Vectors are RFC 3174 §7.3 / NIST / RFC 6455 §1.3.
+import { sha1_hex } from "../src/sha1";
+
+test "sha1_hex: empty string" {
+    assert sha1_hex("") == "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+}
+
+test "sha1_hex: abc" {
+    assert sha1_hex("abc") == "a9993e364706816aba3e25717850c26c9cd0d89d";
+}
+
+test "sha1_hex: 448-bit two-block vector" {
+    assert sha1_hex("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") == "84983e441c3bd26ebaae4aa1f95129e5e54670f1";
+}
+
+test "sha1_hex: 56 'a's forces a second block" {
+    // 56 bytes: 0x80 pad + 64-bit length spill into a second 64-byte block.
+    assert sha1_hex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") == "c2db330f6083854c99d4b5bfb6e8f29f201be699";
+}
+
+test "sha1_hex: websocket accept preimage (RFC 6455 §1.3)" {
+    // SHA-1 of the sample client key concatenated with the RFC 6455 GUID.
+    // The base64 of these 20 digest bytes is the Sec-WebSocket-Accept value
+    // "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" — the exact Phase D use case.
+    assert sha1_hex("dGhlIHNhbXBsZSBub25jZQ==258EAFA5-E914-47DA-95CA-C5AB0DC85B11") == "b37a4f2cc0624f1690f64606cf385945b2bec4ea";
+}

--- a/capsules/sfn/crypto/tests/sha384_test.sfn
+++ b/capsules/sfn/crypto/tests/sha384_test.sfn
@@ -1,0 +1,19 @@
+// Tests for sfn/crypto SHA-384 (pure-Sailfin, FIPS 180-4).
+//
+// Known-answer vectors covering the empty string, the canonical "abc"
+// vector, and a 112-byte input whose padding forces a second 128-byte
+// block (all authoritative FIPS 180-4 / NIST vectors; the 112-byte value
+// is cross-checked against `shasum -a 384`).
+import { sha384_hex } from "../src/sha384";
+
+test "sha384_hex: empty string" {
+    assert sha384_hex("") == "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b";
+}
+
+test "sha384_hex: abc" {
+    assert sha384_hex("abc") == "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7";
+}
+
+test "sha384_hex: 112-byte two-block vector" {
+    assert sha384_hex("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu") == "09330c33f71147e83d192fc782cd1b4753111b173b3b05d22fa08086e3b0f712fcc7c71a557e2db966c3e9fa91746039";
+}

--- a/docs/proposals/0048-native-crypto.md
+++ b/docs/proposals/0048-native-crypto.md
@@ -1,7 +1,7 @@
 ---
-sfep: TBD
+sfep: 0048
 title: Native crypto + TLS stack — removing the OpenSSL dependency
-status: Draft
+status: Accepted
 type: runtime
 created: 2026-07-12
 updated: 2026-07-12
@@ -12,7 +12,7 @@ superseded-by:
 graduates-to:
 ---
 
-# SFEP-XXXX — Native crypto + TLS stack — removing the OpenSSL dependency
+# SFEP-0048 — Native crypto + TLS stack — removing the OpenSSL dependency
 
 ## 1. Summary
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -87,6 +87,7 @@ language gaps surfaced by the 2026-07 grammar/object-model audit:
 | [`draft-derive`](./draft-derive.md) | Derivable Interface Implementations (`@derive`) | language |
 | [`draft-string-interpolation-dollar`](./draft-string-interpolation-dollar.md) | String Interpolation with `${ }` (migrating off `{{ }}`) | language |
 | [`draft-nullable-access-operators`](./draft-nullable-access-operators.md) | Nullable Access Operators (`?.` and `??`) | language |
+| [`draft-native-crypto`](./draft-native-crypto.md) | Native Crypto + TLS Stack — Removing the OpenSSL Dependency | runtime |
 
 SFEP-0038 (`0038-generic-constraints.md`, Implemented) is the root foundation:
 `draft-generic-collections`, `draft-derive`, and SFEP-0028 all depend on it. Draft diagnostic codes are

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -70,6 +70,7 @@ The next number is `max + 1`. Add a row in the same PR that introduces an SFEP.
 | [0045](./0045-shared-frontend-test-runner.md) | Shared-frontend test runner — parent compiles, children only execute | Draft | tooling |
 | [0046](./0046-toolchain-pinning.md) | Native Toolchain Version Pinning + Dispatch | Accepted | tooling |
 | [0047](./0047-compiler-bootstrap-manifest.md) | Compiler Bootstrap Manifest | Accepted | tooling |
+| [0048](./0048-native-crypto.md) | Native Crypto + TLS Stack — Removing the OpenSSL Dependency | Accepted | runtime |
 
 ## Drafts under review (numbers assigned at merge)
 
@@ -87,7 +88,6 @@ language gaps surfaced by the 2026-07 grammar/object-model audit:
 | [`draft-derive`](./draft-derive.md) | Derivable Interface Implementations (`@derive`) | language |
 | [`draft-string-interpolation-dollar`](./draft-string-interpolation-dollar.md) | String Interpolation with `${ }` (migrating off `{{ }}`) | language |
 | [`draft-nullable-access-operators`](./draft-nullable-access-operators.md) | Nullable Access Operators (`?.` and `??`) | language |
-| [`draft-native-crypto`](./draft-native-crypto.md) | Native Crypto + TLS Stack — Removing the OpenSSL Dependency | runtime |
 
 SFEP-0038 (`0038-generic-constraints.md`, Implemented) is the root foundation:
 `draft-generic-collections`, `draft-derive`, and SFEP-0028 all depend on it. Draft diagnostic codes are

--- a/docs/proposals/draft-native-crypto.md
+++ b/docs/proposals/draft-native-crypto.md
@@ -1,0 +1,414 @@
+---
+sfep: TBD
+title: Native crypto + TLS stack — removing the OpenSSL dependency
+status: Draft
+type: runtime
+created: 2026-07-12
+updated: 2026-07-12
+author: "agent:compiler-architect; human review"
+tracking:
+supersedes:
+superseded-by:
+graduates-to:
+---
+
+# SFEP-XXXX — Native crypto + TLS stack — removing the OpenSSL dependency
+
+## 1. Summary
+
+Sailfin links OpenSSL (`-lssl -lcrypto`) into **every** binary it produces —
+including the compiler itself — to provide TLS for the native HTTP/WebSocket
+runtime and a handful of crypto primitives (HMAC-SHA-256, Ed25519 verify,
+WebSocket SHA-1 + base64 + CSPRNG). This is the single largest external
+dependency in the toolchain and a direct obstacle to the capability-sealed
+runtime (SFEP-0016): **you cannot seal a binary whose entire TLS record layer
+and syscall-issuing crypto engine is opaque C you do not own.** The manifest's
+own comment (`runtime/capsule.toml:59`) confirms `-lssl`/`-lcrypto` reaches the
+final link of the compiler binary, so the seal's "one enforcement chokepoint"
+premise is violated the moment libssl issues a `connect(2)` the runtime cannot
+see.
+
+This SFEP records the **full phased path to zero OpenSSL**, and its first
+workflow implements **Phase A only**: extending the *existing*
+`capsules/sfn/crypto/` library capsule with the pure-Sailfin primitives the
+native TLS/WebSocket stack will need but does not yet have — SHA-1, SHA-384,
+HKDF, ChaCha20, Poly1305, and a shared constant-time/masking helper module.
+(SHA-256, base64 encode/decode, HMAC-SHA-256, and Ed25519-verify already ship
+in that capsule; Phase A does not re-found them.) Later phases build the TLS 1.3
+record layer and handshake (Phase B), X.509 chain verification + trust store
+(Phase C), and finally swap the `tls_*` wrappers onto the native stack and
+delete the OpenSSL externs + link wiring (Phase D). Crypto is pure computation
+(no effects); the CSPRNG source and TLS I/O keep their effects. The phasing is
+deliberately sequenced so each phase self-hosts and ships independently, and so
+the highest-risk field arithmetic (Curve25519 / X25519) is **explicitly
+excluded from Phase A** as a blocker pending sized-integer / wide-multiply
+support (§6, §7).
+
+## 2. Motivation
+
+**The seal blocker.** SFEP-0016 (a 1.0 hallmark / hard GA blocker per
+`docs/strategy/decision-brief.md`) requires that every effectful operation pass
+through a syscall chokepoint the runtime owns. Today `-lssl`/`-lcrypto` is in
+the same dependency class as `-lm`/`-lpthread` (`runtime/capsule.toml:59`): it
+is on the link line of every Sailfin binary, and libssl's own `connect`/`read`/
+`write` calls resolve to libc, not to any gated Sailfin stub. As long as TLS is
+OpenSSL, a sealed binary has a hole the width of the entire TLS stack.
+
+**The dependency-footprint problem.** OpenSSL is a large, version-churning C
+dependency with a keg-only Homebrew story on macOS that forces a shell-probed
+`-L` search path (`_openssl_link_search_flags()` in
+`compiler/src/build/runtime_objs.sfn:904`). It is excluded from the Windows
+cross-build entirely (`runtime/ir/windows_stubs.ll` stubs the `tls_*` wrappers),
+so `https://` silently degrades to null on Windows today. Removing it collapses
+three platform forks into one native code path.
+
+**Current surface (ground truth).** Exactly one file
+(`runtime/sfn/platform/tls.sfn`) owns the entire OpenSSL extern surface (24
+`SSL_*`/`SSL_CTX_*` symbols) and defines every `tls_*` wrapper. Three consumers
+(`http.sfn`, `websocket.sfn`, `serve.sfn`) forward-declare the `tls_*` wrapper
+signatures (the #306 cross-module-extern workaround) rather than importing
+`tls.sfn`. Separately, `websocket.sfn` declares three **libcrypto** externs —
+`SHA1`, `EVP_EncodeBlock`, `RAND_bytes` — used **unconditionally** for the RFC
+6455 handshake and frame masking on *every* WebSocket connection, `ws://` and
+`wss://` alike. This matters: naively dropping `-lcrypto` breaks all WebSocket
+traffic, not just TLS. Phase A's SHA-1 + base64 (already shipped) + a CSPRNG
+source are the prerequisites that let Phase D remove those three externs.
+Additionally, `capsules/sfn/crypto/src/mod.sfn` itself uses libcrypto for
+`hmac_sha256` (the `HMAC`/`EVP_sha256` externs) and `ed25519.sfn` uses the
+OpenSSL EVP surface for Ed25519 verify — a fully OpenSSL-free build eventually
+needs pure-Sailfin replacements for those too (out of Phase A scope; noted in §7).
+
+**The honest constraint (§6).** A from-scratch TLS 1.3 stack is a multi-quarter
+effort and a security surface. This SFEP does not pretend otherwise. It scopes
+Phase A to the primitives that are provably constant-correct under Sailfin's
+*current* integer semantics, and it is explicit that X25519 — the one primitive
+TLS 1.3 key exchange cannot do without — is **not** buildable today (§6.4) and
+gates Phase B.
+
+## 3. Design
+
+### 3.1 The four phases
+
+| Phase | Deliverable | External-dep effect | Ships when |
+|---|---|---|---|
+| **A** | Extend `capsules/sfn/crypto/`: SHA-1, SHA-384, HKDF, ChaCha20, Poly1305, a `bits` constant-time/masking helper module (SHA-256, base64, HMAC-SHA-256, Ed25519-verify already ship) | none removed yet; primitives exist natively | this workflow |
+| **B** | TLS 1.3 record layer (AEAD via ChaCha20-Poly1305) + client handshake, then server handshake | still linked (fallback); native path selectable | after X25519 unblocks (§6.4) |
+| **C** | X.509 cert parse + chain verification + system trust-store loading + RFC 6125 hostname check | still linked | after Phase B |
+| **D** | Swap `tls_*` wrapper **bodies** to the native stack; replace `websocket.sfn`'s `SHA1`/`EVP_EncodeBlock`/`RAND_bytes` with the native primitives; replace the `sfn/crypto` HMAC/Ed25519 externs with pure-Sailfin ports; delete all OpenSSL externs; drop `-lssl`/`-lcrypto`; remove `_openssl_link_search_flags()` | **`-lssl`/`-lcrypto` gone from every binary** | after Phase C |
+
+Because the three TLS consumers forward-declare only the **`tls_*` wrapper
+names** (not raw OpenSSL symbols), Phase D changes only `tls.sfn`'s function
+*bodies* and `websocket.sfn`'s three externs — no consumer-signature churn.
+Phase D is where the seal blocker is actually cleared.
+
+### 3.2 Where the code lives
+
+Phase A extends the **existing `capsules/sfn/crypto/`** library capsule
+(`kind = "library"`, `entry = "src/mod.sfn"`, version `0.7.1`), which already
+ships SHA-256, base64, HMAC-SHA-256, and Ed25519-verify (`docs/status.md:435`).
+It does **not** found a new `runtime/sfn/crypto/` tree. Each new primitive is a
+sibling module under `capsules/sfn/crypto/src/` re-exported from `mod.sfn`,
+following the established `ed25519.sfn` precedent:
+
+```sfn
+// capsules/sfn/crypto/src/mod.sfn — new re-export lines
+export { sha1_hex, sha1_bytes } from "./sha1";
+export { sha384_hex } from "./sha384";
+export { hkdf_sha256_extract, hkdf_sha256_expand } from "./hkdf";
+export { chacha20_block, chacha20_xor } from "./chacha20";
+export { poly1305_mac } from "./poly1305";
+```
+
+No `runtime/capsule.toml` / `runtime_objs.sfn` staging is needed: that machinery
+is exclusively for the compiler's own linked-in runtime, and a capsule-library's
+`capsule.toml` `[build] entry` + normal capsule resolution is all that is
+required. Tests live under `capsules/sfn/crypto/tests/<primitive>_test.sfn`.
+
+**Consumption by Phases B–D (the runtime-vs-capsule tension).** Phases B–D need
+these primitives from *compiler-runtime* modules (`tls.sfn`, `websocket.sfn`),
+which cannot depend on a `kind = "library"` capsule — the same dependency-closure
+reason the compiler already vendors SHA-256 into `compiler/src/build/hash.sfn`.
+Phase A does **not** solve that: it lands the primitives in the capsule where
+they get user-facing test coverage and a canonical home. When Phase B begins,
+each primitive it needs is **vendored** into the runtime (a byte-identical copy,
+exactly as `build/hash.sfn` vendors SHA-256), with the capsule copy remaining the
+tested source of truth. Deciding whether to later unify these (e.g. a shared
+`sfn-sources`-staged runtime crypto module the capsule re-exports) is out of
+Phase A scope and deferred to a Phase B design note. Phase A's deliverable is
+correct, tested primitives — not their runtime wiring.
+
+### 3.3 The integer-idiom standard (honest about sized ints)
+
+Sailfin's sized-integer family is **half-real** today
+(`draft-sized-integer-types.md`, still `Draft`): unsigned widths collapse to
+signed LLVM twins (`compiler/src/llvm/type_mapping.sfn:877-895`); `u8 as u64`
+mis-lowers as `sext` (255 → -1) (`core_cast_lowering.sfn:443-449`); `>>` always
+lowers to `ashr`, never `lshr` (`core_helpers.sfn:60-70`); no overflow/wrapping
+semantics exist; literal ranges are unchecked; there are no typed literal
+suffixes; and there is no `64×64 → 128` multiply. Every Phase A module therefore
+obeys a single mandated idiom, proven by the in-tree SHA-256
+(`capsules/sfn/crypto/src/mod.sfn:88-241`, `compiler/src/build/hash.sfn`):
+
+1. **All word arithmetic on plain `int` (signed i64). Never `u32`/`u64` typed
+   locals for arithmetic.** `u8`/`i32`/`usize` appear only in `extern fn` FFI
+   signatures, never in Sailfin-side arithmetic.
+2. **Mask to the algorithm's true width after every op that could exceed it.**
+   32-bit words: `& 4294967295` after every add/xor/rotate/shift. This keeps
+   every value in `[0, 2^32)` — non-negative — which is *what makes `ashr`
+   behave as the logical shift the algorithm needs*. The mask is load-bearing,
+   not decoration.
+3. **Rotate-left / rotate-right via mask-after-shift**, e.g.
+   `((x << n) | (x >> (32 - n))) & 4294967295`.
+4. **64-bit words (SHA-384) held as two 32-bit limbs (`hi`, `lo`), each masked
+   `& 4294967295`.** No 64-bit word is ever stored in a single `int` and shifted
+   as a unit, because a set bit 63 would make `ashr` sign-extend. All 64-bit
+   add/xor/rotate/shift are done limb-wise with explicit inter-limb carry. This
+   keeps every limb non-negative and every limb sum ≤ `2^33` (inside i64). The
+   existing SHA-256 already builds/consumes a 64-bit bit-length as `hi`/`lo`
+   32-bit halves at `mod.sfn:141-150` — the exact template.
+5. **Multi-precision reduction (Poly1305) via narrow limbs whose pairwise
+   products stay inside i64.** Poly1305 uses **five 26-bit limbs**; a limb
+   product is ≤ `2^52`, and a full field-mul accumulates ≤ 5 such products +
+   the ×5 reduction multiplier ≤ ~`2^55` per output column — comfortably inside
+   i64's `2^63`. Exact limb layout mandated in the Phase A `poly1305` spec.
+6. **Bytes via `int[]` + `char_code`/`char_from_code`, masked `& 255`.**
+   Byte value `0x00` is unrepresentable in a Sailfin `string`
+   (`char_from_code(0)` → `""`, `runtime/prelude.sfn:731-769`), so **any
+   function that produces arbitrary binary output does so as `int[]`, never
+   `string`.** Only hex/base64 *encodings* (always NUL-free ASCII) return
+   `string`. This is the fail-closed contract the existing `base64_decode`
+   already follows.
+7. **Constants written in decimal.** Hex literals are unavailable in Sailfin
+   source; round-constant tables and initial state are decimal (`4294967295`
+   is the 0xffffffff mask), matching the shipped SHA-256.
+
+The Phase A implementer follows these idioms exactly; there is no design
+latitude to introduce `u32`/`u64` arithmetic or unmasked shifts.
+
+### 3.4 Worked example (the mandated shape)
+
+```sfn
+// capsules/sfn/crypto/src/bits.sfn — the constant-time / masking helper module.
+// 32-bit mask, decimal (no hex literals in Sailfin source).
+fn mask32() -> int { return 4294967295; }
+
+fn rotl32(x: int, n: int) -> int {
+    return ((x << n) | (x >> (32 - n))) & 4294967295;
+}
+
+// Constant-time byte equality over two equal-length int[] byte arrays.
+// Accumulates the OR of per-byte XOR differences; no early return, no
+// data-dependent branch. Returns true iff every byte matches.
+fn ct_eq_bytes(a: int[], b: int[]) -> bool {
+    if a.length != b.length { return false; }  // length is public
+    let mut diff: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= a.length { break; }
+        diff = diff | ((a[i] & 255) ^ (b[i] & 255));
+        i += 1;
+    }
+    return diff == 0;
+}
+```
+
+## 4. Effect & capability impact
+
+**Deterministic crypto primitives are pure — zero effects.** Every Phase A hash/
+MAC/KDF/cipher function is a deterministic pure computation over its byte-array/
+string inputs (no `![io]`, no `![net]`, no `![rand]`). This mirrors the existing
+`sfn/crypto` capsule (`docs/status.md:435`: "no required effects"). SHA-1,
+SHA-384, HKDF, ChaCha20 (keystream/xor with a caller-supplied nonce+counter),
+Poly1305, and the `bits` helpers all take inputs and return outputs with no
+ambient authority. Bare `assert lhs == rhs;` known-answer tests suffice — no
+`![io]`, no `sfn/test` matchers.
+
+**The CSPRNG is the one effectful boundary — and it is NOT in Phase A.** WebSocket
+key generation and TLS nonces need cryptographically strong randomness, which
+today comes from `RAND_bytes` (libcrypto). A native random source reads the OS
+entropy device (`getrandom(2)` on Linux, `arc4random_buf` / `/dev/urandom` on
+macOS) — that is an I/O syscall and must carry **`![rand]`** at minimum, and
+arguably `![io]`. It is a non-deterministic effectful primitive that cannot be
+known-answer tested and does not belong in a pure-crypto wave. It is therefore
+**deferred to Phase D** (bundled with the `websocket.sfn` extern removal that
+actually consumes it), where the effect cost is visible at the exact call site.
+Phase A ships only pure, deterministic, known-answer-testable primitives. The
+RNG is explicitly **not** folded into any pure module.
+
+**TLS I/O (Phase B+) stays `![net]`.** Replacing OpenSSL's record layer with a
+native one does not change the effect surface: `tls_read`/`tls_write`/
+`tls_connect_fd`/`tls_accept_fd` already carry `![net]` and continue to. The
+*handshake crypto* (key schedule, AEAD) is pure and effect-free; only the socket
+read/write that carries the records is `![net]`.
+
+**Capability-seal payoff (the point of the whole SFEP).** Once Phase D lands,
+the TLS record layer's socket traffic flows through Sailfin-owned `send`/`recv`
+externs (already gated candidates), not through libssl's opaque libc calls. This
+is a **prerequisite** for SFEP-0016's syscall chokepoint: the seal cannot gate
+what it cannot see, and today it cannot see inside libssl.
+
+## 5. Self-hosting impact
+
+**No compiler-pass changes, and no seed dependency for Phase A.** Phase A adds
+only new source modules to the `capsules/sfn/crypto/` *library* capsule and
+their tests. It touches **no** `compiler/src/*.sfn`, no `runtime/sfn/*.sfn`, and
+no `runtime/capsule.toml`. No lexer/parser/AST/typecheck/effect/emitter/lowering
+change is required — the primitives use only constructs the current seed already
+compiles (loops, `int[]`, `int` arithmetic, `char_code`/`char_from_code`,
+bitwise ops), confirmed by the in-tree SHA-256/base64/HMAC which already
+self-host and pass their vector tests under the current compiler.
+
+Because Phase A changes only a library capsule that the compiler's own build
+does **not** depend on, `make compile` is unaffected and **no seed cut is
+required** (`.claude/rules/seed-dependency.md`). The capsule builds and tests
+with whatever compiler binary already exists (`sfn test
+capsules/sfn/crypto/tests/<primitive>_test.sfn`).
+
+**Phase D is the seed-coupled change.** It swaps runtime bodies the compiler
+binary links (`tls.sfn`, `websocket.sfn`) and vendors the primitives into the
+runtime. Per the bundling rule it should land the body swap **and** the
+extern/link-wiring deletion in **one PR** — `make compile` builds the new
+compiler from the old seed and that compiler links the native crypto in the same
+self-host pass, avoiding a seed cut between "native stack exists" and "OpenSSL
+removed." Phase A deliberately front-loads all the seed-independent work so the
+seed-coupled surface is minimized to Phase D.
+
+## 6. Alternatives considered
+
+### 6.1 Vendor BoringSSL / build OpenSSL from source
+Rejected. Vendoring reintroduces a C/CMake build step — the exact thing the
+C-runtime retirement (#822) removed — and BoringSSL deliberately breaks API. It
+would trade a system-lib dependency for a heavier vendored-build dependency and
+still leave an opaque C blob the seal cannot see through. Does not advance
+SFEP-0016.
+
+### 6.2 Keep OpenSSL, gate it at the syscall layer only
+Rejected. SFEP-0016's chokepoint gates *Sailfin-owned* syscall stubs; libssl
+calls libc directly and would bypass the gate unless we interpose every libc
+symbol libssl uses — a fragile, incomplete interposition surface. Owning the
+TLS stack is the clean cut.
+
+### 6.3 rustls-style scope cuts (TLS 1.3 only, no TLS 1.2, no RSA)
+**Adopted for Phases B–D**, and it is what makes the native TLS effort
+tractable. TLS 1.3 only (no 1.2 downgrade), ChaCha20-Poly1305 AEAD only
+(deferring AES-GCM, which needs constant-time AES — hard without hardware AES
+intrinsics the backend does not yet expose), X25519 key exchange only, Ed25519 +
+ECDSA-P256 cert signatures. No session resumption/tickets, no ALPN beyond
+`http/1.1`, no OCSP, no client-cert/mTLS (already out of scope in SFEP-0036).
+This mirrors the deliberately-minimal surface `tls_features_required` documents
+the runtime actually exercises. Phase A ships exactly the *missing* primitives
+this cut needs: ChaCha20 + Poly1305 (AEAD), SHA-384 (SHA-256 already ships;
+transcript hash + HKDF), HKDF (key schedule), SHA-1 (WebSocket handshake accept
+value, the libcrypto removal).
+
+### 6.4 Pure-Sailfin X25519 in Phase A
+**Rejected for Phase A — recorded as a blocker (§7).** Curve25519 field
+arithmetic mod `2^255 − 19` requires either 51-bit limbs (needs a `64×64 → 128`
+multiply that Sailfin cannot express) or 25.5-bit limbs (10 limbs) whose
+field-multiply carry chain runs to ~`2^58` per output column with the ×19
+reduction — inside i64 in principle, but with a thin margin and no
+compiler-enforced overflow check, and requiring a **constant-time conditional
+swap** (`cswap`) whose branch-free correctness is the exact thing the current
+`ashr`-only, unsigned-broken integer model makes hard to guarantee. The
+instruction is explicit: do not spec workarounds not trusted to be
+constant-correct. X25519 is therefore excluded from the Phase A waves and filed
+as a blocker; it gates Phase B (TLS 1.3 key exchange is impossible without it).
+It is the canonical use case for `draft-sized-integer-types` and a future
+`64×64 → 128` widening-multiply intrinsic.
+
+### 6.5 Put the new primitives in `runtime/sfn/crypto/` instead of the capsule
+Rejected for Phase A. The existing crypto surface already lives in the
+`capsules/sfn/crypto/` library capsule, which is where user-facing crypto and
+its vector-test coverage belong; founding a parallel `runtime/sfn/crypto/` tree
+now would fork the surface and duplicate SHA-256/base64. Phases B–D consume the
+primitives from compiler-runtime modules that *cannot* import a library capsule,
+but that is solved by vendoring (§3.2) — the same pattern `build/hash.sfn`
+already uses — not by relocating the tested source of truth out of the capsule.
+
+## 7. Blockers
+
+- **X25519 (Curve25519 ECDH) — not buildable in Phase A.** Requires either a
+  `64×64 → 128` widening multiply (does not exist; no wide-multiply intrinsic)
+  or a 10-limb 25.5-bit schoolbook field-multiply whose carry chain and ×19
+  reduction leave a thin i64 margin with **no** compiler-enforced overflow
+  check, plus a constant-time `cswap` whose branch-free guarantee is undermined
+  by `>>`-is-`ashr` and collapsed-unsigned semantics. **Missing capability:**
+  sized/unsigned integer semantics with defined wrapping
+  (`draft-sized-integer-types`) and/or a widening-multiply intrinsic. **Gates:**
+  Phase B (TLS 1.3 key exchange). Until then, Phase B either stays
+  OpenSSL-backed for the key exchange only or waits.
+
+- **AES-GCM AEAD — deliberately deferred (not a hard blocker for the chosen
+  cut).** Constant-time software AES needs either bitsliced AES (very large,
+  error-prone) or hardware AES-NI intrinsics the backend does not expose. The
+  rustls-style cut (§6.3) sidesteps this by shipping **ChaCha20-Poly1305 only**,
+  which Phase A fully delivers. Recorded so a future "AES-GCM parity" ask lands
+  on a known missing capability (SIMD/AES intrinsics), not a surprise.
+
+- **Pure-Sailfin HMAC-SHA-256 + Ed25519-verify — deferred to Phase D.** The
+  shipped `hmac_sha256` (`mod.sfn`) and `ed25519_verify` (`ed25519.sfn`) are
+  OpenSSL-backed; a fully OpenSSL-free build needs pure ports. HMAC-SHA-256 is
+  trivially portable once Phase A's HKDF (which already composes HMAC over the
+  pure SHA-256) exists — indeed Phase A's HKDF spec includes a pure HMAC-SHA-256
+  helper. Ed25519-verify needs the same Curve25519 field arithmetic X25519 needs
+  and is therefore blocked on the same missing capability. Both are Phase D
+  concerns, not Phase A.
+
+## 8. Stage1 readiness mapping
+
+Phase A adds no language syntax, so the parse/typecheck/emit/lower rows are
+satisfied by *existing* compiler support for the constructs used; the
+feature-completeness bar is regression coverage + a green capsule build.
+
+- [x] Parses — no new syntax; uses existing loops/`int[]`/bitwise ops.
+- [x] Type-checks / effect-checks — pure fns, no new effects; existing effect
+      checker already handles these.
+- [x] Emits valid `.sfn-asm` — same constructs the in-tree SHA-256 emits.
+- [x] Lowers to LLVM IR — ditto.
+- [ ] Regression coverage — new: known-answer-vector tests per primitive
+      (§ Phase A specs), under `capsules/sfn/crypto/tests/<primitive>_test.sfn`.
+- [ ] Self-hosts — `make compile` is unaffected (library-capsule-only change,
+      no seed dependency, §5); the bar is `sfn test capsules/sfn/crypto/tests`
+      green.
+- [ ] `sfn fmt --check` clean — on every new `capsules/sfn/crypto/src/*.sfn`.
+- [ ] Documented in `docs/status.md` + spec — update the `sfn/crypto` row
+      (`docs/status.md:435`) to list SHA-1/SHA-384/HKDF/ChaCha20/Poly1305.
+
+## 9. Test plan
+
+Per the `sfn/crypto` capsule's established convention, each new primitive gets a
+`capsules/sfn/crypto/tests/<primitive>_test.sfn` importing the module under test
+by relative path (`import { sha1_hex } from "../src/sha1";` or via the `mod.sfn`
+re-export). Test bodies are plain `test "<name>" { assert ...; }` blocks with
+hardcoded known-answer vectors from the governing RFC (inlined in the Phase A
+specs): RFC 3174/6234 (SHA-1), FIPS 180-4 / RFC 6234 (SHA-384), RFC 5869 (HKDF),
+RFC 8439 (ChaCha20, Poly1305). Pure fns use bare `assert lhs == rhs;` (no
+`sfn/test` matcher machinery, no `![io]`). Run a single file with `build/bin/sfn
+test capsules/sfn/crypto/tests/sha1_test.sfn`.
+
+Phase B/C/D add: a native-vs-OpenSSL differential test (record-layer round-trip,
+handshake transcript), an X.509 chain-verification vector set, the CSPRNG
+liveness smoke test (`![rand]`, never known-answer), and the loopback e2e
+already established by SFEP-0036 §10 (self-signed cert, `SAILFIN_TLS_CAFILE`)
+re-pointed at the native stack.
+
+## 10. References
+
+- SFEP-0016 (`0016-capability-sealed-runtime.md`, Accepted) — the seal this
+  unblocks; 1.0 hallmark / GA blocker per `docs/strategy/decision-brief.md`.
+- SFEP-0036 (`0036-tls-runtime.md`, Implemented) — the OpenSSL TLS runtime this
+  replaces; its `tls_*` wrapper contracts are the Phase D swap target.
+- SFEP-0015 (`0015-llvm-independence.md`) — backend/syscall ownership; the seal's
+  other prerequisite.
+- `draft-sized-integer-types.md` — the missing capability behind the X25519 /
+  Ed25519 blocker (§7).
+- Prior art: `capsules/sfn/crypto/src/mod.sfn` (SHA-256, base64, HMAC-SHA-256),
+  `capsules/sfn/crypto/src/ed25519.sfn` (OpenSSL-EVP wrapper pattern),
+  `compiler/src/build/hash.sfn` (vendored SHA-256 — the runtime-vendoring
+  template for Phases B–D).
+- Ground-truth extern surface: `runtime/sfn/platform/tls.sfn`,
+  `runtime/sfn/adapters/websocket.sfn:98-102`,
+  `compiler/src/build/runtime_objs.sfn:904-937`, `runtime/capsule.toml:49,59`.
+- RFCs: 4648 (base64, shipped), 3174/6234 (SHA-1), FIPS 180-4 / RFC 6234
+  (SHA-384), 2104/4231 (HMAC), 5869 (HKDF), 8439 (ChaCha20 + Poly1305), 7748
+  (X25519 — blocked).

--- a/docs/status.md
+++ b/docs/status.md
@@ -432,7 +432,7 @@ Capsules ship under `capsules/sfn/` and are imported by bare name
 |---------|--------|--------|---------|-------------|
 | `sfn/strings` | `"strings"` | Shipped | None | Trim, case conversion, split/join, find/replace |
 | `sfn/json` | `"json"` | Shipped | None | JSON parsing, serialization, pretty-print |
-| `sfn/crypto` | `"crypto"` | Shipped | None | Pure Sailfin SHA-256 + base64 encode/decode; OpenSSL-backed Ed25519 verify and HMAC-SHA-256 |
+| `sfn/crypto` | `"crypto"` | Shipped | None | Pure Sailfin SHA-256/SHA-1/SHA-384 + base64, HKDF-SHA-256, ChaCha20, Poly1305, and bit/constant-time helpers (SFEP draft-native-crypto Phase A); OpenSSL-backed Ed25519 verify and HMAC-SHA-256 |
 | `sfn/math` | `"math"` | Shipped | None | abs, min/max, clamp, floor/ceil/round, pow, sum/mean |
 | `sfn/path` | `"path"` | Shipped | None | Path join, dirname, basename, ext, normalize |
 | `sfn/toml` | `"toml"` | Shipped | None | TOML v1.0 parsing, serialization, dotted-path access |

--- a/docs/status.md
+++ b/docs/status.md
@@ -432,7 +432,7 @@ Capsules ship under `capsules/sfn/` and are imported by bare name
 |---------|--------|--------|---------|-------------|
 | `sfn/strings` | `"strings"` | Shipped | None | Trim, case conversion, split/join, find/replace |
 | `sfn/json` | `"json"` | Shipped | None | JSON parsing, serialization, pretty-print |
-| `sfn/crypto` | `"crypto"` | Shipped | None | Pure Sailfin SHA-256/SHA-1/SHA-384 + base64, HKDF-SHA-256, ChaCha20, Poly1305, and bit/constant-time helpers (SFEP draft-native-crypto Phase A); OpenSSL-backed Ed25519 verify and HMAC-SHA-256 |
+| `sfn/crypto` | `"crypto"` | Shipped | None | Pure Sailfin SHA-256/SHA-1/SHA-384 + base64, HKDF-SHA-256, ChaCha20, Poly1305, and bit/constant-time helpers (SFEP-0048 Phase A); OpenSSL-backed Ed25519 verify and HMAC-SHA-256 |
 | `sfn/math` | `"math"` | Shipped | None | abs, min/max, clamp, floor/ceil/round, pow, sum/mean |
 | `sfn/path` | `"path"` | Shipped | None | Path join, dirname, basename, ext, normalize |
 | `sfn/toml` | `"toml"` | Shipped | None | TOML v1.0 parsing, serialization, dotted-path access |


### PR DESCRIPTION
## Summary

First slice of removing the OpenSSL dependency — a prerequisite for the capability-sealed runtime (SFEP-0016 / epic #1639). Adds the **SFEP design record** for the full path to zero OpenSSL and implements **Phase A**: the pure-Sailfin crypto primitive layer.

### SFEP-0048 (docs/proposals/0048-native-crypto.md, Accepted)
- **Phase A** — native primitives in `capsules/sfn/crypto` (this PR)
- **Phase B** — TLS 1.3 record layer + handshake (client, then server)
- **Phase C** — X.509 chain verification + trust store
- **Phase D** — swap the `tls_*` wrappers onto the native stack; delete the externs in `runtime/sfn/platform/tls.sfn` / `websocket.sfn` and the `-lssl -lcrypto` link wiring in `runtime_objs.sfn`

### New modules (all with RFC known-answer vectors)
| Module | RFC | Notes |
|---|---|---|
| `bits.sfn` | — | masked-ashr rotates, LE/BE loads/stores, constant-time byte compare |
| `sha1.sfn` | 3174/6234 | needed for the WebSocket handshake (retires the `SHA1` extern in Phase D) |
| `sha384.sfn` | 6234 | SHA-512 core on hi/lo 32-bit halves |
| `hkdf.sfn` | 5869 | extract/expand over HMAC-SHA-256 |
| `chacha20.sfn` | 8439 | block fn + XOR stream |
| `poly1305.sfn` | 8439 | 5×26-bit limb (donna) schedule — every product bounded inside signed i64 |

All arithmetic uses the capsule&#39;s established `int` + explicit-mask idioms; each module was implemented against an architect-authored spec, mechanically verified (`fmt`/`check`/tests), and Opus-reviewed for round logic, limb bounds, and vector fidelity. The initial poly1305 review caught a missing full-carry pass in finalize; the fix plus an adversarially constructed regression vector (machine-verified against an RFC 8439 big-integer reference; the pre-fix code fails it) are included.

### Recorded blockers (in the SFEP)
- **X25519** (and pure Ed25519): Curve25519 field arithmetic needs a widening multiply or defined unsigned-carry semantics — blocked on `draft-sized-integer-types`. Gates Phase B key exchange.
- **AES-GCM**: deferred (rustls-style ChaCha20-Poly1305-only cut for 1.0).

### Review hardening (Copilot pass)
Follow-up commit addresses the actionable review notes: `load_u32_be`/`load_u32_le` now mask each byte `& 255` (self-contained exported helpers, matching `store_u32_*`/`ct_eq_bytes`), and `hkdf_sha256_expand` fail-closes on a PRK shorter than HashLen (with a regression test). The `rotl32`/`rotr32` n==0 notes were declined (correct across `[0,32)` under the masked-i64 model; verified for n=0..32), and the poly1305 finalize branch is an intentional, SFEP-scoped constant-time tradeoff tracked as a follow-up (SFN-331).

### Verification
- `capsules/sfn/crypto` suite: 11/11 files, 91 tests, 0 failures (existing sha256/hmac/ed25519/base64 untouched and green)
- `sfn fmt --check` clean on all touched `.sfn` files
- No `compiler/src` changes — self-host path untouched (`make compile` green on this tree)

### Follow-up
Phases B–D are groomed into the Linear epic **Native Crypto + TLS Stack — Zero OpenSSL** (under the Capability-Sealed Runtime initiative), citing SFEP-0048: SFN-331/332/333/334 (Ready) and SFN-335–341 (Backlog, with the blocker graph). The CSPRNG `[rand]` source is the existing SFN-123.