### PR TITLE
fix(test): isolate `sfn dev arena` work dir under SAILFIN_TEST_SCRATCH

### DIFF
--- a/compiler/src/cli/commands/dev_arena.sfn
+++ b/compiler/src/cli/commands/dev_arena.sfn
@@ -37,10 +37,17 @@ import {
 } from "../../string_utils";
 import { CliContext } from "../context";
 
-// Where the two emitted `.ll` files land, one pair per module. Mirrors the
-// script's default WORK_DIR so a developer's muscle memory (and any stray
-// gitignore entry) still points at the same tree.
-fn _arena_work_dir() -> string { return "build/arena-test"; }
+// Where the two emitted `.ll` files land, one pair per module. Rooted under
+// `SAILFIN_TEST_SCRATCH` when set so parallel `sfn test --jobs N` children
+// (which the runner isolates via that scratch) never clobber each other's
+// outputs; otherwise the script's default `build/arena-test`, so a
+// developer's muscle memory (and any stray gitignore entry) still points at
+// the same tree.
+fn _arena_work_dir() -> string ![io] {
+    let scratch = env.get("SAILFIN_TEST_SCRATCH");
+    if scratch.length > 0 { return scratch + "/arena-test"; }
+    return "build/arena-test";
+}
 
 // The default single-module coverage the bare command reproduces (the
 // script's no-arg case).


### PR DESCRIPTION
## Summary

Follow-up hardening to the merged SFN-201 (`sfn dev arena`, #2276), addressing a Copilot review point that landed as the PR merged. `_arena_work_dir()` wrote both `.ll` outputs to a fixed `build/arena-test`, so concurrent `sfn dev arena` runs under the parallel `sfn test --jobs N` pool — including the two e2e cases that both check `hello-world.sfn` — could clobber each other's files (one `deleteFile`s / reads a half-written file the other is mid-emit) and produce spurious FAILs. The work dir is now rooted under `SAILFIN_TEST_SCRATCH` when the runner sets it, falling back to `build/arena-test` for normal developer runs — the same per-invocation isolation the no-bash-e2e rule prescribes.

Refs SFN-201

## Changes

- `compiler/src/cli/commands/dev_arena.sfn` — `_arena_work_dir()` returns `<SAILFIN_TEST_SCRATCH>/arena-test` when the env var is set, else `build/arena-test` (now `[io]`).

## Validation

- [x] `sfn fmt --check` clean on the touched `.sfn` file
- [x] `make compile` — compiler self-hosts with the change
- [x] Scratch routing verified: with `SAILFIN_TEST_SCRATCH` set, the `.ll` pair lands under `<scratch>/arena-test/`; unset, under `build/arena-test`
- [x] `sfn test compiler/tests/e2e/dev_arena_equivalence_test.sfn --jobs 2` — all 3 tests pass (no cross-case clobber under parallelism)

Capability envelope: unchanged.

## Notes for reviewers

Pure test-infra isolation fix; no behavior change to the equivalence gate itself. `N/A` for the Stage1 readiness section (no language/runtime feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDErPbttrufxYc8QBdjkhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDErPbttrufxYc8QBdjkhC)_