### PR TITLE
refactor(crypto): branch-free constant-time poly1305 finalize (SFN-331)

### DIFF
--- a/capsules/sfn/crypto/src/poly1305.sfn
+++ b/capsules/sfn/crypto/src/poly1305.sfn
@@ -156,9 +156,9 @@ fn poly1305_mac(msg: int[], key: int[]) -> int[] {
     h1 = h1 + fc;
 
     // Final reduction: h - (2^130-5) via a borrow chain, keeping g only if
-    // it did not borrow past bit 130. The tag is public output (not a
-    // secret comparison), so a plain branch on the sign of g4 is acceptable
-    // here per the spec's constant-time scoping note.
+    // it did not borrow past bit 130. The selection is branch-free (masked)
+    // so finalize is constant-time with respect to the key, matching
+    // poly1305-donna's finish (SFEP-0048 §3.3).
     let g0_raw: int = h0 + 5;
     let mut c2: int = g0_raw >> 26;
     let g0: int = g0_raw & mask;
@@ -173,18 +173,21 @@ fn poly1305_mac(msg: int[], key: int[]) -> int[] {
     let g3: int = g3_raw & mask;
     let g4: int = h4 + c2 - 67108864;
 
-    let mut fh0: int = h0;
-    let mut fh1: int = h1;
-    let mut fh2: int = h2;
-    let mut fh3: int = h3;
-    let mut fh4: int = h4;
-    if g4 >= 0 {
-        fh0 = g0;
-        fh1 = g1;
-        fh2 = g2;
-        fh3 = g3;
-        fh4 = g4;
-    }
+    // Branch-free select: `(g4 >> 63) & 1` is g4's sign bit (1 when the borrow
+    // reached past bit 130, so h < 2^130-5 and we keep h; 0 when we take the
+    // reduced g). Isolating bit 63 with `& 1` is robust regardless of shift
+    // signedness. Spreading the 0/1 flag to an all-ones/all-zeros limb mask via
+    // subtraction: `0 - borrow` and `borrow - 1` land on -1 (two's-complement
+    // all-ones) for exactly one side, so `fh = (h & mask_h) | (g & mask_g)`
+    // picks h or g with no data-dependent branch.
+    let borrow: int = (g4 >> 63) & 1;
+    let mask_h: int = 0 - borrow;
+    let mask_g: int = borrow - 1;
+    let fh0: int = (h0 & mask_h) | (g0 & mask_g);
+    let fh1: int = (h1 & mask_h) | (g1 & mask_g);
+    let fh2: int = (h2 & mask_h) | (g2 & mask_g);
+    let fh3: int = (h3 & mask_h) | (g3 & mask_g);
+    let fh4: int = (h4 & mask_h) | (g4 & mask_g);
 
     // Recombine the five 26-bit limbs into four 32-bit words, then add s.
     let word_mask: int = 4294967295;


### PR DESCRIPTION
## Summary

Replaces the `if g4 >= 0` data-dependent branch in `poly1305_mac`'s final reduction (`capsules/sfn/crypto/src/poly1305.sfn`) with a branch-free masked select derived from `g4`'s sign bit, so the finalize step is constant-time with respect to the key — matching poly1305-donna's constant-time finish. Design: SFEP-0048 §3.3. The tag was already correct; this hardens the constant-time surface flagged on PR #2264.

Fixes SFN-331

## Changes

- runtime capsule (`sfn/crypto`): rewrite the `h` vs `g` limb selection in poly1305 finalize as a branch-free mask:
  - `borrow = (g4 >> 63) & 1` — isolates `g4`'s sign bit (robust to arithmetic-vs-logical shift because `& 1` keeps only bit 63): `1` ⇒ keep `h`, `0` ⇒ take reduced `g`.
  - `mask_h = 0 - borrow`, `mask_g = borrow - 1` — spread the 0/1 flag to full-width two's-complement all-ones/all-zeros masks (binary subtraction; unary `-` is used because the compiler's LLVM lowering can't resolve the return type of the unary `-` operator).
  - `fh_i = (h_i & mask_h) | (g_i & mask_g)` selects `h` or `g` with no branch.
- Limb schedule, r-clamping, the x5 wraparound multipliers, and the block accumulation loop are untouched (per issue `Out:`).

## Validation

- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `sfn check` (fast static analysis) passes — `checked 8 files: ok`
- [x] `sfn test capsules/sfn/crypto/tests/poly1305_test.sfn` — all 4 vectors pass, incl. the adversarial `fullcarryfinalize…dirtyh1limb` regression
- [x] `make compile` — compiler self-hosts (exit 0; not required for a capsule-only change, confirmed anyway)
- [x] N/A — no `compiler/src/*.sfn` touched, so no new `compiler/tests/` coverage; existing `poly1305_test.sfn` vectors exercise this path

## Acceptance Criteria

- [x] No data-dependent branch remains in `poly1305_mac` after the accumulation loop (the only remaining `if` is the fail-closed `key.length != 32` entry guard).
- [x] All existing `poly1305_test.sfn` vectors (incl. the adversarial finalize-carry regression) still pass.
- [x] `sfn fmt --check` + `sfn check` clean on the capsule.

## Map reconciliation

None — the advisory map named exactly `capsules/sfn/crypto/src/poly1305.sfn`, which is the only file changed.

## Notes for reviewers

Reviewed via the Opus `code-reviewer` gate: the masked select is provably equivalent to the original branch across the actual 26-bit limb ranges (`g4 = h4 + c2 - 2^26` may be negative → keep `h`; otherwise → take `g`). Source-level branch-free; true machine-level constant-time additionally relies on LLVM not re-materializing a select into a branch, which is out of scope here and matches poly1305-donna's own approach.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWSPUW56EcoQ9Xcd8Ccczc)_